### PR TITLE
fix broken link

### DIFF
--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -220,7 +220,7 @@
     </div>
     <div class="domain carpooling">
       <h2>Lieux de covoiturage</h2>
-      <p><a href="/datasets/base-nationale-consolidee-des-lieux-de-covoiturage/">Un fichier national</a> décrivant les lieux de covoiturage de 78 départements a été consolidé par le point d’accès national aprés un travail initial de BlaBlaCar.</p>
+      <p><a href="/datasets/base-nationale-des-lieux-de-covoiturage/">Un fichier national</a> décrivant les lieux de covoiturage de 78 départements a été consolidé par le point d’accès national aprés un travail initial de BlaBlaCar.</p>
       <p>La Fabrique des Mobilités a récemment ouvert un fichier relatif à des lieux de rendez-vous de covoiturage (grande variété de points, fichier non consolidé), disponible sur <a href="/datasets/aires-de-covoiturage-base-de-donnees-commune-des-lieux-et/">ici</a>.
       </p>
     </div>


### PR DESCRIPTION
Le lien vers la base nationale des lieux de covoiturage était cassé dans la page de stats.