### PR TITLE
always put a pagination link

### DIFF
--- a/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
+++ b/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
@@ -25,8 +25,6 @@ defmodule TransportWeb.PaginationHelpers do
     end
   end
 
-  def pagination_links(_, %{total_pages: 1}, _), do: ""
-
   def pagination_links(conn, paginator, opts) do
     opts
     |> remove_empty_q
@@ -35,8 +33,6 @@ defmodule TransportWeb.PaginationHelpers do
       opts -> HTML.pagination_links(conn, paginator, opts)
     end
   end
-
-  def pagination_links(_, %{total_pages: 1}, _, _), do: ""
 
   def pagination_links(conn, paginator, args, opts) do
     opts


### PR DESCRIPTION
The AOM page is a bit broken for the moment:

https://transport.data.gouv.fr/datasets/aom/194
![image](https://user-images.githubusercontent.com/3987698/74536439-f9217c80-4f2f-11ea-82b1-6301b59c69a0.png)


It seems it is due to a pagination link missing.

For other page we put a pagination link even for one page (and I feel it's the right thing to do).
So for the dataset page we now always put a pagination link:

![image](https://user-images.githubusercontent.com/3987698/74536512-2706c100-4f30-11ea-8f48-12eac24fd860.png)

I not sure about this though (and I hope I did not break any other part of the website with this change :roll_eyes: 