### PR TITLE
Search highlight

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -41,22 +41,28 @@ const autoCompletejs = new AutoComplete({
     highlight: true,
     searchEngine: (query, record) => {
         // inspired by the 'loose' searchEngine, but that always matches
-        query = query.replace(/ /g, '')
-        const recordLowerCase = record.toLowerCase()
-        const match = []
-        let searchPosition = 0
-        for (let number = 0; number < recordLowerCase.length; number++) {
-            let recordChar = record[number]
-            if (
-                searchPosition < query.length &&
-                recordLowerCase[number] === query[searchPosition]
-            ) {
-                recordChar = `<span class="autoComplete_highlighted">${recordChar}</span>`
-                searchPosition++
+        query = query.replace(/ /g, '').normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        const recordLowerCase = record.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        const fullMatchPos = recordLowerCase.indexOf(query)
+        if (fullMatchPos >= 0) {
+            // full query match has priority
+            return `${record.slice(0, fullMatchPos)}<span class="autoComplete_highlighted">${record.slice(fullMatchPos, fullMatchPos + query.length)}</span>${record.slice(fullMatchPos + query.length)}`
+        } else {
+            const match = []
+            let searchPosition = 0
+            for (let number = 0; number < recordLowerCase.length; number++) {
+                let recordChar = record[number]
+                if (
+                    searchPosition < query.length &&
+                    recordLowerCase[number] === query[searchPosition]
+                ) {
+                    recordChar = `<span class="autoComplete_highlighted">${recordChar}</span>`
+                    searchPosition++
+                }
+                match.push(recordChar)
             }
-            match.push(recordChar)
+            return match.join('')
         }
-        return match.join('')
     },
     maxResults: 7,
     resultsList: {


### PR DESCRIPTION
Petites améliorations pour que soit highlighté le bon segment des résultats.

Avant :
![image](https://user-images.githubusercontent.com/15341118/75970443-a0ab2280-5ed0-11ea-9f5e-c663d216d0f0.png)

Après :
![image](https://user-images.githubusercontent.com/15341118/75970471-aacd2100-5ed0-11ea-8f9f-66fdfc5eafc1.png)


Avant :
![image](https://user-images.githubusercontent.com/15341118/75970557-d0f2c100-5ed0-11ea-94b0-3ce339c88dde.png)

Après :
![image](https://user-images.githubusercontent.com/15341118/75970578-d94afc00-5ed0-11ea-89f7-bd6b0b31c195.png)

Ca marche toujours avec "i d f" :
![image](https://user-images.githubusercontent.com/15341118/75970700-09929a80-5ed1-11ea-9aef-78b18c8172cc.png)
