### PR TITLE
ajout d'une contrainte d'unicité sur le slug

### DIFF
--- a/apps/db/priv/repo/migrations/20200225140241_slug_constraint.exs
+++ b/apps/db/priv/repo/migrations/20200225140241_slug_constraint.exs
@@ -1,0 +1,7 @@
+defmodule DB.Repo.Migrations.SlugConstraint do
+  use Ecto.Migration
+
+  def change do
+    create(unique_index(:dataset, [:slug]))
+  end
+end


### PR DESCRIPTION
ajout d'un index et d'une contrainte d'unicité sur le slug

closes #1073

le cas est super rare, mais on avait un bug si un jdd datagouv était référencé sur transport, puis supprimé et recrée sur datagouv (avec du coup le même slug, mais un id différent), et reréférencé sur transport.

vu que de tt facon on cherche aussi par slug (pour `/dataset/:slug`), je rajoute une contrainte d'unicité sur le slug, comme ca on aura une erreur au référencement directement.