### PR TITLE
Use full size logo on datasets/:id:/

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -12,6 +12,18 @@
   }
 }
 
+.dataset__logo {
+  max-height: 10vh;
+  max-width: 20vw;
+  display: flex;
+  justify-content: center;
+
+  img {
+    max-height: 100%;
+    max-width: 100%;
+  }
+}
+
 .display-more {
   padding-top: 4vh;
   display: block;
@@ -219,6 +231,10 @@
   }
 
   .dataset {
+    .dataset__logo {
+      max-width: 80vw;
+    }
+
     .section {
       padding: 1em 0 1em 0;
     }

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -2,7 +2,7 @@
   <section class="section">
     <div class="container dataset__header">
       <div class="dataset__logo">
-        <%= img_tag(@dataset.logo, alt: @dataset.title) %>
+        <%= img_tag(@dataset.full_logo, alt: @dataset.title) %>
       </div>
       <div class="dataset__title">
         <h1><%= @dataset.title%></h1>


### PR DESCRIPTION
was 
![image](https://user-images.githubusercontent.com/2757318/61308587-d93aa680-a7f0-11e9-8be5-6e6f51fdceff.png)
now
![image](https://user-images.githubusercontent.com/2757318/61308613-e5266880-a7f0-11e9-9bb1-5bbd8012be6d.png)

fix #780 
