### PR TITLE
Fix responsivity on dataset details page

### DIFF
--- a/client/stylesheets/components/_dataset-details.scss
+++ b/client/stylesheets/components/_dataset-details.scss
@@ -1,6 +1,6 @@
-.dataset-details__side-pan {
-  padding-right: 2em;
-  width: 20%;
+div.dataset-details__side-pane {
+  background: $background-white;
+  border: none;
 
   img {
     padding-bottom: 3em;
@@ -10,10 +10,6 @@
   button {
     margin-top: 3em;
   }
-}
-
-.dataset-details__main-pan {
-  width: 80%;
 }
 
 .dataset-details__discussions {

--- a/client/stylesheets/components/_documentation.scss
+++ b/client/stylesheets/components/_documentation.scss
@@ -3,10 +3,10 @@
 }
 
 .side-pane {
-  background: var(--theme-background-grey);
+  background: $background-grey;
   padding: 1em;
-  flex: 0 0 250px;
-  border-right: 1px solid var(--theme-border-lighter);
+  flex: 0 0 1em;
+  border-right: 1px solid $border-lighter;
 }
 
 .side-pane ul {
@@ -26,22 +26,21 @@
   box-sizing: border-box;
   border-radius: 5px;
   margin-bottom: 0.5em;
-  color: var(--theme-dark-text);
+  color: $dark-text;
 }
 
 .side-pane .side-pane__link:hover a {
-  background: var(--light-grey);
+  background: $light-grey;
   transition: background ease-out 0.5s;
 }
 
 .side-pane .side-pane__link.active a {
-  background: var(--theme-primary);
-  color: var(--white);
+  color: $white;
 }
 
 .main-pane {
   padding: 3em;
-  background: var(--white);
+  background: $white;
   flex: 1;
 }
 
@@ -49,14 +48,14 @@
   margin-top: 0;
 }
 
-@media (--smaller-than-tablet) {
+@include mobile {
   .documentation {
     flex-direction: column;
   }
 
   .side-pane {
     border-right: none;
-    border-bottom: 1px solid var(--theme-border-lighter);
+    border-bottom: 1px solid $border-lighter;
     flex: auto;
   }
 }

--- a/lib/transport_web/templates/dataset/details.html.eex
+++ b/lib/transport_web/templates/dataset/details.html.eex
@@ -4,7 +4,7 @@
   <% end %>
   <h1><%= @dataset.title %></h1>
   <div class="documentation">
-    <div class="side-pan dataset-details__side-pan">
+    <div class="dataset-details__side-pane side-pane">
       <div>
         <%= img_tag(@dataset.logo, alt: @dataset.title) %>
         <%= if @dataset.download_uri do %>
@@ -69,7 +69,7 @@
         <a class="button button--fullwidth is-centered" href="<%= user_path(@conn, :organizations, linked_dataset_slug: @dataset.slug) %>"><%= dgettext("page-dataset-details", "Publish a modified version dataset") %></a>
       </div>
     </div>
-    <div class="main-pan dataset-details__main-pan" id="description">
+    <div class="main-pane dataset-details__main-pane" id="description">
       <div class="dataset-detail__markdown">
         <markdown content="<%= @dataset.description %>"></markdown>
         <h1 style="background: hsl(213, 26%, 83%);">Conditions d'utilisation</h1>


### PR DESCRIPTION
Was
![image](https://user-images.githubusercontent.com/2757318/35911666-bc70bdf2-0bfa-11e8-8755-c86bbe6afbba.png)
Now
![image](https://user-images.githubusercontent.com/2757318/35911699-d0e0a7fc-0bfa-11e8-9180-a65d0448364c.png)

fix #205 
