### PR TITLE
Update a resource

### DIFF
--- a/config/datagouvfr.exs
+++ b/config/datagouvfr.exs
@@ -15,5 +15,6 @@ config :oauth2, Authentication,
 
 config :oauth2,
   serializers: %{
+    "multipart/form-data" => Transport.Datagouvfr.MultipartSerializer,
     "application/json"    => Poison
   }

--- a/lib/datagouvfr/client.ex
+++ b/lib/datagouvfr/client.ex
@@ -73,8 +73,11 @@ defmodule Datagouvfr.Client do
     |> get_request("/discussions?for=#{id}", [], follow_redirect: true)
     |> case do
       {:ok, %{"data" => data}} -> data
-      {:error, error} ->
-        Logger.error("When fetching discussions for id #{id}: #{error.reason}")
+      {:error, %{reason: reason}} ->
+        Logger.error("When fetching discussions for id #{id}: #{reason}")
+        nil
+      {:error, %{body: body}} ->
+        Logger.error("When fetching discussions for id #{id}: #{body}")
         nil
     end
   end

--- a/lib/datagouvfr/client/resources.ex
+++ b/lib/datagouvfr/client/resources.ex
@@ -1,0 +1,15 @@
+defmodule Datagouvfr.Client.Resources do
+  @moduledoc """
+  Abstraction of data.gouv.fr resource
+  """
+  import Datagouvfr.Client, only: [post_request: 4]
+
+  def upload(conn, dataset_id, id, file) do
+    post_request(
+      conn,
+      Path.join(["datasets", dataset_id, "resources", id, "upload"]),
+      {"file", file},
+       [{"content-type", "multipart/form-data"}]
+    )
+  end
+end

--- a/lib/datagouvfr/client/reuses.ex
+++ b/lib/datagouvfr/client/reuses.ex
@@ -10,6 +10,9 @@ defmodule Datagouvfr.Client.Reuses do
   def get(%Plug.Conn{} = conn, %{"dataset_id" => dataset_id}) do
     case get_request(conn, @endpoint, [], params: %{"dataset" => dataset_id}) do
       {:ok, %{"data" => data}} -> {:ok, Enum.map(data, &add_name/1)}
+      {:error, %{reason: reason}} ->
+        Logger.error("Unable to get reuses of dataset #{dataset_id} because of #{reason}")
+        {:error, reason}
       {:error, error} ->
         Logger.error(error)
         {:error, error}

--- a/lib/datagouvfr/client/user.ex
+++ b/lib/datagouvfr/client/user.ex
@@ -3,7 +3,7 @@ defmodule Datagouvfr.Client.User do
   An Client to retrieve User information of data.gouv.fr
   """
 
-  import Datagouvfr.Client, only: [get_request: 3]
+  import Datagouvfr.Client, only: [get_request: 2, get_request: 3]
 
   @me_fields ~w(avatar avatar_thumbnail first_name id last_name
                 organizations page id uri apikey email)
@@ -13,8 +13,17 @@ defmodule Datagouvfr.Client.User do
   You can see documentation here: http://www.data.gouv.fr/fr/apidoc/#!/me/
   """
   def me(%Plug.Conn{} = conn, exclude_fields \\ []) do
-    conn
-    |> get_request("me", [{"x-fields", xfields(exclude_fields)}])
+    get_request(conn, "me", [{"x-fields", xfields(exclude_fields)}])
+  end
+
+  @spec datasets(Plug.Conn.t()) :: {:error, OAuth2.Error.t()} | {:ok, OAuth2.Response.t()}
+  def datasets(%Plug.Conn{} = conn) do
+    get_request(conn, Path.join(["me", "datasets"]))
+  end
+
+  @spec org_datasets(Plug.Conn.t()) :: {:error, OAuth2.Error.t()} | {:ok, OAuth2.Response.t()}
+  def org_datasets(%Plug.Conn{} = conn) do
+    get_request(conn, Path.join(["me", "org_datasets"]))
   end
 
   #private functions

