### PR TITLE
Fix OpenAPI spec

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/aom_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/aom_controller.ex
@@ -43,9 +43,9 @@ defmodule TransportWeb.API.AomController do
       tags: ["insee"],
       summary: "Show AOM by INSEE",
       description: "Show covered regions",
-      operationId: "API.AOMController.by_coordinates",
+      operationId: "API.AOMController.by_insee_operation",
       parameters: [
-        Operation.parameter(:insee, :query, :string, "INSEE")
+        Operation.parameter(:insee, :path, :string, "INSEE")
       ],
       responses: %{
         200 => Operation.response("AOM", "application/json", AOMResponse)
@@ -99,7 +99,7 @@ defmodule TransportWeb.API.AomController do
       tags: ["geojson"],
       summary: "Show geojson of AOM",
       description: "Show covered regions",
-      operationId: "API.AOMController.by_coordinates",
+      operationId: "API.AOMController.geojson_operation",
       parameters: [],
       responses: %{
         200 => Operation.response("GeoJSON", "application/json", GeoJSONResponse)

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -39,8 +39,8 @@ defmodule TransportWeb.API.DatasetController do
       tags: ["datasets"],
       summary: "Show given dataset and its resources",
       description: "For one dataset, show its associated resources, url and validity date",
-      operationId: "API.DatasetController.datasets",
-      parameters: [Operation.parameter(:id, :query, :string, "id")],
+      operationId: "API.DatasetController.datasets_by_id",
+      parameters: [Operation.parameter(:id, :path, :string, "id")],
       responses: %{
         200 => Operation.response("Dataset", "application/json", DatasetsResponse)
       }

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -29,6 +29,7 @@ defmodule TransportWeb.API.Schemas do
     require OpenApiSpex
 
     OpenApiSpex.schema(%{
+      title: "NumberItems",
       type: :number
     })
   end


### PR DESCRIPTION
There were several problems with our openapi endpoint (duplicate names,
invalid parameter definition, and empty name).

Strangely swagger ui had no problem with those, but some other
integration were broken.