### PR TITLE
Display a partial dataset page when datagouv is down

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -25,9 +25,17 @@ defmodule TransportWeb.DatasetController do
 
   def details(%Plug.Conn{} = conn, %{"slug" => slug_or_id}) do
     with dataset when not is_nil(dataset) <- Dataset.get_by(slug: slug_or_id, preload: true),
-        organization when not is_nil(organization) <- Dataset.get_organization(dataset),
-        {_, community_ressources} <- CommunityResources.get(dataset.datagouv_id),
-        {_, reuses} <- Reuses.get(dataset) do
+        organization when not is_nil(organization) <- Dataset.get_organization(dataset) do
+
+        community_ressources = case CommunityResources.get(dataset.datagouv_id) do
+          {_, community_ressources} -> community_ressources
+          _ -> nil
+        end
+        reuses = case Reuses.get(dataset) do
+          {_, reuses} -> reuses
+          _ -> nil
+        end
+
         conn
         |> assign(:dataset, dataset)
         |> assign(:community_ressources, community_ressources)


### PR DESCRIPTION
fixes #684 at least for the dataset page

If data.gouv cannot be queried, we display the dataset page anyway, but
without:
* comments
* reuses
* community ressources

in offline mode the page is like:
![image](https://user-images.githubusercontent.com/3987698/65437704-ce654900-de13-11e9-9f3e-b7d9493839de.png)

I have not found how to setup a timeout with cassette, so I did not test this :roll_eyes: 