### PR TITLE
auto discover some tags

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -131,6 +131,18 @@ defmodule DB.Dataset do
     |> where([d], not is_nil(d.aom_id) and d.type == "public-transit")
     |> order_datasets(params)
   end
+  def list_datasets(%{"tags" => tags} = params, s) do
+    resources =
+      Resource
+      |> where([r], fragment("? @> ?::varchar[]", r.auto_tags, ^tags))
+      |> distinct([r], r.dataset_id)
+      |> select([r], %Resource{dataset_id: r.dataset_id})
+
+    s
+    |> list_datasets()
+    |> join(:inner, [d], r in subquery(resources), on: d.id == r.dataset_id)
+    |> order_datasets(params)
+  end
   def list_datasets(%{} = params, s) do
     filters =
       params

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -68,6 +68,7 @@ defmodule DB.Dataset do
         last_update: r.last_update,
         latest_url: r.latest_url,
         content_hash: r.content_hash,
+        auto_tags: r.auto_tags
       },
       where: r.is_available
   end

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -25,7 +25,6 @@ defmodule DB.Resource do
     field :is_available, :boolean, default: true
     field :content_hash, :string
     field :auto_tags, {:array, :string}, default: [] # automatically discovered tags
-    field :manual_tags, {:array, :string},  default: [] # manually added tags
 
     belongs_to :dataset, Dataset
     has_one :validation, Validation, on_replace: :delete
@@ -220,10 +219,6 @@ defmodule DB.Resource do
   end
 
   def get_max_severity_validation_number(_), do: nil
-
-  def tags(%__MODULE__{auto_tags: auto_tags, manual_tags: manual_tags}) do
-    auto_tags ++ manual_tags
-  end
 
   def is_gtfs?(%__MODULE__{format: "GTFS"}), do: true
   def is_gtfs?(%__MODULE__{metadata: m} = r) when not is_nil(m) do

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -131,7 +131,7 @@ defmodule DB.Resource do
     |> cast(
       params,
       [:is_active, :url, :format, :last_import, :title,
-       :metadata, :id, :last_update, :latest_url, :is_available]
+       :metadata, :id, :last_update, :latest_url, :is_available, :auto_tags]
     )
     |> validate_required([:url])
   end

--- a/apps/db/priv/repo/migrations/20191216144800_add_resource_tags.exs
+++ b/apps/db/priv/repo/migrations/20191216144800_add_resource_tags.exs
@@ -4,7 +4,6 @@ defmodule DB.Repo.Migrations.AddResourceTags do
   def change do
     alter table(:resource) do
       add :auto_tags, {:array, :string}, default: []
-      add :manual_tags, {:array, :string}, default: []
     end
   end
 end

--- a/apps/db/priv/repo/migrations/20191216144800_add_resource_tags.exs
+++ b/apps/db/priv/repo/migrations/20191216144800_add_resource_tags.exs
@@ -1,0 +1,10 @@
+defmodule DB.Repo.Migrations.AddResourceTags do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      add :auto_tags, {:array, :string}, default: []
+      add :manual_tags, {:array, :string}, default: []
+    end
+  end
+end

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -16,6 +16,11 @@
                     </span>
                 </div>
             </div>
+            <div>
+                <%= for tag <- @resource.auto_tags do %>
+                    <span class="label"><%= tag %></span>
+                <% end %>
+            </div>
     </div>
     <div class="resource__details">
         <%= if Resource.valid?(@resource) and Resource.is_gtfs?(@resource) do %>


### PR DESCRIPTION
for the moment we only add the GTFS modes as tags


The tags are searchable via url only for the moment:
http://localhost:5000/datasets?tags[]=tramway&tags[]=bus

and rendered simply in each ressource:

![image](https://user-images.githubusercontent.com/3987698/71260285-6a7aef80-2332-11ea-9bf0-aaa82a2e5f5d.png)
