### PR TITLE
Use a single task for importing the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Now you can visit [`127.0.0.1:5000`](http://127.0.0.1:5000) from your browser.
 
 ### Tasks
 
-  * Run `mix transport.reset` to delete datasets from the database.
-  * Run `mix transport.seed` to seed datasets to the database.
-  * Run `mix transport.import_data` to import data from data.gouv.fr.
+  * Run `mix transport.reset_and_import_data` to import all the data. It will run the following tasks:
+    * `mix transport.reset` to delete datasets from the database.
+    * `mix transport.seed` to seed datasets to the database.
+    * `mix transport.import_data` to import data from data.gouv.fr.
   * Run `mix transport.validate_data` to queue dataset validations.
   * Run `mix transport.fetch_validation_results` to fetch all the validation results.
 

--- a/lib/mix/tasks/transport/reset_and_import.ex
+++ b/lib/mix/tasks/transport/reset_and_import.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.Transport.ResetAndImportData do
+  @moduledoc """
+  Resets the dataset database, seeds it and import them.
+
+  This is an alias to avoid running the three tasks one by one.
+  """
+
+  use Mix.Task
+
+  def run(_) do
+    Mix.Task.run("transport.reset", [])
+    Mix.Task.run("transport.seed", [])
+    Mix.Task.run("transport.import_data", [])
+  end
+end


### PR DESCRIPTION
As the 3 tasks are always run one after an other, this reduces the work made by hand