### PR TITLE
Eviter les erreurs 500 pour les urls non reconnues

### DIFF
--- a/apps/transport/client/stylesheets/components/_error.scss
+++ b/apps/transport/client/stylesheets/components/_error.scss
@@ -1,3 +1,13 @@
+.error {
+  margin-top: 48px;
+  text-align: center;
+  h2 {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 24px;
+  }
+}
+
 .error__background {
   background: url('../images/error-background-1920.jpg') no-repeat center center fixed;
   background-size: cover;

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -51,31 +51,37 @@ defmodule TransportWeb.DatasetController do
   end
 
   def by_aom(%Plug.Conn{} = conn, %{"aom" => id} = params) do
-    AOM
-    |> where([a], a.id == ^id)
-    |> Repo.exists?()
-    |> case do
-      false ->
-        message = dgettext("errors", "AOM %{id} does not exist", id: id)
-        error_page(conn, message)
-
-      true ->
-        list_datasets(conn, params)
+    error_aom = error_page(conn,  dgettext("errors", "AOM %{id} does not exist", id: id))
+    try do
+      AOM
+      |> where([a], a.id == ^id)
+      |> Repo.exists?()
+      |> case do
+        false ->
+          error_aom
+        true ->
+          list_datasets(conn, params)
+      end
+    rescue
+      Ecto.Query.CastError -> error_aom
     end
   end
 
   def by_region(%Plug.Conn{} = conn, %{"region" => id} = params) do
-    Region
-    |> where([r], r.id == ^id)
-    |> Repo.exists?()
-    |> case do
-      false ->
-        message = dgettext("errors", "Region %{id} does not exist", id: id)
-
-        error_page(conn, message)
-
-      true ->
-        list_datasets(conn, params)
+    error_region = error_page(conn,  dgettext("errors", "Region %{id} does not exist", id: id))
+    try do
+        Region
+      |> where([r], r.id == ^id)
+      |> Repo.exists?()
+      |> case do
+        false ->
+          message = dgettext("errors", "Region %{id} does not exist", id: id)
+          error_page(conn, message)
+        true ->
+          list_datasets(conn, params)
+      end
+    rescue
+      Ecto.Query.CastError -> error_region
     end
   end
 

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -51,7 +51,8 @@ defmodule TransportWeb.DatasetController do
   end
 
   def by_aom(%Plug.Conn{} = conn, %{"aom" => id} = params) do
-    error_aom = error_page(conn,  dgettext("errors", "AOM %{id} does not exist", id: id))
+    error_aom = error_page(conn, dgettext("errors", "AOM %{id} does not exist", id: id))
+
     try do
       AOM
       |> where([a], a.id == ^id)
@@ -59,6 +60,7 @@ defmodule TransportWeb.DatasetController do
       |> case do
         false ->
           error_aom
+
         true ->
           list_datasets(conn, params)
       end
@@ -68,15 +70,17 @@ defmodule TransportWeb.DatasetController do
   end
 
   def by_region(%Plug.Conn{} = conn, %{"region" => id} = params) do
-    error_region = error_page(conn,  dgettext("errors", "Region %{id} does not exist", id: id))
+    error_region = error_page(conn, dgettext("errors", "Region %{id} does not exist", id: id))
+
     try do
-        Region
+      Region
       |> where([r], r.id == ^id)
       |> Repo.exists?()
       |> case do
         false ->
           message = dgettext("errors", "Region %{id} does not exist", id: id)
           error_page(conn, message)
+
         true ->
           list_datasets(conn, params)
       end


### PR DESCRIPTION
Pour le moment,
* https://transport.data.gouv.fr/datasets/region/coucou
* https://transport.data.gouv.fr/datasets/aom/coucou

renvoient vers des pages blanches et font des erreurs 500.

On les transforme en 404. Je n'ai pas trouvé d'autre moyen que de faire du try...rescue alors que dans le guide Elixir, ils disent que ce n'est pas une pratique habituelle :man_shrugging: 

Au passage, un peu de css sur la page des 404 :

![image](https://user-images.githubusercontent.com/15341118/74829390-3a8ba080-5311-11ea-96ff-f85b62a9b9a2.png)

devient 

![image](https://user-images.githubusercontent.com/15341118/74829402-41b2ae80-5311-11ea-9885-fbc12c4deba0.png)
