### PR TITLE
Api link

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -1,59 +1,51 @@
 <footer class="footer" role="contentinfo" id="footer">
-    <a href="#mail_form" class="mail__button" aria-label="<%= dgettext("page-index", "Ask for help") %>">
-        <i class="fas icon--envelope"></i>
-        <span><%= dgettext("page-index", "Ask for help") %></span>
-    </a>
-
-      <div class="modal__backdrop" id="mail_form">
-        <div class="footer__contact">
-            <a class="footer__contact--close" href="#" aria-label="<%= dgettext("page-index", "Close the form") %>">
-              <i class="fas icon--times-circle"></i>
-            </a>
-
-            <%= form_for @conn, contact_path(@conn, :send_mail), fn f -> %>
-                <h3>Contact</h3>
-              <%= email_input(f, :email, placeholder: gettext("Email address")) %>
-              <%= text_input(f, :topic, value: gettext("Question about transport.data.gouv.fr")) %>
-              <%= textarea(f, :demande, placeholder: gettext("Ask for help")) %>
-              <%= submit gettext("Send email") %>
-            <% end %>
-        </div>
-      </div>
-
-  <div class="container">
-    <div class="footer__logo">
-      <%= link(img_tag("/images/logo-ministere-horizontal.png", alt: "Ministère chargé des transports"), to: "https://www.ecologique-solidaire.gouv.fr/")%>
-      <%= link(img_tag("/images/logo-footer.svg", alt: "transport.data.gouv.fr"), to: "/") %>
-    </div>
-
-    <ul class="footer__links">
-      <%= if assigns[:contact_email] do %>
+  <a href="#mail_form" class="mail__button" aria-label="<%= dgettext("page-index", "Ask for help") %>">
+    <i class="fas icon--envelope"></i>
+    <span><%= dgettext("page-index", "Ask for help") %></span>
+  </a>
+  <div class="modal__backdrop" id="mail_form">
+    <div class="footer__contact">
+      <a class="footer__contact--close" href="#" aria-label="<%= dgettext("page-index", "Close the form") %>">
+        <i class="fas icon--times-circle"></i>
+      </a>
+      <%= form_for @conn, contact_path(@conn, :send_mail), fn f -> %>
+      <h3>Contact</h3>
+      <%= email_input(f, :email, placeholder: gettext("Email address")) %>
+      <%= text_input(f, :topic, value: gettext("Question about transport.data.gouv.fr")) %>
+      <%= textarea(f, :demande, placeholder: gettext("Ask for help")) %>
+      <%= submit gettext("Send email") %>
+    <% end %>
+  </div>
+</div>
+<div class="container">
+  <div class="footer__logo">
+    <%= link(img_tag("/images/logo-ministere-horizontal.png", alt: "Ministère chargé des transports"), to: "https://www.ecologique-solidaire.gouv.fr/")%>
+    <%= link(img_tag("/images/logo-footer.svg", alt: "transport.data.gouv.fr"), to: "/") %>
+  </div>
+  <ul class="footer__links">
+    <%= if assigns[:contact_email] do %>
       <li>
         <a class="footer__link footer__link--contact" href='mailto:<%= @contact_email %>' role="link">
           <%= gettext "Contact" %>
         </a>
       </li>
-      <% end %>
-
-      <li>
-        <a class="footer__link footer__link--tos" href="/validation" role="link"><%= gettext("Check a GTFS file's quality") %></a>
-      </li>
-
-      <li>
-        <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
-      </li>
-
-      <li>
-        <a class="footer__link footer__link--tos" href="/real_time" role="link">
-          <%= gettext "Real time datasets" %>
-        </a>
-      </li>
-
-      <li>
-        <a class="footer__link footer__link--tos" href="/legal" role="link">
-          <%= gettext "Legal Information" %>
-        </a>
-      </li>
-    </ul>
-  </div>
+    <% end %>
+    <li>
+      <a class="footer__link footer__link--tos" href="/validation" role="link"><%= gettext("Check a GTFS file's quality") %></a>
+    </li>
+    <li>
+      <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
+    </li>
+    <li>
+      <a class="footer__link footer__link--tos" href="/real_time" role="link">
+        <%= gettext "Real time datasets" %>
+      </a>
+    </li>
+    <li>
+      <a class="footer__link footer__link--tos" href="/legal" role="link">
+        <%= gettext "Legal Information" %>
+      </a>
+    </li>
+  </ul>
+</div>
 </footer>

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -31,15 +31,11 @@
       </li>
     <% end %>
     <li>
-      <a class="footer__link footer__link--tos" href="/validation" role="link"><%= gettext("Check a GTFS file's quality") %></a>
     </li>
     <li>
       <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="/real_time" role="link">
-        <%= gettext "Real time datasets" %>
-      </a>
     </li>
     <li>
       <a class="footer__link footer__link--tos" href="/legal" role="link">

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -31,11 +31,13 @@
       </li>
     <% end %>
     <li>
+      <a class="footer__link footer__link--tos" href="https://app.gitbook.com/@transport-data-gouv-fr/s/doc/reutilisateurs/apis/" role="link">API</a>
     </li>
     <li>
       <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
     </li>
     <li>
+      <a class="footer__link footer__link--tos" href="https://github.com/etalab/transport-site/" role="link"><%= gettext("Source code")%></a>
     </li>
     <li>
       <a class="footer__link footer__link--tos" href="/legal" role="link">

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.eex
@@ -1,11 +1,12 @@
 <header class="navbar">
   <div class="navbar__container">
     <%= link(img_tag("/images/logo-header.svg", alt: gettext("transport.data.gouv.fr"), class: "navbar__logo"), to: "/", class: "navbar__home") %>
