### PR TITLE
Table triable dans le backoffice

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -72,3 +72,8 @@
 .pt-12 {
   padding-top: 12px;
 }
+
+.sortable > a {
+  text-decoration: none;
+  color: var(--theme-dark-text);
+}

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -8,7 +8,7 @@
   }
   td {
     border: 0px solid black;
-    padding: 6px;
+    padding: 2px;
   }
   tr {
     padding: 6px;
@@ -17,16 +17,19 @@
   tr:hover {
     background-color: #ebebeb;
   }
+  tr:first-of-type > th:first-of-type {
+    width: 250px;
+  }
 }
 
 .bo_dataset_button {
   form > button,
   div > button {
-    padding: 6px;
-    margin: 3px;
+    padding: 2px;
+    margin: 0px;
     &:hover {
-      padding: 6px;
-      margin: 3px;
+      padding: 2px;
+      margin: 0px;
     }
   }
 }
@@ -76,4 +79,9 @@
 .sortable > a {
   text-decoration: none;
   color: var(--theme-dark-text);
+}
+
+.sort-icon {
+  color: var(--grey);
+  padding-left: 3px;
 }

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
@@ -1,11 +1,7 @@
 <tr>
   <td>
     <strong>
-      <%= if @dataset.spatial != "" do %>
-        <%= @dataset.spatial %>
-      <% else %>
-        <%= @dataset.title %>
-      <% end %>
+      <%= @dataset.spatial %>
     </strong>
   </td>
   <td class="is-centered">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
@@ -8,12 +8,12 @@
       <% end %>
     </strong>
   </td>
-  <td>
+  <td class="is-centered">
     <a href="<%= dataset_path(@conn, :details, @dataset.slug) %>">
       <i class="fa fa-link"></i>
     </a>
   </td>
-  <td>
+  <td class="is-centered">
     <a href="<%= Dataset.datagouv_url(@dataset) %>">
       <i class="fa fa-link"></i>
     </a>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -40,14 +40,12 @@
 <table class="backoffice-datasets">
   <tr>
     <th class="sortable"><%= backoffice_sort_link(@conn, "Dataset", :spatial, @order_by) %>
-    <%= get_arrow(@order_by.field == :spatial, @order_by.direction) %>
     </th>
     <th>transport</th>
     <th>data.gouv.fr</th>
     <th>Region</th>
     <th>Commune principale</th>
     <th class=sortable><%= backoffice_sort_link(@conn, "Fin de validité", :end_date, @order_by) %>
-    <%= get_arrow(@order_by.field == :end_date, @order_by.direction) %>
     </th>
     <th class="bo_dataset_button"></th>
     <th class="bo_dataset_button"></th>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -34,17 +34,21 @@
   <% end %>
 </div>
 
-<div class="pt-48">
+<div class="pt-48" id="backoffice-datasets-table">
   <%= pagination_links @conn, @datasets %>
 </div>
 <table class="backoffice-datasets">
   <tr>
-    <th>Dataset</th>
+    <th class="sortable"><%= backoffice_sort_link(@conn, "Dataset", :spatial, @order_by) %>
+    <%= get_arrow(@order_by.field == :spatial, @order_by.direction) %>
+    </th>
     <th>transport</th>
     <th>data.gouv.fr</th>
     <th>Region</th>
     <th>Commune principale</th>
-    <th>Fin de validité</th>
+    <th class=sortable><%= backoffice_sort_link(@conn, "Fin de validité", :end_date, @order_by) %>
+    <%= get_arrow(@order_by.field == :end_date, @order_by.direction) %>
+    </th>
     <th class="bo_dataset_button"></th>
     <th class="bo_dataset_button"></th>
     <th class="bo_dataset_button"></th>

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -1,26 +1,65 @@
 defmodule TransportWeb.Backoffice.PageView do
   use TransportWeb, :view
   alias TransportWeb.PaginationHelpers
+  alias Plug.Conn.Query
   import TransportWeb.DatasetView, only: [end_date: 1]
   alias DB.Dataset
 
   def pagination_links(conn, datasets) do
-    kwargs = [path: &backoffice_page_path/3] |> add_filter(conn)
+    kwargs = [path: &backoffice_page_path/3] |> add_filter(conn.params)
 
     PaginationHelpers.pagination_links(conn, datasets, kwargs)
   end
 
-  defp add_filter(kwargs, %{params: %{"filter" => filter} = p}) do
-    kwargs
-    |> Keyword.put(:filter, filter)
-    |> add_filter(Map.drop(p, ["filter"]))
+  @spec add_filter(list, map) :: list
+  defp add_filter(kwargs, params) do
+    params
+    # filter allowed keys
+    |> Map.take(["filter", "q", "order_by", "dir"])
+    |> Enum.map(fn {key, value} -> {String.to_existing_atom(key), value} end)
+    |> Enum.concat(kwargs)
   end
 
