### PR TITLE
add back redirect_to_slug_or_404 implementation

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -151,21 +151,26 @@ defmodule TransportWeb.DatasetController do
     %{all: Map.get(result, true, 0) + Map.get(result, false, 0), true: Map.get(result, true, 0)}
   end
 
-  @spec redirect_to_slug_or_404(Plug.Conn.t(), number() | binary()) :: Plug.Conn.t()
 
-  defp redirect_to_slug_or_404(conn, nil) do
+  @spec redirect_to_slug_or_404(Plug.Conn.t(), number() | binary()) :: Plug.Conn.t()
+  defp redirect_to_slug_or_404(conn, slug_or_id) when is_integer(slug_or_id) do
+    redirect_to_dataset(conn, Repo.get_by(Dataset, id: slug_or_id))
+  end
+
+  defp redirect_to_slug_or_404(conn, slug_or_id) do
+    redirect_to_dataset(conn, Repo.get_by(Dataset, datagouv_id: slug_or_id))
+  end
+
+  @spec redirect_to_dataset(Plug.Conn.t(), %Dataset{} | nil) :: Plug.Conn.t()
+  defp redirect_to_dataset(conn, nil) do
     conn
     |> put_status(:not_found)
     |> put_view(ErrorView)
     |> render("404.html")
   end
 
-  defp redirect_to_slug_or_404(conn, slug_or_id) when is_integer(slug_or_id) do
-    redirect_to_slug_or_404(conn, Repo.get_by(Dataset, id: slug_or_id))
-  end
-
-  defp redirect_to_slug_or_404(conn, slug_or_id) do
-    redirect_to_slug_or_404(conn, Repo.get_by(Dataset, datagouv_id: slug_or_id))
+  defp redirect_to_dataset(conn, %Dataset{} = dataset) do
+    redirect(conn, to: dataset_path(conn, :details, dataset.slug))
   end
 
   @spec get_name(Ecto.Queryable.t(), binary()) :: binary()

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -151,14 +151,15 @@ defmodule TransportWeb.DatasetController do
     %{all: Map.get(result, true, 0) + Map.get(result, false, 0), true: Map.get(result, true, 0)}
   end
 
-
-  @spec redirect_to_slug_or_404(Plug.Conn.t(), number() | binary()) :: Plug.Conn.t()
-  defp redirect_to_slug_or_404(conn, slug_or_id) when is_integer(slug_or_id) do
-    redirect_to_dataset(conn, Repo.get_by(Dataset, id: slug_or_id))
-  end
-
+  @spec redirect_to_slug_or_404(Plug.Conn.t(), binary()) :: Plug.Conn.t()
   defp redirect_to_slug_or_404(conn, slug_or_id) do
-    redirect_to_dataset(conn, Repo.get_by(Dataset, datagouv_id: slug_or_id))
+    case Integer.parse(slug_or_id) do
+      {id, ""} ->
+        redirect_to_dataset(conn, Repo.get_by(Dataset, id: slug_or_id))
+
+      _ ->
+        redirect_to_dataset(conn, Repo.get_by(Dataset, datagouv_id: slug_or_id))
+    end
   end
 
   @spec redirect_to_dataset(Plug.Conn.t(), %Dataset{} | nil) :: Plug.Conn.t()


### PR DESCRIPTION
commit [4fb8ada3e74a68486ecb77fde1149ff83f](https://github.com/etalab/transport-site/commit/4fb8ada3e74a68486ecb77fde1149ff83fad33bc#diff-1b76c6a5c21bdbb94400c3859d7f3ae7) broke the dataset access by slug, thus breaking url like https://transport.data.gouv.fr/datasets/5defcb1c634f413ad267d96d

This commit fixes it and split it in 2 functions as there is no real reason not to