### PR TITLE
Affiche un message d'information quand il n'y a pas de données

### DIFF
--- a/apps/transport/client/stylesheets/components/_search.scss
+++ b/apps/transport/client/stylesheets/components/_search.scss
@@ -1,0 +1,9 @@
+.search-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  h2 {
+    margin: 0;
+  }
+}

--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -2,10 +2,6 @@
   display: flex;
 }
 
-.shortlist__title {
-  float:left;
-}
-
 .shortlist__pagination {
   margin: 1em 0;
   display: flex;
@@ -179,10 +175,6 @@
 @include tablet {
   .shortlist {
     flex-direction: column;
-  }
-
-  .shortlist__title {
-    float: none;
   }
 
   .shortlist__pagination {

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -202,5 +202,50 @@ defmodule TransportWeb.DatasetController do
     assign(conn, :special_message, raw(message))
   end
 
+  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+         "aom" => id
+       }) do
+    name =
+      case Repo.get(AOM, id) do
+        nil -> id
+        a -> a.nom
+      end
+
+    message = dgettext("page-shortlist", "AOM %{name} has not yet published any datasets", name: name)
+
+    conn
+    |> assign(:special_message, raw(message))
+  end
+
+  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+         "region" => id
+       }) do
+    name =
+      case Repo.get(Region, id) do
+        nil -> id
+        a -> a.nom
+      end
+
+    message = dgettext("page-shortlist", "There is no data for region %{name}", name: name)
+
+    conn
+    |> assign(:special_message, raw(message))
+  end
+
+  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+         "insee_commune" => insee
+       }) do
+    name =
+      case Repo.get_by(Commune, insee: insee) do
+        nil -> insee
+        a -> a.nom
+      end
+
+    message = dgettext("page-shortlist", "There is no data for city %{name}", name: name)
+
+    conn
+    |> assign(:special_message, raw(message))
+  end
+
   defp put_special_message(conn, _params), do: conn
 end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -18,6 +18,7 @@ defmodule TransportWeb.DatasetController do
     |> assign(:order_by, params["order_by"])
     |> assign(:q, Map.get(params, "q"))
     |> put_special_message(params)
+    |> put_empty_message(params)
     |> render("index.html")
   end
 
@@ -202,7 +203,9 @@ defmodule TransportWeb.DatasetController do
     assign(conn, :special_message, raw(message))
   end
 
-  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+  defp put_special_message(conn, _params), do: conn
+
+  defp put_empty_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
          "aom" => id
        }) do
     name =
@@ -214,10 +217,10 @@ defmodule TransportWeb.DatasetController do
     message = dgettext("page-shortlist", "AOM %{name} has not yet published any datasets", name: name)
 
     conn
-    |> assign(:special_message, raw(message))
+    |> assign(:empty_message, raw(message))
   end
 
-  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+  defp put_empty_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
          "region" => id
        }) do
     name =
@@ -229,10 +232,10 @@ defmodule TransportWeb.DatasetController do
     message = dgettext("page-shortlist", "There is no data for region %{name}", name: name)
 
     conn
-    |> assign(:special_message, raw(message))
+    |> assign(:empty_message, raw(message))
   end
 
-  defp put_special_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
+  defp put_empty_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, %{
          "insee_commune" => insee
        }) do
     name =
@@ -244,8 +247,15 @@ defmodule TransportWeb.DatasetController do
     message = dgettext("page-shortlist", "There is no data for city %{name}", name: name)
 
     conn
-    |> assign(:special_message, raw(message))
+    |> assign(:empty_message, raw(message))
   end
 
-  defp put_special_message(conn, _params), do: conn
+  defp put_empty_message(%Plug.Conn{:assigns => %{:datasets => %{:entries => []}}} = conn, _params) do
+    message = dgettext("page-shortlist", "No dataset found")
+
+    conn
+    |> assign(:empty_message, raw(message))
+  end
+
+  defp put_empty_message(conn, _params), do: conn
 end

--- a/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
+++ b/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
@@ -16,6 +16,8 @@ defmodule TransportWeb.PaginationHelpers do
 
   def make_pagination_config(_), do: %Scrivener.Config{page_number: 1, page_size: 10}
 
+  def pagination_links(_, %{total_pages: 1}), do: ""
+
   def pagination_links(conn, paginator) do
     conn.params
     |> remove_empty_q()

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -18,8 +18,8 @@
   </div>
 <% end %>
 <section class="section section-grey datasets">
-  <div class="container">
-    <h2 class="shortlist__title"><%= dgettext("page-shortlist", "Search results") %></h2>
+  <div class="container search-title">
+    <h2><%= dgettext("page-shortlist", "Search results") %></h2>
     <div class="shortlist__pagination">
       <%= pagination_links @conn, @datasets %>
     </div>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -25,69 +25,73 @@
     </div>
   </div>
   <div class="container">