--- a/lib/datagouvfr/multipart_serializer.ex
+++ b/lib/datagouvfr/multipart_serializer.ex
@@ -1,0 +1,24 @@
+defmodule Transport.Datagouvfr.MultipartSerializer do
+  @moduledoc """
+  Use to encode multipart/form-data body of requests
+  """
+  def encode!({name, %Plug.Upload{} = file}) do
+    {
+      :multipart,
+      [
+        {
+          :file,
+           file.path,
+           {
+              "form-data",
+              [
+                {"name", "\"#{name}\""},
+                {"filename", "\"#{file.filename}\""}
+              ]
+           },
+           []
+        }
+      ]
+    }
+  end
+end

--- a/lib/transport_web/controllers/resource_controller.ex
+++ b/lib/transport_web/controllers/resource_controller.ex
@@ -38,6 +38,8 @@ defmodule TransportWeb.ResourceController do
     end
   end
 
+  def choose_action(conn, _), do: render conn, "choose_action.html"
+
   @spec datasets_list(Plug.Conn.t(), any()) :: Plug.Conn.t()
   def datasets_list(conn, _params) do
     filter = fn d -> Repo.get_by(Dataset, datagouv_id: d["id"]) end

--- a/lib/transport_web/endpoint.ex
+++ b/lib/transport_web/endpoint.ex
@@ -23,7 +23,7 @@ defmodule TransportWeb.Endpoint do
   plug Plug.Logger
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :json],
+    parsers: [:urlencoded, :json, :multipart],
     pass: ["*/*"],
     json_decoder: Poison
 

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -66,6 +66,16 @@ defmodule TransportWeb.Router do
 
     scope "/resources" do
       get "/:id", ResourceController, :details
+
+      scope "/update" do
+        pipe_through [:authenticated]
+        get "/datasets", ResourceController, :datasets_list
+        scope "/datasets/:dataset_id/resources" do
+          get "/", ResourceController, :resources_list
+          get "/:resource_id/", ResourceController, :choose_file
+          post "/:resource_id/", ResourceController, :post_file
+        end
+      end
     end
 
     scope "/backoffice", Backoffice, as: :backoffice do

--- a/lib/transport_web/router.ex
+++ b/lib/transport_web/router.ex
@@ -69,6 +69,7 @@ defmodule TransportWeb.Router do
 
       scope "/update" do
         pipe_through [:authenticated]
+        get "/_choose_action", ResourceController, :choose_action
         get "/datasets", ResourceController, :datasets_list
         scope "/datasets/:dataset_id/resources" do
           get "/", ResourceController, :resources_list

--- a/lib/transport_web/templates/layout/_header.html.eex
+++ b/lib/transport_web/templates/layout/_header.html.eex
@@ -5,13 +5,11 @@
     <nav role="navigation">
       <ul class="nav__links">
         <li class="nav__item">
-          <a href="https://www.data.gouv.fr/fr/admin/dataset/new/">
-            <%= gettext "Publish a dataset" %>
-          </a>
+          <%= link(gettext("Publish or update a dataset"), to: resource_path(@conn, :choose_action)) %>
         </li>
         <%= if assigns[:current_user] do %>
           <%= if assigns[:current_user] |> Map.get("organizations", []) |> Enum.any?(fn org -> org["slug"] == "equipe-transport-data-gouv-fr" end) do %>
-            <li>
+            <li class="nav__item">
                 <%= link("Administration", to: "/backoffice") %>
             </li>
           <% end %>

--- a/lib/transport_web/templates/resource/choose_action.html.eex
+++ b/lib/transport_web/templates/resource/choose_action.html.eex
@@ -1,0 +1,14 @@
+<section class="section">
+    <div class="container">
+        <div class="existing">
+            <div class="row">
+                <%= link to: "https://www.data.gouv.fr/fr/admin/dataset/new/", class: "tile section-grey" do %>
+                <h3><%= dgettext("resource", "Publish a new dataset") %></h3>
+                <% end %>
+                <%= link to: resource_path(@conn, :datasets_list), class: "tile section-grey" do %>
+                <h3><%= dgettext("resource", "Update an existing dataset") %></h3>
+                <% end %>
+            </div>
+        </div>
+    </div>
+</section>

