### PR TITLE
fix 404 as 500

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -13,7 +13,7 @@ defmodule TransportWeb.ResourceController do
     |> Repo.preload([:dataset, :validation])
     |> case do
       nil ->
-        render(conn, "404.html")
+        conn |> put_view(ErrorView) |> render("404.html")
 
       resource ->
         issues = resource.validation |> Validation.get_issues(params) |> Scrivener.paginate(config)


### PR DESCRIPTION
When a resource was not found
(http://https://transport.data.gouv.fr/resources/<id>) instead of a 404
we were getting a 500.

This error was flooding the logs.