### PR TITLE
add a link to the /datasets/{id} api in each dataset page

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -139,6 +139,17 @@
         <% end %>
       </div>
     </div>
+
+    <div class="container">
+      <p>
+        <i class="fas fa-cogs"></i>
+          <%= dgettext("page-dataset-details", "Get details about this dataset via an %{start_link}API call%{end_link}",
+          start_link: "<a href=\"/api/datasets/#{@dataset.datagouv_id}\">",
+          end_link: "</a>") |> raw()
+          %>
+      </p>
+    </div>
+
   </section>
   <% end %>
 

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -130,6 +130,8 @@
         <%= pagination_links @conn, @datasets %>
       </div>
     <% end %>
+
+    <i class="fas fa-cogs"></i>
     <%= link(
       dgettext("page-shortlist", "Get dataset list via an API"),
       to: "#{swagger_ui_path(@conn, [path: "/api/openapi"])}#/datasets/API.DatasetController.datasets"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -278,3 +278,7 @@ msgstr ""
 #, elixir-format
 msgid "File"
 msgstr ""
+
+#, elixir-format
+msgid "Get details about this dataset via an %{start_link}API call%{end_link}"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -278,3 +278,7 @@ msgstr "Période de validité"
 #, elixir-format
 msgid "File"
 msgstr "Fichier"
+
+#, elixir-format
+msgid "Get details about this dataset via an %{start_link}API call%{end_link}"
+msgstr "Récupérer des détails sur ce jeu de données via un %{start_link}appel à l'API%{end_link}"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -278,3 +278,7 @@ msgstr ""
 #, elixir-format
 msgid "File"
 msgstr ""
+
+#, elixir-format
+msgid "Get details about this dataset via an %{start_link}API call%{end_link}"
+msgstr ""


### PR DESCRIPTION
This way make a bit of advertising to our api.

![image](https://user-images.githubusercontent.com/3987698/70434895-67077e80-1a7d-11ea-95c3-49a20be45b88.png)

(and I also added the picto to the other api link in the dataset index page:
![image](https://user-images.githubusercontent.com/3987698/70434940-81d9f300-1a7d-11ea-8742-fd009c21011f.png)
)

Note that here I put a direct link to the api whereas in the datasets index the link point to the `/datasets` section of the swagger ui.

I don't think we can poin to `/datasets/{id} in the swagger ui and since there are no parameter to this api, I thought it was enough to add a direct link.

This can be improved when we'll have a `API` page in the web site with
some explanations.