### PR TITLE
Store the content_hash when validating

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -80,7 +80,7 @@ defmodule DB.Resource do
         } = r,
         _force_validation
       ) do
-    # if there is already a validation, we revalidate only if there the file has changed
+    # if there is already a validation, we revalidate only if the file has changed
     if content_hash != validation_latest_content_hash do
       Logger.info("the files for resource #{r.id} have been modified since last validation, we need to revalidate them")
       true

--- a/apps/db/lib/db/validation.ex
+++ b/apps/db/lib/db/validation.ex
@@ -12,6 +12,9 @@ defmodule DB.Validation do
     field(:date, :string)
     # the maximum level of error in this validation
     field(:max_error, :string)
+    # content_hash of the validated resource
+    # This makes it possible to check if we need to revalidate the resource
+    field(:validation_latest_content_hash, :string)
 
     belongs_to(:resource, Resource)
   end

--- a/apps/db/priv/repo/migrations/20200505124346_validation_sha.exs
+++ b/apps/db/priv/repo/migrations/20200505124346_validation_sha.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ValidationSha do
+  use Ecto.Migration
+
+  def change do
+    alter table(:validations) do
+      add :validation_latest_content_hash, :string
+    end
+  end
+end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -39,10 +39,9 @@ defmodule Transport.ImportData do
 
     resources =
       Resource
-      |> preload([:dataset, :validation])
-      |> where([r], r.format == "GTFS")
+      |> preload(:validation)
       |> Repo.all()
-      |> Enum.filter(fn r -> force || Resource.needs_validation(r) end)
+      |> Enum.filter(fn r -> Resource.needs_validation(r, force) end)
 
     Logger.info("launching #{Enum.count(resources)} validations")
 

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -199,8 +199,6 @@ defmodule TransportWeb.API.StatsController do
 
   @spec aom_features :: Ecto.Query.t()
   defp aom_features do
-    dt = Date.utc_today() |> Date.to_iso8601()
-
     AOM
     |> join(:left, [aom], dataset in Dataset, on: dataset.id == aom.parent_dataset_id)
     |> select([aom, parent_dataset], %{

--- a/apps/transport/lib/transport_web/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/stats_controller.ex
@@ -160,7 +160,7 @@ defmodule TransportWeb.StatsController do
   end
 
   @spec ratio_aom_with_at_most_warnings(%{binary() => integer()}, integer()) :: integer()
-  defp ratio_aom_with_at_most_warnings(aom_max_severity, 0) do
+  defp ratio_aom_with_at_most_warnings(_aom_max_severity, 0) do
     0
   end
 
@@ -175,7 +175,7 @@ defmodule TransportWeb.StatsController do
   end
 
   @spec ratio_aom_good_quality(%{binary() => integer()}, integer()) :: integer()
-  defp ratio_aom_good_quality(aom_max_severity, 0) do
+  defp ratio_aom_good_quality(_aom_max_severity, 0) do
     0
   end
 


### PR DESCRIPTION
since the modification dates are not reliable, we store the content hash and revalidate a resource only when this hash has changed