### PR TITLE
Editorialisation de certaines pages de recherche

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -241,18 +241,13 @@ defmodule TransportWeb.DatasetController do
     )
   end
 
-  defp put_page_title(conn, %{"aom" => id}) do
-    aom = AOM |> preload(:region) |> Repo.get!(id)
-
-    assign(
-      conn,
-      :page_title,
-      dgettext("page-shortlist", "Datasets for the aom %{aom}, located in %{region}",
-        aom: aom.nom,
-        region: aom.region.nom
+  defp put_page_title(conn, %{"aom" => id}),
+    do:
+      assign(
+        conn,
+        :page_title,
+        dgettext("page-shortlist", "Datasets for the aom %{aom}", aom: get_name(AOM, id))
       )
-    )
-  end
 
   defp put_page_title(conn, _), do: conn
 end

--- a/apps/transport/lib/transport_web/templates/dataset/_addresses.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_addresses.html.eex
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="notification">
+    <%= dgettext("page-shortlist", "There are 2 open data datasets for addresses:")%>
+    <ul>
+      <li>
+        <%= link("Base Adresse Nationale (BAN)", to: "/datasets/base-adresse-nationale/") %>
+        <%= dgettext("page-shortlist", ": the 'official' one, produced by the Institut géographique national (IGN), La Poste, Etalab and various administrations") %>
+      </li>
+      <li>
+        <%= link("Base d'Adresses Nationale Ouverte (BANO)", to: "/datasets/base-d-adresses-nationale-ouverte-bano") %>
+        <%= dgettext("page-shortlist", " created by OpenStreetMap France when the BAN was not fully open data.") %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/_realtime.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_realtime.html.eex
@@ -1,0 +1,6 @@
+<div class="container">
+  <div class="notification">
+    <%= dgettext("page-shortlist", "More information about realtime") %>
+    <%= link(dgettext("page-shortlist", "here"), to: page_path(@conn, :real_time)) %>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -10,16 +10,16 @@
   </div>
 </div>
 </div>
-<%= if @conn.assigns[:special_message] do %>
-  <div class="container">
-    <div class="notification">
-      <%= @special_message %>
-    </div>
-  </div>
+<%= if @conn.assigns[:custom_context] do %>
+  <%= render TransportWeb.DatasetView, @custom_context, conn: @conn %>
 <% end %>
 <section class="section section-grey datasets">
   <div class="container search-title">
-    <h2><%= dgettext("page-shortlist", "Search results") %></h2>
+    <%= if @conn.assigns[:page_title] do %>
+      <h2> <%= @page_title %> </h2>
+    <% else %>
+      <h2><%= dgettext("page-shortlist", "Search results") %></h2>
+    <% end %>
     <div class="shortlist__pagination">
       <%= pagination_links @conn, @datasets %>
     </div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -270,7 +270,7 @@ msgid "There are 2 open data datasets for addresses:"
 msgstr ""
 
 #, elixir-format, fuzzy
-msgid "Datasets for the aom %{aom}, located in %{region}"
+msgid "Datasets for the aom %{aom}"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -206,10 +206,6 @@ msgid "Search results"
 msgstr ""
 
 #, elixir-format
-msgid "More information about realtime %{realtime_link}"
-msgstr ""
-
-#, elixir-format
 msgid "here"
 msgstr ""
 
@@ -247,4 +243,44 @@ msgstr ""
 
 #, elixir-format
 msgid "There is no data for region %{name}"
+msgstr ""
+
+#, elixir-format
+msgid " created by OpenStreetMap France when the BAN was not fully open data."
+msgstr ""
+
+#, elixir-format
+msgid ": the 'official' one, produced by the Institut géographique national (IGN), La Poste, Etalab and various administrations"
+msgstr ""
+
+#, elixir-format
+msgid "Here are the datasets for the aom %{aom} located in %{region}"
+msgstr ""
+
+#, elixir-format
+msgid "Here are the datasets for the city of "
+msgstr ""
+
+#, elixir-format
+msgid "More information about realtime"
+msgstr ""
+
+#, elixir-format
+msgid "There are 2 open data datasets for addresses:"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Datasets for the aom %{aom}, located in %{region}"
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the region "
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the region %{region}"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -270,8 +270,8 @@ msgid "There are 2 open data datasets for addresses:"
 msgstr "Il y a 2 jeux de données open data pour les adresses :"
 
 #, elixir-format, fuzzy
-msgid "Datasets for the aom %{aom}, located in %{region}"
-msgstr "Jeux de données de l'AOM %{aom} de la région %{region}"
+msgid "Datasets for the aom %{aom}"
+msgstr "Jeux de données de l'AOM %{aom}"
 
 #, elixir-format
 msgid "Datasets for the city %{name}"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -206,10 +206,6 @@ msgid "Search results"
 msgstr "Résultats de recherche"
 
 #, elixir-format
-msgid "More information about realtime %{realtime_link}"
-msgstr "Plus d'informations et d'autres jeux de données temps réel %{realtime_link}"
-
-#, elixir-format
 msgid "here"
 msgstr "ici"
 
@@ -248,3 +244,43 @@ msgstr "Il n'y a pas de données disponibles pour la ville %{name}"
 #, elixir-format
 msgid "There is no data for region %{name}"
 msgstr "Il n'y a pas de données disponibles pour la région %{name}"
+
+#, elixir-format
+msgid " created by OpenStreetMap France when the BAN was not fully open data."
+msgstr " crée par OpenStreetMap France quand la BAN n'était pas encore complétement ouverte"
+
+#, elixir-format
+msgid ": the 'official' one, produced by the Institut géographique national (IGN), La Poste, Etalab and various administrations"
+msgstr ": le jeu de données officiel, produit par l'Institut géographique national (IGN), La Poste, Etalab et diverses administrations"
+
+#, elixir-format
+msgid "Here are the datasets for the aom %{aom} located in %{region}"
+msgstr ""
+
+#, elixir-format
+msgid "Here are the datasets for the city of "
+msgstr ""
+
+#, elixir-format
+msgid "More information about realtime"
+msgstr "Plus d'informations et d'autres jeux de données temps réel"
+
+#, elixir-format
+msgid "There are 2 open data datasets for addresses:"
+msgstr "Il y a 2 jeux de données open data pour les adresses :"
+
+#, elixir-format, fuzzy
+msgid "Datasets for the aom %{aom}, located in %{region}"
+msgstr "Jeux de données de l'AOM %{aom} de la région %{region}"
+
+#, elixir-format
+msgid "Datasets for the city %{name}"
+msgstr "Jeux de données de la commune de %{name}"
+
+#, elixir-format
+msgid "Datasets for the region "
+msgstr "Jeux de données de la région "
+
+#, elixir-format
+msgid "Datasets for the region %{region}"
+msgstr "Jeux de données de la région %{region}"

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -270,7 +270,7 @@ msgid "There are 2 open data datasets for addresses:"
 msgstr ""
 
 #, elixir-format
-msgid "Datasets for the aom %{aom}, located in %{region}"
+msgid "Datasets for the aom %{aom}"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -206,10 +206,6 @@ msgid "Search results"
 msgstr ""
 
 #, elixir-format
-msgid "More information about realtime %{realtime_link}"
-msgstr ""
-
-#, elixir-format
 msgid "here"
 msgstr ""
 
@@ -247,4 +243,44 @@ msgstr ""
 
 #, elixir-format
 msgid "There is no data for region %{name}"
+msgstr ""
+
+#, elixir-format
+msgid " created by OpenStreetMap France when the BAN was not fully open data."
+msgstr ""
+
+#, elixir-format
+msgid ": the 'official' one, produced by the Institut géographique national (IGN), La Poste, Etalab and various administrations"
+msgstr ""
+
+#, elixir-format
+msgid "Here are the datasets for the aom %{aom} located in %{region}"
+msgstr ""
+
+#, elixir-format
+msgid "Here are the datasets for the city of "
+msgstr ""
+
+#, elixir-format
+msgid "More information about realtime"
+msgstr ""
+
+#, elixir-format
+msgid "There are 2 open data datasets for addresses:"
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the aom %{aom}, located in %{region}"
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the region "
+msgstr ""
+
+#, elixir-format
+msgid "Datasets for the region %{region}"
 msgstr ""


### PR DESCRIPTION
* les pages de régions/aom/villes gagnent un titre avec le nom de l'ao/region/ville
* la page adresses explique la différence entre la BAN et BANO
* la page du temps réel renvoie vers la doc


Ca donne ca pour les villes/regions/AO
![image](https://user-images.githubusercontent.com/3987698/75235529-49ac9b80-57b4-11ea-830e-b76a337a3df8.png)
![image](https://user-images.githubusercontent.com/3987698/75235630-75c81c80-57b4-11ea-9875-e6e838794fb3.png)
![image](https://user-images.githubusercontent.com/3987698/75235666-84aecf00-57b4-11ea-95e0-e9db8d63bd1f.png)

Note: je suis pas convaincu par le titre pour l'AO. Je trouvais que sans la région ca pouvait manquer de contexte, mais la ca fait des titres à rallonge (bon l’exemple d'idfm est particulièrement redondant aussi).

et pour les addresses /  TR:
![image](https://user-images.githubusercontent.com/3987698/75235914-ebcc8380-57b4-11ea-8447-eefbd85a3e79.png)
![image](https://user-images.githubusercontent.com/3987698/75235943-f8e97280-57b4-11ea-9cc2-4615b35de851.png)


Pas ultra convaincu en terme de design. Vous en pensez quoi ?

