### PR TITLE
send a mail for newly inactive datasets

### DIFF
--- a/apps/transport/lib/datagouvfr/client/datasets.ex
+++ b/apps/transport/lib/datagouvfr/client/datasets.ex
@@ -157,8 +157,8 @@ defmodule Datagouvfr.Client.Datasets do
   end
   def current_user_subscribed?(_, _), do: false
 
-  def is_active?(dataset_id) do
-    path = Path.join([@endpoint, dataset_id])
+  def is_active?(%{datagouv_id: id}) do
+    path = Path.join([@endpoint, id])
     response =
       path
       |> process_url()

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -9,26 +9,32 @@ defmodule Transport.DataChecker do
   import Ecto.Query
 
   def inactive_data do
-    inactive_ids =
-      Dataset
-      |> select([d], d.datagouv_id)
+    # we first check if some inactive datasets have reapeared
+    reactivated_datasets =
+    Dataset
+      |> where([d], d.is_active == false)
       |> Repo.all()
-      |> Enum.reject(&Datasets.is_active?/1)
+      |> Enum.filter(&Datasets.is_active?/1)
+
+    reactivated_ids = reactivated_datasets |> Enum.map(& &1.datagouv_id)
+
+    Dataset
+    |> where([d], d.datagouv_id in ^reactivated_ids)
+    |> Repo.update_all(set: [is_active: true])
+
+    # then we disable the unreachable datasets
+    inactive_datasets =
+    Dataset
+    |> where([d], d.is_active == true)
+    |> Repo.all()
+    |> Enum.reject(&Datasets.is_active?/1)
+    inactive_ids = inactive_datasets |> Enum.map(& &1.datagouv_id)
 
     Dataset
     |> where([d], d.datagouv_id in ^inactive_ids)
     |> Repo.update_all(set: [is_active: false])
 
-    active_ids =
-      Dataset
-      |> select([d], d.datagouv_id)
-      |> where([d], d.is_active == false)
-      |> Repo.all()
-      |> Enum.filter(&Datasets.is_active?/1)
-
-    Dataset
-    |> where([d], d.datagouv_id in ^active_ids)
-    |> Repo.update_all(set: [is_active: true])
+    send_inactive_dataset_mail(reactivated_datasets, inactive_datasets)
   end
 
   def outdated_data(blank \\ False) do
@@ -40,13 +46,14 @@ defmodule Transport.DataChecker do
         end
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n---------------------\n")
-    |> send_mail(blank)
+    |> send_outdated_data_mail(blank)
   end
 
   defp make_str(%Date{} = date), do: date |> Resource.get_expire_at() |> make_str(date)
   defp make_str([], _date), do: nil
   defp make_str(resources, date) do
     r_str = resources
+    |> Enum.map(& &1.dataset)
     |> Enum.map(&link_and_name/1)
     |> Enum.join("\n")
 
@@ -57,14 +64,14 @@ defmodule Transport.DataChecker do
     """
   end
 
-  defp link_and_name(resource) do
-    link = dataset_url(TransportWeb.Endpoint, :details, resource.dataset.slug)
-    name = resource.dataset.title
+  defp link_and_name(dataset) do
+    link = dataset_url(TransportWeb.Endpoint, :details, dataset.slug)
+    name = dataset.title
 
     " * #{name} - #{link}"
   end
 
-  defp make_body(datasets) do
+  defp make_outdated_data_body(datasets) do
     """
     Bonjour,
     Voici un résumé des jeux de données arrivant à expiration
@@ -75,15 +82,61 @@ defmodule Transport.DataChecker do
     """
   end
 
-  defp send_mail("", _), do: nil
-  defp send_mail(datasets, False) do
+  defp send_outdated_data_mail("", _), do: nil
+  defp send_outdated_data_mail(datasets, False) do
     Client.send_mail(
       "transport.data.gouv.fr",
       "contact@transport.beta.gouv.fr",
       "contact@transport.beta.gouv.fr",
       "Jeux de données arrivant à expiration",
-      make_body(datasets)
+      make_outdated_data_body(datasets)
     )
   end
-  defp send_mail(datasets, True), do: make_body(datasets)
+  defp send_outdated_data_mail(datasets, True), do: make_outdated_data_body(datasets)
+
+  defp fmt_inactive_dataset([]), do: ""
+  defp fmt_inactive_dataset(inactive_datasets) do
+    datasets_str = inactive_datasets
+    |> Enum.map(&link_and_name/1)
+    |> Enum.join("\n")
+    """
+    Certains jeux de données ont disparus de data.gouv.fr :
+    #{datasets_str}
+    """
+  end
+
+  defp fmt_reactivated_dataset([]), do: ""
+  defp fmt_reactivated_dataset(reactivated_datasets) do
+    datasets_str = reactivated_datasets
+    |> Enum.map(&link_and_name/1)
+    |> Enum.join("\n")
+    """
+    Certains jeux de données disparus sont réapparus sur data.gouv.fr :
+    #{datasets_str}
+    """
+  end
+
+    defp make_inactive_dataset_body(reactivated_datasets, inactive_datasets) do
+      reactivated_datasets_str = fmt_reactivated_dataset(reactivated_datasets)
+      inactive_datasets_str = fmt_inactive_dataset(inactive_datasets)
+    """
+    Bonjour,
+    #{inactive_datasets_str}
+    #{reactivated_datasets_str}
+
+    Il faut peut être creuser pour savoir si c'est normal.
+    """
+  end
+
+  defp send_inactive_dataset_mail([], []), do: nil
+  defp send_inactive_dataset_mail(reactivated_datasets, inactive_datasets) do
+    Client.send_mail(
+      "transport.data.gouv.fr",
+      "contact@transport.beta.gouv.fr",
+      "contact@transport.beta.gouv.fr",
+      "Jeux de données qui disparaissent",
+      make_inactive_dataset_body(reactivated_datasets, inactive_datasets)
+    )
+  end
+
 end


### PR DESCRIPTION
Send a email to the team if a dataset is no longer available on data.gouv.fr

Also include in the email the dataset that were inactive but are now again on data.gouv.fr

I have no clue on how to test this :roll_eyes: 