### PR TITLE
better stats css

### DIFF
--- a/apps/transport/client/stylesheets/components/_map.scss
+++ b/apps/transport/client/stylesheets/components/_map.scss
@@ -1,6 +1,6 @@
-#map {
-  height: 40em;
-  width: 100%;
+.map {
+  min-height: 40em;
+  width: 50%;
 
   .info {
     padding: 6px 8px;
@@ -26,15 +26,30 @@
 }
 
 .stats {
+  .domain-stats {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .domain-stats>* {
+    flex: 1 1 500px;
+  }
+
+  .panel {
+    display: grid;
+    grid-template-rows: repeat(auto-fill, 120px);
+    grid-gap: 1em;
+    grid-template-columns: repeat(auto-fill, minmax(200px, auto));
+    width: 50%;
+  }
+
   .tile {
     background-color: $lighter-grey;
-    display: flex;
-    flex-direction: row;
     padding: 2em;
 
-    strong {
+    h3 {
       font-size: 3em;
-      margin-right: 0.25em;
+      margin: 0;
     }
   }
 }

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -2,27 +2,29 @@
 <section class="section deployment">
   <div class="container">
     <h1>État du déploiement</h1>
-    <div id="map"></div>
     <h2>Horaires théoriques – transports en commun</h2>
     <div class="stats">
-      <div class="grid">
+    <div class="domain-stats">
+      <div id="map" class="map"></div>
+      <div class="panel">
         <div class="tile">
-          <strong><%= @nb_datasets %></strong>
+          <h3><%= @nb_datasets %></h3>
           <div>jeux ouverts</div>
         </div>
         <div class="tile">
-          <strong><%= @nb_aoms_with_data %></strong>
+          <h3><%= @nb_aoms_with_data %></h3>
           <div>autorités organisatrices de la mobilité couvertes (sur <%= @nb_aoms %>)</div>
         </div>
         <div class="tile">
-          <strong><%= @nb_regions_completed %></strong>
+          <h3><%= @nb_regions_completed %></h3>
           <div>régions couvertes (sur <%= @nb_regions %>)</div>
         </div>
         <div class="tile">
-          <strong><%= @population_couverte %>M</strong>
+          <h3><%= @population_couverte %>M</h3>
           <div>de la population couverte
             sur <%= @population_totale %>M
           </div>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Before adding more maps and stats to the `/stats` page, refactor a bit
the css

in full screen it looks like:
![image](https://user-images.githubusercontent.com/3987698/69354088-72823980-0c77-11ea-8d68-f5c33346d919.png)


and with a smartphone:
![image](https://user-images.githubusercontent.com/3987698/69354185-99407000-0c77-11ea-8b24-029f6392c351.png)
