### PR TITLE
Import from data.gouv.fr: the format must contain gtfs, not be equal to

### DIFF
--- a/lib/transport/import_data_service.ex
+++ b/lib/transport/import_data_service.ex
@@ -123,6 +123,7 @@ defmodule Transport.ImportDataService do
   filter gtfs resources
 
   ## Examples
+
       iex> [%{"format" => "GTFS"}]
       ...> |> ImportDataService.filter_gtfs
       [%{"format" => "GTFS"}]
@@ -135,10 +136,16 @@ defmodule Transport.ImportDataService do
       ...> |> ImportDataService.filter_gtfs
       [%{"format" => "GTFS"}]
 
+      iex> [%{"format" => "gtfs.zip"}]
+      ...> |> ImportDataService.filter_gtfs
+      [%{"format" => "gtfs.zip"}]
+
   """
   def filter_gtfs(resources) do
     Enum.filter(resources, fn %{"format" => format} ->
-      String.downcase(format) == "gtfs"
+      format
+      |> String.downcase
+      |> String.contains?("gtfs")
     end)
   end
 


### PR DESCRIPTION
It will fix the problem for https://transport.data.gouv.fr/datasets/lignes-dautocars-urbains-et-interurbains-de-la-dlva/ where the neptune is imported