### PR TITLE
Add a map for csv car sharing datasets

### DIFF
--- a/apps/transport/client/javascripts/map-csv.js
+++ b/apps/transport/client/javascripts/map-csv.js
@@ -1,0 +1,89 @@
+import L from 'leaflet'
+import Papa from 'papaparse'
+
+/**
+ * Represents a Mapbox object.
+ * @type {Object}
+ */
+const Mapbox = {
+    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    maxZoom: 18,
+    id: 'mapbox.light'
+}
+
+// possible field names in csv files
+const latLabels = ['Lat', 'Ylat']
+const lonLabels = ['Lng', 'Xlong']
+const namesLabel = ['Nom', 'nom_lieu']
+
+function getLabel (obj, labelsList) {
+    for (const label of labelsList) {
+        if (Object.keys(obj).indexOf(label) >= 0) {
+            return label
+        }
+    }
+    return undefined
+}
+
+function initilizeMap (id) {
+    const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
+    L.tileLayer(Mapbox.url, {
+        accessToken: Mapbox.accessToken,
+        attribution: Mapbox.attribution,
+        maxZoom: Mapbox.maxZoom,
+        id: Mapbox.id
+    }).addTo(map)
+
+    const fg = L.featureGroup().addTo(map)
+    return { map, fg }
+}
+
+function displayData (data, fg, { latField, lonField, nameField }) {
+    const markerOptions = {
+        fillColor: '#0066db',
+        radius: 5,
+        stroke: false,
+        fillOpacity: 0.15
+    }
+    for (const m of data) {
+        if (m[latField] && m[lonField]) {
+            L.circleMarker([m[latField], m[lonField]], markerOptions)
+                .bindPopup(m[nameField])
+                .addTo(fg)
+        }
+    }
+}
+
+function setZoomEvents (map, fg) {
+    map.on('zoomend', () => {
+        if (map.getZoom() > 12) {
+            fg.setStyle({ fillOpacity: 0.4, radius: 10 })
+        } else if (map.getZoom() > 8) {
+            fg.setStyle({ fillOpacity: 0.3, radius: 5 })
+        } else {
+            fg.setStyle({ fillOpacity: 0.15, radius: 5 })
+        }
+    })
+}
+
+function createMap (id, resourceUrl) {
+    Papa.parse(resourceUrl, {
+        download: true,
+        header: true,
+        complete: function (data) {
+            const latField = getLabel(data.data[0], latLabels)
+            const lonField = getLabel(data.data[0], lonLabels)
+            const nameField = getLabel(data.data[0], namesLabel)
+            if (latField && lonField && nameField) {
+                const { map, fg } = initilizeMap(id)
+                displayData(data.data, fg, { latField, lonField, nameField })
+                map.fitBounds(fg.getBounds())
+                setZoomEvents(map, fg)
+            }
+        }
+    })
+}
+
+window.createMap = createMap

--- a/apps/transport/client/package.json
+++ b/apps/transport/client/package.json
@@ -25,6 +25,7 @@
     "imports-loader": "^0.8.0",
     "leaflet": "^1.4.0",
     "node-sass": "^4.12.0",
+    "papaparse": "^5.1.1",
     "phoenix": "file:../../../deps/phoenix",
     "phoenix_html": "file:../../../deps/phoenix_html",
     "phoenix_live_view": "file:../../../deps/phoenix_live_view",

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -257,3 +257,11 @@
 .pt-48 {
   padding-top: 48px;
 }
+
+.mapcsv {
+  width: 50%;
+  height: 400px;
+  margin: 0 auto;
+  margin-top: 48px;
+  margin-bottom: 12px;
+}

--- a/apps/transport/client/webpack.config.js
+++ b/apps/transport/client/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     entry: {
         app: './javascripts/app.js',
         map: './javascripts/map.js',
+        mapcsv: './javascripts/map-csv.js',
         utils: './javascripts/utils.js',
         scss: './stylesheets/app.scss'
     },

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -30,7 +30,7 @@
     <%= if @dataset.type == "carsharing-areas" and other_resources(@dataset) != [] and List.first(other_resources(@dataset)).format == "csv" do %>
       <div class="container">
         <div id='map' class='mapcsv'></div>
-        <div class="is-centered"><%= dgettext("page-dataset-details", "Visualisation of the most recent resource")%> <%= List.first(other_resources(@dataset)).title %>.</div>
+        <div class="is-centered"><%= dgettext("page-dataset-details", "Visualization of the most recent resource")%> <%= List.first(other_resources(@dataset)).title %>.</div>
       </div>
       <script src="<%= static_path(@conn, "/js/mapcsv.js") %>"></script>
       <script>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -27,6 +27,19 @@
         <%= description(@dataset) %>
       </div>
     </div>
+    <%= if @dataset.type == "carsharing-areas" and other_resources(@dataset) != [] and List.first(other_resources(@dataset)).format == "csv" do %>
+      <div class="container">
+        <div id='map' class='mapcsv'></div>
+        <div class="is-centered"><%= dgettext("page-dataset-details", "Visualisation of the most recent resource")%> <%= List.first(other_resources(@dataset)).title %>.</div>
+      </div>
+      <script src="<%= static_path(@conn, "/js/mapcsv.js") %>"></script>
+      <script>
+        document.addEventListener("DOMContentLoaded", function() {
+          createMap('map', "<%= List.first(other_resources(@dataset)).url %>")
+        })
+      </script>
+    <% end %>
+
   </section>
   <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_resources(@dataset), title: dgettext("page-dataset-details", "GTFS resources") %>
   <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gbfs_resources(@dataset), title: dgettext("page-dataset-details", "GBFS resources") %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -289,3 +289,7 @@ msgstr ""
 #, elixir-format
 msgid "compatible with"
 msgstr ""
+
+#, elixir-format
+msgid "Visualization of the most recent resource"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -289,3 +289,7 @@ msgstr "Récupérer des détails sur ce jeu de données via un %{start_link}appe
 #, elixir-format
 msgid "compatible with"
 msgstr "compatible avec"
+
+#, elixir-format
+msgid "Visualization of the most recent resource"
+msgstr "Visualisation de la ressource la plus récente"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -289,3 +289,7 @@ msgstr ""
 #, elixir-format
 msgid "compatible with"
 msgstr ""
+
+#, elixir-format
+msgid "Visualization of the most recent resource"
+msgstr ""


### PR DESCRIPTION
closes #1047 

Ajout d'une carte qui permet de visualiser le contenu de la ressource la plus récente d'un dataset de covoiturage, si c'est un fichier csv. La carte est sur la page du dataset.

![image](https://user-images.githubusercontent.com/15341118/74449357-bfdc0480-4e7c-11ea-88dc-896bc41a3397.png)
