### PR TITLE
Ajout de stat sur la qualitié des données

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -83,13 +83,18 @@ defmodule DB.Resource do
   @spec validate(__MODULE__.t()) :: {:error, any} | {:ok, map()}
   def validate(%__MODULE__{url: nil}), do: {:error, "No url"}
 
-  def validate(%__MODULE__{url: url}) do
+  def validate(%__MODULE__{url: url, format: "GTFS"}) do
     case @client.get("#{endpoint()}?url=#{URI.encode_www_form(url)}", [], recv_timeout: @timeout) do
       {:ok, %@res{status_code: 200, body: body}} -> Poison.decode(body)
       {:ok, %@res{body: body}} -> {:error, body}
       {:error, %@err{reason: error}} -> {:error, error}
       _ -> {:error, "Unknown error in validation"}
     end
+  end
+
+  def validate(%__MODULE__{format: f, id: id}) do
+    Logger.info("cannot validate resource id=#{id} because we don't know how to validate the #{f} format")
+    {:ok, %{"validations" => nil, "metadata" => nil}}
   end
 
   @spec save(__MODULE__.t(), map()) :: {:ok, any()} | {:error, any()}

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -274,7 +274,6 @@ defmodule DB.Resource do
       end,
       fn -> "NoError" end
     )
-    |> IO.inspect()
   end
 
   defp get_max_severity_error(_), do: nil

--- a/apps/db/lib/db/validation.ex
+++ b/apps/db/lib/db/validation.ex
@@ -10,6 +10,8 @@ defmodule DB.Validation do
   typed_schema "validations" do
     field(:details, :map)
     field(:date, :string)
+    # the maximum level of error in this validation
+    field(:max_error, :string)
 
     belongs_to(:resource, Resource)
   end
@@ -30,7 +32,10 @@ defmodule DB.Validation do
   @spec get_issues(%{details: any()} | nil, map()) :: [any()]
   def get_issues(nil, _), do: []
   def get_issues(%{details: nil}, _), do: []
-  def get_issues(%{details: validations}, %{"issue_type" => issue_type}), do: Map.get(validations, issue_type, [])
+
+  def get_issues(%{details: validations}, %{"issue_type" => issue_type}),
+    do: Map.get(validations, issue_type, [])
+
   def get_issues(%{details: validations}, _) when validations == %{}, do: []
 
   def get_issues(%{details: validations}, _) do

--- a/apps/db/mix.exs
+++ b/apps/db/mix.exs
@@ -10,16 +10,16 @@ defmodule Db.MixProject do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.8",
-      elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       gettext: [{:write_reference_comments, false}],
-      compilers: [:gettext] ++ Mix.compilers,
+      compilers: [:gettext] ++ Mix.compilers()
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [
@@ -34,21 +34,16 @@ defmodule Db.MixProject do
       {:ecto_sql, "~> 3.1"},
       {:postgrex, ">= 0.0.0"},
       {:geo_postgis, "~> 2.0"},
-
       {:scrivener, "~> 2.5"},
       {:scrivener_ecto, "~> 2.0"},
-
       {:gettext, "~> 0.11"},
       {:httpoison, ">= 0.0.0"},
       {:phoenix_html, ">= 0.0.0"},
       {:poison, ">= 0.0.0"},
-
       {:datagouvfr, in_umbrella: true},
       {:helpers, in_umbrella: true},
-
       {:ex_aws, ">= 0.0.0"},
       {:ex_aws_s3, ">= 0.0.0"},
-
       {:sentry, ">= 0.0.0"},
       {:typed_ecto_schema, ">= 0.1.1"}
     ]

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -37,7 +37,7 @@ msgstr "Fichier superflus"
 
 #, elixir-format
 msgid "Fatal failures"
-msgstr "Échecs irrecupérables"
+msgstr "Échecs irrécupérables"
 
 #, elixir-format
 msgid "Informations"

--- a/apps/db/priv/repo/migrations/20200420082026_validation_fields.exs
+++ b/apps/db/priv/repo/migrations/20200420082026_validation_fields.exs
@@ -41,7 +41,6 @@ defmodule DB.Repo.Migrations.ValidationFields do
     );
     """)
 
-
     execute("""
     UPDATE resource SET
     start_date = TO_DATE(metadata->>'start_date', 'YYYY-MM-DD'),