--- a/lib/transport_web/templates/resource/choose_file.html.eex
+++ b/lib/transport_web/templates/resource/choose_file.html.eex
@@ -1,0 +1,13 @@
+<section class="section">
+    <div class="container">
+        <%= form_for @conn, @action_path, [multipart: true], fn f -> %>
+        <b><%= dgettext("resource", "Dataset: ") %></b> <%= @dataset["title"] %><br> 
+        <%= for r <- Enum.filter(@dataset["resources"], &(&1["id"] == @conn.params["resource_id"])) do %>
+            <b><%= dgettext("resource", "Resource: ") %></b> <%= r["title"] %>
+        <% end %>
+        <h1><%= dgettext("resource", "Update with a file") %></h1>
+        <%= file_input f, :resource_file %>
+        <%= submit dgettext("resource", "Upload this file") %>
+        <% end %>
+    </div>
+</section>

--- a/lib/transport_web/templates/resource/list.html.eex
+++ b/lib/transport_web/templates/resource/list.html.eex
@@ -1,0 +1,13 @@
+<section class="section">
+    <div class="container">
+        <h1><%= dgettext("resource", "To update a resource, select one of your dataset first.") %></h1>
+        <%= for dataset <- @datasets ++ @org_datasets do %>
+        <div class="panel">
+            <h2><%= dataset["title"] %></h2>
+            <%= link(
+                dgettext("resource", "Select a resource"),
+                to: resource_path(@conn, :resources_list, dataset["id"])) %>
+        </div>
+        <% end %>
+    </div>
+</section>

--- a/lib/transport_web/templates/resource/list.html.eex
+++ b/lib/transport_web/templates/resource/list.html.eex
@@ -1,13 +1,15 @@
-<section class="section">
+<section class="section section-grey">
     <div class="container">
-        <h1><%= dgettext("resource", "To update a resource, select one of your dataset first.") %></h1>
-        <%= for dataset <- @datasets ++ @org_datasets do %>
-        <div class="panel">
-            <h2><%= dataset["title"] %></h2>
-            <%= link(
-                dgettext("resource", "Select a resource"),
-                to: resource_path(@conn, :resources_list, dataset["id"])) %>
+        <div class="existing">
+            <h1><%= dgettext("resource", "To update a resource, select one of your dataset first.") %></h1>
+            <%= for dataset <- @datasets ++ @org_datasets do %>
+            <div class="panel">
+                <h2><%= dataset["title"] %></h2>
+                <%= link(
+                    dgettext("resource", "Select a resource"),
+                    to: resource_path(@conn, :resources_list, dataset["id"])) %>
+            </div>
+            <% end %>
         </div>
-        <% end %>
     </div>
 </section>

--- a/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/lib/transport_web/templates/resource/resources_list.html.eex
@@ -1,0 +1,15 @@
+<section class="section">
+    <div class="container">
+        <b><%= dgettext("resource", "Dataset: ") %></b> <%= @dataset["title"] %> 
+        <h1><%= dgettext("resource", "Choose the resource you want to update") %></h1>
+        <%= for resource <- @dataset["resources"] do %>
+            <div class="panel">
+                <h2><%= resource["title"] %></h2>
+            <%= link(
+                    dgettext("resource", "Update this resource"),
+                    to: resource_path(@conn, :choose_file, @conn.params["dataset_id"], resource["id"])) 
+            %>
+            </div>
+        <% end %>
+    </div>
+</section>

