### PR TITLE
Format the markdown in comments

### DIFF
--- a/client/javascripts/components/discussions/discussions.tag
+++ b/client/javascripts/components/discussions/discussions.tag
@@ -13,7 +13,7 @@
                 <span>{ new Date(comment.posted_on).toLocaleString() }</span>
             </div>
             <div class="discussion-comment__content">
-                { comment.content }
+                <markdown content="{ comment.content }"></markdown>
             </div>
         </div>
 

--- a/client/stylesheets/components/_discussions.scss
+++ b/client/stylesheets/components/_discussions.scss
@@ -30,4 +30,18 @@ discussions {
   .discussion__post {
     padding-top: 2em;
   }
+
+  .discussion-comment__content {
+    p {
+      padding: 0;
+      margin-top: 0.4em;
+      margin-bottom: 0.4em;
+      margin-left: 1em;
+    }
+
+    li {
+      margin-left: 1em;
+      list-style: circle inside;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #240 

### Currently

![image](https://user-images.githubusercontent.com/12235/38317991-a2a27e78-382e-11e8-8dcc-78e0687f1992.png)

### After

![image](https://user-images.githubusercontent.com/12235/38318020-b56a828a-382e-11e8-9bb3-ef9551b507b4.png)