--- a/apps/db/priv/repo/migrations/20200420082026_validation_fields.exs
+++ b/apps/db/priv/repo/migrations/20200420082026_validation_fields.exs
@@ -1,0 +1,59 @@
+defmodule DB.Repo.Migrations.ValidationFields do
+  use Ecto.Migration
+
+  def up do
+    alter table(:validations) do
+      add(:max_error, :string)
+    end
+    alter table(:resource) do
+      add(:start_date, :date)
+      add(:end_date, :date)
+    end
+    create(index(:validations, [:max_error]))
+    create(index(:resource, [:start_date, :end_date]))
+
+    dt = Date.utc_today() |> Date.to_iso8601()
+
+    execute("""
+    UPDATE validations v SET
+    max_error = (
+      SELECT severity FROM (
+        SELECT distinct(json_data.value#>>'{0,severity}') as severity
+        FROM validations
+        JOIN resource ON resource.id = validations.resource_id,
+        json_each(validations.details) json_data
+        WHERE
+        (validations.id = v.id)
+        -- we only consider valid resources
+        AND resource.metadata->>'end_date' IS NOT NULL
+        AND resource.metadata->>'end_date' > '#{dt}'
+      ) AS severities
+      ORDER BY (
+        CASE severity::text
+          WHEN 'Fatal' THEN 1
+          WHEN 'Error' THEN 2
+          WHEN 'Warning' THEN 3
+          WHEN 'Information' THEN 4
+          WHEN 'Irrelevant' THEN 5
+        END
+      ) ASC
+      LIMIT 1
+    );
+    """)
+
+
+    execute("""
+    UPDATE resource SET
+    start_date = TO_DATE(metadata->>'start_date', 'YYYY-MM-DD'),
+    end_date = TO_DATE(metadata->>'end_date', 'YYYY-MM-DD');
+    """)
+  end
+
+  def down do
+    alter table(:validations) do
+      remove(:start_date)
+      remove(:end_date)
+      remove(:max_error)
+    end
+  end
+end

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -393,13 +393,13 @@ function addStaticPTQuality (id, view) {
             fillOpacity: 0.6
         },
         warning: {
-            color: 'green',
+            color: lightGreen,
             weight: 1,
             fillOpacity: 0.6
         },
         good: {
             weight: 1,
-            color: 'blue',
+            color: 'green',
             fillOpacity: 0.6
         },
         unavailable: {
@@ -430,8 +430,8 @@ function addStaticPTQuality (id, view) {
     if (view.display_legend) {
         getLegend(
             '<h4>Qualité des données courantes</h4>',
-            ['red', 'orange', 'green', 'blue', 'grey'],
-            ['Non conforme', 'Erreur', 'Satisfaisante', 'Bonne', 'Pas à jour']
+            ['red', 'orange', lightGreen, 'green', 'grey'],
+            ['Non conforme', 'Erreur', 'Satisfaisante', 'Bonne', 'Pas de données à jour']
         ).addTo(map)
     }
 }

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -271,26 +271,26 @@ function addStaticPTUpToDate (id, view) {
     function onEachAomFeature (feature, layer) {
         const name = feature.properties.nom
         const type = feature.properties.forme_juridique
-        const expired_from = feature.properties.quality.expired_from
-        let text = ""
-        if (expired_from.status === "outdated") {
-            text = `Les données ne sont plus à jour depuis ${expired_from.nb_days} jour`
-            if (expired_from.nb_days > 1) {
-                text += "s"
+        const expiredFrom = feature.properties.quality.expired_from
+        let text = ''
+        if (expiredFrom.status === 'outdated') {
+            text = `Les données ne sont plus à jour depuis ${expiredFrom.nb_days} jour`
+            if (expiredFrom.nb_days > 1) {
+                text += 's'
             }
         } else {
-            if (expired_from.status === "no_data") {
+            if (expiredFrom.status === 'no_data') {
                 text = "Aucune données pour l'AOM"
-            } else if (expired_from.status === "unreadable") {
-                text = "données illisibles"
+            } else if (expiredFrom.status === 'unreadable') {
+                text = 'données illisibles'
             } else {
-                text = "Les données sont à jour"
+                text = 'Les données sont à jour'
             }
         }
         const id = feature.properties.id
         layer.bindPopup(`<a href="/datasets/aom/${id}">${name}</a><br>(${type})<br/>${text}`)
     }
-    
+
     const styles = {
         outdated: {
             weight: 1,
@@ -311,16 +311,16 @@ function addStaticPTUpToDate (id, view) {
             weight: 1,
             color: 'grey',
             fillOpacity: 0.6
-        },
+        }
     }
 
     const style = feature => {
-        const expired_from = feature.properties.quality.expired_from
-        if (expired_from.status === "up_to_date") {
+        const expiredFrom = feature.properties.quality.expired_from
+        if (expiredFrom.status === 'up_to_date') {
             return styles.up_to_date
-        } else if (expired_from.status === "outdated") {
+        } else if (expiredFrom.status === 'outdated') {
             return styles.outdated
-        } else if (expired_from.status === "unreadable") {
+        } else if (expiredFrom.status === 'unreadable') {
             return styles.unreadable
         } else {
             return styles.no_data
@@ -334,35 +334,33 @@ function addStaticPTUpToDate (id, view) {
         getLegend(
             '<h4>Fraicheur des données</h4>',
             ['green', 'orange', 'red', 'grey'],
-            ['à jour', 'pas à jour', 'inconnue', 'pas de données']
+            ['Données à jour', 'Données pas à jour', 'Données illisibles', 'Pas de données']
         ).addTo(map)
     }
 }
 
 function addStaticPTQuality (id, view) {
-    const lighterGreen = "#1daf25"
     const map = makeMapOnView(id, view)
 
     function onEachAomFeature (feature, layer) {
         const name = feature.properties.nom
         const type = feature.properties.forme_juridique
-        const error_level = feature.properties.quality.error_level
-        let text = ""
-        if (error_level === "Error") {
-            text = `Les données contiennent des erreurs.`
-        } else if (error_level === "Warning") {
-            text = `Les données contiennent des avertissements.`
-        } else if (error_level === "Fatal") {
-            text = `Les données sont illisibles.`
-        } else if (error_level === 'Information' || error_level == 'NoError') {
-            text = "Les données sont de bonne qualité."
+        const errorLevel = feature.properties.quality.error_level
+        let text = ''
+        if (errorLevel === 'Error') {
+            text = 'Les données contiennent des erreurs.'
+        } else if (errorLevel === 'Warning') {
+            text = 'Les données contiennent des avertissements.'
+        } else if (errorLevel === 'Fatal') {
+            text = 'Les données ne respectent pas les spécifications.'
+        } else if (errorLevel === 'Information' || errorLevel === 'NoError') {
+            text = 'Les données sont de bonne qualité.'
         } else {
-            text = `Pas de données.`
+            text = 'Pas de données valides disponible.'
         }
         const id = feature.properties.id
         layer.bindPopup(`<a href="/datasets/aom/${id}">${name}</a><br>(${type})<br/>${text}`)
     }
-    
     const styles = {
         fatal: {
             weight: 1,
@@ -388,7 +386,7 @@ function addStaticPTQuality (id, view) {
             weight: 1,
             color: 'grey',
             fillOpacity: 0.6
-        },
+        }
     }
 
     const style = feature => {
@@ -399,7 +397,7 @@ function addStaticPTQuality (id, view) {
             return styles.error
         } else if (quality === 'Warning') {
             return styles.warning
-        } else if (quality === 'Information' || quality == 'NoError') {
+        } else if (quality === 'Information' || quality === 'NoError') {
             return styles.good
         } else {
             return styles.unavailable
@@ -411,9 +409,9 @@ function addStaticPTQuality (id, view) {
 
     if (view.display_legend) {
         getLegend(
-            '<h4>Qualité des données</h4>',
+            '<h4>Qualité des données courantes</h4>',
             ['red', 'orange', 'green', 'blue', 'grey'],
-            ['Illisible', 'Erreur', 'Bonne mais améliorable', 'Bonne', 'Pas à jour']
+            ['Non conforme', 'Erreur', 'Satisfaisante', 'Bonne', 'Pas à jour']
         ).addTo(map)
     }
 }

--- a/apps/transport/client/stylesheets/components/_stats.scss
+++ b/apps/transport/client/stylesheets/components/_stats.scss
@@ -219,6 +219,20 @@
     width: 2em;
     height: 2em;
   }
+
+  .quality .panel {
+    .tile {
+      padding: 1em 2em;
+    }
+
+    .tile + .tile {
+      margin-top: 1em;
+    }
+    .description + .tile {
+      margin-top: 1em;
+    }
+  }
+
 }
 
 .staticPTdata .leaflet-control-layers-selector {

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -34,7 +34,7 @@ defmodule Transport.ImportData do
   end
 
   @spec validate_all_resources() :: :ok
-  def validate_all_resources do
+  def validate_all_resources(force \\ false) do
     Logger.info("Validating all resources")
 
     resources =
@@ -42,7 +42,7 @@ defmodule Transport.ImportData do
       |> preload([:dataset, :validation])
       |> where([r], r.format == "GTFS")
       |> Repo.all()
-      |> Enum.filter(&Resource.needs_validation/1)
+      |> Enum.filter(fn r -> force || Resource.needs_validation(r) end)
 
     Logger.info("launching #{Enum.count(resources)} validations")
 

--- a/apps/transport/lib/transport/import_data_worker.ex
+++ b/apps/transport/lib/transport/import_data_worker.ex
@@ -18,7 +18,7 @@ defmodule Transport.ImportDataWorker do
     GenServer.cast(__MODULE__, {:validate_all})
   end
 
-  @spec validate_all :: :ok
+  @spec force_validate_all :: :ok
   def force_validate_all do
     GenServer.cast(__MODULE__, {:force_validate_all})
   end

--- a/apps/transport/lib/transport/import_data_worker.ex
+++ b/apps/transport/lib/transport/import_data_worker.ex
@@ -18,6 +18,11 @@ defmodule Transport.ImportDataWorker do
     GenServer.cast(__MODULE__, {:validate_all})
   end
 
+  @spec validate_all :: :ok
+  def force_validate_all do
+    GenServer.cast(__MODULE__, {:force_validate_all})
+  end
+
   def start_link do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
@@ -40,6 +45,14 @@ defmodule Transport.ImportDataWorker do
   @impl true
   def handle_cast({:validate_all}, state) do
     ImportData.validate_all_resources()
+    {:noreply, state}
+  rescue
+    e -> Logger.error("error in the validation data worker : #{inspect(e)}")
+  end
+
+  @impl true
+  def handle_cast({:force_validate_all}, state) do
+    ImportData.validate_all_resources(true)
     {:noreply, state}
   rescue
     e -> Logger.error("error in the validation data worker : #{inspect(e)}")

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -233,7 +233,9 @@ defmodule TransportWeb.API.StatsController do
             JOIN resource ON resource.id = validations.resource_id
             JOIN dataset ON dataset.id = resource.dataset_id
             WHERE
-            (dataset.aom_id = ? OR dataset.id = ?)
+              (dataset.aom_id = ? OR dataset.id = ?)
+              AND
+              resource.end_date >= TO_DATE(?, 'YYYY-MM-DD')
             ORDER BY (
               CASE max_error::text
                 WHEN 'Fatal' THEN 1
@@ -247,7 +249,8 @@ defmodule TransportWeb.API.StatsController do
             LIMIT 1
             """,
             aom.id,
-            parent_dataset.id
+            parent_dataset.id,
+            ^dt
           )
       },
       parent_dataset_slug: parent_dataset.slug,

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -224,7 +224,6 @@ defmodule TransportWeb.API.StatsController do
             parent_dataset.id
           ),
         # we get the most serious error of the valid resources
-        # TODO gérer les cas parfait
         error_level:
           fragment(
             """
@@ -238,14 +237,14 @@ defmodule TransportWeb.API.StatsController do
               resource.end_date >= TO_DATE(?, 'YYYY-MM-DD')
             ORDER BY (
               CASE max_error::text
-                WHEN 'Fatal' THEN 1
-                WHEN 'Error' THEN 2
-                WHEN 'Warning' THEN 3
-                WHEN 'Information' THEN 4
-                WHEN 'Irrelevant' THEN 5
-                WHEN 'NoError' THEN 6
+                WHEN 'Fatal' THEN 6
+                WHEN 'Error' THEN 5
+                WHEN 'Warning' THEN 4
+                WHEN 'Information' THEN 3
+                WHEN 'Irrelevant' THEN 2
+                WHEN 'NoError' THEN 1
               END
-            ) ASC
+            ) DESC
             LIMIT 1
             """,
             aom.id,

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -80,7 +80,7 @@ defmodule TransportWeb.API.StatsController do
       dataset_types =
         aom
         |> Map.get(:dataset_types, [])
-        |> Enum.filter(fn {_, v} -> v != nil end)
+        |> Enum.filter(fn {_, v} -> !is_nil(v) end)
         |> Enum.into(%{})
 
       %{

--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -24,6 +24,7 @@ defmodule TransportWeb.API.Router do
       get("/", TransportWeb.API.StatsController, :index)
       get("/regions", TransportWeb.API.StatsController, :regions)
       get("/bike-sharing", TransportWeb.API.StatsController, :bike_sharing)
+      get("/quality", TransportWeb.API.StatsController, :quality)
     end
 
     get("/openapi", OpenApiSpex.Plug.RenderSpec, :show)

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -98,6 +98,15 @@ defmodule TransportWeb.Backoffice.DatasetController do
     |> redirect_to_index()
   end
 
+  @spec validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def force_validate_all(%Plug.Conn{} = conn, _args) do
+    ImportDataWorker.force_validate_all()
+
+    conn
+    |> put_flash(:info, dgettext("backoffice_dataset", "validation of all datasets has been launch"))
+    |> redirect_to_index()
+  end
+
   ## Private functions
 
   @spec flash(:ok | {:ok, any} | {:error, any}, Plug.Conn.t(), binary, binary) :: Plug.Conn.t()

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -98,7 +98,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
     |> redirect_to_index()
   end
 
-  @spec validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec force_validate_all(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def force_validate_all(%Plug.Conn{} = conn, _args) do
     ImportDataWorker.force_validate_all()
 

--- a/apps/transport/lib/transport_web/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/stats_controller.ex
@@ -1,5 +1,5 @@
 defmodule TransportWeb.StatsController do
-  alias DB.{AOM, Dataset, Region, Repo, Resource}
+  alias DB.{AOM, Dataset, Region, Repo, Resource, Validation}
   alias Transport.CSVDocuments
   import Ecto.Query
   require Logger
@@ -24,7 +24,12 @@ defmodule TransportWeb.StatsController do
     regions = Repo.all(from(r in Region, where: r.nom != "National"))
 
     aoms_max_severity = compute_aom_max_severity()
-    total_aom_with_datasets = nb_aom_with_gtfs()
+
+    total_aom_with_datasets =
+      aoms_max_severity
+      |> Map.values()
+      |> Enum.filter(fn error -> not is_nil(error) end)
+      |> Enum.sum()
 
     render(conn, "index.html",
       nb_datasets: Repo.aggregate(Dataset, :count, :id),
@@ -105,26 +110,56 @@ defmodule TransportWeb.StatsController do
 
   @spec compute_aom_max_severity() :: %{binary() => integer()}
   defp compute_aom_max_severity do
+    # consolidate the maximum error for the current dataset for each dataset
+    # return, for each error, the number of AOM with this maximum error
     dt = Date.utc_today()
-    # TODO: this query is wrong
+
+    validations =
+      Validation
+      |> select([v], %{
+        max_error:
+          fragment("""
+          CASE max_error::text
+          WHEN 'Fatal' THEN 5
+          WHEN 'Error' THEN 4
+          WHEN 'Warning' THEN 3
+          WHEN 'Information' THEN 2
+          WHEN 'Irrelevant' THEN 1
+          ELSE 0
+          END
+          """),
+        resource_id: v.resource_id
+      })
+
     AOM
     |> join(:left, [aom], dataset in Dataset, on: dataset.id == aom.parent_dataset_id or dataset.aom_id == aom.id)
     |> join(:left, [_, dataset], _r in assoc(dataset, :resources))
-    |> join(:left, [_, _, resource], _v in assoc(resource, :validation))
+    |> join(:left, [_, _, r], v in subquery(validations), on: v.resource_id == r.id)
     |> where([_a, _d, r, _v], r.format == "GTFS")
-    |> where([_a, _d, r, _v], not is_nil(r.end_date) and r.end_date >= ^dt)
-    |> group_by([_a, _d, _r, v], v.max_error)
+    |> where([_a, _d, r, _v], r.end_date >= ^dt)
+    |> group_by([_a, _d, _r, v], _a.id)
     |> select([a, d, r, v], %{
-      count: count(v.max_error),
-      error: v.max_error
+      aom: a.id,
+      max_error: max(v.max_error)
     })
     |> Repo.all()
-    |> Enum.map(fn %{count: count, error: error} -> {error, count} end)
-    |> Map.new()
-    |> IO.inspect
+    |> List.foldl(%{}, fn %{max_error: max_error}, acc ->
+      max_error =
+        case max_error do
+          5 -> "Fatal"
+          4 -> "Error"
+          3 -> "Warning"
+          2 -> "Information"
+          1 -> "Irrelevant"
+          0 -> "NoError"
+          _ -> nil
+        end
+
+      Map.update(acc, max_error, 0, fn v -> v + 1 end)
+    end)
   end
 
-  @spec ratio_aom_with_at_most_warnings(integer(), integer()) :: integer()
+  @spec ratio_aom_with_at_most_warnings(%{binary() => integer()}, integer()) :: integer()
   defp ratio_aom_with_at_most_warnings(aom_max_severity, 0) do
     0
   end
@@ -135,9 +170,8 @@ defmodule TransportWeb.StatsController do
         Map.get(aom_max_severity, "Information", 0) +
         Map.get(aom_max_severity, "Irrelevant", 0) +
         Map.get(aom_max_severity, "NoError", 0)
-    (sum / nb_aom_with_data *
-       100)
-    |> round
+
+    round(sum / nb_aom_with_data * 100)
   end
 
   @spec ratio_aom_good_quality(%{binary() => integer()}, integer()) :: integer()
@@ -148,33 +182,9 @@ defmodule TransportWeb.StatsController do
   defp ratio_aom_good_quality(aom_max_severity, nb_aom_with_data) do
     sum =
       Map.get(aom_max_severity, "Information", 0) +
-      Map.get(aom_max_severity, "Irrelevant", 0) +
-      Map.get(aom_max_severity, "NoError", 0)
+        Map.get(aom_max_severity, "Irrelevant", 0) +
+        Map.get(aom_max_severity, "NoError", 0)
 
-      (sum *
-      100 /
-      nb_aom_with_data)
-      |> round
-    end
-
-  @spec nb_aom_with_gtfs() :: integer()
-  defp nb_aom_with_gtfs() do
-    resources =
-      Resource
-      |> where([r], not is_nil(r.end_date))
-      |> where([r], r.format == "GTFS")
-      |> group_by([r], r.dataset_id)
-      |> distinct([r], r.dataset_id)
-      |> select([r], %{dataset_id: r.dataset_id})
-
-    datasets = Dataset
-    |> join(:right, [d], r in subquery(resources), on: d.id == r.dataset_id)
-    |> select([d, _r], %{id: d.id, aom_id: d.aom_id})
-
-    AOM
-    |> join(:right, [a], d in subquery(datasets), on: d.aom_id == a.id or d.id == a.parent_dataset_id)
-    |> select([a, _d], a.id)
-    |> Repo.aggregate(:count, :id)
-    |> IO.inspect()
+    round(sum * 100 / nb_aom_with_data)
   end
 end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -96,6 +96,7 @@ defmodule TransportWeb.Router do
         post("/:id/_delete", DatasetController, :delete)
         post("/_all_/_import_validate", DatasetController, :import_validate_all)
         post("/_all_/_validate", DatasetController, :validate_all)
+        post("/_all_/_force_validate", DatasetController, :force_validate_all)
         post("/:id/_import_validate", DatasetController, :import_validate_all)
         post("/:id/_validate", DatasetController, :validation)
       end

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -7,7 +7,7 @@
       <%= form_for @conn, backoffice_dataset_path(@conn, :import_validate_all), [method: "post"], fn _f -> %>
         <%= submit dgettext("backoffice", "Import and validate all") %>
       <% end %>
-      <%= form_for @conn, backoffice_dataset_path(@conn, :validate_all), [method: "post"], fn _f -> %>
+      <%= form_for @conn, backoffice_dataset_path(@conn, :force_validate_all), fn _f -> %>
         <%= submit dgettext("backoffice", "validate all") %>
       <% end %>
     </div>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -118,7 +118,7 @@
         </div>
       </div>
     </div>
-    <div class="domain">
+    <div class="domain quality">
       <div class="domain-stats">
         <%= render("_maps.html", droms: @droms, prefix: "pt_quality") %>
         <div class="panel">
@@ -134,7 +134,6 @@
             Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
             </p>
           </div>
-          <div class="tile-numbers">
             <div class="tile">
               <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
               <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de
@@ -153,7 +152,6 @@
               <h3> <%= @aom_with_fatal %> </h3>
               <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données ne respectant pas les spécifications GTFS</div>
             </div>
-          </div>
         </div>
       </div>
     </div>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -118,19 +118,19 @@
           <div class="tile-numbers">
             <div class="tile">
               <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données de qualité satisfaisante</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de qualité satisfaisante</div>
             </div>
             <div class="tile">
               <h3> <%= @ratio_aom_good_quality %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données de bonne qualité</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de bonne qualité</div>
             </div>
             <div class="tile">
               <h3> <%= @aom_with_errors %> </h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données en erreur</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données en erreur</div>
             </div>
             <div class="tile">
               <h3> <%= @aom_with_fatal %> </h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données ne respectant pas les spécifications GTFS</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données ne respectant pas les spécifications GTFS</div>
             </div>
           </div>
         </div>
@@ -148,22 +148,8 @@
             qui correspond à la période de circulation des différents services du jeu de donnés.
 </p>
 <p>
-            Note: on ne peut calculer une période de validité uniquement pour les jeux de donnée respectant les spécifications GTFS.
+            Note: on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS.
             </p>
-          </div>
-          <div class="tile-numbers">
-            <div class="tile">
-              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données à jour</div>
-            </div>
-            <div class="tile">
-              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données périmées</div>
-            </div>
-            <div class="tile">
-              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données illisbles</div>
-            </div>
           </div>
         </div>
       </div>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -103,42 +103,6 @@
     </div>
     <div class="domain">
       <div class="domain-stats">
-        <%= render("_maps.html", droms: @droms, prefix: "pt_quality") %>
-        <div class="panel">
-          <div class="description">
-            <h3>Zoom sur la qualité des données</h3>
-          <p>
-          La plateforme transport.data.gouv.fr utilise des outils de validation
-          pour contrôler la qualité des jeux de données de transport.
-          </p>
-          <p>
-          Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
-          </p>
-          </div>
-          <div class="tile-numbers">
-            <div class="tile">
-              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de qualité satisfaisante</div>
-            </div>
-            <div class="tile">
-              <h3> <%= @ratio_aom_good_quality %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de bonne qualité</div>
-            </div>
-            <div class="tile">
-              <h3> <%= @aom_with_errors %> </h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données en erreur</div>
-            </div>
-            <div class="tile">
-              <h3> <%= @aom_with_fatal %> </h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données ne respectant pas les spécifications GTFS</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="domain">
-      <div class="domain-stats">
         <%= render("_maps.html", droms: @droms, prefix: "pt_up_to_date") %>
         <div class="panel">
           <div class="description">
@@ -150,6 +114,43 @@
 <p>
             Note: on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS.
             </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="domain">
+      <div class="domain-stats">
+        <%= render("_maps.html", droms: @droms, prefix: "pt_quality") %>
+        <div class="panel">
+          <div class="description">
+            <h3>Zoom sur la qualité des données</h3>
+          <p>
+          Cette carte représente la qualité des données GTFS actuellement valides.
+          </p>
+          <p>
+          Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.          .
+          </p>
+          <p>
+          Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
+          </p>
+          </div>
+          <div class="tile-numbers">
+            <div class="tile">
+              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de qualité satisfaisante (avec aucune erreur)</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @ratio_aom_good_quality %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de bonne qualité (avec ni erreurs ni avertissements)</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @aom_with_errors %> </h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données en erreur</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @aom_with_fatal %> </h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données ne respectant pas les spécifications GTFS</div>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -101,6 +101,73 @@
         </div>
       </div>
     </div>
+    <div class="domain">
+      <div class="domain-stats">
+        <%= render("_maps.html", droms: @droms, prefix: "pt_quality") %>
+        <div class="panel">
+          <div class="description">
+            <h3>Zoom sur la qualité des données</h3>
+          <p>
+          La plateforme transport.data.gouv.fr utilise des outils de validation
+          pour contrôler la qualité des jeux de données de transport.
+          </p>
+          <p>
+          Retrouvez plus d'informations sur ces outils dans la <a href="TODO">documentation</a>.
+          </p>
+          </div>
+          <div class="tile-numbers">
+            <div class="tile">
+              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données de qualité satisfaisante</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @ratio_aom_good_quality %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données de bonne qualité</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @aom_with_errors %> </h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données en erreur</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @aom_with_fatal %> </h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des jeux de données ne respectant pas les spécifications GTFS</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="domain">
+      <div class="domain-stats">
+        <%= render("_maps.html", droms: @droms, prefix: "pt_up_to_date") %>
+        <div class="panel">
+          <div class="description">
+            <h3>Zoom sur la fraicheur des données</h3>
+            <p>
+            Les données GTFS de la plateforme sont analysées pour connaitre leur periode de validité,
+            qui correspond à la période de circulation des différents services du jeu de donnés.
+</p>
+<p>
+            Note: on ne peut calculer une période de validité uniquement pour les jeux de donnée respectant les spécifications GTFS.
+            </p>
+          </div>
+          <div class="tile-numbers">
+            <div class="tile">
+              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données à jour</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données périmées</div>
+            </div>
+            <div class="tile">
+              <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> avec des données illisbles</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="domain rt">
       <h2>Transports en commun - temps réel</h2>
       <div class="domain-stats">

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -110,9 +110,9 @@
             <p>
             Les données GTFS de la plateforme sont analysées pour connaitre leur periode de validité,
             qui correspond à la période de circulation des différents services du jeu de donnés.
-</p>
-<p>
-            Note: on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS.
+            </p>
+            <p>
+            Note : on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS.
             </p>
           </div>
         </div>
@@ -124,24 +124,26 @@
         <div class="panel">
           <div class="description">
             <h3>Zoom sur la qualité des données</h3>
-          <p>
-          Cette carte représente la qualité des données GTFS actuellement valides.
-          </p>
-          <p>
-          Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.          .
-          </p>
-          <p>
-          Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
-          </p>
+            <p>
+            Cette carte représente la qualité des données GTFS actuellement valides.
+            </p>
+            <p>
+            Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.          .
+            </p>
+            <p>
+            Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
+            </p>
           </div>
           <div class="tile-numbers">
             <div class="tile">
               <h3> <%= @ratio_aom_with_at_most_warnings %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de qualité satisfaisante (avec aucune erreur)</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de
+              qualité satisfaisante (sans aucune erreur)</div>
             </div>
             <div class="tile">
               <h3> <%= @ratio_aom_good_quality %>%</h3>
-              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de bonne qualité (avec ni erreurs ni avertissements)</div>
+              <div><acronym title="autorité organistrice de mobilité">AOM</acronym> urbaines avec des jeux de données de bonne qualité
+              (sans erreurs ni avertissements)</div>
             </div>
             <div class="tile">
               <h3> <%= @aom_with_errors %> </h3>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -112,7 +112,7 @@
           pour contrôler la qualité des jeux de données de transport.
           </p>
           <p>
-          Retrouvez plus d'informations sur ces outils dans la <a href="TODO">documentation</a>.
+          Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
           </p>
           </div>
           <div class="tile-numbers">


### PR DESCRIPTION
closes #1120

ajout de 2 cartes sur la page /stats :

### une de fraîcheur de données
![image](https://user-images.githubusercontent.com/3987698/80390561-182b7b80-889c-11ea-84d9-575b5b9c080d.png)

La carte représente, pour chaque AOM urbaine (que les AO, mais en prenant en compte le jdd régional si présent) la fraîcheur des données, c'est à dire si on trouve 1 jdd GTFS valide sur la date du jour.

Note: dans les stats on a le nombre de jour de péremption du jdd, mais le dégradé ne rend pas grand chose, donc j'ai calé simplement la couleur rouge, que le jdd soit périmé d'un jour ou d'un an.
Je suis preneur de retour si vous pensez que ca vaut le coup de faire mieux.

### une sur la qualité des données
![image](https://user-images.githubusercontent.com/3987698/80390603-2aa5b500-889c-11ea-8a82-f1e8ae5a3c34.png)

La carte représente, pour chaque AOM urbaine (que les AO, mais en prenant en compte le jdd régional si présent) le niveau d'erreur max du ou des ressources en cours de validité (on ne prend pas en compte les anciens jdd qui n'auraient pas été remplacé sur coup).

Cette carte est un peu tricky vu qu'on fait un peu du shaming, j'ai donc essayé d'arrondir les angles et de nommé la catégorie avec les `Warnings` "qualité satisfaisante" et de la mettre en vert.
En vrai toutes les données avec des warnings ne sont pas forcément de qualité satisfaisante, mais je trouvais pas mieux comme wording.

Vous en pensez quoi ?


## GOTCHA
* Vu que ces cartes font du shaming, je suis preneur de retour attentif sur mes requêtes SQL pour être sur que je ne me suis pas trompé :grin: 
* je suis de manière général preneur de retour sur la forme, le choix des couleurs, le wording, ...
* La requête SQL `/api/stats` doit maintenant faire une jointure sur toutes les validations. même en rajoutant des indexes, ca fait passer la requête de 700ms à 1.3s sur mon PC. je sais pas si c'est acceptable, ou si au moins il faudrait faire ca sur une autre api pour que les autres carte s'affichent plus vite.
* j'ai rajouté du [bout de doc](https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee) sur la qualité des données et le validateur, je suis preneur d'une relecture
* J'ai du externaliser certain champs car notre version de postgres ne gère pas d'index sur les champs JSON (faut PG 12). j'ai fait une requête pour peupler la base, mais elle est pas parfaite, et il faudra relancer une validation des jdd pour avoir le champ bien rempli partout.
* j'ai du coup changé le bouton "tout valider" du backoffice pour relancer une validation sur toutes les ressources, même si elles avaient déjà été validées avant.
* j'avais pushé sur prochainement, mais je me suis fait écraser par @fchabouis , si vous voulez voir ca sur prochainement, il faudra attendre qu'on ai mergé la PR de refacto des datasets