### PR TITLE
Filter message in hasher

### DIFF
--- a/apps/helpers/lib/hasher.ex
+++ b/apps/helpers/lib/hasher.ex
@@ -12,7 +12,7 @@ defmodule Hasher do
       content_hash
     else
       {:error, error} ->
-        Logger.error(fn -> inspect(error) end)
+        Logger.error(fn -> "error while computing content_hash #{inspect(error)}" end)
         nil
 
       nil ->


### PR DESCRIPTION
## Contexte
le [module](https://github.com/etalab/transport-site/blob/5167f79c2a73cf3208eea2163599219da612c6d5/apps/helpers/lib/hasher.ex) `Hasher` génère les logs étranges `"Unknown error in stream"`.

## Problème
Du coup en creusant je me suis rendu compte que la génération des hash la nuit merdait.
En gros quand on lance les hash séparément on calcule le bon sha256, mais quand on les calculs via le `GenServer` ([ImportDataWorker](https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport/import_data_worker.ex)) les calculs ne sont plus bons.

Le log étrange vient du fait que notre implem de lib [Mint](https://github.com/elixir-mint/mint) reçoit un message qui ne lui est pas destiné (et du coup on reçoit un `:unknown`)

### Reproduction minimale
J'ai fait un petit exemple de code pour comprendre ce qui se passait. (je prend des fichiers statiques car l'analyse a été compliquée par le fait d'utiliser des ressources GTFS qui pouvait être modifiées sans que je m'en rende compte...)

```elixir
defmodule Transport.ImportDataWorkerTest do
  use GenServer
  require Logger

  def urls,
    do: [
      "https://codeursenliberte.fr/bios/francis.jpg",
      "https://codeursenliberte.fr/bios/tristram.jpg"
    ]

  def serial_hash_all do
    urls() |> Enum.each(&hash/1)
  end

  @spec hash_all :: :ok
  def hash_all do
    urls() |> Enum.each(fn r -> GenServer.cast(__MODULE__, {:hash, r}) end)
  end

  defp hash(url) do
    Logger.info("hashing #{url} ")
    hash = Hasher.compute_sha256(url)

    Logger.info("for resource #{url} hash = #{hash}")
  end

  ## GenServer implementations
  def start_link do
    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
  end

  @impl true
  def init(stack) do
    {:ok, stack}
  end

  @impl true
  def handle_cast({:hash, url}, state) do
    hash(url)

    {:noreply, state}
  end

  @impl true
  def handle_info(_msg, state) do
    {:noreply, state}
  end
end

```

Quand on lance ca ca donne:

tristram = https://codeursenliberte.fr/bios/tristram.jpg
francis = https://codeursenliberte.fr/bios/francis.jpg

| nom      | ref                 | serial_hash_all() | hash_all()    |
| -------- | ------------------- | ----------------- | ------------- |
| francis  | 70921d50f21e936565b | 70921d50f21e93    | e3b0c44298fc1 |
| tristram | f03df26d5e407a6     | f03df26d5e407a    | -             |


### Quoi se passe ?
En fait le problème vient du fait que dans notre implem du `HTTPStream` (qui permet de streamer le fichier distant pour calculer le sha256 à la volée), on écoute tous les messages qui arrivent dans le process ([ici](https://github.com/etalab/transport-site/blob/5167f79/apps/helpers/lib/http_stream.ex#L50)).

Et du coup à un moment on reçoit le message du `GenServer` demandant le calcul du sha256 pour `tristram.
 => donc le sha est pas bon et en plus on ne lance pas le calcul pour le 2eme fichier...

 ### Comment fixer ca ?
Je suis vraiment pas certain de l'approche utilisée (mais ca fixe le soucis :grin: ), en gros on filtre pour ne garder que les messages HTTP dans le `HTTPStream`. Sachant que potentiellement c'est pas non plus pour nous (ie. il ya plein d'utilisations du `HTTPStream` qui pourraient encore mener à des bugs, mais dans notre cas ca fonctionne :sweat_smile: ). Du coup le `HTTPStream` ne prend pas en compte les messages du `GenServer` (mais les message du `GenServer` ne sont pas perdus, ils sont bien catchés par le `GenServer`).

Par contre je vois pas du tout comment rajouter des tests la dessus vu que ca dépend que d'appels distants (et j'ai pas trouvé de mock pour `Mint`)