### PR TITLE
add a netlify deploy config file

### DIFF
--- a/blog/netlify.toml
+++ b/blog/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-publish = "blog/public"
+publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]

--- a/blog/netlify.toml
+++ b/blog/netlify.toml
@@ -1,0 +1,30 @@
+[build]
+publish = "blog/public"
+command = "hugo --gc --minify"
+
+[context.production.environment]
+HUGO_VERSION = "0.72.0"
+HUGO_ENV = "production"
+HUGO_ENABLEGITINFO = "true"
+
+[context.split1]
+command = "hugo --gc --minify --enableGitInfo"
+
+[context.split1.environment]
+HUGO_VERSION = "0.72.0"
+HUGO_ENV = "production"
+
+[context.deploy-preview]
+command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+
+[context.deploy-preview.environment]
+HUGO_VERSION = "0.72.0"
+
+[context.branch-deploy]
+command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+HUGO_VERSION = "0.72.0"
+
+[context.next.environment]
+HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
Test de fichier de config, afin que les liens sur les sites de previews netlify soient relatifs et non pas absolus (ce qui éviterait de sortir du site de preview au premier clic).

https://gohugo.io/hosting-and-deployment/hosting-on-netlify/