### PR TITLE
make it possible de reference road networks

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -49,6 +49,7 @@ defmodule DB.Dataset do
     "air-transport" => dgettext("dataset", "Aerial"),
     "train" => dgettext("dataset", "Train timetable"),
     "bike-sharing" => dgettext("dataset", "Bike sharing"),
+    "road-network" => dgettext("dataset", "Road networks"),
     "long-distance-coach" => dgettext("dataset", "Long distance coach")
   }
 

--- a/apps/db/priv/gettext/dataset.pot
+++ b/apps/db/priv/gettext/dataset.pot
@@ -73,3 +73,7 @@ msgstr ""
 #, elixir-format
 msgid "Train timetable"
 msgstr ""
+
+#, elixir-format
+msgid "Road networks"
+msgstr ""

--- a/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -36,15 +36,7 @@ msgid "Micro mobility"
 msgstr ""
 
 #, elixir-format
-msgid "Public transit"
-msgstr ""
-
-#, elixir-format
 msgid "Stops referential"
-msgstr ""
-
-#, elixir-format
-msgid "Train"
 msgstr ""
 
 #, elixir-format
@@ -73,4 +65,16 @@ msgstr "Other open"
 
 #, elixir-format
 msgid "See on data.gouv.fr"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Public transit timetable"
+msgstr ""
+
+#, elixir-format
+msgid "Train timetable"
+msgstr ""
+
+#, elixir-format
+msgid "Road networks"
 msgstr ""

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -36,16 +36,8 @@ msgid "Micro mobility"
 msgstr "Micro mobilité"
 
 #, elixir-format
-msgid "Public transit timetable"
-msgstr "Horaires théoriques de transport public"
-
-#, elixir-format
 msgid "Stops referential"
 msgstr "Référentiel d'arrêts"
-
-#, elixir-format
-msgid "Train timetables"
-msgstr "Horaires ferroviaire"
 
 #, elixir-format
 msgid "Unable to find INSEE code"
@@ -74,3 +66,15 @@ msgstr "Autre ouverte"
 #, elixir-format
 msgid "See on data.gouv.fr"
 msgstr "Voir sur data.gouv.fr"
+
+#, elixir-format
+msgid "Public transit timetable"
+msgstr "Horaires théoriques de transport public"
+
+#, elixir-format, fuzzy
+msgid "Train timetable"
+msgstr "Horaires ferroviaire"
+
+#, elixir-format
+msgid "Road networks"
+msgstr "Réseaux routiers"

--- a/apps/transport/client/images/icons/map.svg
+++ b/apps/transport/client/images/icons/map.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 19" fill-rule="evenodd" clip-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5">
+  <g fill="none" stroke="#26353f">
+    <path d="M5.753 2.14v15.65l5.252-1.64V.5L5.753 2.14zM5.753 2.14v15.65L.5 16.15V.5l5.253 1.64zM16.258 2.14v15.65l-5.253-1.64V.5l5.253 1.64z"/>
+  </g>
+</svg>
+

--- a/apps/transport/lib/transport_web/templates/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.eex
@@ -55,6 +55,11 @@
                     <h3 class="text-center"><%= dgettext("page-index", "Railroad data") %></h3>
                     <p><%= dngettext("page-index", "dataset", "datasets", @count_by_type["train"]) %></p>
                 </a>
+                <a class="tile" href="<%= dataset_path(@conn, :index, type: "road-network") %>">
+                    <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/map.svg") %>" alt="" />
+                    <h3 class="text-center"><%= dgettext("page-index", "Road networks") %></h3>
+                    <p><%= dngettext("page-index", "dataset", "datasets", @count_by_type["road-network"]) %></p>
+                </a>
             </div>
         </div>
         <div class="upcoming">
@@ -71,10 +76,6 @@
                 <div class="tile">
                     <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/scooter-grey.svg") %>" alt="" />
                     <h3 class="text-center"><%= dgettext("page-index", "Freefloating vehicles") %></h3>
-                </div>
-                <div class="tile">
-                    <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/map-grey.svg") %>" alt="" />
-                    <h3 class="text-center"><%= dgettext("page-index", "Road networks") %></h3>
                 </div>
                 <div class="tile">
                     <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/boat-grey.svg") %>" alt="" />


### PR DESCRIPTION
fixes #925

Add a type `road-network` to reference road network data.
The main page is now looking like:

![image](https://user-images.githubusercontent.com/3987698/70419356-2bf55300-1a5d-11ea-931d-4fa05d4cfef4.png)


 I'm not sure about the name `Road network` as it is not car specific, but do we want a car specific names ? I kept `Road network` as it was already referenced as this