### PR TITLE
cleanup big log

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -234,7 +234,7 @@ defmodule Transport.ImportData do
     end
   end
 
-  defp read_datagouv_zone(%{"id" => id}) do
+  defp read_datagouv_zone(%{"features" => [%{"id" => id} | _]}) do
     Logger.info("For the moment we can only handle cities, we cannot handle the zone #{id}")
     []
   end


### PR DESCRIPTION
I was sure to already have shortened this log :thinking: 

since this function signature was wrong, we often entered the default method catch with an inspect on the geometry