### PR TITLE
handle empty string for territory

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -671,6 +671,12 @@ defmodule DB.Dataset do
     |> put_assoc(:communes, [])
   end
 
+  defp cast_datagouv_zone(changeset, _, "") do
+    changeset
+    |> change
+    |> put_assoc(:communes, [])
+  end
+
   defp cast_datagouv_zone(changeset, %{"zones" => zones_insee}, _associated_territory_name) do
     communes =
       zones_insee

--- a/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
@@ -170,6 +170,33 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   @tag :external
+  test "Add a dataset linked to an AO and with an empty territory name", %{conn: conn} do
+    conn =
+      use_cassette "session/create-2" do
+        conn
+        |> init_test_session(redirect_path: "/datasets")
+        |> get(session_path(conn, :create, %{"code" => "secret"}))
+      end
+
+    dataset =
+      @dataset_with_zones
+      |> Map.put("region_id", nil)
+      |> Map.put("associated_territory_name", "")
+      |> Map.put("national_dataset", "true")
+
+    conn =
+      use_cassette "dataset/dataset-with-multiple-cities.json" do
+        post(conn, backoffice_dataset_path(conn, :post), dataset)
+      end
+
+    # It should be possible to link a dataset to an AOM if the territory name
+    # is empty (but not null since it comes from a form)
+    assert redirected_to(conn, 302) == backoffice_page_path(conn, :index)
+    assert Resource |> Repo.all() |> length() == 1
+    assert get_flash(conn, :info) =~ "ajouté"
+  end
+
+  @tag :external
   test "Add a dataset linked to a region and to the country", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do


### PR DESCRIPTION
This was making it impossible to import datasets already associated to cities in data.gouv as attached to an AOM in transport.