### PR TITLE
fallback on real url when no stable url

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -15,13 +15,13 @@ defmodule DB.Resource do
 
   schema "resource" do
     field :is_active, :boolean
-    field :url, :string
+    field :url, :string # real url
     field :format, :string
     field :last_import, :string
     field :title, :string
     field :metadata, :map
     field :last_update, :string
-    field :latest_url, :string
+    field :latest_url, :string # stable data.gouv.fr url if exists, else (for ODS gtfs as csv) it's the real url
     field :is_available, :boolean, default: true
     field :content_hash, :string
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -117,7 +117,9 @@ defmodule Transport.ImportData do
             "title" => get_title(resource),
             "last_import" => DateTime.utc_now |> DateTime.to_string,
             "last_update" => resource["last_modified"],
-            "latest_url" => resource["latest"],
+            # For ODS gtfs as csv we do not have a 'latest' field
+            # (the 'latest' field is the stable data.gouv.fr url)
+            "latest_url" => resource["latest"] || resource["url"],
             "id" => get_resource_id(resource),
             "is_available" => available?(resource)
           }


### PR DESCRIPTION
Some datasets have no stable data.gouv.fr url (for example for ODS gtfs
as CSV). In those case we fallback on the real ressource url, this way a
ressource always has an url in the API or the atom feed