### PR TITLE
add dataset's publisher to api

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -74,7 +74,14 @@ defmodule TransportWeb.API.DatasetController do
       "resources" => Enum.map(dataset.resources, &transform_resource/1),
       "aom" => transform_aom(dataset.aom),
       "type" => dataset.type,
-      "publisher" => %{"organization" => dataset.organization},
+      "publisher" => get_publisher(dataset),
+    }
+  end
+
+  defp get_publisher(dataset) do
+    %{
+      "name" => dataset.organization,
+      "type" => "organization"
     }
   end
 

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -74,6 +74,7 @@ defmodule TransportWeb.API.DatasetController do
       "resources" => Enum.map(dataset.resources, &transform_resource/1),
       "aom" => transform_aom(dataset.aom),
       "type" => dataset.type,
+      "publisher" => %{"organization" => dataset.organization},
     }
   end
 


### PR DESCRIPTION
close #855

add a publisher field to a dataset object:
```js

    {
        "aom": {
            "name": "Perpignan Méditerranée Métropole",
            "siren": "200027183"
        },
        "created_at": "2018-12-18",
        "datagouv_id": "5c18fc4b634f41320c6251e3",
        "id": "5c18fc4b634f41320c6251e3",
        "publisher": {                          // <-- new field
            "organization": "Sankéo"
        },
        "resources": [
            {
                "end_calendar_validity": "2019-10-20",
                "format": "GTFS",
                "start_calendar_validity": "2019-08-23",
                "title": "190902.zip",
                "updated": "2019-08-23T16:17:08.309+02:00",
"url":
"https://www.data.gouv.fr/fr/datasets/r/00deb486-8d0a-47fd-bda3-0dc012ab4dc4"
            }
        ],
        "title": "Sankéo",
        "type": "public-transit",
        "updated": "2019-08-23T16:17:08.309+02:00"
    }

```

I don't know how to test this though :thinking: 