### PR TITLE
Revamp of the readme for easier onboarding process

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,10 +1,32 @@
-export SECRET_KEY_BASE=asdf1234
-export DATAGOUVFR_SITE=https://www.data.gouv.fr
+# Set the mix_env to dev. Only for dev purpose.
+export MIX_ENV=dev
+
+# Configuration for the data.gouv.fr connection
+export DATAGOUVFR_SITE=https://www.next.data.gouv.fr # This is data.gouv.fr test environment
 export DATAGOUVFR_CLIENT_ID=asdf1234
 export DATAGOUVFR_CLIENT_SECRET= asdf1234
-export DATAGOUVFR_REDIRECT_URI=http://127.0.0.1:5000/auth/callback
-export GTFS_VALIDATOR_URL=http://127.0.0.1:7878
-export PG_URL=ecto://user:password@host/db_name
-export PG_URL_TEST=ecto://user:password@host/db_name_test
+export DATAGOUVFR_REDIRECT_URI=http://localhost:5000/login/callback
+
+# Phoenix secret key. Can be generated with `mix phx.gen.secret`
+export SECRET_KEY_BASE=asdf1234
+
+# ecto url of the postgresql database
+export PG_URL=ecto://postgres:postgres@localhost/transport_repo
+
+# ecto url of the test database
+export PG_URL_TEST=ecto://postgres:postgres@localhost/transport_test
+
+# URL to the GTFS validator (https://github.com/etalab/transport-validator/)
+export GTFS_VALIDATOR_URL=https://transport-validator.cleverapps.io
+
+# Clever cloud cellar keys. If empty no dataset history is available
 export CELLAR_ACCESS_KEY_ID=
 export CELLAR_SECRET_ACCESS_KEY=
+export CELLAR_NAMESPACE=
+
+# Mailjet configuration
+export MJ_APIKEY_PUBLIC=
+export MJ_APIKEY_PRIVATE=
+
+# GBFS configuration
+export JCDECAUX_APIKEY=

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,15 @@ RUN mkdir /app/_build
 RUN mkdir /app/deps/
 WORKDIR /app/
 
+# fetch a wait-for-it script to wait for postgres startup
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/54d1f0bfeb6557adf8a3204455389d0901652242/wait-for-it.sh /opt/bin/
+RUN chmod +x /opt/bin/wait-for-it.sh
+
+ADD docker_phoenix_startup.sh /docker_phoenix_startup.sh
+RUN chmod +x /docker_phoenix_startup.sh
+
 ADD mix.exs mix.lock /app/
 ADD config /app/config/
 ADD apps /app/apps/