--- a/lib/transport_web/views/input_helpers.ex
+++ b/lib/transport_web/views/input_helpers.ex
@@ -15,6 +15,7 @@ defmodule TransportWeb.InputHelpers do
       import Phoenix.HTML.Form, except: [
         email_input: 3,
         form_for: 3, form_for: 4,
+        file_input: 2, file_input: 3,
         select: 3, select: 4,
         search_input: 3,
         submit: 1, submit: 2,
@@ -88,5 +89,9 @@ defmodule TransportWeb.InputHelpers do
 
   def textarea(form, field, opts \\ []) do
     form_group(Form.textarea(form, field, opts))
+  end
+
+  def file_input(form, field, opts \\ []) do
+    form_group(Form.file_input(form, field, opts))
   end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,3 +52,7 @@ msgstr ""
 
 msgid "Publish a dataset"
 msgstr ""
+
+#, elixir-format
+msgid "Publish or update a dataset"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -49,3 +49,10 @@ msgstr ""
 #, elixir-format
 msgid "Question about transport.data.gouv.fr"
 msgstr ""
+
+msgid "Publish a dataset"
+msgstr ""
+
+#, elixir-format
+msgid "Publish or update a dataset"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -196,13 +196,13 @@ msgid "reusers list description"
 msgstr "Reusers listed here are the ones who declared one reuse on the platform."
 
 #, elixir-format
-msgid "Deployment status"
-msgstr ""
-
-#, elixir-format
 msgid "Ask for help"
 msgstr ""
 
 #, elixir-format
 msgid "Close the form"
+msgstr ""
+
+#, elixir-format
+msgid "I wish to follow the development of transport.data.gouv.fr"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -202,3 +202,7 @@ msgstr ""
 #, elixir-format
 msgid "Ask for help"
 msgstr ""
+
+#, elixir-format
+msgid "Close the form"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/priv/gettext/en/LC_MESSAGES/resource.po
@@ -40,3 +40,11 @@ msgstr ""
 #, elixir-format
 msgid "Upload this file"
 msgstr ""
+
+#, elixir-format
+msgid "Publish a new dataset"
+msgstr ""
+
+#, elixir-format
+msgid "Update an existing dataset"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/priv/gettext/en/LC_MESSAGES/resource.po
@@ -1,0 +1,42 @@
+msgid "Unable to get resources, please retry."
+msgstr ""
+
+#, elixir-format
+msgid "Choose the resource you want to update"
+msgstr ""
+
+#, elixir-format
+msgid "Dataset: "
+msgstr ""
+
+#, elixir-format
+msgid "File uploaded!"
+msgstr ""
+
+#, elixir-format
+msgid "Resource: "
+msgstr ""
+
+#, elixir-format
+msgid "Select a resource"
+msgstr ""
+
+#, elixir-format
+msgid "To update a resource, select one of your dataset first."
+msgstr ""
+
+#, elixir-format
+msgid "Unable to upload file"
+msgstr ""
+
+#, elixir-format
+msgid "Update this resource"
+msgstr ""
+
+#, elixir-format
+msgid "Update with a file"
+msgstr ""
+
+#, elixir-format
+msgid "Upload this file"
+msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -51,4 +51,8 @@ msgid "Question about transport.data.gouv.fr"
 msgstr "Question au sujet de transport.data.gouv.fr"
 
 msgid "Publish a dataset"
-msgstr "Publier un jeu de données"
+msgstr "Publier ou mettre à jour des données"
+
+#, elixir-format
+msgid "Publish or update a dataset"
+msgstr "Publier ou mettre à jour des données"

--- a/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -40,3 +40,11 @@ msgstr "Mettre à jour"
 #, elixir-format
 msgid "Upload this file"
 msgstr "Envoyer ce fichier"
+
+#, elixir-format
+msgid "Publish a new dataset"
+msgstr "Publier un nouveau jeu de données"
+
+#, elixir-format
+msgid "Update an existing dataset"
+msgstr "Mettre à jour un jeu de données existant"

--- a/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -1,0 +1,42 @@
+msgid "Unable to get resources, please retry."
+msgstr "Impossible d'accéder à la resource, réessayez"
+
+#, elixir-format
+msgid "Choose the resource you want to update"
+msgstr "Choisisseez la ressource à mettre à jour"
+
+#, elixir-format
+msgid "Dataset: "
+msgstr "Jeu de données"
+
+#, elixir-format
+msgid "File uploaded!"
+msgstr "Fichier mise à jour !"
+
+#, elixir-format
+msgid "Resource: "
+msgstr "Ressource"
+
+#, elixir-format
+msgid "Select a resource"
+msgstr "Selectionnez une ressource"
+
+#, elixir-format
+msgid "To update a resource, select one of your dataset first."
+msgstr "Pour mettre à jour une ressource, selectionnez un jeu de données"
+
+#, elixir-format
+msgid "Unable to upload file"
+msgstr "Impossible de mettre à jour le fichier"
+
+#, elixir-format
+msgid "Update this resource"
+msgstr "Mettre à jour cette ressource"
+
+#, elixir-format
+msgid "Update with a file"
+msgstr "Mettre à jour"
+
+#, elixir-format
+msgid "Upload this file"
+msgstr "Envoyer ce fichier"

--- a/priv/gettext/page-index.pot
+++ b/priv/gettext/page-index.pot
@@ -202,3 +202,7 @@ msgstr ""
 #, elixir-format
 msgid "Ask for help"
 msgstr ""
+
+#, elixir-format
+msgid "Close the form"
+msgstr ""

--- a/priv/gettext/page-index.pot
+++ b/priv/gettext/page-index.pot
@@ -196,13 +196,13 @@ msgid "reusers list description"
 msgstr ""
 
 #, elixir-format
-msgid "Deployment status"
-msgstr ""
-
-#, elixir-format
 msgid "Ask for help"
 msgstr ""
 
 #, elixir-format
 msgid "Close the form"
+msgstr ""
+
+#, elixir-format
+msgid "I wish to follow the development of transport.data.gouv.fr"
 msgstr ""

--- a/priv/gettext/resource.pot
+++ b/priv/gettext/resource.pot
@@ -40,3 +40,11 @@ msgstr ""
 #, elixir-format
 msgid "Upload this file"
 msgstr ""
+
+#, elixir-format
+msgid "Publish a new dataset"
+msgstr ""
+
+#, elixir-format
+msgid "Update an existing dataset"
+msgstr ""

--- a/priv/gettext/resource.pot
+++ b/priv/gettext/resource.pot
@@ -1,0 +1,42 @@
+msgid "Unable to get resources, please retry."
+msgstr ""
+
+#, elixir-format
+msgid "Choose the resource you want to update"
+msgstr ""
+
+#, elixir-format
+msgid "Dataset: "
+msgstr ""
+
+#, elixir-format
+msgid "File uploaded!"
+msgstr ""
+
+#, elixir-format
+msgid "Resource: "
+msgstr ""
+
+#, elixir-format
+msgid "Select a resource"
+msgstr ""
+
+#, elixir-format
+msgid "To update a resource, select one of your dataset first."
+msgstr ""
+
+#, elixir-format
+msgid "Unable to upload file"
+msgstr ""
+
+#, elixir-format
+msgid "Update this resource"
+msgstr ""
+
+#, elixir-format
+msgid "Update with a file"
+msgstr ""
+
+#, elixir-format
+msgid "Upload this file"
+msgstr ""


### PR DESCRIPTION
Adds an easier way to update a resource.
There's no direct access to this feature now, we'll do it when we'll be sure of the feature.
You can access to your datasets on this page if you're logged in: /resources/update/datasets
![image](https://user-images.githubusercontent.com/2757318/55811014-bfe6d780-5ae8-11e9-9806-140c27f59c91.png)
Then you have to choose the resource you want to update:
![image](https://user-images.githubusercontent.com/2757318/55811063-d2f9a780-5ae8-11e9-950d-e49299c1a04c.png)
You can upload a file on the next page
![image](https://user-images.githubusercontent.com/2757318/55811099-e3118700-5ae8-11e9-8fd2-350e301442c2.png)
Finally you'll be redirected to the dataset page with a nice message !
![image](https://user-images.githubusercontent.com/2757318/55811161-fae90b00-5ae8-11e9-9ef3-e209d54a2d5b.png)
