### PR TITLE
Better gtfs validation page

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -229,7 +229,8 @@ defmodule DB.Resource do
       "DupplicateObjectId" => dgettext("validations", "Dupplicate object id"),
       "UnloadableModel" => dgettext("validations", "Not compliant with the GTFS specification"),
       "MissingMandatoryFile" => dgettext("validations", "Missing mandatory file"),
-      "ExtraFile" => dgettext("validations", "Extra file")
+      "ExtraFile" => dgettext("validations", "Extra file"),
+      "ImpossibleToInterpolateStopTimes" => dgettext("validations", "Impossible to interpolate stop times")
     }
 
   @spec valid?(__MODULE__.t()) :: boolean()

--- a/apps/db/lib/db/validation.ex
+++ b/apps/db/lib/db/validation.ex
@@ -9,6 +9,9 @@ defmodule DB.Validation do
 
   typed_schema "validations" do
     field(:details, :map)
+    # metadatas are stored for performance reasons in the associated resource
+    # for on the fly validation, there is no resource, so we store it here
+    field(:on_the_fly_validation_metadata, :map)
     field(:date, :string)
     # the maximum level of error in this validation
     field(:max_error, :string)

--- a/apps/db/lib/db/validation.ex
+++ b/apps/db/lib/db/validation.ex
@@ -35,7 +35,7 @@ defmodule DB.Validation do
   @spec severities(binary()) :: %{level: integer(), text: binary()}
   def severities(key), do: severities_map()[key]
 
-  @spec get_issues(%{details: any()} | nil, map()) :: [any()]
+  @spec get_issues(%{required(:details) => any(), optional(any) => any} | nil, map()) :: [any()]
   def get_issues(nil, _), do: []
   def get_issues(%{details: nil}, _), do: []
 

--- a/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
@@ -142,3 +142,7 @@ msgstr ""
 #, elixir-format
 msgid "Not compliant with the GTFS specification"
 msgstr ""
+
+#, elixir-format
+msgid "Impossible to interpolate stop times"
+msgstr ""

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -142,3 +142,7 @@ msgstr "Avertissements"
 #, elixir-format
 msgid "Not compliant with the GTFS specification"
 msgstr "Spécifications GTFS non respectées"
+
+#, elixir-format
+msgid "Impossible to interpolate stop times"
+msgstr "Interpolation de l'horaire impossible"

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -145,4 +145,4 @@ msgstr "Spécifications GTFS non respectées"
 
 #, elixir-format
 msgid "Impossible to interpolate stop times"
-msgstr "Interpolation de l'horaire impossible"
+msgstr "Interpolation de certains horaires impossible"

--- a/apps/db/priv/gettext/validations.pot
+++ b/apps/db/priv/gettext/validations.pot
@@ -141,3 +141,7 @@ msgstr ""
 #, elixir-format
 msgid "Not compliant with the GTFS specification"
 msgstr ""
+
+#, elixir-format
+msgid "Impossible to interpolate stop times"
+msgstr ""

--- a/apps/db/priv/repo/migrations/20200603103539_add_metadatas_for_on_the_fly_validations.exs
+++ b/apps/db/priv/repo/migrations/20200603103539_add_metadatas_for_on_the_fly_validations.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddMetadatasForOnTheFlyValidations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:validations) do
+      add(:on_the_fly_validation_metadata, :map)
+    end
+  end
+end

--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -32,10 +32,27 @@ nav.validation {
   }
 }
 
