### PR TITLE
Filter unloadable datasets in backoffice

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -44,6 +44,18 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render_index(conn, params)
   end
 
+  def index(%Plug.Conn{} = conn, %{"filter" => "not_compliant"} = params) do
+    resources =
+      Resource
+      |> where([r], fragment("metadata->'issues_count'->>'UnloadableModel' IS NOT NULL"))
+      |> distinct([r], r.dataset_id)
+      |> select([r], %Resource{dataset_id: r.dataset_id})
+
+    Dataset
+    |> join(:inner, [d], r in subquery(resources), on: d.id == r.dataset_id)
+    |> render_index(conn, params)
+  end
+
   def index(%Plug.Conn{} = conn, %{"dataset_id" => dataset_id} = params) do
     conn =
       Dataset

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
@@ -1,33 +1,38 @@
-    <tr>
-    <td><%= link(@dataset.spatial,
-            to: dataset_path(@conn, :details, @dataset.slug),
-            role: "link") %></td>
-      <td>
-        <%= end_date(@dataset) %>
-      </td>
-      <td>
-          <i class="icon icon--link" aria-hidden="true"></i>
-          <%= Dataset.link_to_datagouv(@dataset) %>
-      </td>
-      <td>
-        <%= form_for @conn, backoffice_dataset_path(@conn, :import_from_data_gouv_fr, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
-          <%= submit "Importer", [class: "button", nodiv: true] %>
-        <% end %>
-      </td>
-      <td>
-        <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView, session: %{dataset_id: @dataset.id, locale: get_session(@conn, :locale)}) %>
-      </td>
-      <td>
-        <%= form_for @conn, backoffice_page_path(@conn, :index), [nodiv: true, method: "get"], fn f -> %>
-          <%= hidden_input f, :dataset_id, [value: @dataset.id] %>
-          <%= submit "Editer", [class: "button", nodiv: true] %>
-        <% end %>
-      </td>
-      <td>
-        <%= form_for @conn, backoffice_dataset_path(@conn, :delete, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
-          <%= submit "Supprimer", [class: "button", nodiv: true] %>
-        <% end %>
-      </td>
-      <td><%= if @dataset.region do @dataset.region.nom else "" end %></td>
-      <td><%= if @dataset.aom do @dataset.aom.insee_commune_principale else "" end %></td>
-    </tr>
+<tr>
+  <td>
+    <%= if @dataset.spatial != "" do %>
+      <%= link(@dataset.spatial, to: dataset_path(@conn, :details, @dataset.slug), role: "link") %>
+    <% else %>
+      <%= link(@dataset.title, to: dataset_path(@conn, :details, @dataset.slug), role: "link") %>
+    <% end %>
+  </td>
+  <td>
+    <%= end_date(@dataset) %>
+  </td>
+  <td>
+    <i class="icon icon--link" aria-hidden="true"></i>
+    <%= Dataset.link_to_datagouv(@dataset) %>
+  </td>
+  <td>
+    <%= form_for @conn, backoffice_dataset_path(@conn, :import_from_data_gouv_fr, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
+      <%= submit "Importer", [class: "button", nodiv: true] %>
+    <% end %>
+  </td>
+  <td>
+    <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView, session: %{dataset_id: @dataset.id, locale: get_session(@conn, :locale)}) %>
+  </td>
+  <td>
+    <%= form_for @conn, backoffice_page_path(@conn, :index), [nodiv: true, method: "get"], fn f -> %>
+    <%= hidden_input f, :dataset_id, [value: @dataset.id] %>
+    <%= submit "Editer", [class: "button", nodiv: true] %>
+  <% end %>
+  </td>
+  <td>
+    <%= form_for @conn, backoffice_dataset_path(@conn, :delete, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
+    <%= submit "Supprimer", [class: "button", nodiv: true] %>
+  <% end %>
+  </td>
+  <td><%= if @dataset.region do @dataset.region.nom else "" end %></td>
+  <td><%= if @dataset.aom do @dataset.aom.insee_commune_principale else "" end %></td>
+</tr>
+

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -13,7 +13,7 @@
 <%= pagination_links @conn, @datasets %>
 <table class="backoffice-datasets">
   <tr>
-    <th>Territoire</th>
+    <th>Dataset</th>
     <th>Fin de validité</th>
     <th></th>
     <th></th>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -1,6 +1,9 @@
 <section class="dataset-container">
   <%= render("_form_dataset.html", conn: @conn, regions: @regions, dataset_types: @dataset_types, dataset: @conn.assigns[:dataset]) %>
-  <h1><%= dgettext("backoffice", "Valid datasets available") %></h1>
+  <h1>
+    <a name="list_datasets" href="#list_datasets" class="anchor"></a>
+    <%= dgettext("backoffice", "Valid datasets available") %>
+  </h1>
   <%= form_for @conn, backoffice_page_path(@conn, :index), [method: "get"], fn f -> %>
   <%= search_input f, :q, [value: assigns[:q] || "", placeholder: dgettext("page-index", "Find dataset")] %>
 <% end %>
@@ -25,17 +28,17 @@
 <%= pagination_links @conn, @datasets %>
 <br>
 <%= if is_nil(@conn.params["filter"]) or @conn.params["filter"] == "" do %>
-  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "outdated"}) %>">
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "outdated"}) %>#list_datasets">
     <%= dgettext("backoffice", "Show outdated datasets only") %>
   </a>
