### PR TITLE
change bike sharing stats map

### DIFF
--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -95,9 +95,15 @@ function displayBikes (map, featureFunction, style) {
         })
     }
     bikeStats.then(response => {
+        const options = {
+            fillColor: '#0066db',
+            radius: 5,
+            stroke: false,
+            fillOpacity: 0.9
+        }
         const geoJSON = Leaflet.geoJSON(response, {
             onEachFeature: featureFunction,
-            style: style
+            pointToLayer: (_, latlng) => Leaflet.circleMarker(latlng, options)
         })
         map.addLayer(geoJSON)
     })
@@ -380,12 +386,6 @@ function addBikesMap (id, view) {
 
         const bind = `<a href="/datasets/${slug}" target="_blank">${name}<br/></a>`
         layer.bindPopup(bind)
-    }, _ => {
-        return {
-            weight: 1,
-            fillOpacity: 0.5,
-            color: 'green'
-        }
     })
 }
 

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -211,7 +211,7 @@ defmodule TransportWeb.API.StatsController do
     DatasetGeographicView
     |> join(:left, [gv], dataset in Dataset, on: dataset.id == gv.dataset_id)
     |> select([gv, dataset], %{
-      geometry: gv.geom,
+      geometry: fragment("ST_Centroid(geom)"),
       id: gv.dataset_id,
       nom: dataset.spatial,
       parent_dataset_slug: dataset.slug


### PR DESCRIPTION
change the bike-sharing map because the city polygons were too small

before:
![image](https://user-images.githubusercontent.com/3987698/75371403-967c9900-58be-11ea-9d95-44ee6367f0e8.png)

after:
![image](https://user-images.githubusercontent.com/3987698/75371378-8c5a9a80-58be-11ea-9fcb-ca27deae7214.png)
