### PR TITLE
also look at the title to guess if it's a GTFS

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -32,9 +32,7 @@ defmodule Transport.ImportData do
     base_url = Application.get_env(:transport, :datagouvfr_site)
     url      = "#{base_url}/api/1/datasets/#{id}/"
 
-    Logger.info(" <message>  Importing dataset")
-    Logger.info(" <id>       #{id}")
-    Logger.info(" <url>      #{url}")
+    Logger.info("Importing dataset #{id} (url = #{url})")
 
     with {:ok, response}  <- HTTPoison.get(url, [], hackney: [follow_redirect: true]),
          {:ok, json} <- Poison.decode(response.body),
@@ -42,9 +40,7 @@ defmodule Transport.ImportData do
       {:ok, dataset}
     else
       {:error, error} ->
-        Logger.error("<message>  #{inspect error}")
-        Logger.error("<id>       #{id}")
-        Logger.error("<url>      #{url}")
+        Logger.error("Error while importing dataset #{id} (url = #{url}) : #{inspect error}")
         {:error, error}
     end
   end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -188,6 +188,7 @@ defmodule Transport.ImportData do
       is_format?(url, "csv") -> false
       is_format?(url, "shp") -> false
       is_gtfs?(params["description"]) -> true
+      is_gtfs?(params["title"]) -> true
       true -> false
     end
   end


### PR DESCRIPTION
fixes [dlva](https://www.data.gouv.fr/fr/datasets/lignes-dautocars-urbains-et-interurbains-de-la-dlva/) which have 2 resources, and the up to date is not seen in [transport](https://transport.data.gouv.fr/datasets/lignes-dautocars-urbains-et-interurbains-de-la-dlva/) because the format is not found as gtfs

Add also a small improvement on log format