### PR TITLE
Do not consider accents in search

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -87,7 +87,7 @@ defmodule DB.Dataset do
     resource_query = no_validations_query()
 
     __MODULE__
-    |> where([d], fragment("search_vector @@ plainto_tsquery('simple', ?) or title = ?", ^q, ^q))
+    |> where([d], fragment("search_vector @@ plainto_tsquery('simple', ?) or unaccent(title) = unaccent(?)", ^q, ^q))
     |> order_by([l], desc: fragment("ts_rank_cd(search_vector, plainto_tsquery('simple', ?), 32) DESC, population", ^q))
     |> select_active
     |> select_or_not(s)

--- a/apps/db/priv/repo/migrations/20200110124026_unaccent.exs
+++ b/apps/db/priv/repo/migrations/20200110124026_unaccent.exs
@@ -1,0 +1,20 @@
+defmodule DB.Repo.Migrations.Unaccent do
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE EXTENSION unaccent")
+
+    execute(
+      """
+      ALTER TEXT SEARCH CONFIGURATION simple
+      ALTER MAPPING FOR hword, hword_part, hword_asciipart, word
+      WITH unaccent, simple;
+      """,
+      """
+      ALTER TEXT SEARCH CONFIGURATION simple
+      ALTER MAPPING FOR hword, hword_part, hword_asciipart, word
+      WITH simple;
+      """
+    )
+  end
+end


### PR DESCRIPTION
change full text search configuration to ignore accents.

The search "Orleans", "chateauroux", "noumea", now gives appropriate results

closes #974 