### PR TITLE
Ajout du champ type sur les datasets

### DIFF
--- a/lib/transport/reusable_data/dataset.ex
+++ b/lib/transport/reusable_data/dataset.ex
@@ -25,6 +25,7 @@ defmodule Transport.ReusableData.Dataset do
     :commune_principale,
     :import_date,
     :validation_date,
+    :type,
     validations: [],
     tags: [],
   ]
@@ -53,6 +54,7 @@ defmodule Transport.ReusableData.Dataset do
           commune_principale: String.t(),
           import_date: String.t(),
           validation_date: String.t(),
+          type: String.t()
         }
 
   def regions_lookup, do:  %{"$lookup" => %{

--- a/lib/transport_web/templates/backoffice/index.html.eex
+++ b/lib/transport_web/templates/backoffice/index.html.eex
@@ -16,6 +16,7 @@
     <%= text_input f, :spatial, [{"placeholder", dgettext("backoffice", "name")}] %>
     <%= text_input f, :commune_principale, [{"placeholder", dgettext("backoffice", "INSEE Code")}] %>
     <%= select f, :region, @regions %>
+    <%= select f, :type, [{dgettext("backoffice", "transport static"), "transport-statique"}]%>
     <%= submit dgettext("backoffice", "Add") %>
   <% end %>
 

--- a/priv/gettext/alert.pot
+++ b/priv/gettext/alert.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/router.ex:147
+#: lib/transport_web/router.ex:141
 msgid "You need to be connected before doing this."
 msgstr ""
 
@@ -18,6 +18,6 @@ msgstr ""
 msgid "An error occured, please try again"
 msgstr ""
 
-#: lib/transport_web/router.ex:164
+#: lib/transport_web/router.ex:158
 msgid "You need to be a member of the transport.data.gouv.fr team."
 msgstr ""

--- a/priv/gettext/backoffice.pot
+++ b/priv/gettext/backoffice.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:19
+#: lib/transport_web/templates/backoffice/index.html.eex:20
 msgid "Add"
 msgstr ""
 
@@ -40,4 +40,9 @@ msgstr ""
 
 #: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
+msgstr ""
+
+#, elixir-format
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "transport static"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/priv/gettext/en/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/router.ex:147
+#: lib/transport_web/router.ex:141
 msgid "You need to be connected before doing this."
 msgstr "Vous devez être connecté avant de poursuivre."
 
@@ -18,6 +18,6 @@ msgstr "Vous devez être connecté avant de poursuivre."
 msgid "An error occured, please try again"
 msgstr "Il y a eu une erreur, veuillez ré-essayer"
 
-#: lib/transport_web/router.ex:164
+#: lib/transport_web/router.ex:158
 msgid "You need to be a member of the transport.data.gouv.fr team."
 msgstr "Vous devez être membre de l’équipe transport.data.gouv.fr."

--- a/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:19
+#: lib/transport_web/templates/backoffice/index.html.eex:20
 msgid "Add"
 msgstr ""
 
@@ -40,4 +40,9 @@ msgstr ""
 
 #: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
+msgstr ""
+
+#, elixir-format
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "transport static"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:50
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:10
 #: lib/transport_web/templates/dataset/details.html.eex:140
 #: lib/transport_web/templates/dataset/index.html.eex:64
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:43
+#: lib/transport_web/templates/backoffice/index.html.eex:44
 #: lib/transport_web/templates/dataset/details.html.eex:19
 #: lib/transport_web/templates/dataset/index.html.eex:55
 msgid "See on data.gouv.fr"

--- a/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/router.ex:147
+#: lib/transport_web/router.ex:141
 msgid "You need to be connected before doing this."
 msgstr "Vous devez être préalablement connecté·e."
 
@@ -18,6 +18,6 @@ msgstr "Vous devez être préalablement connecté·e."
 msgid "An error occured, please try again"
 msgstr "Une erreur est survenue, veuillez réessayer"
 
-#: lib/transport_web/router.ex:164
+#: lib/transport_web/router.ex:158
 msgid "You need to be a member of the transport.data.gouv.fr team."
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:19
+#: lib/transport_web/templates/backoffice/index.html.eex:20
 msgid "Add"
 msgstr "Ajouter"
 
@@ -41,3 +41,8 @@ msgstr "Jeux de données ajouté avec succès"
 #: lib/transport_web/controllers/backoffice_controller.ex:38
 msgid "Dataset not added"
 msgstr "Échec à l’ajout du jeu de données"
+
+#, elixir-format
+#: lib/transport_web/templates/backoffice/index.html.eex:19
+msgid "transport static"
+msgstr "transport statique"

--- a/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Language: fr\n"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:50
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:10
 #: lib/transport_web/templates/dataset/details.html.eex:140
 #: lib/transport_web/templates/dataset/index.html.eex:64
@@ -22,7 +22,7 @@ msgstr "Télécharger"
 msgid "Licence"
 msgstr "License"
 
-#: lib/transport_web/templates/backoffice/index.html.eex:43
+#: lib/transport_web/templates/backoffice/index.html.eex:44
 #: lib/transport_web/templates/dataset/details.html.eex:19
 #: lib/transport_web/templates/dataset/index.html.eex:55
 msgid "See on data.gouv.fr"

--- a/priv/gettext/page-shortlist.pot
+++ b/priv/gettext/page-shortlist.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:50
+#: lib/transport_web/templates/backoffice/index.html.eex:51
 #: lib/transport_web/templates/dataset/details.html.eex:10
 #: lib/transport_web/templates/dataset/details.html.eex:140
 #: lib/transport_web/templates/dataset/index.html.eex:64
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/transport_web/templates/backoffice/index.html.eex:43
+#: lib/transport_web/templates/backoffice/index.html.eex:44
 #: lib/transport_web/templates/dataset/details.html.eex:19
 #: lib/transport_web/templates/dataset/index.html.eex:55
 msgid "See on data.gouv.fr"


### PR DESCRIPTION
Après avoir déployé cette PR il faut lancer cette commande sur mongo:
`db.datasets.update({}, {$set: {"type": "transport-statique"}}, false, true)`

Fixes #401 
Fixes #408 