### PR TITLE
fix image size pour chromium

### DIFF
--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -56,6 +56,7 @@
   
   .dataset__image img {
     object-fit: contain;
+    height: 100%;
   }
   
   .side-pane__submenu a {
@@ -103,6 +104,10 @@
     margin-right: 1em;
   }
   
+  .dataset__type img {
+    height: 100%;
+  }
+
   .panel__extra {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
honestly I'm way over my head on this, but on all chromium based the dataset images are poorly rendered:
![image](https://user-images.githubusercontent.com/3987698/72148095-e8617200-3397-11ea-951d-ed28a47d282a.png)
(either the company logo or the type pictogram).

I did not found a generic css property to make this right so I used a chromium specify one, but I'm sure there is a better way for this. (any idea @thimy ?)

now it look like (the same in firefox):
![image](https://user-images.githubusercontent.com/3987698/72148248-3e361a00-3398-11ea-9264-eaafc6f62d8f.png)
