### PR TITLE
Keep button margin when active

### DIFF
--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -140,3 +140,7 @@ nav.navigation input {
     padding: .5em 0;
   }
 }
+
+.input__group .button {
+  margin-left: var(--space-s) !important;
+}


### PR DESCRIPTION
Lorsque l'on clique sur la petite loupe de la barre de recherche, sur la page de garde, le bouton perd sa marge et le champ de recherche se retrouve collé au bouton.

![image](https://user-images.githubusercontent.com/15341118/74330614-423bca00-4d92-11ea-9a03-d5251030d0d5.png)

Ce comportement vient du fichier externe '~template.data.gouv.fr/dist/main.css'
