### PR TITLE
Add a backoffice bouton to validate all datasets

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -180,12 +180,16 @@ defmodule DB.Resource do
 
   @spec validate_and_save_all([binary()]) :: :ok
   def validate_and_save_all(args \\ ["--all"]) do
+    Logger.info("Validating all resources")
+
     __MODULE__
     |> preload(:dataset)
     |> Repo.all()
     |> Enum.filter(fn r -> r.dataset.type == "public-transit" end)
     |> Enum.filter(&(List.first(args) == "--all" or needs_validation(&1)))
     |> Enum.each(&validate_and_save/1)
+
+    Logger.info("All resources have been validated")
   end
 
   @spec is_outdated?(__MODULE__) :: boolean

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -11,7 +11,12 @@ defmodule Transport.ImportData do
   import Ecto.Query
 
   @spec all :: [{:ok, Ecto.Schema.t()} | {:error, any}]
-  def all, do: Dataset |> Repo.all() |> Enum.map(&call/1)
+  def all do
+    Logger.info("reimporting all datasets")
+    res = Dataset |> Repo.all() |> Enum.map(&call/1)
+    Logger.info("all datasets have been reimported")
+    res
+  end
 
   @spec import_validate_all :: :ok
   def import_validate_all do

--- a/apps/transport/lib/transport/import_data_worker.ex
+++ b/apps/transport/lib/transport/import_data_worker.ex
@@ -9,11 +9,18 @@ defmodule Transport.ImportDataWorker do
 
   ## API ##
 
-  @spec all :: :ok
-  def all do
+  @spec import_validate_all :: :ok
+  def import_validate_all do
     Dataset
     |> Repo.all()
     |> Enum.each(fn dataset -> GenServer.cast(__MODULE__, {:import_and_validation, dataset}) end)
+  end
+
+  @spec validate_all :: :ok
+  def validate_all do
+    Dataset
+    |> Repo.all()
+    |> Enum.each(fn dataset -> GenServer.cast(__MODULE__, {:validate_all, dataset}) end)
   end
 
   def start_link do
@@ -37,6 +44,13 @@ defmodule Transport.ImportDataWorker do
   @impl true
   def handle_cast({:validate, resource}, state) do
     Resource.validate_and_save(resource)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:validate_all, dataset}, state) do
+    queue_validations(dataset)
 
     {:noreply, state}
   end

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -2,7 +2,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
   use TransportWeb, :controller
   alias Datagouvfr.Client.Datasets
 
-  alias DB.{Dataset, ImportDataWorker, Repo}
+  alias DB.{Dataset, ImportDataWorker, Repo, Resource}
   alias Transport.{ImportData, ImportDataWorker}
   require Logger
 
@@ -80,12 +80,21 @@ defmodule TransportWeb.Backoffice.DatasetController do
     |> redirect_to_index()
   end
 
-  @spec validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def validate_all(%Plug.Conn{} = conn, _args) do
-    ImportDataWorker.all()
+  @spec import_validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def import_validate_all(%Plug.Conn{} = conn, _args) do
+    ImportDataWorker.import_validate_all()
 
     conn
     |> put_flash(:info, dgettext("backoffice_dataset", "Import and validation of all datasets have been launch"))
+    |> redirect_to_index()
+  end
+
+  @spec validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def validate_all(%Plug.Conn{} = conn, _args) do
+    ImportDataWorker.validate_all()
+
+    conn
+    |> put_flash(:info, dgettext("backoffice_dataset", "validation of all datasets has been launch"))
     |> redirect_to_index()
   end
 

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -94,7 +94,9 @@ defmodule TransportWeb.Router do
         post("/", DatasetController, :post)
         post("/:id/_import", DatasetController, :import_from_data_gouv_fr)
         post("/:id/_delete", DatasetController, :delete)
+        post("/_all_/_import_validate", DatasetController, :import_validate_all)
         post("/_all_/_validate", DatasetController, :validate_all)
+        post("/:id/_import_validate", DatasetController, :import_validate_all)
         post("/:id/_validate", DatasetController, :validation)
       end
 

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -4,8 +4,11 @@
       <i class="fas fa-plus"></i> <%= dgettext("backoffice", "Add a dataset") %>
     </a>
     <div class="import-all">
-      <%= form_for @conn, backoffice_dataset_path(@conn, :validate_all), [method: "post"], fn _f -> %>
+      <%= form_for @conn, backoffice_dataset_path(@conn, :import_validate_all), [method: "post"], fn _f -> %>
         <%= submit dgettext("backoffice", "Import and validate all") %>
+      <% end %>
+      <%= form_for @conn, backoffice_dataset_path(@conn, :validate_all), [method: "post"], fn _f -> %>
+        <%= submit dgettext("backoffice", "validate all") %>
       <% end %>
     </div>
   <h1 class="pt-48">

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -167,3 +167,7 @@ msgstr ""
 #, elixir-format
 msgid "Cancel"
 msgstr ""
+
+#, elixir-format
+msgid "validate all"
+msgstr ""

--- a/apps/transport/priv/gettext/backoffice_dataset.pot
+++ b/apps/transport/priv/gettext/backoffice_dataset.pot
@@ -57,3 +57,7 @@ msgstr ""
 #, elixir-format
 msgid "Validating"
 msgstr ""
+
+#, elixir-format
+msgid "validation of all datasets has been launch"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -166,3 +166,7 @@ msgstr ""
 #, elixir-format
 msgid "Cancel"
 msgstr ""
+
+#, elixir-format
+msgid "validate all"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
@@ -58,3 +58,7 @@ msgstr ""
 #, elixir-format
 msgid "Validating"
 msgstr ""
+
+#, elixir-format, fuzzy
+msgid "validation of all datasets has been launch"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -105,7 +105,7 @@ msgstr "Impossible de trouver le jeu de données"
 
 #, elixir-format
 msgid "Import and validate all"
-msgstr "Importer et valider tous les jeux de donées"
+msgstr "Importer et valider tous les jeux de données"
 
 #, elixir-format
 msgid "Show outdated datasets only"
@@ -167,3 +167,6 @@ msgstr "Montrer les jeux de données ne respectant pas les spec"
 msgid "Cancel"
 msgstr "Annuler"
 
+#, elixir-format
+msgid "validate all"
+msgstr "Valider tous les jeux de données"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
@@ -33,7 +33,7 @@ msgstr "Dataset ajouté"
 
 #, elixir-format
 msgid "Import and validation of all datasets have been launch"
-msgstr "L'import et la validation de tous les jeux de données a été lancé."
+msgstr "L'import et la validation de tous les jeux de données ont été lancés."
 
 #, elixir-format
 msgid "Could not edit dataset"
@@ -58,3 +58,7 @@ msgstr "Validé"
 #, elixir-format
 msgid "Validating"
 msgstr "En cours"
+
+#, elixir-format, fuzzy
+msgid "validation of all datasets has been launch"
+msgstr "La validation de tous les jeux de données a été lancée."


### PR DESCRIPTION
We seem to have some problems with the daily import / validation process.

In order to debug this, this PR adds a new backoffice bouton to only validate all the datasets (without reimporting them, thus speeding the process).

![image](https://user-images.githubusercontent.com/3987698/77748329-1316aa80-7018-11ea-8ab8-1bc2428bef5d.png)

It also adds some logs in the daily import/validation process