-
     <nav role="navigation">
       <a href="#menu">
         <div class="nav__hamburger">
-          <div>&nbsp;</div><div>&nbsp;</div><div>&nbsp;</div>
+          <div>&nbsp;</div>
+          <div>&nbsp;</div>
+          <div>&nbsp;</div>
         </div>
       </a>
       <div id="menu">
@@ -25,33 +26,33 @@
           <%= if assigns[:current_user] do %>
             <%= if assigns[:current_user] |> Map.get("organizations", []) |> Enum.any?(fn org -> org["slug"] == "equipe-transport-data-gouv-fr" end) do %>
               <li class="nav__item">
-                  <%= link("Administration", to: "/backoffice") %>
+                <%= link("Administration", to: "/backoffice") %>
               </li>
             <% end %>
-          <li class="nav__item">
-            <%= if assigns[:current_user]["avatar_thumbnail"] do %>
-                  <img src="<%= assigns[:current_user]["avatar_thumbnail"] %>" alt="Avatar" class="nav__avatar"> </img>
+            <li class="nav__item">
+              <%= if assigns[:current_user]["avatar_thumbnail"] do %>
+                <img src="<%= assigns[:current_user]["avatar_thumbnail"] %>" alt="Avatar" class="nav__avatar"> </img>
             <% end %>
             <span class="nav__username">
               <%= assigns[:current_user]["first_name"] %> <%= assigns[:current_user]["last_name"] %>
             </span>
           </li>
           <li class="nav__item">
-              <a class="navigation__link nagivation__link--logout" href="<%= session_path @conn, :delete %>" role="link">
-                  <i class="icon icon--logout" aria-hidden="true"></i>
-                  <span><%= gettext "Sign Out" %></span>
-              </a>
-            </li>
-          <% else %>
+            <a class="navigation__link nagivation__link--logout" href="<%= session_path @conn, :delete %>" role="link">
+              <i class="icon icon--logout" aria-hidden="true"></i>
+              <span><%= gettext "Sign Out" %></span>
+            </a>
+          </li>
+        <% else %>
           <li class="nav__item">
-              <a class="navigation__link navigation__link--login" href="<%= page_path @conn, :login, redirect_path: current_path(@conn) %>" role="link">
+            <a class="navigation__link navigation__link--login" href="<%= page_path @conn, :login, redirect_path: current_path(@conn) %>" role="link">
               <i class="icon icon--login" aria-hidden="true"></i>
               <span><%= gettext "Sign In" %></span>
-              </a>
+            </a>
           </li>
-          <% end %>
-        </ul>
-      </div>
-    </nav>
-  </div>
+        <% end %>
+      </ul>
+    </div>
+  </nav>
+</div>
 </header>

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.eex
@@ -21,6 +21,9 @@
             <%= link(gettext("Blog"), to: "/blog") %>
           </li>
           <li class="nav__item">
+            <%= link(gettext("Check a GTFS file's quality"), to: "/validation") %>
+          </li>
+          <li class="nav__item">
             <%= link(gettext("Publish or update a dataset"), to: resource_path(@conn, :choose_action)) %>
           </li>
           <%= if assigns[:current_user] do %>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -62,13 +62,13 @@ msgid "Check a GTFS file's quality"
 msgstr ""
 
 #, elixir-format
-msgid "Real time datasets"
-msgstr ""
-
-#, elixir-format
 msgid "About"
 msgstr ""
 
 #, elixir-format
 msgid "Blog"
+msgstr ""
+
+#, elixir-format
+msgid "Source code"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -62,13 +62,13 @@ msgid "Check a GTFS file's quality"
 msgstr ""
 
 #, elixir-format
-msgid "Real time datasets"
-msgstr ""
-
-#, elixir-format
 msgid "About"
 msgstr ""
 
 #, elixir-format
 msgid "Blog"
+msgstr ""
+
+#, elixir-format
+msgid "Source code"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -62,13 +62,13 @@ msgid "Check a GTFS file's quality"
 msgstr "Analyser la qualité d’un fichier GTFS"
 
 #, elixir-format
-msgid "Real time datasets"
-msgstr "Jeux de données temps réel"
-
-#, elixir-format
 msgid "About"
 msgstr "À propos"
 
 #, elixir-format
 msgid "Blog"
 msgstr "Blog"
+
+#, elixir-format
+msgid "Source code"
+msgstr "Code source"


### PR DESCRIPTION
closes #836 and #846 


reorganize the footer and header:

header:
![image](https://user-images.githubusercontent.com/3987698/71911969-98eb2e00-316c-11ea-9b7c-4c3f5fa0d7f1.png)

footer:
![image](https://user-images.githubusercontent.com/3987698/71911943-8e309900-316c-11ea-84ef-96af5ef6d89d.png)
The api link points to the new [API gitbook entry](https://app.gitbook.com/@transport-data-gouv-fr/s/doc/reutilisateurs/apis/).

Note: the header is now quite loaded, and the reduced view is not very nice. On a smartphone it's ok because there is a burger instead of the list and I changed the minimal width for the burger.
![image](https://user-images.githubusercontent.com/3987698/71912358-42322400-316d-11ea-903b-84aa24ec3977.png)

but on a small tablet it looks like:
![image](https://user-images.githubusercontent.com/3987698/71912167-e7003180-316c-11ea-87fc-35d3ceefaf52.png)

I'm a bit afraid of the side effects of increasing too much the minimal width :pensive: 