### PR TITLE
fixes sentry 1859616

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -41,6 +41,7 @@ defmodule TransportWeb.ResourceController do
     |> List.first
   end
 
+  def validation_summary(nil), do: []
   def validation_summary(%{details: issues}) do
     existing_issues = issues
     |> Enum.map(fn {key, issues} -> {key, %{


### PR DESCRIPTION
a resource can have no validation (the last sentry error was for example for a GBFS resource)

should fix https://sentry.data.gouv.fr/etalab/site/issues/1859616/