-  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "other_resources"}) %>">
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "other_resources"}) %>#list_datasets">
     <%= dgettext("backoffice", "Show datasets with unidentified resources") %>
   </a>
-  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "not_compliant"}) %>">
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "not_compliant"}) %>#list_datasets">
     <%= dgettext("backoffice", "Show datasets not compliant to spec") %>
   </a>
 <% else %>
-  <a class="button" href="<%= backoffice_page_path(@conn, :index) %>">
+  <a class="button" href="<%= backoffice_page_path(@conn, :index) %>#list_datasets">
     <%= dgettext("backoffice", "Show all datasets") %>
   </a>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -1,19 +1,14 @@
 <section class="dataset-container">
   <%= render("_form_dataset.html", conn: @conn, regions: @regions, dataset_types: @dataset_types, dataset: @conn.assigns[:dataset]) %>
-
   <h1><%= dgettext("backoffice", "Valid datasets available") %></h1>
-
   <%= form_for @conn, backoffice_page_path(@conn, :index), [method: "get"], fn f -> %>
-    <%= search_input f, :q, [value: assigns[:q] || "", placeholder: dgettext("page-index", "Find dataset")] %>
-  <% end %>
-
-  <%= form_for @conn, backoffice_dataset_path(@conn, :validate_all), [method: "post"], fn _f -> %>
-    <%= submit dgettext("backoffice", "Import and validate all") %>
-  <% end %>
-
-  <%= pagination_links @conn, @datasets %>
-
-  <table class="backoffice-datasets">
+  <%= search_input f, :q, [value: assigns[:q] || "", placeholder: dgettext("page-index", "Find dataset")] %>
+<% end %>
+<%= form_for @conn, backoffice_dataset_path(@conn, :validate_all), [method: "post"], fn _f -> %>
+<%= submit dgettext("backoffice", "Import and validate all") %>
+<% end %>
+<%= pagination_links @conn, @datasets %>
+<table class="backoffice-datasets">
   <tr>
     <th>Territoire</th>
     <th>Fin de validité</th>
@@ -26,14 +21,23 @@
     <th>Commune principale</th>
   </tr>
   <%= render_many(@datasets, TransportWeb.Backoffice.PageView, "_dataset.html", as: :dataset, conn: @conn)%>
-  </table>
-  <%= pagination_links @conn, @datasets %>
-  <br>
-  <%= if is_nil(@conn.params["filter"]) or @conn.params["filter"] == "" do %>
-    <%= link(dgettext("backoffice", "Show outdated datasets only"), to: backoffice_page_path(@conn, :index, %{"filter" => "outdated"}))%>
-    <%= link(dgettext("backoffice", "Show datasets with unidentified resources"), to: backoffice_page_path(@conn, :index, %{"filter" => "other_resources"}))%>
-  <% else %>
-    <%= link(dgettext("backoffice", "Show all datasets"), to: backoffice_page_path(@conn, :index))%>
-  <% end %>
+</table>
+<%= pagination_links @conn, @datasets %>
+<br>
+<%= if is_nil(@conn.params["filter"]) or @conn.params["filter"] == "" do %>
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "outdated"}) %>">
+    <%= dgettext("backoffice", "Show outdated datasets only") %>
+  </a>
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "other_resources"}) %>">
+    <%= dgettext("backoffice", "Show datasets with unidentified resources") %>
+  </a>
+  <a class="button" href="<%= backoffice_page_path(@conn, :index, %{"filter" => "not_compliant"}) %>">
+    <%= dgettext("backoffice", "Show datasets not compliant to spec") %>
+  </a>
+<% else %>
+  <a class="button" href="<%= backoffice_page_path(@conn, :index) %>">
+    <%= dgettext("backoffice", "Show all datasets") %>
+  </a>
+<% end %>
 </section>
 <script src="js/app.js"></script>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -159,3 +159,7 @@ msgstr ""
 #, elixir-format
 msgid "Use data.gouv.fr's zones"
 msgstr ""
+
+#, elixir-format
+msgid "Show datasets not compliant to spec"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -158,3 +158,7 @@ msgstr ""
 #, elixir-format
 msgid "Use data.gouv.fr's zones"
 msgstr ""
+
+#, elixir-format
+msgid "Show datasets not compliant to spec"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -158,3 +158,7 @@ msgstr "Jeu de données national"
 #, elixir-format
 msgid "Use data.gouv.fr's zones"
 msgstr "Utiliser les zones de data.gouv.fr"
+
+#, elixir-format
+msgid "Show datasets not compliant to spec"
+msgstr "Montrer les jeux de données ne respectant pas les spec"


### PR DESCRIPTION
closes #987 

I did not send an email with the unloadable datasets, for the moment I only added a filter in the backoffice to check them.
I also changed the filters to better see that they are links.

before:
![image](https://user-images.githubusercontent.com/3987698/74728387-8f101c80-523a-11ea-85e7-d127b0dd2f57.png)

after:
![image](https://user-images.githubusercontent.com/3987698/74728361-828bc400-523a-11ea-93a9-f4094b44087a.png)

I also added an anchor the not return to the top of the page when using those filters, but to stay on the list of datasets

I also now use the dataset title when `spatial` is empty (and thus renamed the column from `territoire` to `dataset` (not found a better name)) this way we always have a link (non pt dataset might not have a spatial):
![image](https://user-images.githubusercontent.com/3987698/74730356-db109080-523d-11ea-9c57-5a03fb9c746f.png)
