### PR TITLE
Tag the current resource in history

### DIFF
--- a/apps/transport/lib/transport/history.ex
+++ b/apps/transport/lib/transport/history.ex
@@ -7,7 +7,7 @@ defmodule Transport.History do
   import Ecto.{Query}
   require Logger
 
-  def backup_resources do
+  def backup_resources(force_update \\ false) do
     if Application.get_env(:ex_aws, :access_key_id) == nil ||
          Application.get_env(:ex_aws, :secret_access_key) == nil do
       Logger.warn("no cellar credential set, we skip resource backup")
@@ -31,7 +31,7 @@ defmodule Transport.History do
 
         r
       end)
-      |> Stream.filter(&needs_to_be_updated/1)
+      |> Stream.filter(fn r -> force_update || needs_to_be_updated(r) end)
       |> Stream.each(&backup/1)
       |> Stream.run()
     end

--- a/apps/transport/lib/transport/history.ex
+++ b/apps/transport/lib/transport/history.ex
@@ -12,6 +12,7 @@ defmodule Transport.History do
          Application.get_env(:ex_aws, :secret_access_key) == nil do
       Logger.warn("no cellar credential set, we skip resource backup")
     else
+      Logger.info("backuping the resources")
       Resource
       |> where(
         [r],
@@ -103,6 +104,7 @@ defmodule Transport.History do
       }
       |> maybe_put(:start, resource.metadata["start_date"])
       |> maybe_put(:end, resource.metadata["end_date"])
+      |> maybe_put(:content_hash, resource.content_hash)
 
     case HTTPoison.get(resource.url) do
       {:ok, %{status_code: 200, body: body}} ->

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -159,7 +159,11 @@
           <tbody>
             <%= for resource_history <- @history_resources do %>
               <tr>
-                <td><%= link(resource_history.metadata["title"], to: resource_history.href) %></td>
+                <td><%= link(resource_history.metadata["title"], to: resource_history.href) %>
+                  <%= if resource_history.is_current do %>
+                  <span class="label"><%= dgettext("page-dataset-details", "current")%></span>
+                  <% end %>
+                </td>
                 <td><%= resource_history.metadata["updated-at"] |> String.split("T") |> List.first() %></td>
                 <td>
                   <%= unless resource_history.metadata["start"] == nil do %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -260,6 +260,10 @@ msgid "%{start} to %{end}"
 msgstr ""
 
 #, elixir-format
+msgid "current"
+msgstr ""
+
+#, elixir-format
 msgid "Format"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -260,6 +260,10 @@ msgid "%{start} to %{end}"
 msgstr "%{start} au %{end}"
 
 #, elixir-format
+msgid "current"
+msgstr "courant"
+
+#, elixir-format
 msgid "Format"
 msgstr "Format"
 

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -260,6 +260,10 @@ msgid "%{start} to %{end}"
 msgstr ""
 
 #, elixir-format
+msgid "current"
+msgstr ""
+
+#, elixir-format
 msgid "Format"
 msgstr ""
 


### PR DESCRIPTION
store the content_hash field and use it to tell if the resource is the current one or not.

if it's the current, a tag is added.

furthermore, the resources history are now sorted by date.

This looks like:

![image](https://user-images.githubusercontent.com/3987698/65704566-4c288f00-e076-11e9-900f-2492a696951f.png)
