### PR TITLE
better handling datagouv zones while reimporting

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -245,7 +245,7 @@ defmodule DB.Dataset do
         dataset -> dataset
       end
 
-    territory_name = dataset.associated_territory_name
+    territory_name = Map.get(params, "associated_territory_name") || dataset.associated_territory_name
 
     dataset
     |> Repo.preload([:resources, :communes, :region])

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -86,10 +86,10 @@ defmodule DB.Resource do
   end
 
   @spec save(__MODULE__.t(), map()) :: {:ok, any()} | {:error, any()}
-  def save(%__MODULE__{id: id, url: url} = r, %{"validations" => validations, "metadata" => metadata}) do
+  def save(%__MODULE__{id: id, url: url, format: format} = r, %{"validations" => validations, "metadata" => metadata}) do
     # When the validator is unable to open the archive, it will return a fatal issue
     # And the metadata will be nil (as it couldn’t read them)
-    if is_nil(metadata), do: Logger.warn("Unable to validate: #{id}")
+    if is_nil(metadata) and format == "GTFS", do: Logger.warn("Unable to validate: #{id}")
 
     __MODULE__
     |> preload(:validation)

--- a/apps/db/priv/gettext/dataset.pot
+++ b/apps/db/priv/gettext/dataset.pot
@@ -63,10 +63,6 @@ msgid "Unable to find INSEE code '%{insee}'"
 msgstr ""
 
 #, elixir-format
-msgid "If the data.gouv's zones are used, you should fill the associated territory name"
-msgstr ""
-
-#, elixir-format
 msgid "INSEE code '%{insee}' not associated with an AOM"
 msgstr ""
 

--- a/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -64,10 +64,6 @@ msgid "Unable to find INSEE code '%{insee}'"
 msgstr ""
 
 #, elixir-format
-msgid "If the data.gouv's zones are used, you should fill the associated territory name"
-msgstr ""
-
-#, elixir-format
 msgid "INSEE code '%{insee}' not associated with an AOM"
 msgstr ""
 

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -64,10 +64,6 @@ msgid "Unable to find INSEE code '%{insee}'"
 msgstr "Impossible de trouver le code INSEE '%{insee}'"
 
 #, elixir-format
-msgid "If the data.gouv's zones are used, you should fill the associated territory name"
-msgstr "Si les zones de data.gouv.fr sont utilisées, vous devez donner le nom du territoire"
-
-#, elixir-format
 msgid "INSEE code '%{insee}' not associated with an AOM"
 msgstr "Le code INSEE '%{insee}' n'est pas associé à une AOM"
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -32,7 +32,7 @@ defmodule Transport.ImportData do
     else
       {:error, error} ->
         Logger.error("Unable to import data of dataset #{datagouv_id}: #{inspect(error)}")
-        {:error, error}
+        {:error, "impossible to import because of: #{inspect(error)}"}
     end
   end
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -189,7 +189,7 @@ defmodule Transport.ImportData do
     end
   end
 
-  defp read_datagouv_zone(%{"id" => id}) do
+  defp read_datagouv_zone(%{"features" => [%{"id" => id} | _]}) do
     Logger.info("For the moment we can only handle cities, we cannot handle the zone #{id}")
     []
   end

--- a/apps/transport/lib/transport/import_data_worker.ex
+++ b/apps/transport/lib/transport/import_data_worker.ex
@@ -6,6 +6,7 @@ defmodule Transport.ImportDataWorker do
 
   alias DB.{Dataset, Repo, Resource}
   alias Transport.ImportData
+  require Logger
 
   ## API ##
 
@@ -35,17 +36,21 @@ defmodule Transport.ImportDataWorker do
   end
 
   @impl true
-  def handle_cast({:import_and_validation, dataset}, state) do
+  def handle_cast({:import_and_validation, %Dataset{id: id} = dataset}, state) do
     ImportData.call(dataset)
     queue_validations(dataset)
     {:noreply, state}
+  rescue
+    e -> Logger.error("error in the import data worker for dataset #{id}: #{inspect(e)}")
   end
 
   @impl true
-  def handle_cast({:validate, resource}, state) do
+  def handle_cast({:validate, %Resource{id: id} = resource}, state) do
     Resource.validate_and_save(resource)
 
     {:noreply, state}
