### PR TITLE
use a materialized view for search

### DIFF
--- a/apps/db/lib/db/place.ex
+++ b/apps/db/lib/db/place.ex
@@ -1,0 +1,15 @@
+defmodule DB.Place do
+  @moduledoc """
+  Commune schema
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  @primary_key false
+  typed_schema "places" do
+    field(:nom, :string)
+    field(:type, :string)
+    field(:place_id, :string)
+    field(:indexed_name, :string)
+  end
+end

--- a/apps/db/priv/repo/migrations/20200224093551_places_mat_view.exs
+++ b/apps/db/priv/repo/migrations/20200224093551_places_mat_view.exs
@@ -1,0 +1,84 @@
+defmodule DB.Repo.Migrations.TestPlaces do
+  use Ecto.Migration
+
+  def up do
+    # we use pg_trgm extension for trigram match
+    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+
+    execute("""
+    CREATE MATERIALIZED VIEW places AS
+    SELECT nom, place_id, type, indexed_name
+    FROM
+    (
+        (
+          SELECT
+          c.nom AS nom,
+          c.insee AS place_id,
+          'commune' AS type,
+          unaccent(replace(nom, ' ', '-')) AS indexed_name
+          FROM commune c
+        )
+        UNION
+        (
+          SELECT
+          r.nom AS nom,
+          CAST(r.id AS varchar) AS place_id,
+          'region' AS type,
+          unaccent(replace(nom, ' ', '-')) AS indexed_name
+          FROM region r
+        )
+        UNION
+        (
+          SELECT a.nom AS nom,
+          CAST(a.id AS varchar) AS place_id,
+          'aom' AS type,
+          unaccent(replace(nom, ' ', '-')) AS indexed_name
+          FROM aom a
+        )
+    ) AS place
+    WITH DATA
+    """)
+
+    execute("CREATE INDEX indexed_name_index ON places USING GIN(indexed_name gin_trgm_ops);")
+
+    # Define a trigger function to refresh the materialized view
+    execute("""
+    CREATE OR REPLACE FUNCTION refresh_places()
+    RETURNS trigger AS $$
+    BEGIN
+      REFRESH MATERIALIZED VIEW places;
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    # Call of the trigger for region, aom and commune update
+    execute("""
+    CREATE TRIGGER refresh_places_region_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON region
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_places();
+    """)
+
+    execute("""
+    CREATE TRIGGER refresh_places_aom_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON aom
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_places();
+    """)
+
+    execute("""
+    CREATE TRIGGER refresh_places_commune_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON commune
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_places();
+    """)
+  end
+
+  def down do
+    execute("DROP MATERIALIZED VIEW places;")
+  end
+end

--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -1,60 +1,44 @@
 defmodule TransportWeb.API.PlacesController do
   use TransportWeb, :controller
-  alias DB.Repo
-  alias Ecto.Adapters.SQL
+  alias DB.{Place, Repo}
   alias Helpers
   alias OpenApiSpex.Operation
   alias TransportWeb.API.Schemas.{AutocompleteResponse}
+  import Ecto.{Query}
 
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])
 
-  @spec get_result_url(Plug.Conn.t(), %{binary() => binary()}) :: binary()
-  def get_result_url(conn, %{"id" => id, "type" => "commune"}), do: dataset_path(conn, :by_commune_insee, id)
-
-  def get_result_url(conn, %{"id" => id, "type" => "region"}), do: dataset_path(conn, :by_region, id)
-
-  def get_result_url(conn, %{"id" => id, "type" => "aom"}), do: dataset_path(conn, :by_aom, id)
+  @spec get_result_url(Plug.Conn.t(), %Place{}) :: binary()
+  defp get_result_url(conn, %Place{:place_id => id, :type => "commune"}), do: dataset_path(conn, :by_commune_insee, id)
+  defp get_result_url(conn, %Place{:place_id => id, :type => "region"}), do: dataset_path(conn, :by_region, id)
+  defp get_result_url(conn, %Place{:place_id => id, :type => "aom"}), do: dataset_path(conn, :by_aom, id)
 
   @spec autocomplete(Plug.Conn.t(), map) :: Plug.Conn.t()
   def autocomplete(%Plug.Conn{} = conn, %{"q" => query}) do
