### PR TITLE
Fix la mise à jour / ajout des resources

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/resources.ex
@@ -7,7 +7,7 @@ defmodule Datagouvfr.Client.Resources do
 
   @format_to_mime %{
     "GTFS" => "application/zip",
-    "NeTeX" => "application/zip"
+    "netex" => "application/zip"
   }
   @fields ["url", "format", "title", "filetype"]
 

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -476,7 +476,7 @@ defmodule DB.Dataset do
     |> if do
       {:error, "Unable to validate dataset #{id}"}
     else
-      :ok
+      {:ok, nil}
     end
   end
 

--- a/apps/db/priv/gettext/dataset.pot
+++ b/apps/db/priv/gettext/dataset.pot
@@ -72,4 +72,4 @@ msgstr ""
 
 #, elixir-format
 msgid "Private parking"
-msgstr "Stationnement hors voirie"
+msgstr ""

--- a/apps/transport/client/stylesheets/components/_choose_file.scss
+++ b/apps/transport/client/stylesheets/components/_choose_file.scss
@@ -1,11 +1,21 @@
 .choose-file {
-  form {
-    max-width: 80%;
-    width: 80%;
-  }
-  .form__group {
-    max-width: 35em;
+  max-width: 50em;
+  margin: auto;
+  .panel {
 
+    background-color: var(--theme-background-grey);
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-top: 1em;
+    h1 {
+      font-size: 1.5em;
+    }
+    h2 {
+      font-size: 1em;
+    }
+
+  .form__group {
     .filler {
       margin-left: 1em;
     }
@@ -13,7 +23,7 @@
   .forms {
     display: flex;
     align-items: center;
-    margin-top: 10vh;
+    margin-top: 5vh;
     justify-content: space-between;
     @media (max-width: $breakpoint-tablet) {
       margin-top: 2vh;
@@ -36,16 +46,19 @@
     }
   }
 
-  .help {
-    margin-top: 10vh;
-    justify-content: center;
-  }
-
   .container {
     display: flex;
+    flex-direction: column;
 
     @media (max-width: $breakpoint-tablet) {
       flex-direction: column;
     }
   }
+}
+
+.help {
+  margin-top: 10vh;
+  justify-content: center;
+}
+
 }

--- a/apps/transport/client/stylesheets/components/_choose_file.scss
+++ b/apps/transport/client/stylesheets/components/_choose_file.scss
@@ -1,6 +1,7 @@
 .choose-file {
   max-width: 50em;
   margin: auto;
+
   .panel {
 
     background-color: var(--theme-background-grey);
@@ -8,57 +9,62 @@
     align-items: center;
     flex-direction: column;
     margin-top: 1em;
+
     h1 {
       font-size: 1.5em;
     }
+
     h2 {
       font-size: 1em;
     }
 
-  .form__group {
-    .filler {
-      margin-left: 1em;
-    }
-  }
-  .forms {
-    display: flex;
-    align-items: center;
-    margin-top: 5vh;
-    justify-content: space-between;
-    @media (max-width: $breakpoint-tablet) {
-      margin-top: 2vh;
+    .form__group {
+      .filler {
+        margin-left: 1em;
+      }
     }
 
-    form {
-      margin: 0;
-    }
-  }
+    .forms {
+      display: flex;
+      align-items: center;
+      margin-top: 5vh;
+      justify-content: space-between;
 
-  .description {
-    justify-content: space-around;
-    div {
+      @media (max-width: $breakpoint-tablet) {
+        margin-top: 2vh;
+      }
+
+      form {
+        margin: 0;
+      }
+    }
+
+    .description {
+      justify-content: space-around;
+
+      div {
+        display: flex;
+        flex-direction: column;
+
+        p {
+          margin: 0;
+          box-sizing: initial;
+        }
+      }
+    }
+
+    .container {
       display: flex;
       flex-direction: column;
-      p {
-        margin: 0;
-        box-sizing: initial;
+
+      @media (max-width: $breakpoint-tablet) {
+        flex-direction: column;
       }
     }
   }
 
-  .container {
-    display: flex;
-    flex-direction: column;
-
-    @media (max-width: $breakpoint-tablet) {
-      flex-direction: column;
-    }
+  .help {
+    margin-top: 10vh;
+    justify-content: center;
   }
-}
-
-.help {
-  margin-top: 10vh;
-  justify-content: center;
-}
-
 }

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -105,6 +105,8 @@ defmodule TransportWeb.API.DatasetController do
   end
 
   @spec to_feature(MultiPolygon.t(), binary) :: map()
+  defp to_feature(nil, name), do: %{}
+
   defp to_feature(geom, name) do
     %{
       "geometry" => geom |> JSON.encode!(),

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -274,7 +274,7 @@ defmodule TransportWeb.API.Schemas do
                 type: :string,
                 description: "The first day in the GTFS calendar. null if the file couldn’t be read"
               },
-              format: %Schema{type: :string, description: "The format of the resource (GTFS, NeTex, ...)"},
+              format: %Schema{type: :string, description: "The format of the resource (GTFS, NeTEx, ...)"},
               content_hash: %Schema{
                 type: :string,
                 description:

--- a/apps/transport/lib/transport_web/templates/resource/_specify_url.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_specify_url.html.eex
@@ -1,0 +1,11 @@
+<div>
+    <h2><%= dgettext("resource", " with a URL") %></h2>
+    <%= text_input(
+        @f,
+        :url,
+        label: dgettext("resource", "Resource's URL"),
+        placeholder: "https://data.ville.fr/gtfs.zip",
+        value: @resource["url"]
+    ) %>
+    <%= submit dgettext("resource", "Update with this URL") %>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/_upload_file.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_upload_file.html.eex
@@ -1,0 +1,10 @@
+<div>
+    <h2><%= dgettext("resource", "Upload a file") %></h2>
+    <%= unless is_nil(@resource["url"]) do %>
+    <p>
+        <%= dgettext("resource", "Current file: %{current_file}", current_file: Path.basename(@resource["url"])) %>
+    </p>
+    <% end %>
+    <%= file_input @f, :resource_file, label: dgettext("resource", "Choose a file") %>
+    <%= submit dgettext("resource", "Upload this file") %>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/choose_action.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/choose_action.html.eex
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="existing">
             <div class="row">
-                <%= link to: "https://www.data.gouv.fr/fr/admin/dataset/new/", class: "tile section-grey" do %>
+                <%= link to: dataset_creation(), class: "tile section-grey" do %>
                 <h3><%= dgettext("resource", "Publish a new dataset") %></h3>
                 <% end %>
                 <%= link to: resource_path(@conn, :datasets_list), class: "tile section-grey" do %>

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -6,59 +6,42 @@
                 <h1><%= title(@conn) %></h1>
                 <b><%= dgettext("resource", "Dataset: ") %>  <%= @dataset["title"] %></b>
             </p>
-            <p>
             <% resource = Enum.find(@dataset["resources"], &(&1["id"] == @conn.params["resource_id"])) %>
-            <%= unless is_nil(resource) do %>
-                <b><%= dgettext("resource", "Resource: ") %></b> <%= resource["title"] %>
-            <% end %>
-            </p>
-            <p>
-            </p>
+            <% new_resource = is_nil(resource) %>
         </div>
     </div>
     <div class="container">
-        <%= form_for @conn, action_path(@conn), [multipart: true, name: :dataset], fn f -> %>
-            <%= text_input f, :title, label: dgettext("resource", "title"), placeholder: "Horaires au format GTFS", value: resource["title"] %>
+        <%= form_for @conn, action_path(@conn), [multipart: true], fn f -> %>
+            <%= text_input f, :title, label: dgettext("resource", "title"), placeholder: "Horaires au format GTFS", value: resource["title"]%>
             <%= text_input(
-                    f,
-                    :format,
-                    label: label f, :format do [
-                        dgettext("resource", "format"),
-                        content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
-                        content_tag(:a, "NeTeX", class: "filler", onclick: "fill(this);"),
-                    ]
-                    end,
-                    placeholder: "GTFS, NeTeX, …",
-                    value: resource["format"]
-                )
+                f,
+                :format,
+                label: label f, :format do [
+                    dgettext("resource", "format"),
+                    content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
+                    content_tag(:a, "netex", class: "filler", onclick: "fill(this);"),
+                ]
+                end,
+                placeholder: "GTFS, netex, …",
+                value: resource["format"]
+            )
             %>
             <div class="forms">
-                <div>
-                    <h2><%= dgettext("resource", "Upload a file") %></h2>
-                    <%= unless remote?(resource) or is_nil(resource["url"]) do %>
-                    <p>
-                        <%= dgettext("resource", "Current file: %{current_file}", current_file: Path.basename(resource["url"])) %>
-                    </p>
+                <%= if new_resource do %>
+                    <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
+                    <div>
+                        <p>
+                            - <%= dgettext("resource", "or") %> -
+                        </p>
+                    </div>
+                    <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+                <% else %>
+                    <%= if remote?(resource) do %>
+                        <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+                    <% else %>
+                        <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
                     <% end %>
-                    <%= file_input f, :resource_file, label: dgettext("resource", "Choose a file") %>
-                    <%= submit dgettext("resource", "Upload this file") %>
-                </div>
-                <div>
-                    <p>
-                        - <%= dgettext("resource", "or") %> -
-                    </p>
-                </div>
-                <div>
-                    <h2><%= dgettext("resource", " with a URL") %></h2>
-                    <%= text_input(
-                        f,
-                        :url,
-                        label: dgettext("resource", "Resource's URL"),
-                        placeholder: "https://data.ville.fr/gtfs.zip",
-                        value: if remote?(resource) do resource["url"] else nil end
-                     ) %>
-                    <%= submit dgettext("resource", "Update with this URL") %>
-                </div>
+                <% end %>
             </div>
         <% end %>
     </div>

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -1,62 +1,86 @@
 <section class="section choose-file">
-    <%= unless @dataset == [] do %>
+  <%= unless @dataset == [] do %>
     <div class="container description">
-        <div>
-            <p>
-                <h1><%= title(@conn) %></h1>
-                <b><%= dgettext("resource", "Dataset: ") %>  <%= @dataset["title"] %></b>
-            </p>
-            <% resource = Enum.find(@dataset["resources"], &(&1["id"] == @conn.params["resource_id"])) %>
-            <% new_resource = is_nil(resource) %>
-        </div>
-    </div>
-    <div class="container">
-        <%= form_for @conn, action_path(@conn), [multipart: true], fn f -> %>
-            <%= text_input f, :title, label: dgettext("resource", "title"), placeholder: "Horaires au format GTFS", value: resource["title"]%>
-            <%= text_input(
-                f,
-                :format,
-                label: label f, :format do [
-                    dgettext("resource", "format"),
-                    content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
-                    content_tag(:a, "netex", class: "filler", onclick: "fill(this);"),
-                ]
-                end,
-                placeholder: "GTFS, netex, …",
-                value: resource["format"]
-            )
-            %>
-            <div class="forms">
-                <%= if new_resource do %>
-                    <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
-                    <div>
-                        <p>
-                            - <%= dgettext("resource", "or") %> -
-                        </p>
-                    </div>
-                    <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
-                <% else %>
-                    <%= if remote?(resource) do %>
-                        <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
-                    <% else %>
-                        <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
-                    <% end %>
-                <% end %>
-            </div>
-        <% end %>
-    </div>
-    <div class="container help">
+      <div>
         <p>
-            <%= link(
+          <h2><%= title(@conn) %> <%= link(@dataset["title"], to: "/datasets/#{@dataset["id"]}") %> </h2>
+        </p>
+        <% resource = Enum.find(@dataset["resources"], &(&1["id"] == @conn.params["resource_id"])) %>
+        <% new_resource = is_nil(resource) %>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="container">
+        <div>
+          <h1> <%= dgettext("resource", "Option 1: Directly update the resource") %> </h1>
+        </div>
+        <div>
+          <%= form_for @conn, action_path(@conn), [multipart: true], fn f -> %>
+          <%= text_input f, :title, label: dgettext("resource", "title"), placeholder: "Horaires au format GTFS", value: resource["title"]%>
+          <%= text_input(
+                    f,
+                    :format,
+                    label: label f, :format do [
+                        dgettext("resource", "format"),
+                        content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
+                        content_tag(:a, "netex", class: "filler", onclick: "fill(this);"),
+                    ]
+                    end,
+                    placeholder: "GTFS, netex, …",
+                    value: resource["format"]
+                )
+                %>
+          <div class="forms">
+            <%= if new_resource do %>
+              <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
+              <div>
+                <p>
+                  - <%= dgettext("resource", "or") %> -
+                </p>
+              </div>
+              <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+            <% else %>
+              <%= if remote?(resource) do %>
+                <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+              <% else %>
+                <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="panel">
+      <div class="container">
+        <h1><%= dgettext("resource", "Option 2: For more options during modification, edit it on data.gouv.fr") %></h1>
+      </div>
+      <div>
+        <%= if new_resource do %>
+          <a class="button" href="<%= link_to_datagouv_resource_creation(@dataset["id"]) %>" role="link" target="_blank">
+            <i class="icon icon--link" aria-hidden="true"></i>
+            <%=dgettext("resource", "Create it directly on data.gouv.fr")%>
+          </a>
+        <% else %>
+          <a class="button" href="<%= link_to_datagouv_resource_edit(@dataset["id"], @conn.params["resource_id"]) %>" role="link" target="_blank">
+            <i class="icon icon--link" aria-hidden="true"></i>
+            <%= dgettext("resource", "Edit directly on data.gouv.fr") %>
+          </a>
+        <% end %>
+      </div>
+  </div>
+  <div class="container help">
+    <p>
+      <%= link(
                 dgettext("resource", "I'm not sure. Learn more."),
                 to: "https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees"
             )%>
-        </p>
-    </div>
-    <% end %>
+    </p>
+  </div>
+<% end %>
 </section>
 <script>
-function fill(id) {
-    id.parentNode.control.value = id.innerHTML
-}
+  function fill(id) {
+      id.parentNode.control.value = id.innerHTML
+  }
 </script>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -39,8 +39,8 @@ defmodule TransportWeb.ResourceView do
 
   def action_path(%Plug.Conn{params: params} = conn), do: resource_path(conn, :post_file, params["dataset_id"])
 
-  def title(%Plug.Conn{params: %{"resource_id" => _}}), do: dgettext("resource", "Modifiy resource")
-  def title(_), do: dgettext("resource", "Add a resource")
+  def title(%Plug.Conn{params: %{"resource_id" => _}}), do: dgettext("resource", "Modify resource for dataset ")
+  def title(_), do: dgettext("resource", "Add a resource for dataset ")
 
   def remote?(%{"filetype" => "remote"}), do: true
   def remote?(_), do: false
@@ -55,5 +55,5 @@ defmodule TransportWeb.ResourceView do
     do:
       :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/#{dataset_id}?new_resource=")
 
-  def dataset_creation(), do: :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/new/")
+  def dataset_creation, do: :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/new/")
 end

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -39,11 +39,21 @@ defmodule TransportWeb.ResourceView do
 
   def action_path(%Plug.Conn{params: params} = conn), do: resource_path(conn, :post_file, params["dataset_id"])
 
-  # dgettext("resource", "Modifiy resource")
-  def title(%Plug.Conn{params: %{"resource_id" => _}}), do: "Modify a resource"
-  # dgettext("resource", "Add a resource")
-  def title(_), do: "Add a resource"
+  def title(%Plug.Conn{params: %{"resource_id" => _}}), do: dgettext("resource", "Modifiy resource")
+  def title(_), do: dgettext("resource", "Add a resource")
 
   def remote?(%{"filetype" => "remote"}), do: true
   def remote?(_), do: false
+
+  def link_to_datagouv_resource_edit(dataset_id, resource_id),
+    do:
+      :transport
+      |> Application.get_env(:datagouvfr_site)
+      |> Path.join("/fr/admin/dataset/#{dataset_id}/resource/#{resource_id}")
+
+  def link_to_datagouv_resource_creation(dataset_id),
+    do:
+      :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/#{dataset_id}?new_resource=")
+
+  def dataset_creation(), do: :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/new/")
 end

--- a/apps/transport/priv/gettext/backoffice_dataset.pot
+++ b/apps/transport/priv/gettext/backoffice_dataset.pot
@@ -61,3 +61,7 @@ msgstr ""
 #, elixir-format
 msgid "validation of all datasets has been launched"
 msgstr ""
+
+#, elixir-format
+msgid "validation of all datasets has been launch"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
@@ -62,3 +62,7 @@ msgstr ""
 #, elixir-format
 msgid "validation of all datasets has been launched"
 msgstr ""
+
+#, elixir-format
+msgid "validation of all datasets has been launch"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -14,10 +14,6 @@ msgid "File uploaded!"
 msgstr ""
 
 #, elixir-format
-msgid "Resource: "
-msgstr ""
-
-#, elixir-format
 msgid "Unable to upload file"
 msgstr ""
 
@@ -91,4 +87,28 @@ msgstr ""
 
 #, elixir-format
 msgid "title"
+msgstr ""
+
+#, elixir-format
+msgid "Create it directly on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Edit directly on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Option 1: Directly update the resource"
+msgstr ""
+
+#, elixir-format
+msgid "Option 2: For more options during modification, edit it on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Add a resource for dataset "
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Modify resource for dataset "
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
@@ -62,3 +62,7 @@ msgstr "En cours"
 #, elixir-format
 msgid "validation of all datasets has been launched"
 msgstr "La validation de tous les jeux de données a été lancée."
+
+#, elixir-format
+msgid "validation of all datasets has been launch"
+msgstr "La validation de tous les jeux de données a été lancée."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -14,10 +14,6 @@ msgid "File uploaded!"
 msgstr "Fichier mis à jour !"
 
 #, elixir-format
-msgid "Resource: "
-msgstr "Ressource"
-
-#, elixir-format
 msgid "Unable to upload file"
 msgstr "Impossible de mettre à jour le fichier"
 
@@ -92,3 +88,27 @@ msgstr "Format"
 #, elixir-format
 msgid "title"
 msgstr "Titre"
+
+#, elixir-format
+msgid "Create it directly on data.gouv.fr"
+msgstr "Créer directement la ressource sur data.gouv.fr"
+
+#, elixir-format
+msgid "Edit directly on data.gouv.fr"
+msgstr "Éditer directement la ressource sur data.gouv.fr"
+
+#, elixir-format
+msgid "Option 1: Directly update the resource"
+msgstr "Option 1 : mettre à jour la ressource simplement"
+
+#, elixir-format
+msgid "Option 2: For more options during modification, edit it on data.gouv.fr"
+msgstr "Option 2 : Pour plus d'options, éditer la ressource sur data.gouv.fr"
+
+#, elixir-format
+msgid "Add a resource for dataset "
+msgstr "Ajouter une nouvelle ressource "
+
+#, elixir-format, fuzzy
+msgid "Modify resource for dataset "
+msgstr "Modifier la ressource pour le jeu de données "

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -14,10 +14,6 @@ msgid "File uploaded!"
 msgstr ""
 
 #, elixir-format
-msgid "Resource: "
-msgstr ""
-
-#, elixir-format
 msgid "Unable to upload file"
 msgstr ""
 
@@ -91,4 +87,28 @@ msgstr ""
 
 #, elixir-format
 msgid "title"
+msgstr ""
+
+#, elixir-format
+msgid "Create it directly on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Edit directly on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Option 1: Directly update the resource"
+msgstr ""
+
+#, elixir-format
+msgid "Option 2: For more options during modification, edit it on data.gouv.fr"
+msgstr ""
+
+#, elixir-format
+msgid "Add a resource for dataset "
+msgstr ""
+
+#, elixir-format
+msgid "Modify resource for dataset "
 msgstr ""


### PR DESCRIPTION
La fonctionalité "Publier ou mettre à jour des données" dans le header du site était toute cassée.

Certains chemins buguaient complètement.
Quand on modifiait le titre ou le format de la ressource ca modifiait le titre du jdd en fait, voir ca créait un nouveau jdd.
De plus data.gouv bloque si on modifie une ressource fichier pour la changer en ressource distante.
Et dernier point, l'ajout de nouveau jdd renvoyait toujours vers data.gouv.fr, même si on avait configuré en local vers le demo.data.gouv.fr.

Les écrans restent un peu moches, mais je trouve ca plus clair.

Avant:
![image](https://user-images.githubusercontent.com/3987698/82873748-7cd20880-9f24-11ea-9e26-93c7e2c98f5f.png)

Aprés:
![image](https://user-images.githubusercontent.com/3987698/82873806-95dab980-9f24-11ea-9a3e-8a3e483b6795.png)
Pour l'édition (et si c'est une ressource distante, on ne propose que la mise à jour de l'url), et pour la création : 
![image](https://user-images.githubusercontent.com/3987698/82873875-b3a81e80-9f24-11ea-81e2-c64991213d89.png)

(ca ca mériterait un coup de polich, pour le choix)