### PR TITLE
Add discussions

### DIFF
--- a/client/javascripts/components/discussions/discussions.tag
+++ b/client/javascripts/components/discussions/discussions.tag
@@ -1,0 +1,142 @@
+<discussions>
+  <div class="discussion" each={ discussion in discussion_page.data } id="discussion-{ discussion.id}">
+    <div class="discussion__title">
+      <h1>{ discussion.title }</h1>
+    </div>
+    <div class="discussion-comment" each={ comment in discussion.discussion }>
+      <div class="discussion-comment__header">
+        <a href={ comment.posted_by.page }>
+          { comment.posted_by.first_name } { comment.posted_by.last_name }
+        </a>
+        <span> { opts.posted_on } </span>
+        <span>{ new Date(comment.posted_on).toLocaleString() }</span>
+      </div>
+      <div class="discussion-comment__content">
+        { comment.content }
+      </div>
+    </div>
+    <span if={ !opts.connected }>
+      { opts.connection_needed }
+    </span>
+    <a if={ opts.connected && !respond_comment_visible[discussion.id] } onclick={ show_respond_comment }>
+      { opts.respond_comment }
+    </a>
+    <form class="discussion-comment__form"
+          if={ respond_comment_visible[discussion.id] }
+          onsubmit={ send_comment }>
+      <div class="form__group">
+        <textarea ref="comment-{ discussion.id }"></textarea>
+      </div>
+      <div class="form__group">
+        <button>{ opts.respond_comment }</button>
+      </div>
+    </form>
+  </div>
+  <div class="discussion__post">
+    <a if={ opts.connected && !post_discussion_visible } onclick={ show_post_discussion }>
+      { opts.post_discussion }
+    </a>
+    <form class="discussion__form"
+          if={ post_discussion_visible }
+          onsubmit={ post_discussion }>
+      <div class="form__group">
+        <input type="text" placeholder={ opts.title } ref="discussion_title">
+      </div>
+      <div class="form__group">
+        <textarea ref="discussion_comment"></textarea>
+      </div>
+      <div class="form__group">
+        <button>{ opts.respond_comment }</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="discussions--error" if={ error }>
+   { this.opts.errorText }
+  </div>
+  <script>
+    this.on('before-mount', () => {
+        this.error = false
+        this.discussion_page = []
+        this.respond_comment_visible = {}
+        this.post_discussion_visible = false
+    })
+
+    this.show_respond_comment = (e) => {
+      Object.keys(this.respond_comment_visible).map(
+        k => { this.respond_comment_visible[k] = false}
+      )
+      let id = e.target.parentNode.id.split("-")[1]
+      this.respond_comment_visible[id] = true
+    }
+
+    this.show_post_discussion = (e) => {
+        this.post_discussion_visible = true
+    }
+
+    this.on('mount', () => {
+      this.update_discussions()
+    })
+
+    this.send_comment = (e) => {
+      e.preventDefault()
+      let id = e.target.parentNode.id.split("-")[1]
+      let form = new FormData()
+      form.append("comment", this.refs["comment-" + id].value)
+
+      let headers = new Headers()
+      headers.append("X-CSRF-TOKEN", document.querySelector("meta[name=csrf]").content)
+      fetch("/discussions/" + id, {
+        method: "POST",
+        body: form,
+        headers: headers,
+        credentials: 'same-origin'
+      }).then( response => {
+        this.update_discussions()
+      }).catch( error => {
+        this.display(false)
+      })
+    }
+
+    this.post_discussion = (e) => {
+      e.preventDefault()
+      let form = new FormData()
+      form.append("title", this.refs.discussion_title.value)
+      form.append("comment", this.refs.discussion_comment.value)
+      form.append("id_", this.opts.datasetid)
+
+      let headers = new Headers()
+      headers.append("X-CSRF-TOKEN", document.querySelector("meta[name=csrf]").content)
+      fetch("/discussions/", {
+        method: "POST",
+        body: form,
+        headers: headers,
+        credentials: 'same-origin'
+      }).then( response => {
+        this.update_discussions()
+      }).catch( error => {
+        this.display(false)
+      })
+    }
+
+
+    this.update_discussions = () => {
+      fetch(this.opts.datagouvfrsite + '/api/1/discussions/?for=' + this.opts.datasetid,
+        {method: 'GET',
+         mode: 'cors'
+      }).then(response => {
+        return response.json()
+      }).then(data => {
+        this.discussion_page = data
+        Object.values(this.discussion_page).map(
+          d => { this.respond_comment_visible[d.id] = false;}
+        )
+        this.update()
+      }).catch(error => {
+        this.error = true
+        this.update()
+      })
+    }
+
+  </script>
+</discussions>

--- a/client/stylesheets/components/_discussions.scss
+++ b/client/stylesheets/components/_discussions.scss
@@ -1,0 +1,29 @@
+discussions {
+  h1 {
+    font-size: 1.2em;
+    margin-bottom: .2em;
+    text-align: left;
+  }
+
+  .discussion-comment {
+    padding-left: 1em;
+    margin-bottom: 1em;
+  }
+
+  .discussion-comment__form {
+    padding-left: 1em;
+  }
+
+  textarea {
+    height: 10em;
+    width: 70%;
+  }
+
+  input {
+    width: 70%;
+  }
+
+  .discussion__post {
+    padding-top: 2em;
+  }
+}

--- a/lib/transport/datagouvfr/client.ex
+++ b/lib/transport/datagouvfr/client.ex
@@ -25,6 +25,15 @@ defmodule Transport.Datagouvfr.Client do
     |> Transport.Datagouvfr.Client.request(conn, url, body, headers, opts)
   end
 