-  defp add_filter(kwargs, %{params: %{"q" => q} = p}) do
-    kwargs
-    |> Keyword.put(:q, q)
-    |> add_filter(Map.drop(p, ["q"]))
+  @spec backoffice_sort_link(Plug.Conn.t(), String.t(), atom, %{field: atom, direction: atom}) :: any
+  def backoffice_sort_link(conn, text, order_by, current_order) do
+    dir =
+      case current_order.field == order_by do
+        false ->
+          :asc
+
+        true ->
+          case current_order.direction do
+            :asc -> :desc
+            _ -> :asc
+          end
+      end
+
+    params =
+      conn.query_params
+      |> Map.put("order_by", order_by)
+      |> Map.put("dir", dir)
+
+    full_url =
+      conn.request_path
+      |> URI.parse()
+      |> Map.put(:query, Query.encode(params))
+      |> URI.to_string()
+      |> Kernel.<>("#backoffice-datasets-table")
+
+    link(text, to: full_url)
   end
 
-  defp add_filter(kwargs, _), do: kwargs
+  @spec get_arrow(boolean, atom) :: String.t()
+  def get_arrow(show, direction) do
+    case {show, direction} do
+      {false, _} ->
+        ""
+
+      {true, :asc} ->
+        ~E"<i class=\"fa fa-long-arrow-alt-down\"></i>"
+
+      {true, :desc} ->
+        ~E"<i class=\"fa fa-long-arrow-alt-up\"></i>"
+    end
+  end
 end

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -1,7 +1,7 @@
 defmodule TransportWeb.Backoffice.PageView do
   use TransportWeb, :view
-  alias TransportWeb.PaginationHelpers
   alias Plug.Conn.Query
+  alias TransportWeb.PaginationHelpers
   import TransportWeb.DatasetView, only: [end_date: 1]
   alias DB.Dataset
 
@@ -20,7 +20,8 @@ defmodule TransportWeb.Backoffice.PageView do
     |> Enum.concat(kwargs)
   end
 
-  @spec backoffice_sort_link(Plug.Conn.t(), String.t(), atom, %{field: atom, direction: atom}) :: any
+  @spec backoffice_sort_link(Plug.Conn.t(), String.t(), atom, %{field: atom, direction: atom}) ::
+          any
   def backoffice_sort_link(conn, text, order_by, current_order) do
     dir =
       case current_order.field == order_by do

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -47,20 +47,21 @@ defmodule TransportWeb.Backoffice.PageView do
       |> URI.to_string()
       |> Kernel.<>("#backoffice-datasets-table")
 
-    link(text, to: full_url)
+    sort_arrow = get_arrow(current_order.field == order_by, current_order.direction)
+    link(raw("#{text} #{sort_arrow}"), to: full_url)
   end
 
-  @spec get_arrow(boolean, atom) :: String.t()
-  def get_arrow(show, direction) do
-    case {show, direction} do
+  @spec get_arrow(boolean, atom) :: <<_::64, _::_*8>>
+  defp get_arrow(column_is_sorted, direction) do
+    case {column_is_sorted, direction} do
       {false, _} ->
-        ""
+        "<i class=\"sort-icon fa fa-sort\"></i>"
 
       {true, :asc} ->
-        ~E"<i class=\"fa fa-long-arrow-alt-down\"></i>"
+        "<i class=\"sort-icon fa fa-sort-up\"></i>"
 
       {true, :desc} ->
-        ~E"<i class=\"fa fa-long-arrow-alt-up\"></i>"
+        "<i class=\"sort-icon fa fa-sort-down\"></i>"
     end
   end
 end

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -58,10 +58,10 @@ defmodule TransportWeb.Backoffice.PageView do
         "<i class=\"sort-icon fa fa-sort\"></i>"
 
       {true, :asc} ->
-        "<i class=\"sort-icon fa fa-sort-up\"></i>"
+        "<i class=\"sort-icon fa fa-sort-down\"></i>"
 
       {true, :desc} ->
-        "<i class=\"sort-icon fa fa-sort-down\"></i>"
+        "<i class=\"sort-icon fa fa-sort-up\"></i>"
     end
   end
 end


### PR DESCRIPTION
closes #1105 

Permettre de trier la table des datasets dans le backoffice par nom ou par date de fin de validité.

![image](https://user-images.githubusercontent.com/15341118/77925393-183c5980-72a5-11ea-9256-51335051096c.png)

Les 2 difficultés rencontrées alors que je ne m'y attendais pas :
- adapter la pagination, car on change de numéro de page, il faut conserver le tri en cours s'il y en a un.
- compatibilité avec les autres filtres. Par exemple si on a sélectionné "jeux de données avec ressources autres", il y a dans la requête un  `select id from ressources where(type==autre)`. Sauf que si je transforme juste en `select id, max(validity_date) from ressources where(type==autre)`, ça ne marche pas car je fais le max des dates de validité sur les ressources de type autre, alors qu'on veut probablement voir les datasets qui ont un type de ressource autre, mais comme date de validité le max sur _toutes_ les ressources du dataset. D'ou le fait de remplacer le _where_ par un _having_ => `select id, max(validity_date) from ressources group by dataset_id having(nombre de ressources autres > 0)`