### PR TITLE
Correction link dataset regions

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -47,7 +47,7 @@ defmodule DB.Dataset do
     # - or a list of cities.
     belongs_to(:region, Region)
     belongs_to(:aom, AOM)
-    many_to_many(:communes, Commune, join_through: "dataset_communes")
+    many_to_many(:communes, Commune, join_through: "dataset_communes", on_replace: :delete)
 
     has_many(:resources, Resource, on_replace: :delete, on_delete: :delete_all)
   end
@@ -670,5 +670,9 @@ defmodule DB.Dataset do
     |> put_assoc(:communes, communes)
   end
 
-  defp cast_datagouv_zone(changeset, _), do: changeset
+  defp cast_datagouv_zone(changeset, _) do
+    changeset
+    |> change
+    |> put_assoc(:communes, [])
+  end
 end

--- a/apps/db/priv/repo/migrations/20200311095433_correction_of_dataset_geographic_view.exs
+++ b/apps/db/priv/repo/migrations/20200311095433_correction_of_dataset_geographic_view.exs
@@ -1,0 +1,137 @@
+defmodule DB.Repo.Migrations.CorrectionOfDatasetGeographicView do
+  @moduledoc """
+  Correction in the materialized view.
+  No region_id was fetched for dataset linked to communes only
+  """
+  use Ecto.Migration
+
+  def up do
+    # drop the materialized view
+    execute("DROP TRIGGER refresh_dataset_geographic_view_trigger ON dataset;")
+    execute("DROP FUNCTION refresh_dataset_geographic_view;")
+    execute("DROP MATERIALIZED VIEW dataset_geographic_view;")
+
+    execute("""
+    CREATE MATERIALIZED VIEW dataset_geographic_view AS
+    SELECT
+      id as dataset_id,
+      COALESCE(
+        -- We take either directly the region
+        region_id,
+        -- Or the region of the aom
+        (SELECT region_id FROM aom WHERE aom.id = aom_id),
+        -- Or the region of a random city linked to the dataset
+        (SELECT c.region_id
+       		FROM dataset_communes dc
+       		LEFT JOIN commune c
+       		ON dc.commune_id = c.id
+       		WHERE dc.dataset_id = dataset.id
+       		order BY aom_res_id desc
+       		LIMIT 1
+        )
+      ) as region_id,
+      COALESCE(
+        (SELECT aom.geom FROM aom WHERE aom.id = aom_id),
+        (SELECT region.geom FROM region WHERE region.id = region_id),
+        -- If the dataset is linked to cities, we get the union of the cities's geometry
+        (SELECT
+          ST_UNION(commune.geom)
+          FROM commune
+          LEFT JOIN dataset_communes ON commune.id = dataset_communes.commune_id
+          WHERE dataset_communes.dataset_id = dataset.id
+        )
+      ) as geom
+    FROM dataset
+    WITH DATA;
+    """)
+
+    # Add an index on dataset_id since we'll often make a join on this
+    execute("CREATE INDEX dataset_id_idx ON dataset_geographic_view (dataset_id);")
+
+    # Define a trigger function to refresh the materialized view
+    execute("""
+    CREATE OR REPLACE FUNCTION refresh_dataset_geographic_view()
+    RETURNS trigger AS $$
+    BEGIN
+      REFRESH MATERIALIZED VIEW dataset_geographic_view;
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    # Call of the trigger
+    execute("""
+    CREATE TRIGGER refresh_dataset_geographic_view_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON dataset
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_dataset_geographic_view();
+    """)
+  end
+
+  def down do
+    # restore the previous materialized view
+    execute("DROP TRIGGER refresh_dataset_geographic_view_trigger ON dataset;")
+    execute("DROP FUNCTION refresh_dataset_geographic_view;")
+    execute("DROP MATERIALIZED VIEW dataset_geographic_view;")
+
+    execute("""
+    CREATE MATERIALIZED VIEW dataset_geographic_view AS
+    SELECT
+      id as dataset_id,
+      COALESCE(
+        -- We take either directly the region
+        region_id,
+        -- Or the region of the aom
+        (SELECT region_id FROM aom WHERE aom.id = aom_id),
+        -- Or the region of a random city linked to the dataset
+        (SELECT
+          region_id
+          FROM aom
+          WHERE aom.id IN
+            (SELECT
+              max(commune.aom_res_id)
+              FROM commune
+              LEFT JOIN dataset_communes ON dataset.id = dataset_communes.dataset_id
+            )
+        )
+      ) as region_id,
+      COALESCE(
+        (SELECT aom.geom FROM aom WHERE aom.id = aom_id),
+        (SELECT region.geom FROM region WHERE region.id = region_id),
+        -- If the dataset is linked to cities, we get the union of the cities's geometry
+        (SELECT
+          ST_UNION(commune.geom)
+          FROM commune
+          LEFT JOIN dataset_communes ON commune.id = dataset_communes.commune_id
+          WHERE dataset_communes.dataset_id = dataset.id
+        )
+      ) as geom
+    FROM dataset
+    WITH DATA;
+    """)
+
+    # Add an index on dataset_id since we'll often make a join on this
+    execute("CREATE INDEX dataset_id_idx ON dataset_geographic_view (dataset_id);")
+
+    # Define a trigger function to refresh the materialized view
+    execute("""
+    CREATE OR REPLACE FUNCTION refresh_dataset_geographic_view()
+    RETURNS trigger AS $$
+    BEGIN
+      REFRESH MATERIALIZED VIEW dataset_geographic_view;
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    # Call of the trigger
+    execute("""
+    CREATE TRIGGER refresh_dataset_geographic_view_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON dataset
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_dataset_geographic_view();
+    """)
+  end
+end

--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -41,22 +41,28 @@ const autoCompletejs = new AutoComplete({
     highlight: true,
     searchEngine: (query, record) => {
         // inspired by the 'loose' searchEngine, but that always matches
-        query = query.replace(/ /g, '')
-        const recordLowerCase = record.toLowerCase()
-        const match = []
-        let searchPosition = 0
-        for (let number = 0; number < recordLowerCase.length; number++) {
-            let recordChar = record[number]
-            if (
-                searchPosition < query.length &&
-                recordLowerCase[number] === query[searchPosition]
-            ) {
-                recordChar = `<span class="autoComplete_highlighted">${recordChar}</span>`
-                searchPosition++
+        query = query.replace(/ /g, '').normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        const recordLowerCase = record.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        const fullMatchPos = recordLowerCase.indexOf(query)
+        if (fullMatchPos >= 0) {
+            // full query match has priority
+            return `${record.slice(0, fullMatchPos)}<span class="autoComplete_highlighted">${record.slice(fullMatchPos, fullMatchPos + query.length)}</span>${record.slice(fullMatchPos + query.length)}`
+        } else {
+            const match = []
+            let searchPosition = 0
+            for (let number = 0; number < recordLowerCase.length; number++) {
+                let recordChar = record[number]
+                if (
+                    searchPosition < query.length &&
+                    recordLowerCase[number] === query[searchPosition]
+                ) {
+                    recordChar = `<span class="autoComplete_highlighted">${recordChar}</span>`
+                    searchPosition++
+                }
+                match.push(recordChar)
             }
-            match.push(recordChar)
+            return match.join('')
         }
-        return match.join('')
     },
     maxResults: 7,
     resultsList: {


### PR DESCRIPTION
1. Il n'était pas possible d'éditer un dataset qui avait été lié aux zones de datagouv.fr et de le passer en autre chose (jeu de données rattaché  une région par exemple)

2. La materialized view dataset_geographic_view était fausse pour les datasets qui étaient liés aux zones de datagouv.fr. Ce qui touchait en particulier les dataset de vélos.

Par exemple pour les dataset de vélo en Rhones Alpes :

Avant :

![image](https://user-images.githubusercontent.com/15341118/76409409-9d131200-638e-11ea-8cf2-29185f41da75.png)

Après :

![image](https://user-images.githubusercontent.com/15341118/76409456-ad2af180-638e-11ea-8820-08030fa1f704.png)

Quelques lignes de code qui m'ont demandé beaucoup d'efforts :D