### PR TITLE
Make CSS responsive on /datasets

### DIFF
--- a/client/stylesheets/components/_shortlist.scss
+++ b/client/stylesheets/components/_shortlist.scss
@@ -1,6 +1,7 @@
 .shortlist .panel__header {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .shortlist .panel__header::after {
@@ -8,6 +9,7 @@
 }
 
 .shortlist .panel__header .shortlist-image {
+  flex-basis: 200px;
   flex-shrink: 0;
 }
 
@@ -21,6 +23,7 @@
 }
 
 .shortlist .panel__side {
+  padding-top: 1em;
   flex-basis: 200px;
   flex-shrink: 0;
 }
@@ -44,7 +47,9 @@
 
 .shortlist__notice {
   padding-right: 1.5em;
+  flex-flow: column wrap;
   flex-shrink: 0;
+  max-width: 100%;
 }
 
 .shortlist__pagination {
@@ -78,4 +83,13 @@
 
 .shortlist-form {
   padding-bottom: 1em;
+}
+
+@include mobile {
+  .shortlist .panel__header .shortlist-image + a {
+    margin-left: 0em;
+  }
+  h3 {
+    font-size: 1em;
+  }
 }

--- a/lib/transport_web/templates/dataset/index.html.eex
+++ b/lib/transport_web/templates/dataset/index.html.eex
@@ -13,7 +13,7 @@
       <%= pagination_links @conn, @datasets %>
     </div>
       <div class="documentation shortlist-documentation">
-        <nav class="side-pane" role="navigation">
+        <nav class="side-pane shortlist " role="navigation">
           <ul class="side-pane__menu">
             <li class="side-pane__title">
               <h3><%= dgettext("page-shortlist", "Order by") %></h3>


### PR DESCRIPTION
This is what it looks like
![image](https://user-images.githubusercontent.com/2757318/53944743-4cecda00-40c0-11e9-8aa0-5be189819acd.png)

There's still a problem the top pagination that appears before the menu. Maybe we can hid it.
![image](https://user-images.githubusercontent.com/2757318/53944806-6beb6c00-40c0-11e9-8562-481bca2250f7.png)