-.validation-pane {
-  min-width: 0;
-  max-width: 1200px;
-  padding: 10px;
+.validation-title {
+  padding-top: 48px;
+}
+
+.validation-content {
+  background-color: var(--theme-background-grey);
+  padding-top: 24px;
+  padding-bottom: 48px;
+  margin-top: 48px;
+  .validation-metadata {
+    display: inline-block;
+  }
+  .validation-content-details {
+    table {
+      table-layout: fixed;
+      width: 100%;
+    }
+    td {
+      word-wrap: break-word;
+    }
+  }
 }
 
 .mt-48 {

--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -18,14 +18,14 @@ nav.validation {
   }
 }
 
-.issues_list {
+.issues-list {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
 }
 
-.validation_issue {
-  padding: 30px;
+.validation-issue {
+  padding: 12px 48px 12px 48px;
   border-radius: 10px;
   @media (max-width: $breakpoint-tablet) {
     padding: 10px;

--- a/apps/transport/lib/transport_web/templates/resource/_resources_details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details.html.eex
@@ -1,0 +1,27 @@
+<%= unless is_nil(@metadata) do %>
+  <div>
+    <%= if @metadata["start_date"] != nil and @metadata["end_date"] != nil do %>
+      <p><%= dgettext("validations", "It is valid from")%> <strong><%= @metadata["start_date"] %></strong> <%= dgettext("validations", "to")%> <strong><%= @metadata["end_date"] %></strong>.</p>
+    <% end %>
+    <ul>
+    <%= if @metadata["modes"] != [] do %>
+      <li><%= dngettext("validations", "transport mode", "transport modes", length(@metadata["networks"])) %> : <strong><%= Enum.join(@metadata["modes"], ", ") %></strong> </li>
+    <% end %>
+    <%= if @metadata["networks"] != [] do %>
+      <li>
+        <div>
+          <div class="networks-list">
+            <%= dngettext("validations", "network", "networks", length(@metadata["networks"])) %> : <strong><%= Enum.join(@metadata["networks"], ", ")%></strong>
+          </div>
+        </div>
+      </li>
+    <% end %>
+    <%= if @metadata["stop_points"] != nil do %>
+      <li><%= dgettext("validations", "number of stop points")%> : <strong><%= @metadata["stop_points"]%></strong></li>
+    <% end %>
+    <%= if @metadata["stop_areas_count"] != nil do %>
+      <li><%= dgettext("validations", "number of stop areas")%> : <strong><%= @metadata["stop_areas_count"]%></strong></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_speed_issue.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_speed_issue.html.eex
@@ -9,6 +9,7 @@
         <th><%= dgettext("validations-explanations", "Stop ID") %></th>
         <th><%= dgettext("validations-explanations", "Stop name") %></th>
         <th><%= dgettext("validations-explanations", "Next stop and service") %></th>
+        <th><%= dgettext("validations-explanations", "details") %></th>
     </tr>
 
     <%= for issue <- @issues do %>
@@ -16,6 +17,8 @@
         <td><%= issue["object_id"] %></td>
         <td><%= issue["object_name"] %></td>
         <td><ul><%= format_related_objects(issue["related_objects"]) %></ul></td>
+        <td><%= issue["details"] %></td>
+
     </tr>
     <% end %>
 </table>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.eex
@@ -1,6 +1,6 @@
 <%= for {severity, issues} <- @validation_summary do %>
 <%= if Map.get(@severities_count, severity, 0) > 0 do %>
-    <div class="validation_issue">
+    <div class="validation-issue">
     <h4><%= @severities_count[severity] %> <%= severities(severity).text %></h4>
     <ul>
     <%= for {key, issue} <- issues do %>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -9,29 +9,7 @@
           </a>
         </p>
         <p><%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.title, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.</p>
-        <%= if @resource.metadata["start_date"] != nil and @resource.metadata["end_date"] != nil do %>
-          <p><%= dgettext("validations", "It is valid from")%> <strong><%= @resource.metadata["start_date"] %></strong> <%= dgettext("validations", "to")%> <strong><%= @resource.metadata["end_date"] %></strong>.</p>
-        <% end %>
-        <ul>
-        <%= if @resource.metadata["modes"] != [] do %>
-          <li><%= dngettext("validations", "transport mode", "transport modes", length(@resource.metadata["networks"])) %> : <strong><%= Enum.join(@resource.metadata["modes"], ", ") %></strong> </li>
-        <% end %>
-        <%= if @resource.metadata["networks"] != [] do %>
-          <li>
-            <div>
-              <div class="networks-list">
-                <%= dngettext("validations", "network", "networks", length(@resource.metadata["networks"])) %> : <strong><%= Enum.join(@resource.metadata["networks"], ", ")%></strong>
-              </div>
-            </div>
-          </li>
-        <% end %>
-        <%= if @resource.metadata["stop_points"] != nil do %>
-          <li><%= dgettext("validations", "number of stop points")%> : <strong><%= @resource.metadata["stop_points"]%></strong></li>
-        <% end %>
-        <%= if @resource.metadata["stop_areas_count"] != nil do %>
-          <li><%= dgettext("validations", "number of stop areas")%> : <strong><%= @resource.metadata["stop_areas_count"]%></strong></li>
-        <% end %>
-        </ul>
+        <%= render "_resources_details.html", metadata: @resource.metadata %>
         </div>
 
         <div class="mt-48 panel" id="issues">

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -36,7 +36,7 @@
 
         <div class="mt-48 panel" id="issues">
           <h1><%= dgettext("validations", "Validation report")%></h1>
-          <nav class="issues_list validation" role="navigation">
+          <nav class="issues-list validation" role="navigation">
               <%= unless @resource.validation do %>
                   <%= dgettext("validations", "No validation available") %>
               <% else %>

--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -1,27 +1,39 @@
 <section>
-  <div class="documentation dataset-details">
-    <nav class="side-pane validation" role="navigation">
-      <div class="pt-48"></div>
-      <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
-    </nav>
-    <div class="main-pane validation-pane">
+  <div class="container">
+    <div class="validation-title">
       <h2><%= dgettext("validations", "GTFS review report")%></h2>
-      <p class="pb-48">
-        <div>
-          <%= dgettext("validations", "explanations") %>
-        </div>
-        <div>
-          <%= dgettext("validations", "This report can be shared with") %>
-          <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn) )%>.
-        </div>
+      <p>
+        <%= dgettext("validations", "explanations") %>
       </p>
-      <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
-            path: &validation_path/4, action: :show %>
-      <%= if has_errors?(@validation_summary) do %>
-        <%= render template(@issues), issues: @issues || [] , conn: @conn %>
-      <% else %>
-        <h2><%= dgettext("validations", "Nice work, there are no issues!")%></h2>
-      <% end %>
+      <p>
+        <%= dgettext("validations", "This report can be shared with") %>
+        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn) )%>.
+      </p>
+    </div>
+  </div>
+
+  <div class="validation-content">
+    <div class="container">
+      <div class="panel validation-metadata">
+          <%= render "_resources_details.html", metadata: @metadata %>
+      </div>
+      <div class="validation-navigation">
+        <nav class="issues-list validation" role="navigation">
+          <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
+        </nav>
+      </div>
+
+      <div class="validation-content-details">
+        <div class="panel" style="overflow-x:auto;">
+          <%= if has_errors?(@validation_summary) do %>
+            <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
+                path: &validation_path/4, action: :show %>
+            <%= render template(@issues), issues: @issues || [] , conn: @conn %>
+          <% else %>
+            <h2><%= dgettext("validations", "Nice work, there are no issues!")%></h2>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -113,10 +113,10 @@ msgstr ""
 msgid "This option allows you to update the resource on data.gouv.fr, directly from here."
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "Option 1: Directly add the resource"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "This option allows you to add the resource on data.gouv.fr, directly from here."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -78,3 +78,7 @@ msgstr ""
 #, elixir-format
 msgid "Error on file"
 msgstr ""
+
+#, elixir-format
+msgid "details"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -113,10 +113,10 @@ msgstr "Donner un lien vers la ressource"
 msgid "This option allows you to update the resource on data.gouv.fr, directly from here."
 msgstr "Cette option vous permet de mettre à jour la ressource sur data.gouv.fr depuis ici, sans avoir à vous y rendre."
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "Option 1: Directly add the resource"
 msgstr "Option 1 : ajouter la ressource simplement"
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "This option allows you to add the resource on data.gouv.fr, directly from here."
 msgstr "Cette option vous permet d'ajouter la ressource sur data.gouv.fr depuis ici, sans avoir à vous y rendre."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -78,3 +78,7 @@ msgstr "Aperçu du fichier"
 #, elixir-format
 msgid "Error on file"
 msgstr "Erreur sur le fichier"
+
+#, elixir-format
+msgid "details"
+msgstr "détails"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -44,7 +44,7 @@ msgstr "ce lien permanent"
 
 #, elixir-format
 msgid "Nice work, there are no issues!"
-msgstr "Félicitation, aucune erreur n'a été trouvée !"
+msgstr "Félicitations, aucune erreur n'a été trouvée !"
 
 #, elixir-format
 msgid "network"
@@ -64,7 +64,7 @@ msgstr "Nom du fichier"
 
 #, elixir-format
 msgid "It is valid from"
-msgstr "Elle est valide du"
+msgstr "Le fichier couvre la période du "
 
 #, elixir-format
 msgid "Resource details"

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -77,3 +77,7 @@ msgstr ""
 #, elixir-format
 msgid "Error on file"
 msgstr ""
+
+#, elixir-format
+msgid "details"
+msgstr ""


### PR DESCRIPTION
Ajout de metadatas dans le rapport de validation à la volée du site.

![image](https://user-images.githubusercontent.com/15341118/83657928-d213b700-a5c1-11ea-8e5c-894083de3843.png)

Et puis petit re-design de la page pour qu'elle ressemble aux autres.

Ajout de la colonne des détails pour les problèmes de vitesse, afin de faire apparaître les messages du validateur.

J'ai essayé de bien découper le commit, donc il sera peut-être plus facile à relire commit par commit.