### PR TITLE
Backoffice

### DIFF
--- a/lib/transport/reusable_data/dataset.ex
+++ b/lib/transport/reusable_data/dataset.ex
@@ -27,6 +27,8 @@ defmodule Transport.ReusableData.Dataset do
     :last_update,
     :metadata,
     :fatal_error,
+    :region,
+    :commune_principale,
     validations: [],
     tags: [],
   ]
@@ -57,6 +59,8 @@ defmodule Transport.ReusableData.Dataset do
           metadata: Map.t(),
           fatal_error: Map.t(),
           tags: [String.t()],
+          region: String.t(),
+          commune_principale: String.t(),
         }
 
   @doc """

--- a/lib/transport/reusable_data/reusable_data.ex
+++ b/lib/transport/reusable_data/reusable_data.ex
@@ -49,7 +49,6 @@ defmodule Transport.ReusableData do
     query_datasets(%{
       # We display also datasets with anomalies
       # anomalies: [],
-      coordinates: %{"$ne" => nil},
       download_url: %{"$ne" => nil}
     })
   end

--- a/lib/transport_web/controllers/backoffice_controller.ex
+++ b/lib/transport_web/controllers/backoffice_controller.ex
@@ -1,0 +1,50 @@
+defmodule TransportWeb.BackofficeController do
+  use TransportWeb, :controller
+  alias Transport.{ImportDataService, ReusableData}
+  require Logger
+
+  defp region_names() do
+    :mongo
+    |> Mongo.find("regions", %{}, pool:  DBConnection.Poolboy)
+    |> Enum.map(fn r -> r["properties"]["NOM_REG"] end)
+  end
+
+  def index(%Plug.Conn{} = conn, _params) do
+    conn
+    |> assign(:regions, region_names())
+    |> assign(:datasets, ReusableData.list_datasets)
+    |> render("index.html")
+  end
+
+  defp insert_into_mongo(%{} = dataset) do
+    case Mongo.insert_one(:mongo, "datasets", dataset, pool: DBConnection.Poolboy) do
+      {:ok, %Mongo.InsertOneResult{inserted_id: mongo_id}} ->
+        {:ok, %{"_id" => mongo_id, "id" => dataset["id"]}}
+      error ->
+        error
+    end
+  end
+
+  defp import_data({:ok, ids}) do
+    ImportDataService.call(ids)
+  end
+  defp import_data(error), do: error
+
+  defp flash({:ok, _message}, conn) do
+    put_flash(conn, :info, dgettext("backoffice", "Dataset added with success"))
+  end
+
+  defp flash({:error, message}, conn) do
+    put_flash(conn, :error, dgettext("backoffice", "Dataset not added") <> "(" <> message <> ")")
+  end
+
+  def new_dataset(%Plug.Conn{} = conn, params) do
+    params
+    |> Map.take(["spatial", "id", "commune_principale", "region"])
+    |> insert_into_mongo
+    |> import_data
+    |> flash(conn)
+    |> index(%{})
+  end
+
+end

--- a/lib/transport_web/controllers/backoffice_controller.ex
+++ b/lib/transport_web/controllers/backoffice_controller.ex
@@ -3,7 +3,7 @@ defmodule TransportWeb.BackofficeController do
   alias Transport.{ImportDataService, ReusableData}
   require Logger
 
-  defp region_names() do
+  defp region_names do
     :mongo
     |> Mongo.find("regions", %{}, pool:  DBConnection.Poolboy)
     |> Enum.map(fn r -> r["properties"]["NOM_REG"] end)

--- a/lib/transport_web/controllers/session_controller.ex
+++ b/lib/transport_web/controllers/session_controller.ex
@@ -42,7 +42,7 @@ defmodule TransportWeb.SessionController do
   #private functions
 
   defp user_params(%{} = user) do
-    Map.take(user, ["id", "apikey", "email", "first_name", "last_name", "avatar_thumbnail"])
+    Map.take(user, ["id", "apikey", "email", "first_name", "last_name", "avatar_thumbnail", "organizations"])
   end
 
   defp get_redirect_path(conn) do

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -155,14 +155,15 @@ defmodule TransportWeb.Router do
   defp transport_data_gouv_member(conn, _) do
     conn.assigns[:current_user]
     |> Map.get("organizations", [])
-    |> case do
-      [%{"slug" => "equipe-transport-data-gouv-fr" } | _] ->
+    |> Enum.any?(fn org -> org["slug"] == "equipe-transport-data-gouv-fr" end)
+    |> if do
         conn
-      _ ->  conn
-            |> put_flash(:error, dgettext("alert", "You need to be a member of the transport.data.gouv.fr team."))
-            |> redirect(to: Helpers.page_path(conn, :login,
-                        redirect_path: current_path(conn)))
-            |> halt()
-    end
+       else
+        conn
+        |> put_flash(:error, dgettext("alert", "You need to be a member of the transport.data.gouv.fr team."))
+        |> redirect(to: Helpers.page_path(conn, :login,
+                    redirect_path: current_path(conn)))
+        |> halt()
+       end
   end
 end

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -50,6 +50,10 @@ defmodule TransportWeb.Router do
       get "/region/:region", DatasetController, :by_region
     end
 
+    scope "/backoffice" do
+      get "/", BackofficeController, :index
+    end
+
     scope "/user" do
       pipe_through [:authentication_required]
       get "/organizations/", UserController, :organizations

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -52,6 +52,7 @@ defmodule TransportWeb.Router do
 
     scope "/backoffice" do
       get "/", BackofficeController, :index
+      post "/", BackofficeController, :new_dataset
     end
 
     scope "/user" do

--- a/lib/transport_web/templates/backoffice/index.html.eex
+++ b/lib/transport_web/templates/backoffice/index.html.eex
@@ -1,0 +1,61 @@
+<section class="dataset-container">
+  <h1><%= dgettext("backoffice", "Valid datasets available") %></h1>
+
+  <h2><%= dgettext("backoffice", "Add a dataset") %></h2>
+
+  <%= if get_flash(@conn, :info) do %>
+  FLASH INFO : <%= get_flash(@conn, :info) %>
+  <% end %>
+
+  <%= if get_flash(@conn, :error) do %>
+  FLASH ERROR : <%= get_flash(@conn, :error) %>
+  <% end %>
+
+  <%= form_for @conn, backoffice_path(@conn, :new_dataset), fn f -> %>
+    <%= text_input f, :id, [{"placeholder", dgettext("backoffice", "data.gouv.fr id")}] %>
+    <%= text_input f, :spatial, [{"placeholder", dgettext("backoffice", "name")}] %>
+    <%= text_input f, :commune_principale, [{"placeholder", dgettext("backoffice", "INSEE Code")}] %>
+    <%= select f, :region, @regions %>
+    <%= submit dgettext("backoffice", "Add") %>
+  <% end %>
+
+  <table>
+  <tr>
+    <th>Territoire</th>
+    <th>Fin de validité</th>
+    <th></th>
+    <th></th>
+    <th>Region</th>
+    <th>Commune principale</th>
+  </tr>
+
+  <%= for dataset <- @datasets do %>
+    <tr>
+      <td><%= dataset.spatial %></td>
+      <td>
+        <%= if dataset.metadata do %>
+          <%= dataset.metadata["end_date"] %>
+        <% end %>
+      </td>
+      <td>
+        <%= if dataset.download_url do %>
+            <i class="icon icon--link" aria-hidden="true"></i>
+            <%= link(dgettext("page-shortlist", "See on data.gouv.fr"),
+                    to: "https://www.data.gouv.fr/datasets/#{dataset.id}/",
+                    role: "link") %>
+        <% end %>
+      </td>
+      <td>
+        <%= if dataset.download_url do %>
+            <i class="icon icon--download" aria-hidden="true"></i>
+            <%= link(dgettext("page-shortlist", "Download"),
+                    to: dataset.download_url,
+                    role: "link") %>
+        <% end %>
+      </td>
+      <td><%= dataset.region %></td>
+      <td><%= dataset.commune_principale %>
+    </tr>
+  <% end %>
+    </table>
+</section>

--- a/lib/transport_web/views/backoffice_view.ex
+++ b/lib/transport_web/views/backoffice_view.ex
@@ -1,0 +1,3 @@
+defmodule TransportWeb.BackofficeView do
+  use TransportWeb, :view
+end

--- a/priv/gettext/alert.pot
+++ b/priv/gettext/alert.pot
@@ -10,10 +10,14 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/router.ex:136
+#: lib/transport_web/router.ex:146
 msgid "You need to be connected before doing this."
 msgstr ""
 
 #: lib/transport_web/controllers/session_controller.ex:29
 msgid "An error occured, please try again"
+msgstr ""
+
+#: lib/transport_web/router.ex:162
+msgid "You need to be a member of the transport.data.gouv.fr team."
 msgstr ""

--- a/priv/gettext/alert.pot
+++ b/priv/gettext/alert.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/router.ex:132
+#: lib/transport_web/router.ex:136
 msgid "You need to be connected before doing this."
 msgstr ""
 

--- a/priv/gettext/backoffice.pot
+++ b/priv/gettext/backoffice.pot
@@ -34,10 +34,10 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lib/transport_web/controllers/backoffice_controller.ex:44
+#: lib/transport_web/controllers/backoffice_controller.ex:34
 msgid "Dataset added with success"
 msgstr ""
 
-#: lib/transport_web/controllers/backoffice_controller.ex:48
+#: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
 msgstr ""

--- a/priv/gettext/backoffice.pot
+++ b/priv/gettext/backoffice.pot
@@ -1,0 +1,43 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "Add"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:4
+msgid "Add a dataset"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:17
+msgid "INSEE Code"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:2
+msgid "Valid datasets available"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:15
+msgid "data.gouv.fr id"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:16
+msgid "name"
+msgstr ""
+
+#: lib/transport_web/controllers/backoffice_controller.ex:44
+msgid "Dataset added with success"
+msgstr ""
+
+#: lib/transport_web/controllers/backoffice_controller.ex:48
+msgid "Dataset not added"
+msgstr ""

--- a/priv/gettext/dataset.pot
+++ b/priv/gettext/dataset.pot
@@ -76,6 +76,6 @@ msgstr ""
 msgid "Invalid dataset identifier"
 msgstr ""
 
-#: lib/transport_web/controllers/dataset_controller.ex:73
+#: lib/transport_web/controllers/dataset_controller.ex:72
 msgid "Your modified version of this dataset has beed added"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/priv/gettext/en/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/router.ex:132
+#: lib/transport_web/router.ex:136
 msgid "You need to be connected before doing this."
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/priv/gettext/en/LC_MESSAGES/alert.po
@@ -10,10 +10,14 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/router.ex:136
+#: lib/transport_web/router.ex:146
 msgid "You need to be connected before doing this."
-msgstr ""
+msgstr "Vous devez être connecté avant de poursuivre."
 
 #: lib/transport_web/controllers/session_controller.ex:29
 msgid "An error occured, please try again"
-msgstr ""
+msgstr "Il y a eu une erreur, veuillez ré-essayer"
+
+#: lib/transport_web/router.ex:162
+msgid "You need to be a member of the transport.data.gouv.fr team."
+msgstr "Vous devez être membre de l’équipe transport.data.gouv.fr."

--- a/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -1,0 +1,43 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "Add"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:4
+msgid "Add a dataset"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:17
+msgid "INSEE Code"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:2
+msgid "Valid datasets available"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:15
+msgid "data.gouv.fr id"
+msgstr ""
+
+#: lib/transport_web/templates/backoffice/index.html.eex:16
+msgid "name"
+msgstr ""
+
+#: lib/transport_web/controllers/backoffice_controller.ex:44
+msgid "Dataset added with success"
+msgstr ""
+
+#: lib/transport_web/controllers/backoffice_controller.ex:48
+msgid "Dataset not added"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -34,10 +34,10 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lib/transport_web/controllers/backoffice_controller.ex:44
+#: lib/transport_web/controllers/backoffice_controller.ex:34
 msgid "Dataset added with success"
 msgstr ""
 
-#: lib/transport_web/controllers/backoffice_controller.ex:48
+#: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -76,6 +76,6 @@ msgstr ""
 msgid "Invalid dataset identifier"
 msgstr ""
 
-#: lib/transport_web/controllers/dataset_controller.ex:73
+#: lib/transport_web/controllers/dataset_controller.ex:72
 msgid "Your modified version of this dataset has beed added"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -10,6 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
+#: lib/transport_web/templates/backoffice/index.html.eex:33
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -21,6 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
+#: lib/transport_web/templates/backoffice/index.html.eex:25
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -51,6 +53,7 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:33
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:25
+#: lib/transport_web/templates/backoffice/index.html.eex:43
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -53,7 +53,6 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -10,10 +10,14 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/router.ex:136
+#: lib/transport_web/router.ex:146
 msgid "You need to be connected before doing this."
 msgstr "Vous devez être préalablement connecté·e."
 
 #: lib/transport_web/controllers/session_controller.ex:29
 msgid "An error occured, please try again"
 msgstr "Une erreur est survenue, veuillez réessayer"
+
+#: lib/transport_web/router.ex:162
+msgid "You need to be a member of the transport.data.gouv.fr team."
+msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/router.ex:132
+#: lib/transport_web/router.ex:136
 msgid "You need to be connected before doing this."
 msgstr "Vous devez être préalablement connecté·e."
 

--- a/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -34,10 +34,10 @@ msgstr "id data.gouv.fr"
 msgid "name"
 msgstr "nom"
 
-#: lib/transport_web/controllers/backoffice_controller.ex:44
+#: lib/transport_web/controllers/backoffice_controller.ex:34
 msgid "Dataset added with success"
 msgstr "Jeux de données ajouté avec succès"
 
-#: lib/transport_web/controllers/backoffice_controller.ex:48
+#: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
 msgstr "Échec à l’ajout du jeu de données"

--- a/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -1,0 +1,43 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "Add"
+msgstr "Ajouter"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:4
+msgid "Add a dataset"
+msgstr "Ajouter un jeu de données"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:17
+msgid "INSEE Code"
+msgstr "Code INSEE"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:2
+msgid "Valid datasets available"
+msgstr "Jeux de données disponibles"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:15
+msgid "data.gouv.fr id"
+msgstr "id data.gouv.fr"
+
+#: lib/transport_web/templates/backoffice/index.html.eex:16
+msgid "name"
+msgstr "nom"
+
+#: lib/transport_web/controllers/backoffice_controller.ex:44
+msgid "Dataset added with success"
+msgstr "Jeux de données ajouté avec succès"
+
+#: lib/transport_web/controllers/backoffice_controller.ex:48
+msgid "Dataset not added"
+msgstr "Échec à l’ajout du jeu de données"

--- a/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -76,6 +76,6 @@ msgstr "Un fichier contenant un jeu de données est requis"
 msgid "Invalid dataset identifier"
 msgstr "L’identificateur du jeu de données n’est pas valide"
 
-#: lib/transport_web/controllers/dataset_controller.ex:73
+#: lib/transport_web/controllers/dataset_controller.ex:72
 msgid "Your modified version of this dataset has beed added"
 msgstr "Votre version a été ajoutée"

--- a/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -10,6 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
+#: lib/transport_web/templates/backoffice/index.html.eex:33
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -21,6 +22,7 @@ msgstr "Télécharger"
 msgid "Licence"
 msgstr "License"
 
+#: lib/transport_web/templates/backoffice/index.html.eex:25
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -51,6 +53,7 @@ msgstr "Invalide"
 msgid "Valid"
 msgstr "Valide"
 
+#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr "Jeux de données valides disponibles"

--- a/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:33
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -22,7 +22,7 @@ msgstr "Télécharger"
 msgid "Licence"
 msgstr "License"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:25
+#: lib/transport_web/templates/backoffice/index.html.eex:43
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -53,7 +53,6 @@ msgstr "Invalide"
 msgid "Valid"
 msgstr "Valide"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr "Jeux de données valides disponibles"

--- a/priv/gettext/page-shortlist.pot
+++ b/priv/gettext/page-shortlist.pot
@@ -10,6 +10,7 @@
 msgid ""
 msgstr ""
 
+#: lib/transport_web/templates/backoffice/index.html.eex:33
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -21,6 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
+#: lib/transport_web/templates/backoffice/index.html.eex:25
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -51,6 +53,7 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr ""

--- a/priv/gettext/page-shortlist.pot
+++ b/priv/gettext/page-shortlist.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:33
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:14
 #: lib/transport_web/templates/dataset/details.html.eex:160
 #: lib/transport_web/templates/dataset/index.html.eex:44
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:25
+#: lib/transport_web/templates/backoffice/index.html.eex:43
 #: lib/transport_web/templates/dataset/details.html.eex:23
 #: lib/transport_web/templates/dataset/index.html.eex:35
 msgid "See on data.gouv.fr"
@@ -53,7 +53,6 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:2
 #: lib/transport_web/templates/dataset/index.html.eex:2
 msgid "Valid datasets available"
 msgstr ""

--- a/test/transport_web/integrations/backoffice_test.exs
+++ b/test/transport_web/integrations/backoffice_test.exs
@@ -1,0 +1,38 @@
+defmodule TransportWeb.Integration.BackofficeTest do
+  use TransportWeb.ConnCase, async: true
+  use TransportWeb.UserFacingCase
+  import Plug.Test
+
+  @tag :integration
+  test "deny acces to backoffice if not logged" do
+
+    @endpoint
+    |> backoffice_url(:index)
+    |> navigate_to
+
+    :class
+    |> find_element("message--info")
+    |> visible_text
+    |> Kernel.==("Vous devez être préalablement connecté·e.")
+    |> assert
+  end
+
+  @tag :integration
+  test "check that you belong to the right organization", %{conn: conn} do
+    conn
+    |> init_test_session(%{current_user: %{"organizations" => [%{"slug" => "pouet pouet"}]}})
+    |> get("/backoffice")
+    |> get_flash(:error)
+    |> Kernel.=~("You need to be a member of the transport.data.gouv.fr team.")
+    |> assert
+  end
+
+  @tag :integration
+  test "show add new dataset form", %{conn: conn} do
+    conn
+    |> init_test_session(%{current_user: %{"organizations" => [%{"slug" => "blurp"}, %{"slug" => "equipe-transport-data-gouv-fr"}]}})
+    |> get("/backoffice")
+    |> html_response(200)
+  end
+
+end


### PR DESCRIPTION
Permet d’ajouter un jeu de données directement depuis le site, sans passer par des PR