### PR TITLE
Fix blog custom message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ apps/transport/priv/static/js/*
 # secrets file as long as you replace its contents by environment
 # variables.
 /config/prod.secret.exs
+
+# the blog build folder
+/blog/public

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -220,7 +220,7 @@
     </div>
     <div class="domain carpooling">
       <h2>Lieux de covoiturage</h2>
-      <p><a href="/datasets/base-nationale-consolidee-des-lieux-de-covoiturage/">Un fichier national</a> décrivant les lieux de covoiturage de 78 départements a été consolidé par le point d’accès national aprés un travail initial de BlaBlaCar.</p>
+      <p><a href="/datasets/base-nationale-des-lieux-de-covoiturage/">Un fichier national</a> décrivant les lieux de covoiturage de 78 départements a été consolidé par le point d’accès national aprés un travail initial de BlaBlaCar.</p>
       <p>La Fabrique des Mobilités a récemment ouvert un fichier relatif à des lieux de rendez-vous de covoiturage (grande variété de points, fichier non consolidé), disponible sur <a href="/datasets/aires-de-covoiturage-base-de-donnees-commune-des-lieux-et/">ici</a>.
       </p>
     </div>

--- a/blog/themes/mediumish/layouts/_default/list.html
+++ b/blog/themes/mediumish/layouts/_default/list.html
@@ -5,12 +5,12 @@
 {{ define "main" }}
     <div class="main-content pt-48 mh-80">
         <!-- Posts Index
-        ================================================== -->        
-        <section class="recent-posts">            
-            <div class="section-title">                
+        ================================================== -->
+        <section class="recent-posts">
+            <div class="section-title">
                 <h2><span>Tous les billets de la catégorie {{ .Title }}</span></h2>
             </div>
-            {{ if (eq .Title "réutilisations")}}
+            {{ if (eq .Title "réutilisation")}}
             <div class="article-description pb-48">
                 {{ .Site.Params.reutilisateurs.msg }}
             </div>

--- a/blog/themes/mediumish/layouts/_default/single.html
+++ b/blog/themes/mediumish/layouts/_default/single.html
@@ -10,10 +10,10 @@
         <div class="container">
             <div class="row">
                 <!-- Post Share -->
-                <div class="col-md-2 pl-0">      
+                <div class="col-md-2 pl-0">
                     {{- partial "single-partials/share.html" . -}}
                 </div>
-                <!-- Post -->                
+                <!-- Post -->
                 <div class="col-md-9 flex-first flex-md-unordered">
                     <h1 class="posttitle pt-48">{{ .Title }}</h1>
                     <div class="article-description">
@@ -35,7 +35,7 @@
                             <i class="far fa-clock clock"></i>
                             {{ .ReadingTime }} min de lecture
                         </span>
-                    </span>	
+                    </span>
 
                     <!-- Post Categories -->
                     <div class="pt-24">
@@ -50,7 +50,7 @@
                     </div>
                     <!-- End Categories -->
 
-                    {{ if in .Params.tags "réutilisations"}}
+                    {{ if in .Params.tags "réutilisation"}}
                         <blockquote>
                             {{ .Site.Params.reutilisateurs.msg }}
                         </blockquote>
@@ -66,7 +66,7 @@
                     <div class="article-post pt-48">
                         {{ .Content}}
                     </div>
-                    
+
                     <!-- Next and PrevPage inside current section -->
                     <!-- <div class="row PageNavigation d-flex justify-content-between font-weight-bold">
                         {{with .NextInSection}}


### PR DESCRIPTION
J'avais cassé l'affichage du petit message custom pour les réutilisations lorsque j'avais modifié le nom des tags.

![image](https://user-images.githubusercontent.com/15341118/83420065-56c9ce00-a426-11ea-839b-a1b6c1d8206b.png)
