### PR TITLE
change siren to string and add it in /datasets

### DIFF
--- a/apps/transport/lib/transport/aom.ex
+++ b/apps/transport/lib/transport/aom.ex
@@ -12,7 +12,7 @@ defmodule Transport.AOM do
       field :composition_res_id, :integer
       field :insee_commune_principale, :string
       field :departement, :string
-      field :siren, :integer
+      field :siren, :string
       field :nom, :string
       field :forme_juridique, :string
       field :nombre_communes, :integer

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -96,7 +96,8 @@ defmodule TransportWeb.API.DatasetController do
   defp transform_aom(nil), do: %{"name" => nil}
   defp transform_aom(aom) do
     %{
-      "name" => aom.nom
+      "name" => aom.nom,
+      "siren" => aom.siren,
     }
   end
 end

--- a/apps/transport/priv/repo/migrations/20190910091521_change_siren.exs
+++ b/apps/transport/priv/repo/migrations/20190910091521_change_siren.exs
@@ -1,0 +1,9 @@
+defmodule Transport.Repo.Migrations.ChangeSiren do
+  use Ecto.Migration
+
+  def change do
+    alter table(:aom) do
+      modify :siren, :string
+    end
+  end
+end


### PR DESCRIPTION
now add the siren of the aom in the `/datasets` api:

```js
    {
        "aom": {
            "name": "Brest Métropole",
            "siren": "242900314"  // <----------- new field
        },
        "created_at": "2015-09-21",
        "datagouv_id": "55ffbe0888ee387348ccb97d",
        "id": "55ffbe0888ee387348ccb97d",
        "resources": [ { } ],
        "title": "Bibus",
        "type": "public-transit",
        "updated": "2016-09-14T17:20:28.365+02:00"
    }

```

change also the type of the field from integer to string (as it can
starts with a leading '0')

this change is also reflected in the `/aoms` api:
```json
{
    "departement": "75",
    "forme_juridique": "Etablissement public administratif",
    "insee_commune_principale": "75056",
    "nom": "Île-de-France Mobilités",
    "siren": "217500016"
}

```