### PR TITLE
Fix post outdated_comment

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -4,7 +4,7 @@ defmodule Transport.DataChecker do
   """
   alias Datagouvfr.Client.{Datasets, Discussions}
   alias Mailjet.Client
-  alias Transport.{Dataset, Repo, Resource}
+  alias Transport.{Dataset, Repo}
   import TransportWeb.Router.Helpers
   import Ecto.Query
   require Logger
@@ -46,39 +46,39 @@ defmodule Transport.DataChecker do
   def outdated_data(blank \\ false) do
     for delay <- [0, 7, 14],
         date = Date.add(Date.utc_today, delay) do
-          {delay, Resource.get_expire_at(date)}
+          {delay, Dataset.get_expire_at(date)}
         end
     |> Enum.reject(fn {_, d} -> d == [] end)
     |> send_outdated_data_mail(blank)
     |> post_outdated_data_comments(blank)
   end
 
-  def post_outdated_data_comments(delays_resources, blank) do
-    case Enum.find(delays_resources, fn {delay, _} -> delay == 7 end) do
+  def post_outdated_data_comments(delays_datasets, blank) do
+    case Enum.find(delays_datasets, fn {delay, _} -> delay == 7 end) do
       nil ->
         Logger.info "No datasets need a comment about outdated resources"
-      {_, resources} ->
-        Enum.map(resources, fn r -> post_outdated_data_comment(r, blank) end)
+      {delay, datasets} ->
+        Enum.map(datasets, fn r -> post_outdated_data_comment(r, delay, blank) end)
     end
   end
 
-  def post_outdated_data_comment(resource, blank) do
+  def post_outdated_data_comment(dataset, delay, blank) do
     Discussions.post(
-      resource.dataset.datagouv_id,
+      dataset.datagouv_id,
       "Jeu de données arrivant à expiration",
 """
 Bonjour,
-Ce jeu de données arrive à expiration dans 7 jours.
+Ce jeu de données arrive à expiration dans #{delay} jour#{if delay != 1 do "s" end}.
 Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour prochainement.
 L’équipe transport.data.gouv.fr
 """, blank)
   end
 
-  defp make_str({delay, resources}) do
-    r_str = resources
-    |> Enum.map(& &1.dataset)
-    |> Enum.map(&link_and_name/1)
-    |> Enum.join("\n")
+  defp make_str({delay, datasets}) do
+    r_str =
+      datasets
+      |> Enum.map(&link_and_name/1)
+      |> Enum.join("\n")
 
     """
     Jeux de données expirant #{delay_str(delay)}:

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -43,7 +43,7 @@ defmodule Transport.DataChecker do
       |> Enum.filter(&Datasets.is_active?/1)
   end
 
-  def outdated_data(blank \\ False) do
+  def outdated_data(blank \\ false) do
     for delay <- [0, 7, 14],
         date = Date.add(Date.utc_today, delay) do
           {delay, Resource.get_expire_at(date)}

--- a/apps/transport/lib/transport/resource.ex
+++ b/apps/transport/lib/transport/resource.ex
@@ -166,14 +166,6 @@ defmodule Transport.Resource do
     |> Enum.each(&validate_and_save/1)
   end
 
-  def get_expire_at(%Date{} = date), do: get_expire_at("#{date}")
-  def get_expire_at(date) do
-    __MODULE__
-    |> where([r], fragment("metadata->>'end_date' = ?", ^date))
-    |> preload([:dataset])
-    |> Repo.all()
-  end
-
   @spec is_outdated?(any) :: boolean
   def is_outdated?(%__MODULE__{metadata: %{"end_date" => nil}}), do: false
   def is_outdated?(%__MODULE__{metadata: %{"end_date" => end_date}}), do:


### PR DESCRIPTION
False evaluates to true… so we were not sending comments…

@antoine-de Since I cannot connect to the prod server can you run this snippet to send comments to outdated datasets
```elixir
import Ecto.Query
Transport.Dataset \
|> join(:inner, [d], r in Transport.Resource, on: r.dataset_id == d.id) \
|> group_by([d, r], d.id) \
|> having([d, r], fragment("max(?->>'end_date') <= '2019-09-19'", r.metadata)) \
|> Transport.Repo.all() \
|> Enum.filter(& &1.is_active) \
|> Enum.map(fn dataset -> 
IO.inspect(dataset)

Datagouvfr.Client.Discussions.post(dataset.datagouv_id,
"Jeu de données expiré",
"""
Bonjour,
Ce jeu de données est expiré.
Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour prochainement.
L’équipe transport.data.gouv.fr
""", false)
:timer.sleep(15_000)
end)
```