### PR TITLE
check content-hash before backuping

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -322,7 +322,7 @@ defmodule DB.Dataset do
       []
     else
       try do
-        bucket = "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{dataset.datagouv_id}"
+        bucket = history_bucket_id(dataset)
         bucket
         |> S3.list_objects
         |> ExAws.stream!
@@ -348,6 +348,10 @@ defmodule DB.Dataset do
         []
       end
     end
+  end
+
+  def history_bucket_id(%__MODULE__{} = dataset) do
+    "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{dataset.datagouv_id}"
   end
 
   def get_expire_at(%Date{} = date), do: get_expire_at("#{date}")

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -351,7 +351,7 @@ defmodule DB.Dataset do
   end
 
   def history_bucket_id(%__MODULE__{} = dataset) do
-    "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{dataset.datagouv_id}"
+    "#{System.get_env("CELLAR_NAMESPACE")}dataset-#{dataset.datagouv_id}"
   end
 
   def get_expire_at(%Date{} = date), do: get_expire_at("#{date}")

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -322,7 +322,7 @@ defmodule DB.Dataset do
       []
     else
       try do
-        bucket = "dataset-#{dataset.datagouv_id}"
+        bucket = "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{dataset.datagouv_id}"
         bucket
         |> S3.list_objects
         |> ExAws.stream!

--- a/apps/transport/lib/transport/history.ex
+++ b/apps/transport/lib/transport/history.ex
@@ -61,7 +61,7 @@ defmodule Transport.History do
     end
   end
 
-  defp bucket_id(r), do: "dataset-#{r.dataset.datagouv_id}"
+  defp bucket_id(r), do: "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{r.dataset.datagouv_id}"
 
   defp get_already_backuped_resources(resource) do
     resource

--- a/apps/transport/lib/transport/history.ex
+++ b/apps/transport/lib/transport/history.ex
@@ -47,21 +47,23 @@ defmodule Transport.History do
     max_last_modified =
       backuped_resources
       |> Enum.map(fn r ->
-        r.updated_at
+        {r.updated_at, r.content_hash}
       end)
-      |> Enum.max(fn -> nil end)
+      |> Enum.max_by(fn {date, _hash} -> date end, fn -> nil end)
 
     case max_last_modified do
       nil ->
         true
 
-      max_last_modified ->
+      {max_last_modified, content_hash} ->
         modification_date = modification_date(resource)
-        max_last_modified < modification_date
+        max_last_modified < modification_date && content_hash != resource.content_hash
     end
   end
 
-  defp bucket_id(r), do: "#{System.get_env("CELLAR_NAMESPACE") || ""}dataset-#{r.dataset.datagouv_id}"
+  def bucket_id(resource) do
+    Dataset.history_bucket_id(resource.dataset)
+  end
 
   defp get_already_backuped_resources(resource) do
     resource
@@ -73,7 +75,8 @@ defmodule Transport.History do
 
       %{
         key: o.key,
-        updated_at: metadata["updated-at"]
+        updated_at: metadata["updated-at"],
+        content_hash: metadata["content-hash"],
       }
     end)
   end


### PR DESCRIPTION
I though the modification date was enough, but it was not.

This led to dataset (like tisseo) with a **lot** of history (1/day).

I cleaned up the history too.

This PR also add a namespace to the cellar. This way it's easier to test a another bucket (since the bucket names are unique, even accross cellars), just add `CELLAR_NAMESPACE=test` to test on `test_data_history`