+
+CMD [ "/docker_phoenix_startup.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,31 +1,114 @@
 # Transport
 
-## Installation
+This is the repository of the french National Access Point (NAP) for mobility data.
+
+This project brings a mobility focus on data hosted on [data.gouv.fr](https://www.data.gouv.fr), the french open data portal.
+
+# Installation
+
+You can install this 2 different ways:
+* [manually](#manual_install), this is the best way to install it if you plan to work often on the project.
+* [with docker](#docker_install), this is an easier installation process at the cost of a slightly more cumbersome development workflow.
+
+## Manual installation <a name="manual_install"></a>
 
   * Make sure you have **Elixir**, **Node**, **Yarn** and **Docker** installed and up-to-date
+    * **Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects. The project needx at least **Elixir** 1.8 and **Erlang** 21.0
   * Install Elixir dependencies with `mix deps.get`
   * Install Node.js dependencies with `mix yarn install`
 
-In order to validate datasets:
+### Postgresql
 
-  * Make sure you have [**gtfs-validator**](https://github.com/etalab/transport-validator) installed and up-to-date
-  * Set the environment variable `GTFS_VALIDATOR_URL` to your datatools running instance URL.
+You also need an up to date postgresql with postgis installed.
+
+#### Creating a database
+
+With the permission to create a database (on Debian based system, you need to be logged as `postgres`)
+
+`createdb transport_repo` (or you can use `mix ecto.create`).
+
+#### Applying the migrations
+
+To have an up to date database schema run `mix ecto.migrate` (with an up to date configuration).
+
+#### Restoring the production database
+
+The production database does not contains any sensitive data, you can retreive it for dev purpose.
+* You can retreive the [latest clever-cloud backup](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/addons/addon_beebaa5e-c3a4-4c57-b124-cf9d1473450a) (you need some permissions to access it, if you don't have them, you can ask someone on the team to give you the database)
+* restore this backup on you database: `./restore_db.sh <path_to_the_backup>`
+
+## Configuration
+
+For easier configuration handling you can use [direnv](https://direnv.net/).
+
+* copy the example file `cp .envrc.example .envrc`;
+* put the right values in it;
+* allow direnv to export those variables `direnv allow .`
 
 ## Usage
 
-  * Run the server with `mix phx.server`
-  * Run the webdriver server with `docker run -p 4444:4444 --network=host selenium/standalone-chrome:3.141.59-oxygen`
-  * Run the tests with `mix test`
-  * Run the integration tests with `mix test --only integration`
-  * Run the solution tests with `mix test --only solution`
-  * Run the external tests with `mix test --only external`
+Run the server with `mix phx.server` and you can visit [`127.0.0.1:5000`](http://127.0.0.1:5000) on your browser.
+
+## Development
+
+### Testing
+
+Before running the integration tests, you need to start a selenium web driver with `docker run -p 4444:4444 --network=host selenium/standalone-chrome:3.141.59-oxygen`
+
+Run the tests with `MIX_ENV=test mix test`
+
+You can also:
+
+  * Run the integration tests with `MIX_ENV=test mix test --only integration`
+  * Run the solution tests with `MIX_ENV=test mix test --only solution`
+  * Run the external tests with `MIX_ENV=test mix test --only external`
+
+### Linting
+
   * Run the elixir linter with `mix credo --strict`
   * Run the javascript linter with `mix npm "run linter:ecma"`
   * Run the sass linter with `mix npm "run linter:sass"`
 
-Now you can visit [`127.0.0.1:5000`](http://127.0.0.1:5000) from your browser.
+### Misc Elixir command
 
-## Docker
+#### Translations
+
+To extract all translations from the source, you can run `mix gettext.extract --merge` (and then edit the modified .po files).
+
+#### DB migrations
+
+To generate a new migration file:
+`cd apps/db && mix ecto.gen.migration <name of the migration> && cd ..`
+
+The generated [ecto](https://hexdocs.pm/ecto/Ecto.html) migration file will be `apps/db/priv/repo/migrations/<timestamp>_<name of the migration>.exs`
+
+To apply all migrations on you database:
+`mix ecto.migrate`
+
+
+## Docker installation <a name="docker_install"></a>
+
+### Development
+
+If you don't plan to work a lot on this project, the docker installation is way easier.
+
+You need a .env file with the same variables that you have in .envrc.example (but you'll need to remove `export` at the beginning of each line.
+(No need to setup the variable `PG_URL`, it is defined in the docker-compose.yml)
+
+Then you only need to run:
+  `docker-compose up`
+
+And access it at http://localhost:5000
+
+You can do code changes in the repository, those changes will be applied with hot reload.
+
+You can run any `mix` command with:
+
+`docker-compose run -e MIX_ENV=test web mix test`
+
+For the tests you also need to add an environment variable:
+
+`docker-compose run -e MIX_ENV=test web mix test`
 
 ### Production
 
@@ -33,31 +116,3 @@ Now you can visit [`127.0.0.1:5000`](http://127.0.0.1:5000) from your browser.
   https://github.com/etalab/transport-ops
 
   Update it if needed (e.g. updating Elixir’s version) and then update `.circleci/config.yml`.
-
-### Development
-
-  You can use docker-compose to develop on this project
-  You need a .env file with the same variables that you have in .envrc.example (but you'll need to remove `export` at the beginning of each line.
-  In this file as PG_URL use `PG_URL=ecto://postgres:example@database/transport_repo`
-
-  To install elixir dependencies run these commands:
-
-  - `docker-compose run web mix deps.get`
-  - `docker-compose run web mix deps.compile`
-
-  Install yarn:
-  `docker-compose run web mix yarn install`
-
-  If you have access to a database file you can run this command to restore the database:
-  `docker-compose run web ./restore_db.sh name_of_the_file`
-  _the file needs to be in this directory_
-
-  If you don't have access to such file run
-  - `docker-compose run web mix ecto.create`
-  - `docker-compose run web mix ecto.migrate`
-
-  You can now start the application with:
-  `docker-compose up`
-
-  And access it at http://localhost:5000
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   database:
-    image: transport_db
+    image: antoinede/transport_data_gouv_dev_database
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: "3"
 services:
   database:
-    image: mdillon/postgis:11-alpine
+    image: transport_db
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_DB: transport_repo
+      POSTGRES_PASSWORD: postgres # obviously do not use this in production
   web:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: mix phx.server
     ports:
       - 5000:5000
     volumes:
@@ -19,6 +19,9 @@ services:
       - ./apps:/app/apps/
     env_file:
         - .env
+    environment:
+        PG_URL: ecto://postgres:postgres@database/transport_repo
+        PG_URL_TEST: ecto://postgres:postgres@database/transport_test
     depends_on:
         - database
 volumes:

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,0 +1,12 @@
+FROM mdillon/postgis:11-alpine
+
+# PATH to the clever cloud backup file
+ARG BACKUP_PATH
+
+ENV POSTGRES_DB transport_repo
+
+COPY restore_db.sh /docker-entrypoint-initdb.d/
+COPY create_test_db.sh /docker-entrypoint-initdb.d/
+COPY ${BACKUP_PATH} /db_backup
+
+

--- a/docker/database/create_test_db.sh
+++ b/docker/database/create_test_db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# create test database
+createdb transport_test

--- a/docker/database/readme.md
+++ b/docker/database/readme.md
@@ -1,0 +1,15 @@
+# Script to build a database docker image
+
+To build the image run:
+
+`docker build -t transport_data_gouv_dev_database --build-arg BACKUP_PATH=<path_to_the_backup_file> .`
+
+Note: backup file needs to be in the directory.
+
+If you want to push it to dockerhub (change the destination image name if needed):
+
+`docker login`
+
+`docker tag transport_data_gouv_dev_database antoinede/transport_data_gouv_dev_database:latest`
+
+`docker push antoinede/transport_data_gouv_dev_database:latest`

--- a/docker/database/restore_db.sh
+++ b/docker/database/restore_db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+DB_NAME="transport_repo"
+BACKUP_PATH="/db_backup"
+
+# the pg_restore fail for some obscure reasons, but the import seems to be ok
+pg_restore --dbname=$DB_NAME --format=c --no-owner --clean $BACKUP_PATH || true
+
+# add a check
+nb_datasets=`psql -qtAX $DB_NAME -c "select count(*) from dataset;"`
+
+if [[ $nb_datasets -eq 0 ]]; then
+    echo "no datasets loaded, something is strange"
+    exit 1
+fi

--- a/docker_phoenix_startup.sh
+++ b/docker_phoenix_startup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# wait for postgresql to be up
+/opt/bin/wait-for-it.sh database:5432 --timeout=1000
+
+# settings up the dependencies
+mix deps.get
+mix deps.compile
+mix yarn install
+
+# migrating the database schema
+mix ecto.migrate
+
+# starting up the server, you can visit localhost:5000/
+mix phx.server


### PR DESCRIPTION
Change a bit the readme to ease the on boarding.

* more explicit installation guidelines
* cleanup mock .envrc file and add some comments
* list the main mix commands
* easier docker-compose workflow

I pushed an image with a builtin transport.data.gouv database on [dockerhub](https://hub.docker.com/r/antoinede/transport_data_gouv_dev_database). All the scripts needed to do this have been pushed to `docker/database`. For the moment it's on my account, but I can change this if needed.

Open question:
Can we put the url of the production validator in the example configuration file ? I don't think it's harmful to do so.