### PR TITLE
XSS vulnerability: remove not needed raw

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -98,7 +98,7 @@ defmodule TransportWeb.DatasetController do
     conn
     |> put_status(:not_found)
     |> put_view(ErrorView)
-    |> assign(:reason, raw(msg))
+    |> assign(:reason, msg)
     |> render("404.html")
   end
 


### PR DESCRIPTION
It let go some user input to the template (when a unknown territory id was used)