### PR TITLE
better display of 'unloadable model' errors 

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -170,7 +170,7 @@ defmodule DB.Resource do
       "MissingLanguage" => dgettext("validations", "Missing language"),
       "InvalidLanguage" => dgettext("validations", "Invalid language"),
       "DupplicateObjectId" => dgettext("validations", "Dupplicate object id"),
-      "UnloadableModel" => dgettext("validations", "Not compliant to the GTFS specification"),
+      "UnloadableModel" => dgettext("validations", "Not compliant with the GTFS specification"),
       "MissingMandatoryFile" => dgettext("validations", "Missing mandatory file"),
       "ExtraFile" => dgettext("validations", "Extra file")
     }

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -170,7 +170,7 @@ defmodule DB.Resource do
       "MissingLanguage" => dgettext("validations", "Missing language"),
       "InvalidLanguage" => dgettext("validations", "Invalid language"),
       "DupplicateObjectId" => dgettext("validations", "Dupplicate object id"),
-      "UnloadableModel" => dgettext("validations", "Unloadable model"),
+      "UnloadableModel" => dgettext("validations", "Not compliant to the GTFS specification"),
       "MissingMandatoryFile" => dgettext("validations", "Missing mandatory file"),
       "ExtraFile" => dgettext("validations", "Extra file")
     }

--- a/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
@@ -140,5 +140,5 @@ msgid "Warnings"
 msgstr ""
 
 #, elixir-format
-msgid "Not compliant to the GTFS specification"
+msgid "Not compliant with the GTFS specification"
 msgstr ""

--- a/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
@@ -132,13 +132,13 @@ msgid "Slow"
 msgstr ""
 
 #, elixir-format
-msgid "Unloadable model"
-msgstr ""
-
-#, elixir-format
 msgid "Unused stops"
 msgstr ""
 
 #, elixir-format
 msgid "Warnings"
+msgstr ""
+
+#, elixir-format
+msgid "Not compliant to the GTFS specification"
 msgstr ""

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -132,13 +132,13 @@ msgid "Slow"
 msgstr "Vitesse entre deux arrêts très faible"
 
 #, elixir-format
-msgid "Unloadable model"
-msgstr "Impossible de charger le modèle"
-
-#, elixir-format
 msgid "Unused stops"
 msgstr "Arrêt inutilisé"
 
 #, elixir-format
 msgid "Warnings"
 msgstr "Avertissements"
+
+#, elixir-format
+msgid "Not compliant to the GTFS specification"
+msgstr "Spécifications GTFS non respectées"

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -140,5 +140,5 @@ msgid "Warnings"
 msgstr "Avertissements"
 
 #, elixir-format
-msgid "Not compliant to the GTFS specification"
+msgid "Not compliant with the GTFS specification"
 msgstr "Spécifications GTFS non respectées"

--- a/apps/db/priv/gettext/validations.pot
+++ b/apps/db/priv/gettext/validations.pot
@@ -139,5 +139,5 @@ msgid "Warnings"
 msgstr ""
 
 #, elixir-format
-msgid "Not compliant to the GTFS specification"
+msgid "Not compliant with the GTFS specification"
 msgstr ""

--- a/apps/db/priv/gettext/validations.pot
+++ b/apps/db/priv/gettext/validations.pot
@@ -131,13 +131,13 @@ msgid "Slow"
 msgstr ""
 
 #, elixir-format
-msgid "Unloadable model"
-msgstr ""
-
-#, elixir-format
 msgid "Unused stops"
 msgstr ""
 
 #, elixir-format
 msgid "Warnings"
+msgstr ""
+
+#, elixir-format
+msgid "Not compliant to the GTFS specification"
 msgstr ""

--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -52,3 +52,25 @@ nav.validation {
   padding-top: 48px;
   padding-bottom: 48px;
 }
+
+.validation-details {
+  div {
+    margin-top: 12px;
+  }
+
+  .file-table {
+    display: flex;
+    overflow: auto;
+  }
+
+  .raw-values {
+    background-color: var(--theme-background-grey);
+  }
+}
+
+.error-details {
+  margin-top: 6px;
+  display: block;
+  background-color: var(--theme-background-grey);
+  padding: 4px 0 4px 25px;
+}

--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -32,6 +32,12 @@ nav.validation {
   }
 }
 
+.validation-pane {
+  min-width: 0;
+  max-width: 1200px;
+  padding: 10px;
+}
+
 .mt-48 {
   margin-top: 48px;
 }
@@ -53,6 +59,10 @@ nav.validation {
   padding-bottom: 48px;
 }
 
