### PR TITLE
update slack invitation link

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.eex
@@ -227,7 +227,7 @@
        </form>
        <div class="mailing-list__social-container">
             <img src="<%= static_path(@conn, "/images/Twitter_Logo_Blue.svg") %>" alt="Twitter" /><a href="https://twitter.com/transportdatafr"><%= dgettext("page-index", "Follow us on twitter") %></a>
-            <img src="<%= static_path(@conn, "/images/Slack_Mark.svg") %>" alt="Slack" /><a href="https://join.slack.com/transportdatagouvfr/shared_invite/MjA2ODkzODQyOTk4LTE0OTg4MDUyNTktNmM2OWJmOGQwOA"><%= dgettext("page-index", "Join us on Slack") %></a>
+            <img src="<%= static_path(@conn, "/images/Slack_Mark.svg") %>" alt="Slack" /><a href="https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA"><%= dgettext("page-index", "Join us on Slack") %></a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
I don't really understand why, but the old link stoped working, so I put a new one