### PR TITLE
 add aerial type

### DIFF
--- a/apps/transport/lib/transport/dataset.ex
+++ b/apps/transport/lib/transport/dataset.ex
@@ -44,6 +44,7 @@ defmodule Transport.Dataset do
     "stops-ref" => dgettext("dataset", "Stops referential"),
     "charging-stations" => dgettext("dataset", "Charging stations"),
     "micro-mobility" => dgettext("dataset", "Micro mobility"),
+    "air-transport" => dgettext("dataset", "Aerial"),
     "bike-sharing" => dgettext("dataset", "Bike sharing"),
     "long-distance-coach" => dgettext("dataset", "Long distance coach")
   }

--- a/apps/transport/priv/gettext/dataset.pot
+++ b/apps/transport/priv/gettext/dataset.pot
@@ -96,3 +96,7 @@ msgstr ""
 #, elixir-format
 msgid "Long distance coach"
 msgstr ""
+
+#, elixir-format
+msgid "Aerial"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -96,3 +96,7 @@ msgstr ""
 #, elixir-format
 msgid "Long distance coach"
 msgstr ""
+
+#, elixir-format
+msgid "Aerial"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -180,6 +180,6 @@ msgstr "This is the automated evalation of the GTFS datafile. "
 msgid "permanent link to this validation"
 msgstr ""
 
-#, elixir-format
-msgid "Nice work, there are no issues !"
+#, elixir-format, fuzzy
+msgid "Nice work, there are no issues!"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -96,3 +96,7 @@ msgstr "Impossible de trouver le code INSEE"
 #, elixir-format
 msgid "Long distance coach"
 msgstr "Car longue distance"
+
+#, elixir-format
+msgid "Aerial"
+msgstr "Aérien"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -179,5 +179,5 @@ msgid "permanent link to this validation"
 msgstr ""
 
 #, elixir-format
-msgid "Nice work, there are no issues !"
+msgid "Nice work, there are no issues!"
 msgstr ""


### PR DESCRIPTION
to be able to reference https://www.data.gouv.fr/fr/datasets/programme-simplifie-par-saison-iata/ we need a new category "Aerial" (or "Aérien" in french).

feel free to suggest better name as I'm not utterly convinced by the naming