-    commune =
-      SQL.query!(
-        Repo,
-        "
-        SELECT nom, id, type FROM
-        (
-          (
-            SELECT c.nom AS nom, c.insee AS id, 'commune' AS type
-            FROM commune c WHERE unaccent(nom) ilike '%' || unaccent($1) || '%'
-            ORDER BY levenshtein(unaccent(c.nom), unaccent($1))
-            limit 10
-          )
-          UNION
-          (
-            SELECT r.nom AS nom, CAST(r.id AS varchar) AS id, 'region' AS type
-            FROM region r WHERE unaccent(r.nom) ilike '%' || unaccent($1) || '%'
-            ORDER BY levenshtein(unaccent(r.nom), unaccent($1))
-            limit 3
-          )
-          UNION
-          (
-            SELECT a.nom AS nom, CAST(a.id AS varchar) AS id, 'aom' AS type
-            FROM aom a WHERE unaccent(a.nom) ilike '%' || unaccent($1) || '%'
-            ORDER BY levenshtein(unaccent(a.nom), unaccent($1))
-            limit 5
-          )
-        ) AS results
-        ORDER BY levenshtein(unaccent(nom), unaccent($1))
-        LIMIT 10
-        ",
-        [query]
-      )
+    query =
+      query
+      # we replace '-' to ' ' because we also did this transformation for indexed_name
+      |> String.replace("-", " ")
+      # we replace ' ' to '%' to search for composite name to be easily searchable
+      # we can look for "d'Urfé" with either "d'urfe" or "d urfe",
+      # or "ile de france" with pattern like "i d f"
+      |> String.replace(" ", "%")
+
+    query = "%#{query}%"
+
+    places =
+      Place
+      |> where([p], ilike(p.indexed_name, ^query))
+      |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
+      |> limit(10)
+      |> Repo.all()
 
     results =
-      commune.rows
-      |> Enum.map(fn res -> commune.columns |> Enum.zip(res) |> Enum.into(%{}) end)
-      |> Enum.map(fn res -> %{name: res["nom"], type: res["type"], url: get_result_url(conn, res)} end)
+      places
+      |> Enum.map(fn res ->
+        %{name: res.nom, type: res.type, url: get_result_url(conn, res)}
+      end)
 
     conn
     |> assign(:data, results)

--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -29,7 +29,7 @@ defmodule TransportWeb.API.PlacesController do
 
     places =
       Place
-      |> where([p], ilike(p.indexed_name, ^query))
+      |> where([p], fragment("indexed_name ilike unaccent(?)", ^query))
       |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
       |> limit(10)
       |> Repo.all()

--- a/apps/transport/test/support/database_case.ex
+++ b/apps/transport/test/support/database_case.ex
@@ -33,6 +33,7 @@ defmodule TransportWeb.DatabaseCase do
 
         Repo.insert(%Region{nom: "Pays de la Loire"})
         Repo.insert(%Region{nom: "Auvergne-Rhône-Alpes"})
+        Repo.insert(%Region{nom: "Île-de-France"})
 
         Repo.insert(%AOM{
           insee_commune_principale: "53130",
@@ -77,6 +78,13 @@ defmodule TransportWeb.DatabaseCase do
           wikipedia: "fr:Chas",
           surf_ha: 254.0,
           aom_res_id: 3
+        })
+
+        Repo.insert(%AOM{
+          insee_commune_principale: "75056",
+          nom: "Île-de-France Mobilités",
+          region: Repo.get_by(Region, nom: "Île-de-France"),
+          composition_res_id: 4
         })
 
         Repo.insert(%Commune{

--- a/apps/transport/test/transport_web/controllers/places_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/places_controller_test.exs
@@ -67,6 +67,28 @@ defmodule TransportWeb.API.PlacesControllerTest do
   end
 
   @tag :external
+  test "Search a place with multiple word", %{conn: conn} do
+    r =
+      conn
+      |> get(Helpers.places_path(conn, :autocomplete, q: "ile de fr"))
+      |> json_response(200)
+
+    assert sort_and_clean(r) ==
+             Enum.sort([
+               %{
+                 "name" => "Île-de-France Mobilités",
+                 "type" => "aom",
+                 "url" => "/datasets/aom/:id"
+               },
+               %{
+                 "name" => "Île-de-France",
+                 "type" => "region",
+                 "url" => "/datasets/region/:id"
+               }
+             ])
+  end
+
+  @tag :external
   test "Search a unknown place", %{conn: conn} do
     r =
       conn


### PR DESCRIPTION
use a materialized view for autocomplete instead of multiple unions

This makes it easier to tweak search and more performant mainly by
adding a composite field(indexed_name), cleaned up and indexed for
search.

This makes it possible to search for "ile de france" or "i d f".

We loose some control though, we cannot limit by type not (like asking
for 5 cities, 3 aoms, and 2 regions).

dumb bench or queries using the median of an `ab -n 10`.
(knowing that a huge part is not due to ecto, but it's easier to use
`ab`
than to check the db query time to get some rough estimation)

```markdown
| search        | before                | after  |
| ------------- | --------------------- | ------ |
| montreuil     | 130 ms                | 40 ms  |
| pa            | 110 ms                | 92 ms  |
| a             | 129 ms                | 150 ms |
| ile de france | 1 ms (but no results) | 1 ms   |
| ile-de-france | 120 ms                | 1 ms   |
```

There is still 2 problem in the search, we do not handle well duplicate.
A search on `montreuil` will lead to 4 similars `Montreuil` in the results.
I don't know if it's a big problem though since it's quite a rare. If we want to tackle this, the first easiest choice would be to add the insee code, but I don't know it this makes it possible for a user to choose the right one