### PR TITLE
Bump Elixir to v1.6.1

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5.1
+FROM elixir:1.6.1
 
 # Install system dependencies
 RUN apt-get update \
@@ -28,7 +28,7 @@ RUN curl https://gist.githubusercontent.com/maukoquiroga/48e9aa501ca8c7d63615644
 RUN chmod +x /etc/init.d/phantomjs
 
 #Install data-validator
-RUN apt-get install -y mongodb-server python-pip python-virtualenv
+RUN apt-get install -y mongodb-server python-dev python-pip python-virtualenv
 RUN git clone https://github.com/etalab/transport-validator
 WORKDIR transport-validator
 RUN virtualenv venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: maukoquiroga/transport:0.0.5
+      - image: maukoquiroga/transport:0.0.6
         environment:
           MIX_ENV: test
           MONGODB_URL: mongodb://localhost/transport_test

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
 erlang_version=20.0
-elixir_version=1.5.1
+elixir_version=1.6.1

--- a/lib/transport_web/api/views/dataset_view.ex
+++ b/lib/transport_web/api/views/dataset_view.ex
@@ -6,6 +6,9 @@ defmodule TransportWeb.API.DatasetView do
   end
 
   def render(_conn, %{errors: errors}) do
-    Poison.encode(errors)
+    case Poison.encode(errors) do
+      {:ok, body} -> body
+      {:error, error} -> error
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Transport.Mixfile do
     [
       app: :transport,
       version: "0.0.1",
-      elixir: "~> 1.5",
+      elixir: "~> 1.6.1",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,
       build_embedded: Mix.env == :prod,


### PR DESCRIPTION
In order to use ```ExUnit.Callbacks.start_supervised!```, for testing ```GenServer```.