+  rescue
+    e -> Logger.error("error in the import data worker validation for resource #{id}: #{inspect(e)}")
   end
 
   @impl true

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -2,7 +2,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
   use TransportWeb, :controller
   alias Datagouvfr.Client.Datasets
 
-  alias DB.{Dataset, ImportDataWorker, Repo, Resource}
+  alias DB.{Dataset, ImportDataWorker, Repo}
   alias Transport.{ImportData, ImportDataWorker}
   require Logger
 

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
@@ -28,7 +28,7 @@
     <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView, session: %{dataset_id: @dataset.id, locale: get_session(@conn, :locale)}) %>
   </td>
   <td class="bo_dataset_button">
-    <%= form_for @conn, backoffice_page_path(@conn, :edit, @dataset.id), [nodiv: true, method: "get"], fn f -> %>
+    <%= form_for @conn, backoffice_page_path(@conn, :edit, @dataset.id), [nodiv: true, method: "get"], fn _ -> %>
     <%= submit "Editer", [class: "button", nodiv: true] %>
   <% end %>
   </td>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -56,9 +56,6 @@
       <%= dgettext("backoffice", "Dataset linked to a list of cities in data.gouv.fr") %>
       <div>
       <div class="pt-12">
-        <%= checkbox f, :use_datagouv_zones, value: not is_nil(@dataset) && not is_nil(@dataset.associated_territory_name) %><%= dgettext("backoffice", "Use data.gouv.fr's zones") %>
-      </div>
-      <div class="pt-12">
         <%= text_input f, :associated_territory_name, [
         placeholder: dgettext("backoffice", "Name of the associtated territory (used in the title of the dataset)"),
         value: if not is_nil(@dataset) do @dataset.associated_territory_name else "" end

--- a/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
@@ -127,7 +127,6 @@ defmodule TransportWeb.BackofficeControllerTest do
       |> Map.put("region_id", nil)
       |> Map.put("insee", nil)
       |> Map.put("associated_territory_name", "pouet")
-      |> Map.put("use_datagouv_zones", "true")
 
     conn =
       use_cassette "dataset/dataset-with-multiple-cities.json" do
@@ -137,34 +136,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert redirected_to(conn, 302) == backoffice_page_path(conn, :index)
     assert Resource |> Repo.all() |> length() == 1
     assert get_flash(conn, :info) =~ "ajouté"
-  end
-
-  @tag :external
-  test "Add a dataset linked to cities without name", %{conn: conn} do
-    conn =
-      use_cassette "session/create-2" do
-        conn
-        |> init_test_session(redirect_path: "/datasets")
-        |> get(session_path(conn, :create, %{"code" => "secret"}))
-      end
-
-    dataset =
-      @dataset_with_zones
-      |> Map.put("region_id", nil)
-      |> Map.put("insee", nil)
-      |> Map.put("use_datagouv_zones", "true")
-
-    # we do not put an associated_territory_name, there should be an error
-
-    conn =
-      use_cassette "dataset/dataset-with-multiple-cities-no-name.json" do
-        post(conn, backoffice_dataset_path(conn, :post), dataset)
-      end
-
-    assert redirected_to(conn, 302) == backoffice_page_path(conn, :index)
-    assert Resource |> Repo.all() |> length() == 0
-    flash = get_flash(conn, :error)
-    assert flash =~ "Si les zones de data.gouv.fr sont utilisées, vous devez donner le nom du territoire"
   end
 
   @tag :external
@@ -181,7 +152,6 @@ defmodule TransportWeb.BackofficeControllerTest do
       |> Map.put("region_id", nil)
       |> Map.put("insee", nil)
       |> Map.put("associated_territory_name", "pouet")
-      |> Map.put("use_datagouv_zones", "true")
       |> Map.put("national_dataset", "true")
 
     conn =


### PR DESCRIPTION
the reimport of dataset using datagouv's zones was not working because we expected a parameter `use_datagouv_zones` used only in the backoffice.

we thus remove the field use_datagouv_zones in the backoffice since we don't have it while reimporting the datasets and now we consider that we use the datagouv zones if the associated_territory_name is filled
![image](https://user-images.githubusercontent.com/3987698/77939138-3787b680-72a6-11ea-8a57-9f7522722688.png)


This PR also adds some logs as they were usefull to debug this mess.

Note: I think there is still a problem while computing the sha256, the file stream seems to stop, thus the computed sha is not correct, but this will be for another PR