### PR TITLE
Publish reuse button is now readable

### DIFF
--- a/client/stylesheets/base/_buttons.scss
+++ b/client/stylesheets/base/_buttons.scss
@@ -23,7 +23,8 @@ button,
   }
 
   &:hover {
-    box-shadow: inset 0 0 0 2em $box-shadow-button-hover;
+    box-shadow: inset 0 0 0 4em $box-shadow-button-hover;
+    color: $white;
     text-decoration: none;
   }
 

--- a/lib/transport_web/templates/dataset/details.html.eex
+++ b/lib/transport_web/templates/dataset/details.html.eex
@@ -64,7 +64,7 @@
         </div>
       </div>
       <div>
-        <a class="button is-centered" href="<%= user_path(@conn, :organizations, linked_dataset_slug: @dataset.slug) %>"><%= dgettext("page-dataset-details", "Publish a modified version dataset") %></a>
+        <a class="button button--fullwidth is-centered" href="<%= user_path(@conn, :organizations, linked_dataset_slug: @dataset.slug) %>"><%= dgettext("page-dataset-details", "Publish a modified version dataset") %></a>
       </div>
     </div>
     <div class="main-pan dataset-details__main-pan" id="description">


### PR DESCRIPTION
fix #202 
Was:
![image](https://user-images.githubusercontent.com/2757318/36035819-5cd23fdc-0db8-11e8-8fb0-56ecdcc0c764.png)
Now:
![image](https://user-images.githubusercontent.com/2757318/36035848-79b61cae-0db8-11e8-93a7-b13436841ca2.png)
