### PR TITLE
Possibilité de filtrer les résultats de recherche par région

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -331,6 +331,7 @@ defmodule DB.Dataset do
     |> join(:inner, [d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id)
     |> distinct([d], d.id)
     |> where([d, r, d_geo], d.is_active and "bus" in r.auto_tags and d_geo.region_id == 14)
+    # 14 is the national "region". It means that it is not bound to a region or local territory
     |> Repo.aggregate(:count, :id)
   end
 

--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -158,7 +158,7 @@
   margin-top: 3em;
 }
 
-.side-pane__submenu .activefilter {
+.activefilter {
   font-weight: 700;
 }
 
@@ -267,5 +267,23 @@
     a {
       color: var(--grey);
     }
+  }
+}
+
+.order-by {
+  padding-bottom: 12px;
+  display: flex;
+  justify-content: center;
+  .order-by__title {
+    padding-right: 6px;
+    color: var(--darker-grey);
+  }
+}
+
+.order-by-option {
+  padding-left: 12px;
+  a {
+    text-decoration: none;
+    color: var(--darker-grey);
   }
 }

--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -273,7 +273,7 @@
 .order-by {
   padding-bottom: 12px;
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   .order-by__title {
     padding-right: 6px;
     color: var(--darker-grey);

--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -287,3 +287,7 @@
     color: var(--darker-grey);
   }
 }
+
+.pt-36 {
+  padding-top: 36px;
+}

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -12,10 +12,11 @@ defmodule TransportWeb.DatasetController do
 
   @spec list_datasets(Plug.Conn.t(), map(), boolean) :: Plug.Conn.t()
   def list_datasets(%Plug.Conn{} = conn, %{} = params, count_by_region \\ false) do
-    conn = case count_by_region do
-      true -> assign(conn, :regions, get_regions(params))
-      false -> conn
-    end
+    conn =
+      case count_by_region do
+        true -> assign(conn, :regions, get_regions(params))
+        false -> conn
+      end
 
     conn
     |> assign(:datasets, get_datasets(params))
@@ -122,13 +123,12 @@ defmodule TransportWeb.DatasetController do
 
   @spec get_regions(map()) :: [Region.t()]
   defp get_regions(params) do
