### PR TITLE
Carte des aires covoiturage compatible avec les écrans mobiles

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -259,7 +259,8 @@
 }
 
 .mapcsv {
-  width: 50%;
+  width: 90%;
+  max-width: 700px;
   height: 400px;
   margin: 0 auto;
   margin-top: 48px;


### PR DESCRIPTION
Juste un petit coup de css pour ne pas que la carte soit rikiki sur mobile.

avant :

![image](https://user-images.githubusercontent.com/15341118/74823953-d7494080-5307-11ea-9110-6e3f5e02361f.png)


apres : 

![image](https://user-images.githubusercontent.com/15341118/74824669-d1a02a80-5308-11ea-8428-562473181147.png)
