### PR TITLE
Epci

### DIFF
--- a/apps/db/lib/db/epci.ex
+++ b/apps/db/lib/db/epci.ex
@@ -1,0 +1,19 @@
+defmodule DB.EPCI do
+  @moduledoc """
+  EPCI schema
+
+  Link the EPCI to some Communes.
+  The EPCI are loaded once and for all by the task transport/lib/transport/import_epci.ex
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  typed_schema "epci" do
+    field(:code, :string)
+    field(:nom, :string)
+
+    # for the moment we don't need a link relational link to the Commune table,
+    # so we only store an array of insee code
+    field(:communes_insee, {:array, :string}, default: [])
+  end
+end

--- a/apps/db/priv/repo/migrations/20200130152852_epci.exs
+++ b/apps/db/priv/repo/migrations/20200130152852_epci.exs
@@ -1,0 +1,12 @@
+defmodule DB.Repo.Migrations.Epci do
+  use Ecto.Migration
+
+  def change do
+    create table(:epci) do
+      add :code, :string
+      add :nom, :string
+      add :communes_insee, {:array, :string}
+    end
+
+  end
+end

--- a/apps/transport/lib/mix/tasks/transport/import_epci.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_epci.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Transport.ImportEPCI do
+  @moduledoc """
+  Import the EPCI file to get the relation between the cities and the EPCI
+  """
+
+  use Mix.Task
+  alias Ecto.Changeset
+  alias DB.{EPCI, Repo}
+
+  @epci_file "https://unpkg.com/@etalab/decoupage-administratif@0.7.0/data/epci.json"
+
+  def run(params) do
+    if params[:no_start] do
+      HTTPoison.start()
+    else
+      Mix.Task.run("app.start", [])
+    end
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(@epci_file),
+         {:ok, json} <- Jason.decode(body) do
+      json
+      |> Enum.each(&insert_epci/1)
+    end
+  end
+
+  defp get_or_create_epci(code) do
+    EPCI
+    |> Repo.get_by(code: code)
+    |> case do
+      nil ->
+        %EPCI{}
+
+      epci ->
+        epci
+    end
+  end
+
+  defp insert_epci(%{"code" => code, "nom" => nom, "membres" => m}) do
+    code
+    |> get_or_create_epci()
+    |> Changeset.change(%{
+      code: code,
+      nom: nom,
+      communes_insee: get_insees(m)
+    })
+    |> IO.inspect()
+    |> Repo.insert_or_update()
+  end
+
+  defp get_insees(members) do
+    members
+    |> Enum.map(fn m -> m["code"] end)
+  end
+end


### PR DESCRIPTION
Handle the EPCI while importing data.gouv's zones.

For the moment it was possible to use data.gouv's zones only if the dataset was linked to some cities.
Thus it was impossible to reference https://www.data.gouv.fr/fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt/ that was linked to an [EPCI](https://fr.wikipedia.org/wiki/%C3%89tablissement_public_de_coop%C3%A9ration_intercommunale).

This PR fixes this. When a dataset is linked to an EPCI, we fetch the cities contained by the EPCI and link the dataset to them.

This PR brings a new `Task` that import a table of EPCI and there cities. This tasks will need to be run on prod. 