+  @spec post_request(%Plug.Conn{}, binary, OAuth2Client.body,
+                    OAuth2Client.headers, Keyword.t)
+                    :: {:ok, Response.t} | {:error, Error.t}
+  def post_request(%Plug.Conn{} = conn, url, body \\ "", headers \\ [], opts \\ []) do
+    headers = [{"content-type", "application/json"} | headers]
+    :post
+    |> Transport.Datagouvfr.Client.request(conn, url, body, headers, opts)
+  end
+
   #credo:disable-for-lines:9
   @doc """
   We disable for now the credo test because the arity is to high
@@ -54,6 +63,7 @@ defmodule Transport.Datagouvfr.Client do
   def post_process_request(response) do
     case response do
       {:ok, %OAuth2.Response{status_code: 200, body: body}} -> {:ok, body}
+      {:ok, %OAuth2.Response{status_code: 201, body: body}} -> {:ok, body}
       {:ok, %OAuth2.Response{status_code: _, body: body}} -> {:error, body}
       {:error, error} -> {:error, error}
     end

--- a/lib/transport/datagouvfr/client/discussions.ex
+++ b/lib/transport/datagouvfr/client/discussions.ex
@@ -1,0 +1,31 @@
+defmodule Transport.Datagouvfr.Client.Discussions do
+  @moduledoc """
+  An API client for data.gouv.fr discussions
+  """
+
+  import Transport.Datagouvfr.Client, only: [post_request: 3]
+
+  @endpoint "discussions"
+
+  @doc """
+  Call to post /api/1/discussions/:id/
+  You can see documentation here: https://www.data.gouv.fr/fr/apidoc/#!/discussions/comment_discussion
+  """
+  @spec post(%Plug.Conn{}, String.t, String.t) :: {atom, [map]}
+  def post(%Plug.Conn{} = conn, id_, comment) do
+    conn
+    |> post_request(Path.join(@endpoint, id_), %{comment: comment})
+  end
+
+  @doc """
+  Call to post /api/1/discussions/
+  You can see documentation here: https://www.data.gouv.fr/fr/apidoc/#!/discussions/create_discussion
+  """
+  @spec post(%Plug.Conn{}, String.t, String.t, String.t) :: {atom, [map]}
+  def post(%Plug.Conn{} = conn, id_, comment, title) do
+    conn
+    |> post_request(@endpoint,
+                    %{comment: comment, title: title,
+                      subject: %{class: "Dataset", id: id_}})
+  end
+end

--- a/lib/transport_web/controllers/discussion_controller.ex
+++ b/lib/transport_web/controllers/discussion_controller.ex
@@ -1,0 +1,23 @@
+defmodule TransportWeb.DiscussionController do
+  use TransportWeb, :controller
+
+  alias Transport.Datagouvfr.Client.Discussions
+
+  def post_discussion_id(conn, %{"id_" => id_, "comment" => comment}) do
+    conn
+    |> Discussions.post(id_, comment)
+    |> case do
+      {:ok, _} -> render conn, "ok.json"
+      {:error, error} -> render conn, "error.json", error
+    end
+  end
+
+  def post_discussion(conn, %{"comment" => comment, "id_" => id_, "title" => title}) do
+    conn
+    |> Discussions.post(id_, comment, title)
+    |> case do
+      {:ok, _} -> render conn, "ok.json"
+      {:error, error} -> render conn, "error.json", error
+    end
+  end
+end

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -37,6 +37,12 @@ defmodule TransportWeb.Router do
       get "/datasets/:slug/_add", UserController, :add_badge_dataset
     end
 
+    scope "/discussions" do
+      pipe_through [:authentication_required]
+      post "/", DiscussionController, :post_discussion
+      post "/:id_", DiscussionController, :post_discussion_id
+    end
+
     # Authentication
 
     scope "/login" do

--- a/lib/transport_web/views/discussion_view.ex
+++ b/lib/transport_web/views/discussion_view.ex
@@ -1,0 +1,11 @@
+defmodule TransportWeb.DiscussionView do
+  use TransportWeb, :view
+
+  def render("ok.json", _) do
+    %{ok: "ok"}
+  end
+
+  def render("error.json", error) do
+    %{error: error}
+  end
+end

--- a/priv/gettext/alert.pot
+++ b/priv/gettext/alert.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/router.ex:80
+#: lib/transport_web/router.ex:86
 msgid "You need to be connected before doing this."
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/priv/gettext/en/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/router.ex:80
+#: lib/transport_web/router.ex:86
 msgid "You need to be connected before doing this."
 msgstr ""
 

--- a/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/router.ex:80
+#: lib/transport_web/router.ex:86
 msgid "You need to be connected before doing this."
 msgstr "Vous devez être préalablement connecté·e."
 


### PR DESCRIPTION
partial_fix #112 
fixes etalab/transport-datatools-ui#4

Be sure you cherry-pick `ac91a1aef38d34443861134dd05975decabb833b` before

You can add this to any controller
You need to assign
  :datagouvfrsite =>Application.get_env(:oauth2,Authentication)[:site])
to the connection

And add
<discussions datasetid="59d503d90b5b3901fed55f91"
             datagouvfrsite=<%= @datagouvfrsite %>
             posted_on="le"
             connected=<%= @current_user != nil %>
             respond_comment="Répondre"
             post_discussion="Ouvrir une nouvelle discussion"
             title="Titre"></discussions>
to the view