### PR TITLE
Unroll help message when the mouse is over the help button

### DIFF
--- a/client/javascripts/components/footer/footer-help.tag
+++ b/client/javascripts/components/footer/footer-help.tag
@@ -8,10 +8,13 @@
     </div>
 
     <div>
-        <a href="#"onclick={toggleVisibility}><div class="footer-help__round" if={ roundVisible }>?</div></a>
+        <a href="#"onclick={ showMessageBox }>
+          <div class="footer-help--on" if={ roundVisible } onmouseover={ showHelpMessage }>?</div>
+          <div class="footer-help--on" if={ helpMessageVisible } onmouseleave={ showRound }>{ opts.ask_for_help }</div>
+        </a>
 
         <div class="footer-help__contact" if={ contactVisible }>
-            <a class="footer-help__contact--close" onclick={toggleVisibility}>{ opts.close }</a>
+            <a class="footer-help__contact--close" onclick={ showRound }>{ opts.close }</a>
 
             <div class="footer-help__contact--header">
                 <h6>Contact</h6>
@@ -33,16 +36,32 @@
 
     <script type="es6">
         this.on('mount', () => {
-            this.roundVisible   = true
-            this.contactVisible = false
-            this.successVisible = false
-            this.errorVisible   = false
+            this.roundVisible       = true
+            this.helpMessageVisible = false
+            this.contactVisible     = false
+            this.successVisible     = false
+            this.errorVisible       = false
             this.update()
         })
 
-        this.toggleVisibility = () => {
-            this.roundVisible   = !this.roundVisible
-            this.contactVisible = !this.contactVisible
+        this.showHelpMessage = () => {
+            this.roundVisible   = false
+            this.contactVisible = false
+            this.helpMessageVisible = true
+            this.update()
+        }
+
+        this.showRound = () => {
+            this.roundVisible   = true
+            this.contactVisible = false
+            this.helpMessageVisible = false
+            this.update()
+        }
+
+        this.showMessageBox = () => {
+            this.roundVisible   = false
+            this.contactVisible = true
+            this.helpMessageVisible = false
             this.update()
         }
 

--- a/client/stylesheets/components/_footer-help.scss
+++ b/client/stylesheets/components/_footer-help.scss
@@ -1,4 +1,4 @@
-.footer-help__round {
+.footer-help--on {
   background-color: $dark-blue;
   border-radius: 1.8em;
   bottom: 1em;
@@ -12,6 +12,12 @@
   text-align: center;
   width: 1.8em;
   z-index: 10000;
+}
+
+.footer-help--on:hover {
+  padding-left: 1em;
+  padding-right: 1em;
+  width: auto;
 }
 
 .footer-help__contact {
@@ -63,7 +69,7 @@
        width: 40em;
     }
 
-    .footer-help__round {
+    .footer-help__alwayson {
        bottom: 2.5em;
     }
 

--- a/lib/transport_web/templates/layout/_footer.html.eex
+++ b/lib/transport_web/templates/layout/_footer.html.eex
@@ -3,7 +3,7 @@
     send_email='<%= gettext("Send email") %>''
     mail_sent='<%= gettext("Your email has been sent, we will contact you soon") %>'
     mail_error='<%= gettext("There has been an error, try again later") %>''
-    ask_for_help='<%= gettext("Ask help") %>'
+    ask_for_help='<%= gettext("Ask for help") %>'
     close='<%= gettext("Close") %>'>
   </footer-help>
   <div class="footer__container">

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -31,10 +31,6 @@ msgstr ""
 msgid "Publish, improve and reuse French public transport data"
 msgstr ""
 
-#: lib/transport_web/templates/layout/_footer.html.eex:6
-msgid "Ask help"
-msgstr ""
-
 #: lib/transport_web/templates/layout/_footer.html.eex:7
 msgid "Close"
 msgstr ""
@@ -58,4 +54,8 @@ msgstr ""
 #: lib/transport_web/templates/layout/_header.html.eex:4
 #: lib/transport_web/templates/layout/app.html.eex:11
 msgid "transport.data.gouv.fr"
+msgstr ""
+
+#: lib/transport_web/templates/layout/_footer.html.eex:6
+msgid "Ask for help"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -31,10 +31,6 @@ msgstr ""
 msgid "Publish, improve and reuse French public transport data"
 msgstr ""
 
-#: lib/transport_web/templates/layout/_footer.html.eex:6
-msgid "Ask help"
-msgstr ""
-
 #: lib/transport_web/templates/layout/_footer.html.eex:7
 msgid "Close"
 msgstr ""
@@ -58,4 +54,9 @@ msgstr ""
 #: lib/transport_web/templates/layout/_header.html.eex:4
 #: lib/transport_web/templates/layout/app.html.eex:11
 msgid "transport.data.gouv.fr"
+msgstr ""
+
+#, fuzzy
+#: lib/transport_web/templates/layout/_footer.html.eex:6
+msgid "Ask for help"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -31,10 +31,6 @@ msgstr "Conditions d'utilisation"
 msgid "Publish, improve and reuse French public transport data"
 msgstr "Rendre disponible, valoriser et améliorer les données transports"
 
-#: lib/transport_web/templates/layout/_footer.html.eex:6
-msgid "Ask help"
-msgstr "Demander de l'aide"
-
 #: lib/transport_web/templates/layout/_footer.html.eex:7
 msgid "Close"
 msgstr "fermer"
@@ -59,3 +55,7 @@ msgstr "Votre email a été envoyé, nous vous recontacterons prochainement."
 #: lib/transport_web/templates/layout/app.html.eex:11
 msgid "transport.data.gouv.fr"
 msgstr ""
+
+#: lib/transport_web/templates/layout/_footer.html.eex:6
+msgid "Ask for help"
+msgstr "Demander de l'aide"

--- a/test/transport_web/integrations/contact_test.exs
+++ b/test/transport_web/integrations/contact_test.exs
@@ -10,7 +10,7 @@ defmodule TransportWeb.Integration.ContactTest do
 
     assert visible_page_text() =~ "?"
 
-    find_element(:class, "footer-help__round")
+    find_element(:class, "footer-help--on")
     |> inner_text
     |> Kernel.=~("?")
     |> assert


### PR DESCRIPTION
When the mouse is over the button with the `?` you have this message that appears.

![image](https://user-images.githubusercontent.com/2757318/35866514-ad598e46-0b57-11e8-9809-5f47e25329ba.png)
