### PR TITLE
change the page not found error page

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -104,7 +104,7 @@ defmodule TransportWeb.DatasetController do
 
   defp redirect_to_slug_or_404(conn, nil) do
     conn
-    |> put_status(:internal_server_error)
+    |> put_status(:not_found)
     |> put_view(ErrorView)
     |> render("404.html")
   end

--- a/apps/transport/lib/transport_web/templates/error/not_found_error.html.eex
+++ b/apps/transport/lib/transport_web/templates/error/not_found_error.html.eex
@@ -1,0 +1,5 @@
+<section class="error">
+  <h1><%= dgettext("errors", "404: Page not available") %></h1>
+  <h2><%= assigns[:reason] %></h2>
+  <div class="error__background"></div>
+</section>

--- a/apps/transport/lib/transport_web/views/error_view.ex
+++ b/apps/transport/lib/transport_web/views/error_view.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.ErrorView do
     render(__MODULE__, "internal_server_error.html", assigns)
   end
 
-  def render("404.html", _assigns) do
-    render(__MODULE__, "internal_server_error.html", %{reason: dgettext("errors", "404: Page not available")})
+  def render("404.html", assigns) do
+    render(__MODULE__, "not_found_error.html", assigns)
   end
 end


### PR DESCRIPTION
now for an invalid dataset url, return a 404 status code, and render the
error via a 404 template

maybe fixes #621, but not sure since the issue lacks a bit of context :stuck_out_tongue_winking_eye: 


```bash
& http HEAD :5000/datasets/pouet
HTTP/1.1 404 Not Found
```

the error page is now:
![image](https://user-images.githubusercontent.com/3987698/65424994-7f5fe980-ddfc-11e9-91e7-b646c9866d7b.png)

and before it was:
![image](https://user-images.githubusercontent.com/3987698/65425068-a61e2000-ddfc-11e9-9eee-2e049116f9ff.png)