-    IO.inspect(params)
     sub =
       params
       |> clean_datasets_query("region")
       |> exclude(:order_by)
       |> join(:left, [d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id)
-      |> select([d, d_geo], %{id: d.id, region_id: d_geo.region_id})
+      |> get_regions_select(params)
 
     Region
     |> join(:left, [r], d in subquery(sub), on: d.region_id == r.id)
@@ -136,6 +136,15 @@ defmodule TransportWeb.DatasetController do
     |> select([r, d], %{nom: r.nom, id: r.id, count: count(d.id)})
     |> order_by([r], r.nom)
     |> Repo.all()
+  end
+
+  defp get_regions_select(query, %{"tags" => _tags}) do
+    # when there are some tags filters, the DatasetGeographicView is the third join, not the second.
+    query |> select([d, r, d_geo], %{id: d.id, region_id: d_geo.region_id})
+  end
+
+  defp get_regions_select(query, %{}) do
+    query |> select([d, d_geo], %{id: d.id, region_id: d_geo.region_id})
   end
 
   @spec get_types(map()) :: [%{type: binary(), msg: binary(), count: integer}]

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -33,31 +33,49 @@
   <div class="container">
     <div class="shortlist">
       <nav class="side-pane" role="navigation">
-        <ul class="side-pane__menu">
+        <div class="pt-36">
+          <ul class="side-pane__menu">
 
-          <li class="side-pane__title">
-            <h3><%= dgettext("page-shortlist", "Data type") %></h3>
-            <li class="side-pane__dropdown unfolded">
-              <ul class="side-pane__submenu">
-                <li><%= type_link(@conn, %{msg: dgettext("page-shortlist", "All"), type: nil, count: @types |> Enum.map(&(&1.count)) |> Enum.sum}) %></li>
-                <%= for type <- @types do %>
-                  <li><%= type_link(@conn, type) %></li>
-                <% end %>
-              </ul>
+            <li class="side-pane__title">
+              <h3><%= dgettext("page-shortlist", "Data type") %></h3>
+              <li class="side-pane__dropdown unfolded">
+                <ul class="side-pane__submenu">
+                  <li><%= type_link(@conn, %{msg: dgettext("page-shortlist", "All"), type: nil, count: @types |> Enum.map(&(&1.count)) |> Enum.sum}) %></li>
+                  <%= for type <- @types do %>
+                    <li><%= type_link(@conn, type) %></li>
+                  <% end %>
+                </ul>
+              </li>
             </li>
-          </li>
 
-          <li class="side-pane__title">
-            <h3><%= dgettext("page-shortlist", "Real Time") %></h3>
-            <li class="side-pane__dropdown unfolded">
-              <ul class="side-pane__submenu">
-                <li><%= real_time_link(@conn, %{only_realtime: false, msg: dgettext("page-shortlist", "Any"), count: @number_realtime_datasets.all}) %></li>
-                <li><%= real_time_link(@conn, %{only_realtime: true, msg: dgettext("page-shortlist", "with real time"), count: @number_realtime_datasets.true}) %></li>
-              </ul>
+            <li class="side-pane__title">
+              <h3><%= dgettext("page-shortlist", "Real Time") %></h3>
+              <li class="side-pane__dropdown unfolded">
+                <ul class="side-pane__submenu">
+                  <li><%= real_time_link(@conn, %{only_realtime: false, msg: dgettext("page-shortlist", "Any"), count: @number_realtime_datasets.all}) %></li>
+                  <li><%= real_time_link(@conn, %{only_realtime: true, msg: dgettext("page-shortlist", "with real time"), count: @number_realtime_datasets.true}) %></li>
+                </ul>
+              </li>
             </li>
-          </li>
 
-        </ul>
+            <%= if assigns[:regions] do %>
+              <li class="side-pane__title">
+                <h3><%= dgettext("page-shortlist", "Regions") %></h3>
+                <li class="side-pane__dropdown unfolded">
+                  <ul class="side-pane__submenu">
+                    <li><%= region_link(@conn, %{nom: dgettext("page-shortlist", "All"), count: @regions |> Enum.map(&(&1.count)) |> Enum.sum, id: nil}) %></li>
+                    <%= for region <- @regions do %>
+                      <%= unless region.count == 0 do %>
+                        <li><%= region_link(@conn, region) %></li>
+                      <% end %>
+                    <% end %>
+                  </ul>
+                </li>
+              </li>
+            <% end %>
+
+          </ul>
+        </div>
       </nav>
         <div class="main-pane transparent">
           <%= if @conn.assigns[:empty_message] do %>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -34,15 +34,6 @@
     <div class="shortlist">
       <nav class="side-pane" role="navigation">
         <ul class="side-pane__menu">
-          <li class="side-pane__title">
-            <h3><%= dgettext("page-shortlist", "Order by") %></h3>
-            <li class="side-pane__dropdown unfolded">
-              <ul class="side-pane__submenu">
-                <li><%= order_link(@conn, "alpha") %></li>
-                <li><%= order_link(@conn, "most_recent") %> </li>
-              </ul>
-            </li>
-          </li>
 
           <li class="side-pane__title">
             <h3><%= dgettext("page-shortlist", "Data type") %></h3>
@@ -76,6 +67,12 @@
               </div>
             </div>
           <% else %>
+            <div class="order-by">
+              <span class="order-by__title"><%= dgettext("page-shortlist", "Order by") %></span>
+              <span class="order-by-option"><%= order_link(@conn, "alpha") %></span>
+              <span class="order-by-option"><%= order_link(@conn, "most_recent") %> </span>
+            </div>
+
             <%= for dataset <- @datasets do %>
               <div class="panel dataset__panel">
                 <div class="panel__content">

--- a/apps/transport/lib/transport_web/templates/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.eex
@@ -44,7 +44,7 @@
                     <p><%= dngettext("page-index", "dataset", "datasets", @count_has_realtime || 0) %></p>
                 </a>
                 <!-- 14 is the region « national » We defined coaches as buses not bound to a region or AOM -->
-                <a class="tile" href="<%= dataset_path(@conn, :index, ["tags[]": "bus", region: 14]) %>">
+                <a class="tile" href="<%= dataset_path(@conn, :by_region, 14, "tags[]": "bus") %>">
                     <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/bus.svg") %>" alt="" />
                     <h3 class="text-center"><%= dgettext("page-index", "Long distance coach") %></h3>
                     <p><%= dngettext("page-index", "dataset", "datasets", @count_coach || 0) %></p>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -5,7 +5,7 @@ defmodule TransportWeb.DatasetView do
   alias Plug.Conn.Query
   alias TransportWeb.PaginationHelpers
   alias TransportWeb.Router.Helpers
-  import Phoenix.Controller, only: [current_path: 1, current_url: 2]
+  import Phoenix.Controller, only: [current_path: 1, current_path: 2, current_url: 2]
 
   def render_sidebar_from_type(conn, dataset), do: render_panel_from_type(conn, dataset, "sidebar")
 
@@ -101,7 +101,7 @@ defmodule TransportWeb.DatasetView do
     params = conn.query_params
     full_url = url <> "?" <> Query.encode(params) <> "#datasets-results"
 
-    case Phoenix.Controller.current_path(conn, %{}) do
+    case current_path(conn, %{}) do
       ^url -> ~E"<span class=\"activefilter\"><%= nom %> (<%= count %>)</span>"
       _ -> link("#{nom} (#{count})", to: full_url)
     end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -91,6 +91,22 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
+  def region_link(conn, %{nom: nom, count: count, id: id}) do
+    url =
+      case id do
+        nil -> dataset_path(conn, :index)
+        _ -> dataset_path(conn, :by_region, id)
+      end
+
+    params = conn.query_params
+    full_url = url <> "?" <> Query.encode(params) <> "#datasets-results"
+
+    case Phoenix.Controller.current_path(conn, %{}) do
+      ^url -> ~E"<span class=\"activefilter\"><%= nom %> (<%= count %>)</span>"
+      _ -> link("#{nom} (#{count})", to: full_url)
+    end
+  end
+
   def type_link(conn, %{type: type, msg: msg, count: count}) do
     params =
       case type do

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -179,7 +179,7 @@ msgstr "Récemment ajouté"
 
 #, elixir-format
 msgid "Order by"
-msgstr "Tri par"
+msgstr "Trier par"
 
 #, elixir-format
 msgid "here"


### PR DESCRIPTION
Le but est de pouvoir filtrer les résultats par région.

![image](https://user-images.githubusercontent.com/15341118/81201232-570cb000-8fc5-11ea-8879-c728d5a1fe37.png)

J'ai trouvé que cela n'avait de sens que lorsque l'on est sur la page [de tous les datasets](https://transport.data.gouv.fr/datasets) ou sur la page d'une [région en particulier](https://transport.data.gouv.fr/datasets/region/11) afin de pouvoir passer vers une autre région.

Si l'on est sur une page d'AOM ou de commune, le filtre n’apparaît pas, car à priori tous les datasets sont dans une même région. Et si l'on veut changer de zone géographique, et bien on fait une nouvelle recherche.

Le filtre des régions est compatible avec celui du type de données et du temps réel. Ce qui permet un scénario du type "depuis la page de garde, je sélectionne les datasets vélo partagés, puis sur la page des résultats, je clique sur le nom d'une région en particulier => je vois les datasets de vélo pour cette région".