### PR TITLE
Handle bad extension

### DIFF
--- a/lib/transport/datagouvfr/client.ex
+++ b/lib/transport/datagouvfr/client.ex
@@ -70,6 +70,7 @@ defmodule Transport.Datagouvfr.Client do
     case response do
       {:ok, %OAuth2.Response{status_code: 200, body: body}} -> {:ok, body}
       {:ok, %OAuth2.Response{status_code: 201, body: body}} -> {:ok, body}
+      {:error, %OAuth2.Response{status_code: 400, body: body}} -> {:bad_request, body}
       {:ok, %OAuth2.Response{status_code: _, body: body}} -> {:error, body}
       {:error, error} -> {:error, error}
     end

--- a/lib/transport_web/controllers/dataset_controller.ex
+++ b/lib/transport_web/controllers/dataset_controller.ex
@@ -39,6 +39,10 @@ defmodule TransportWeb.DatasetController do
         conn
         |> put_flash(:errors, Enum.map(errors, fn({_, _, _, s}) -> s end))
         |> redirect(to: dataset_path(conn, :new, organization))
+      {:bad_request, error} ->
+        conn
+        |> put_flash(:errors, [error["message"]])
+        |> redirect(to: dataset_path(conn, :new, organization))
       {:error, error} ->
         Logger.error(error)
         conn

--- a/test/fixture/cassettes/dataset/upload-dataset-file-bad-format.json
+++ b/test/fixture/cassettes/dataset/upload-dataset-file-bad-format.json
@@ -1,0 +1,30 @@
+[
+  {
+    "request": {
+      "body": "{:multipart, [{:file, \"test/fixture/files/unknow_file_format\", {\"form-data\", [{\"name\", \"\\\"file\\\"\"}, {\"filename\", \"\\\"francis_lalanne.wave\\\"\"}]}, []}]}",
+      "headers": {
+        "accept": "multipart/form-data",
+        "content-type": "multipart/form-data"
+      },
+      "method": "post",
+      "options": {
+        "timeout": 15000
+      },
+      "request_body": "",
+      "url": "https://next.data.gouv.fr/api/1/datasets/5a0b1b240b5b39318769c3b1/upload/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"message\": \"Bad file extension\"}",
+      "headers": {
+        "Server": "nginx",
+        "Date": "Thu, 22 Mar 2018 10:17:21 GMT",
+        "Content-Type": "application/json",
+        "Content-Length": "276",
+        "Connection": "keep-alive"
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/test/transport/data_improvement/repositories/dataset_repository_test.exs
+++ b/test/transport/data_improvement/repositories/dataset_repository_test.exs
@@ -28,4 +28,27 @@ defmodule Transport.DataImprovement.DatasetRepositoryTest do
       assert {:ok, _} = DatasetRepository.update_file(dataset, conn)
     end
   end
+
+  test "upload a file with an unknown format", %{conn: conn} do
+    file = %Plug.Upload{
+      path: "test/fixture/files/unknow_file_format",
+      filename: "francis_lalanne.wave"
+    }
+
+    conn =
+      init_test_session(
+      conn,
+      current_user: %{},
+      client: Authentication.client("secret")
+    )
+
+    dataset = %Dataset{
+      dataset_uuid: "5a0b1b240b5b39318769c3b1",
+      file: file
+    }
+
+    use_cassette "dataset/upload-dataset-file-bad-format" do
+      assert {:bad_request, %{"message" => _ }} = DatasetRepository.update_file(dataset, conn)
+    end
+  end
 end


### PR DESCRIPTION
When a bad extension was given, an error 400 is returned by udata which is transformed in 500.

What is still missing in this PR:
* tests
* translate the error message

![image](https://user-images.githubusercontent.com/12235/36911866-318fd940-1e45-11e8-8b22-25a4798c88be.png)
