### PR TITLE
Reference the SNCF and AF Apis

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/real_time.html.md
+++ b/apps/transport/lib/transport_web/templates/page/real_time.html.md
@@ -17,10 +17,11 @@ Cependant, certains réseaux de transport disposent de données temps-réel non 
 <th>Prochains passages</th>
 <th>Position véhicules</th>
 <th>Messages d’alerte</th>
+<th>Documentation générale</th>
 </tr>
 <%= for p <- @providers do %>
 <tr>
-<td><%= p["aom"] %></td>
+<td><%= p["nom"] %></td>
 <td><%= p["format"] %></td>
 <td><%= thumb(p["bulk"]) %></td>
 <td><%= thumb(p["acces_ouvert"]) %></td>
@@ -28,6 +29,7 @@ Cependant, certains réseaux de transport disposent de données temps-réel non 
 <td><%= make_link(p["prochains_passages"]) %></td>
 <td><%= make_link(p["position_vehicules"]) %></td>
 <td><%= make_link(p["alertes"]) %></td>
+<td><%= make_link(p["doc_generale"]) %></td>
 </tr>
 <% end %>
 </table>

--- a/apps/transport/lib/transport_web/templates/page/real_time.html.md
+++ b/apps/transport/lib/transport_web/templates/page/real_time.html.md
@@ -1,4 +1,4 @@
-# Données temps-réel non standardisées
+# Données temps-réel de transport en commun, non standardisées
 
 Le Point d'Accès National aux données de transport (PAN) fournit un accès **homogène** à ces données pour en faciliter l’intégration et la réutilisation.
 
@@ -35,3 +35,13 @@ Cependant, certains réseaux de transport disposent de données temps-réel non 
 </table>
 
 Vous pouvez signaler à l'équipe du PAN un jeu de données à ajouter ci-dessus en écrivant à contact@transport.beta.gouv.fr.