+.scrolable-table {
+  overflow: auto;
+}
+
 .validation-details {
   div {
     margin-top: 12px;
@@ -60,7 +70,6 @@ nav.validation {
 
   .file-table {
     display: flex;
-    overflow: auto;
   }
 
   .raw-values {

--- a/apps/transport/lib/transport_web/templates/resource/_unloadable_model_issue.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_unloadable_model_issue.html.eex
@@ -1,0 +1,40 @@
+<p>
+  <%= dgettext("validations-explanations", "The file does not comply with the GTFS specification, the tool cannot perform all the checks.") %>
+</p>
+<%= for issue <- @issues do %>
+  <%= unless issue["related_file"] |> is_nil do %>
+    <div class="validation-details">
+      <div>
+        <%= dgettext("validations-explanations", "Error on file")%> <tt><%= issue["related_file"]["file_name"] %></tt>
+        <%= unless issue["related_file"]["line"] |> is_nil do %>
+          <%= dgettext("validations-explanations", "at line")%> <b><%= issue["related_file"]["line"]["line_number"] %></b>
+        <% end %>
+      </div>
+      <%= unless issue["related_file"]["line"] |> is_nil do %>
+        <div>
+          <div>
+            <%= dgettext("validations-explanations", "Glimpse of the file")%>
+            <table class="table file-table">
+              <tr>
+                <%= for header <- issue["related_file"]["line"]["headers"] do %>
+                  <th><%= header %></th>
+                <% end %>
+              </tr>
+              <tr>
+                <%= for value <- issue["related_file"]["line"]["values"] do %>
+                  <td><span class="raw-values"><%= value %></span></td>
+                <% end %>
+              </tr>
+            </table>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <div>
+    <%= dgettext("validations-explanations", "Error detail:")%>
+    <div class="error-details">
+      <%= issue["details"] %>
+    </div>
+  </div>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_unloadable_model_issue.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_unloadable_model_issue.html.eex
@@ -14,18 +14,20 @@
         <div>
           <div>
             <%= dgettext("validations-explanations", "Glimpse of the file")%>
-            <table class="table file-table">
-              <tr>
-                <%= for header <- issue["related_file"]["line"]["headers"] do %>
-                  <th><%= header %></th>
-                <% end %>
-              </tr>
-              <tr>
-                <%= for value <- issue["related_file"]["line"]["values"] do %>
-                  <td><span class="raw-values"><%= value %></span></td>
-                <% end %>
-              </tr>
-            </table>
+            <div class="scrolable-table">
+              <table class="table file-table">
+                <tr>
+                  <%= for header <- issue["related_file"]["line"]["headers"] do %>
+                    <th><%= header %></th>
+                  <% end %>
+                </tr>
+                <tr>
+                  <%= for value <- issue["related_file"]["line"]["values"] do %>
+                    <td><span class="raw-values"><%= value %></span></td>
+                  <% end %>
+                </tr>
+              </table>
+            </div>
           </div>
         </div>
       <% end %>

--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -1,24 +1,27 @@
 <section>
-    <div class="documentation dataset-details">
-        <nav class="side-pane validation" role="navigation">
-        <div class="pt-48"></div>
-          <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
-        </nav>
-        <div class="main-pane">
-          <h2><%= dgettext("validations", "GTFS review report")%></h2>
-          <p class="pb-48">
-            <%= dgettext("validations", "explanations") %>
-            <%= link(dgettext("validations", "permanent link to this validation"), to: current_url(@conn) )%>.
-          </p>
-
-          <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
-            path: &validation_path/4, action: :show %>
-
-          <%= if has_errors?(@validation_summary) do %>
-          <%= render template(@issues), issues: @issues || [] , conn: @conn %>
-          <% else %>
-          <h2><%= dgettext("validations", "Nice work, there are no issues!")%></h2>
-          <% end %>
+  <div class="documentation dataset-details">
+    <nav class="side-pane validation" role="navigation">
+      <div class="pt-48"></div>
+      <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
+    </nav>
+    <div class="main-pane validation-pane">
+      <h2><%= dgettext("validations", "GTFS review report")%></h2>
+      <p class="pb-48">
+        <div>
+          <%= dgettext("validations", "explanations") %>
         </div>
+        <div>
+          <%= dgettext("validations", "This report can be shared with") %>
+          <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn) )%>.
+        </div>
+      </p>
+      <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
+            path: &validation_path/4, action: :show %>
+      <%= if has_errors?(@validation_summary) do %>
+        <%= render template(@issues), issues: @issues || [] , conn: @conn %>
+      <% else %>
+        <h2><%= dgettext("validations", "Nice work, there are no issues!")%></h2>
+      <% end %>
     </div>
+  </div>
 </section>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -16,6 +16,7 @@ defmodule TransportWeb.ResourceView do
   def template(issues) do
     Map.get(
       %{
+        "UnloadableModel" => "_unloadable_model_issue.html",
         "DuplicateStops" => "_duplicate_stops_issue.html",
         "ExtraFile" => "_extra_file_issue.html",
         "MissingFile" => "_missing_file_issue.html",

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -58,3 +58,23 @@ msgstr "Existing stop that never occurs in any service"
 #, elixir-format
 msgid "CoordinatesIssue"
 msgstr "Coordinates of stops are mandatory in the GTFS specification"
+
+#, elixir-format
+msgid "Error detail:"
+msgstr ""
+
+#, elixir-format
+msgid "at line"
+msgstr ""
+
+#, elixir-format
+msgid "The file does not comply with the GTFS specification, the tool cannot perform all the checks."
+msgstr ""
+
+#, elixir-format
+msgid "Glimpse of the file"
+msgstr ""
+
+#, elixir-format
+msgid "Error on file"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -38,10 +38,13 @@ msgstr ""
 msgid "explanations"
 msgstr "This is the automated evalation of the GTFS datafile. "
 "This validation only considers the datastructure and does not give any information about completeness nor exactitude of the timetables. "
-"This report can be shared with"
 
 #, elixir-format
-msgid "permanent link to this validation"
+msgid "This report can be shared with"
+msgstr ""
+
+#, elixir-format
+msgid "this permanent link"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -41,7 +41,7 @@ msgstr "This is the automated evalation of the GTFS datafile. "
 "This report can be shared with"
 
 #, elixir-format
-msgid "this permanent link"
+msgid "permanent link to this validation"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -103,11 +103,11 @@ msgstr "Nom de route manquant"
 msgid "MissingId"
 msgstr "Identifiant manquant"
 
-msgid "MissingName"
-msgstr "Nom manquant"
-
 msgid "MissingCoordinates"
 msgstr "Coordonnées manquantes"
+
+msgid "MissingName"
+msgstr "Nom manquant"
 
 msgid "InvalidCoordinates"
 msgstr "Coordonnées manquantes"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -58,3 +58,23 @@ msgstr "Arrêt présent mais n’apparaissant dans aucune circulation"
 #, elixir-format
 msgid "CoordinatesIssue"
 msgstr "Les coordonnées des arrêts sont obligatoires dans la spécification GTFS"
+
+#, elixir-format
+msgid "Error detail:"
+msgstr "Détails de l'erreur :"
+
+#, elixir-format
+msgid "at line"
+msgstr "à la ligne"
+
+#, elixir-format
+msgid "The file does not comply with the GTFS specification, the tool cannot perform all the checks."
+msgstr "Le fichier ne respecte pas les spécifications GTFS, le validateur ne peut effectuer toutes les vérifications."
+
+#, elixir-format
+msgid "Glimpse of the file"
+msgstr "Aperçu du fichier"
+
+#, elixir-format
+msgid "Error on file"
+msgstr "Erreur sur le fichier"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -38,10 +38,14 @@ msgstr "Rapport de l’analyse de fichier GTFS"
 msgid "explanations"
 msgstr "Voici le bilan automatisé sur la qualité du fichier GTFS. "
 "Cette validation ne concerne que la structure des données et pas la complétude ni l’exactitude des horaires. "
-"Ce bilan peut être partagé via"
+
 
 #, elixir-format
-msgid "permanent link to this validation"
+msgid "This report can be shared with"
+msgstr "Ce bilan peut être partagé via"
+
+#, elixir-format
+msgid "this permanent link"
 msgstr "ce lien permanent"
 
 #, elixir-format

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -57,3 +57,23 @@ msgstr ""
 #, elixir-format
 msgid "CoordinatesIssue"
 msgstr ""
+
+#, elixir-format
+msgid "Error detail:"
+msgstr ""
+
+#, elixir-format
+msgid "at line"
+msgstr ""
+
+#, elixir-format
+msgid "The file does not comply with the GTFS specification, the tool cannot perform all the checks."
+msgstr ""
+
+#, elixir-format
+msgid "Glimpse of the file"
+msgstr ""
+
+#, elixir-format
+msgid "Error on file"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -35,11 +35,11 @@ msgid "GTFS review report"
 msgstr ""
 
 #, elixir-format
-msgid "explanations"
+msgid "This report can be shared with"
 msgstr ""
 
 #, elixir-format
-msgid "permanent link to this validation"
+msgid "this permanent link"
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
change the "unable to load model" cryptic error to "Not compliant to theGTFS specification" (not found better :/)

And add a custom page displaying the file in error if found
![image](https://user-images.githubusercontent.com/3987698/74341879-6ef6de00-4da0-11ea-82aa-201d84537cc9.png)

The error is still technical but at least the line in problem is displayed making the debug easier.

Note:
It would be better to display the field in error, but due to the fact that the csv can have different number of column than the header we use in the [gtfs structures](https://github.com/rust-transit/gtfs-structure/) project an option (`flexible`) to handle this and that makes the error not directly linked to the field. I think we can see later if we manage to implement this on [rust csv](https://github.com/BurntSushi/rust-csv/)
