### PR TITLE
Deploy even if external tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,6 @@ workflows:
             - test_unit
             - test_integration
             - test_solution
-            - test_external
           filters:
             branches:
               only: master


### PR DESCRIPTION
Errors will be shown in the pull requests,
but if we override them (as it can be an external failure),
it won’t block the deploy.