+
+# Autre données temps-réel
+
+## Velo en libre service
+
+Plusieurs jeux de données de données temps-réel de vélo en libre service sont [disponibles sur la plateforme](https://transport.data.gouv.fr//datasets?type=bike-sharing). Ces données sont standardisées en [BGFS](https://github.com/NABSA/gbfs/blob/master/gbfs.md).
+
+## Aérien
+
+Air France propose une [API](https://developer.airfranceklm.com/) non standardisée avec des données temps-réel.

--- a/apps/transport/priv/real_time_providers.csv
+++ b/apps/transport/priv/real_time_providers.csv
@@ -1,16 +1,17 @@
-aom;aom_insee_principal;format;bulk;acces_ouvert;licence;prochains_passages;position_vehicules;alertes
-Rennes Star;35238;Spécifique;y;y;ODbL;https://data.rennesmetropole.fr/explore/dataset/prochains-passages-des-lignes-de-metro-du-reseau-star-en-temps-reel/table/;https://data.explore.star.fr/explore/dataset/tco-bus-vehicules-position-tr/;https://data.rennesmetropole.fr/explore/dataset/alertes-trafic-en-temps-reel-sur-les-lignes-du-reseau-star/information/
-Montpellier Tam;34172;Spécifique;y;y;ODbL;http://data.montpellier3m.fr/dataset/offre-de-transport-tam-en-temps-reel;;
-Nantes TAN;44109;Spécifique;n;y;ODbL;https://data.nantesmetropole.fr/explore/dataset/244400404_api-temps-reel-tan/information/;;https://data.nantesmetropole.fr/explore/dataset/244400404_info-trafic-tan-temps-reel/table/
-Strasbourg;67482;Siri-lite;y;n;Inconnue;https://api.cts-strasbourg.eu/index.html;;
-Saint-Pierre;;Spécifique;n;y;Inconnue;;;https://www.carjaune.re/fr/rss/Disruptions
-Lyon;69123;Spécifique;n;n;Associée;https://data.beta.grandlyon.com/fr/datasets/prochains-passages-temps-reel-reseau-transports-commun-lyonnais/info;;
-Lille;59350;Spécifique;n;y;LO;https://opendata.lillemetropole.fr/explore/dataset/ilevia-prochainspassages/api/;;https://opendata.lillemetropole.fr/explore/dataset/ilevia-perturbations/information/
-Angers;49007;Spécifique;n;y;ODbL;https://data.angers.fr/explore/dataset/bus-tram-circulation-passages/api/;https://data.angers.fr/explore/dataset/bus-tram-position-tr/api/;
-Toulouse;31555;Spécifique;n;n;ODbL;https://data.toulouse-metropole.fr/explore/dataset/api-temps-reel-tisseo/information/;;
-Île-de-France mobilités;75056;Siri-lite;y;n;ODbL;https://opendata.stif.info/pages/api-stif/;;
-Brest;29019;Spécifique;;n;LO;https://geo.pays-de-brest.fr/donnees/Pages/TempsReel.aspx;;https://geo.pays-de-brest.fr/donnees/Pages/TempsReel.aspx
-Nice;06088;Spécifique;n;n;LO;http://opendata.nicecotedazur.org/site/developers;;
-Besancon;25056;Spécifique;n;n;LO;https://api.ginko.voyage/#tr;;https://api.ginko.voyage/#tr
-Saint-Etienne;42218;Spécifique;y;n;Inconnue;https://data.saint-etienne-metropole.fr/;;
-Bordeaux;33063;Spécifique;y;n;LO;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_horai_a/information/;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_vehic_p/information/;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_messa_a/information/
+nom;aom_insee_principal;format;bulk;acces_ouvert;licence;doc_generale;prochains_passages;position_vehicules;alertes
+Rennes Star;35238;Spécifique;y;y;ODbL;;https://data.rennesmetropole.fr/explore/dataset/prochains-passages-des-lignes-de-metro-du-reseau-star-en-temps-reel/table/;https://data.explore.star.fr/explore/dataset/tco-bus-vehicules-position-tr/;https://data.rennesmetropole.fr/explore/dataset/alertes-trafic-en-temps-reel-sur-les-lignes-du-reseau-star/information/
+Montpellier Tam;34172;Spécifique;y;y;ODbL;;http://data.montpellier3m.fr/dataset/offre-de-transport-tam-en-temps-reel;;
+Nantes TAN;44109;Spécifique;n;y;ODbL;;https://data.nantesmetropole.fr/explore/dataset/244400404_api-temps-reel-tan/information/;;https://data.nantesmetropole.fr/explore/dataset/244400404_info-trafic-tan-temps-reel/table/
+Strasbourg;67482;Siri-lite;y;n;Inconnue;;https://api.cts-strasbourg.eu/index.html;;
+Saint-Pierre;;Spécifique;n;y;Inconnue;;;;https://www.carjaune.re/fr/rss/Disruptions
+Lyon;69123;Spécifique;n;n;Associée;;https://data.beta.grandlyon.com/fr/datasets/prochains-passages-temps-reel-reseau-transports-commun-lyonnais/info;;
+Lille;59350;Spécifique;n;y;LO;;https://opendata.lillemetropole.fr/explore/dataset/ilevia-prochainspassages/api/;;https://opendata.lillemetropole.fr/explore/dataset/ilevia-perturbations/information/
+Angers;49007;Spécifique;n;y;ODbL;;https://data.angers.fr/explore/dataset/bus-tram-circulation-passages/api/;https://data.angers.fr/explore/dataset/bus-tram-position-tr/api/;
+Toulouse;31555;Spécifique;n;n;ODbL;;https://data.toulouse-metropole.fr/explore/dataset/api-temps-reel-tisseo/information/;;
+Île-de-France mobilités;75056;Siri-lite;y;n;ODbL;;https://opendata.stif.info/pages/api-stif/;;
+Brest;29019;Spécifique;;n;LO;;https://geo.pays-de-brest.fr/donnees/Pages/TempsReel.aspx;;https://geo.pays-de-brest.fr/donnees/Pages/TempsReel.aspx
+Nice;06088;Spécifique;n;n;LO;;http://opendata.nicecotedazur.org/site/developers;;
+Besancon;25056;Spécifique;n;n;LO;;https://api.ginko.voyage/#tr;;https://api.ginko.voyage/#tr
+Saint-Etienne;42218;Spécifique;y;n;Inconnue;;https://data.saint-etienne-metropole.fr/;;
+Bordeaux;33063;Spécifique;y;n;LO;;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_horai_a/information/;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_vehic_p/information/;https://opendata.bordeaux-metropole.fr/explore/dataset/sv_messa_a/information/
+SNCF;;Spécifique;n;n;LO;https://www.digital.sncf.com/startup/api;http://doc.navitia.io/#next-departures-and-arrivals;;http://doc.navitia.io/#traffic-reports


### PR DESCRIPTION
closes #1016 

* SCNF
It's a bit difficult to reference it correctly, so I added the general page of the SCNF API.

For more concrete links I put navitia documentation since sncf does not have a specific page explaining the API nor documentation

* add a section to reference the GBFS apis and the AF apis