### PR TITLE
Handle error message for deactivated datasets

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -37,6 +37,7 @@ defmodule TransportWeb.DatasetController do
         |> assign(:is_subscribed, Datasets.current_user_subscribed?(conn, dataset.datagouv_id))
         |> assign(:reuses, reuses)
         |> assign(:other_datasets, Dataset.get_other_datasets(dataset, organization))
+        |> put_status(if dataset.is_active do :ok else :not_found end)
         |> render("details.html")
     else
       nil ->

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -1,3 +1,9 @@
+<%= unless @dataset.is_active do %>
+<div class="notification error full-width">
+  <%= dgettext("page-dataset-details", "This dataset has been removed from data.gouv.fr") %>
+</div>
+<% end %>
+
 <div class="dataset">
   <section class="section">
     <div class="container dataset__header">
@@ -71,6 +77,7 @@
   </section>
   <% end %>
 
+  <%= if @dataset.is_active do %>
   <section class="section">
     <div class="container">
       <div class="dataset-details__discussions panel">
@@ -126,6 +133,7 @@
       </div>
     </div>
   </section>
+  <% end %>
   <section class="section section-grey">
     <div class="container">
       <div class="shortlist__link shortlist__link--external-link">

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -246,3 +246,7 @@ msgstr ""
 #, elixir-format
 msgid "No error detected"
 msgstr ""
+
+#, elixir-format
+msgid "This dataset has been removed from data.gouv.fr"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -246,3 +246,7 @@ msgstr "Identifiez vous pour vous abonner aux discussions de ce jeu de données.
 #, elixir-format
 msgid "No error detected"
 msgstr "Pas d'erreur"
+
+#, elixir-format
+msgid "This dataset has been removed from data.gouv.fr"
+msgstr "Ce jeu de données a été supprimé de data.gouv.fr"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -246,3 +246,7 @@ msgstr ""
 #, elixir-format
 msgid "No error detected"
 msgstr ""
+
+#, elixir-format
+msgid "This dataset has been removed from data.gouv.fr"
+msgstr ""


### PR DESCRIPTION
If the dataset is deactivated we display this error message 

![image](https://user-images.githubusercontent.com/2757318/61634177-0ffd3a80-ac91-11e9-9bbc-093e59c9f958.png)
We send a 404 status code but perhaps we should have send a 204...
