### PR TITLE
fix openapi for bike sharing api

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -38,6 +38,20 @@ defmodule TransportWeb.API.StatsController do
     }
   end
 
+  @spec bike_sharing_operation() :: Operation.t()
+  def bike_sharing_operation do
+    %Operation{
+      tags: ["bike-sharing"],
+      summary: "Show bike sharing stats",
+      description: "Show bike sharing stats",
+      operationId: "API.StatsController.bike_sharing",
+      parameters: [],
+      responses: %{
+        200 => Operation.response("GeoJSON", "application/json", GeoJSONResponse)
+      }
+    }
+  end
+
   def geojson(features) do
     %{
       "type" => "FeatureCollection",
@@ -203,8 +217,8 @@ defmodule TransportWeb.API.StatsController do
     })
   end
 
-  @spec bikes(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def bikes(%Plug.Conn{} = conn, _params) do
+  @spec bike_sharing(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def bike_sharing(%Plug.Conn{} = conn, _params) do
     render(conn, %{
       data:
         geojson(

--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -22,7 +22,7 @@ defmodule TransportWeb.API.Router do
     scope "/stats" do
       get("/", TransportWeb.API.StatsController, :index)
       get("/regions", TransportWeb.API.StatsController, :regions)
-      get("/bike-sharing", TransportWeb.API.StatsController, :bikes)
+      get("/bike-sharing", TransportWeb.API.StatsController, :bike_sharing)
     end
 
     get("/openapi", OpenApiSpex.Plug.RenderSpec, :show)


### PR DESCRIPTION
this was causing 500 errors on /stats/openapi due to some black [magic code generation](https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport_web/api/controllers/stats_controller.ex#L11:L11):

```

2020-02-11T10:33:01+00:00 (open_api_spex) lib/open_api_spex/path_item.ex:72: OpenApiSpex.PathItem.from_valid_routes/1
2020-02-11T10:33:01+00:00 ** (exit) an exception was raised:
2020-02-11T10:33:01+00:00 ** (UndefinedFunctionError) function https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport_web/api/controllers/stats_controller.ex#L11:L11)TransportWeb.API.StatsController.bikes_operation/0 is undefined or private 
```