-    <%= if Enum.empty? @datasets do %>
-      <%= dgettext("page-shortlist", "No dataset found") %>
-    <% else %>
-      <div class="shortlist">
-        <nav class="side-pane" role="navigation">
-          <ul class="side-pane__menu">
+    <div class="shortlist">
+      <nav class="side-pane" role="navigation">
+        <ul class="side-pane__menu">
+          <li class="side-pane__title">
+            <h3><%= dgettext("page-shortlist", "Order by") %></h3>
+            <li class="side-pane__dropdown unfolded">
+              <ul class="side-pane__submenu">
+                <li><%= order_link(@conn, "alpha") %></li>
+                <li><%= order_link(@conn, "most_recent") %> </li>
+              </ul>
+            </li>
             <li class="side-pane__title">
-              <h3><%= dgettext("page-shortlist", "Order by") %></h3>
-              <li class="side-pane__dropdown unfolded">
-                <ul class="side-pane__submenu">
-                  <li><%= order_link(@conn, "alpha") %></li>
-                  <li><%= order_link(@conn, "most_recent") %> </li>
-                </ul>
-              </li>
-              <li class="side-pane__title">
-                <h3><%= dgettext("page-shortlist", "Filters") %></h3>
-              </li>
-              <li class="side-pane__dropdown unfolded">
-                <h4><%= dgettext("page-shortlist", "Area type") %></h4>
-                <ul class="side-pane__submenu">
-                  <li><%= area_type_link(@conn, "urban_public_transport") %></li>
-                  <li><%= area_type_link(@conn, "intercities_public_transport") %></li>
-                </ul>
-              </li>
-              <li class="side-pane__dropdown unfolded">
-                <h4><%= dgettext("page-shortlist", "Regions") %></h4>
-                <ul class="side-pane__submenu">
-                  <%= for region <- @regions do %>
-                    <li><%= region_link(@conn, region) %></li>
-                  <% end%>
-                  <%= if display_all_regions_links?(@conn) do %>
-                    <li><%= link(
+              <h3><%= dgettext("page-shortlist", "Filters") %></h3>
+            </li>
+            <li class="side-pane__dropdown unfolded">
+              <h4><%= dgettext("page-shortlist", "Area type") %></h4>
+              <ul class="side-pane__submenu">
+                <li><%= area_type_link(@conn, "urban_public_transport") %></li>
+                <li><%= area_type_link(@conn, "intercities_public_transport") %></li>
+              </ul>
+            </li>
+            <li class="side-pane__dropdown unfolded">
+              <h4><%= dgettext("page-shortlist", "Regions") %></h4>
+              <ul class="side-pane__submenu">
+                <%= for region <- @regions do %>
+                  <li><%= region_link(@conn, region) %></li>
+                <% end%>
+                <%= if display_all_regions_links?(@conn) do %>
+                  <li><%= link(
                     dgettext("page-shortlist", "All regions"),
                     to: dataset_path(@conn, :index)
                   )
                   %></li>
-                  <% end %>
-                </ul>
-              </li>
-              <li class="side-pane__dropdown unfolded">
-                <h4><%= dgettext("page-shortlist", "Data types") %></h4>
-                <ul class="side-pane__submenu">
-                  <%= for type <- @types do %>
-                    <li><%= type_link(@conn, type) %></li>
-                  <% end %>
-                  <%= if display_all_types_links?(@conn) do %>
-                    <li><%= link(
+                <% end %>
+              </ul>
+            </li>
+            <li class="side-pane__dropdown unfolded">
+              <h4><%= dgettext("page-shortlist", "Data types") %></h4>
+              <ul class="side-pane__submenu">
+                <%= for type <- @types do %>
+                  <li><%= type_link(@conn, type) %></li>
+                <% end %>
+                <%= if display_all_types_links?(@conn) do %>
+                  <li><%= link(
                   dgettext("page-shortlist", "All types"),
                   to: dataset_path(@conn, :index)
                   )
                 %></li>
-                  <% else %>
-                    <li><%= link(
+                <% else %>
+                  <li><%= link(
                     dgettext("page-shortlist", "Realtime timetables"),
                     to: dataset_path(@conn, :index, filter: "has_realtime")
                   )
                   %></li>
-                  <% end %>
-                </ul>
-              </li>
-            </ul>
-          </nav>
-          <div class="main-pane transparent">
+                <% end %>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+        <div class="main-pane transparent">
+          <%= if @conn.assigns[:empty_message] do %>
+            <div class="container">
+              <div class="notification">
+                <%= @empty_message %>
+              </div>
+            </div>
+          <% else %>
             <%= for dataset <- @datasets do %>
               <div class="panel dataset__panel">
                 <div class="panel__content">
@@ -131,12 +135,12 @@
                 </div>
               </div>
             <% end %>
-          </div>
+          <% end %>
         </div>
-        <div class="shortlist__pagination">
-          <%= pagination_links @conn, @datasets %>
-        </div>
-      <% end %>
+      </div>
+      <div class="shortlist__pagination">
+        <%= pagination_links @conn, @datasets %>
+      </div>
       <div>
         <i class="fas fa-cogs"></i>
         <%= link(

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/errors.po
@@ -24,10 +24,10 @@ msgstr ""
 msgid "Impossible to find a city with the insee code %{insee}"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "AOM %{id} does not exist"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "Region %{id} does not exist"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -236,3 +236,15 @@ msgstr "Jeux de données disponibles"
 #, elixir-format
 msgid "Realtime timetables"
 msgstr ""
+
+#, elixir-format
+msgid "AOM %{name} has not yet published any datasets"
+msgstr ""
+
+#, elixir-format
+msgid "There is no data for city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "There is no data for region %{name}"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -35,11 +35,6 @@ msgid "GTFS review report"
 msgstr ""
 
 #, elixir-format
-msgid "explanations"
-msgstr "This is the automated evalation of the GTFS datafile. "
-"This validation only considers the datastructure and does not give any information about completeness nor exactitude of the timetables. "
-
-#, elixir-format
 msgid "This report can be shared with"
 msgstr ""
 
@@ -94,3 +89,8 @@ msgstr ""
 #, elixir-format
 msgid "to"
 msgstr ""
+
+#, elixir-format
+msgid "explanations"
+msgstr "This is the automated evalation of the GTFS datafile. "
+"This validation only considers the datastructure and does not give any information about completeness nor exactitude of the timetables. "

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/errors.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/errors.po
@@ -20,7 +20,6 @@ msgstr "Essayez de recharger la page ou contactez-nous."
 msgid "404: Page not available"
 msgstr "404: Page non disponible"
 
-
 #, elixir-format
 msgid "Impossible to find a city with the insee code %{insee}"
 msgstr "Impossible de trouver la commune avec le code insee %{insee}"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -236,3 +236,15 @@ msgstr "Jeux de données disponibles"
 #, elixir-format
 msgid "Realtime timetables"
 msgstr "Horaires en temps réel de transport publics"
+
+#, elixir-format
+msgid "AOM %{name} has not yet published any datasets"
+msgstr "L'AOM %{name} n'a pas encore publié de données"
+
+#, elixir-format
+msgid "There is no data for city %{name}"
+msgstr "Il n'y a pas de données disponibles pour la ville %{name}"
+
+#, elixir-format
+msgid "There is no data for region %{name}"
+msgstr "Il n'y a pas de données disponibles pour la région %{name}"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -35,12 +35,6 @@ msgid "GTFS review report"
 msgstr "Rapport de l’analyse de fichier GTFS"
 
 #, elixir-format
-msgid "explanations"
-msgstr "Voici le bilan automatisé sur la qualité du fichier GTFS. "
-"Cette validation ne concerne que la structure des données et pas la complétude ni l’exactitude des horaires. "
-
-
-#, elixir-format
 msgid "This report can be shared with"
 msgstr "Ce bilan peut être partagé via"
 
@@ -95,3 +89,8 @@ msgstr "nombre de stops (stop points)"
 #, elixir-format
 msgid "to"
 msgstr "au"
+
+#, elixir-format
+msgid "explanations"
+msgstr "Voici le bilan automatisé sur la qualité du fichier GTFS. "
+"Cette validation ne concerne que la structure des données et pas la complétude ni l’exactitude des horaires. "

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -236,3 +236,15 @@ msgstr ""
 #, elixir-format
 msgid "Realtime timetables"
 msgstr ""
+
+#, elixir-format
+msgid "AOM %{name} has not yet published any datasets"
+msgstr ""
+
+#, elixir-format
+msgid "There is no data for city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "There is no data for region %{name}"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -89,3 +89,7 @@ msgstr ""
 #, elixir-format
 msgid "to"
 msgstr ""
+
+#, elixir-format
+msgid "explanations"
+msgstr ""


### PR DESCRIPTION
closes #1027 

Affiche un message quand il n'y a pas de données pour une AO / région / commune (mais dans les faits ca n'arrivera que pour une AO)

![image](https://user-images.githubusercontent.com/3987698/74672775-def0d400-51a5-11ea-8343-5ac64e6bf862.png)


fixe aussi la page de recherche quand il n'y a pas de données, on affiche maintenant tout le temps la barre latéral

avant: 
![image](https://user-images.githubusercontent.com/3987698/74673028-5aeb1c00-51a6-11ea-82ea-7af52c9848fe.png)

aprés:
![image](https://user-images.githubusercontent.com/3987698/74673062-6b9b9200-51a6-11ea-90c2-018fc713ecec.png)
