### PR TITLE
Disable map test

### DIFF
--- a/test/transport_web/solutions/data_reuse/using_map_test.exs
+++ b/test/transport_web/solutions/data_reuse/using_map_test.exs
@@ -30,7 +30,9 @@ defmodule TransportWeb.Solution.DataReuse.UsingMapTest do
     :ok
   end
 
-  @tag :solution
+  # NOTE: Please reactive this test as soon as the landing page's hero is finished.
+  # @tag :solution
+  @tag :pending
   test "I can use the map to find and download transport data" do
     @endpoint
     |> page_url(:index)


### PR DESCRIPTION
As we're still building the new frontpage, we're disabling this test.

Why? Because map element is not active, and PhantomJS can't reach it.

The cost of making it work is greater than the benefits, as we don't
know yet if we'll keep this layout.