### PR TITLE
Ajout de titre spécifiques pour un meilleur référencement

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -395,12 +395,16 @@ defmodule DB.Dataset do
   def get_other_dataset(_), do: []
 
   @spec get_territory(__MODULE__.t()) :: {:ok, binary()} | {:error, binary()}
+  def get_territory(%__MODULE__{aom: %{nom: nom}}), do: {:ok, nom}
+
   def get_territory(%__MODULE__{aom_id: aom_id}) when not is_nil(aom_id) do
     case Repo.get(AOM, aom_id) do
       nil -> {:error, "Could not find territory of AOM with id #{aom_id}"}
       aom -> {:ok, aom.nom}
     end
   end
+
+  def get_territory(%__MODULE__{region: %{nom: nom}}), do: {:ok, nom}
 
   def get_territory(%__MODULE__{region_id: region_id}) when not is_nil(region_id) do
     case Repo.get(Region, region_id) do
@@ -413,6 +417,14 @@ defmodule DB.Dataset do
     do: {:ok, associated_territory_name}
 
   def get_territory(_), do: {:error, "Trying to find the territory of an unkown entity"}
+
+  @spec get_territory_or_nil(__MODULE__.t()) :: binary()
+  def get_territory_or_nil(%__MODULE__{} = d) do
+    case get_territory(d) do
+      {:ok, t} -> t
+      _ -> nil
+    end
+  end
 
   @spec get_covered_area_names(__MODULE__.t()) :: binary | [any]
   def get_covered_area_names(%__MODULE__{aom_id: aom_id}) when not is_nil(aom_id) do

--- a/apps/transport/lib/transport_web.ex
+++ b/apps/transport/lib/transport_web.ex
@@ -45,6 +45,7 @@ defmodule TransportWeb do
       import TransportWeb.ErrorHelpers
       import TransportWeb.InputHelpers
       import TransportWeb.Gettext
+      import TransportWeb.SeoMetadata
       import Helpers
 
       import Phoenix.LiveView,

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -287,5 +287,13 @@ defmodule TransportWeb.DatasetController do
         %{type: "AOM", name: get_name(AOM, id)}
       )
 
+  defp put_page_title(conn, %{"type" => t} = f) when map_size(f) == 1,
+    do:
+      assign(
+        conn,
+        :page_title,
+        %{type: dgettext("page-shortlist", "category"), name: Dataset.type_to_str(t)}
+      )
+
   defp put_page_title(conn, _), do: conn
 end

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -223,7 +223,7 @@
           <%= img_tag(@dataset.full_logo, alt: @dataset.title) %>
         </div>
         <div>
-          <i class="fa fa-map-marker-alt"></i> <%= localization(@dataset) %>
+          <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(@dataset) %>
         </div>
         <div class="pt-12">
           <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "data type")%></span>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -112,7 +112,7 @@
                           <% end %>
                         </h3>
                         <div class="dataset-localization">
-                          <i class="fa fa-map-marker-alt"></i> <%= localization(dataset) %></<i>
+                          <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(dataset) %></<i>
                         </div>
                       </div>
                     </div>

--- a/apps/transport/lib/transport_web/templates/layout/app.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.eex
@@ -4,11 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content='<%= gettext "Publish, improve and reuse French public transport data" %>'>
     <meta name="author" content="DINSIC">
     <meta name="csrf" content="<%= get_csrf_token() %>">
 
-    <title><%= gettext "transport.data.gouv.fr" %></title>
+    <% seo = metadata(assigns) %>
+    <meta name="description" content='<%= seo[:description] || dgettext("seo", "Publish, improve and reuse French public transport data") %>'>
+    <title><%= seo[:title] || dgettext("seo", "National Access Point for transport open data") %></title>
+
     <link rel="stylesheet" media="all" href="<%= static_path(@conn, "/css/app.css") %>">
     <link rel="alternate" type="application/atom+xml"  href="<%= atom_url(@conn, :index) %>" title="Resources feed" >
     <%= if @mix_env == :prod do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -222,15 +222,6 @@ defmodule TransportWeb.DatasetView do
   def licence_url("odc-odbl"), do: "https://opendatacommons.org/licenses/odbl/1.0/"
   def licence_url(_), do: nil
 
-  @spec localization(DB.Dataset.t()) :: binary | nil
-  def localization(%Dataset{aom: %{nom: nom}}), do: nom
-  def localization(%Dataset{region: %{nom: nom}}), do: nom
-
-  def localization(%Dataset{associated_territory_name: associated_territory_name}),
-    do: associated_territory_name
-
-  def localization(_), do: nil
-
   def description(%Dataset{} = dataset) do
     {:safe, sanitized_md} = sanitize(dataset.description)
 

--- a/apps/transport/lib/transport_web/views/seo_metadata.ex
+++ b/apps/transport/lib/transport_web/views/seo_metadata.ex
@@ -1,0 +1,84 @@
+defmodule TransportWeb.SeoMetadata do
+  @moduledoc """
+  Module to set a title and a description for each pages.
+  The default title/description are defined in app.html.eex
+  """
+  import TransportWeb.Gettext
+
+  @spec metadata(any()) :: %{optional(:title) => binary(), optional(:description) => binary()}
+  def metadata(%{view_module: TransportWeb.DatasetView, q: q}) when not is_nil(q),
+    do: %{
+      title: dgettext("seo", "Transport open datasets for search %{q}", q: q)
+    }
+
+  def metadata(%{view_module: TransportWeb.DatasetView, dataset: dataset}) do
+    formats =
+      case DB.Dataset.formats(dataset) do
+        [] -> ""
+        l -> " (#{Enum.join(l, ", ")})"
+      end
+
+    %{
+      title:
+        dgettext("seo", "Transport open datasets on %{type} for %{spatial} - %{territory}%{formats}",
+          spatial: dataset.spatial,
+          territory: DB.Dataset.get_territory_or_nil(dataset),
+          type: dataset.type,
+          formats: formats
+        )
+    }
+  end
+
+  def metadata(%{view_module: TransportWeb.DatasetView, page_title: %{type: "AOM", name: name}}),
+    do: %{
+      title: dgettext("seo", "Transport open datasets for AOM %{name}", name: name)
+    }
+
+  def metadata(%{
+        view_module: TransportWeb.DatasetView,
+        page_title: %{name: name},
+        conn: %{params: %{"insee_commune" => _}}
+      }),
+      do: %{
+        title: dgettext("seo", "Transport open datasets for city %{name}", name: name)
+      }
+
+  def metadata(%{view_module: TransportWeb.DatasetView, page_title: %{type: type, name: name}}),
+    do: %{
+      title: dgettext("seo", "Transport open datasets for %{type} %{name}", type: type, name: name)
+    }
+
+  def metadata(%{view_module: TransportWeb.ResourceView, resource: %{format: format, title: title, dataset: dataset}}),
+    do: %{
+      title:
+        dgettext("seo", "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}",
+          spatial: dataset.spatial,
+          territory: DB.Dataset.get_territory_or_nil(dataset),
+          format: format,
+          title: title
+        )
+    }
+
+  def metadata(%{view_module: TransportWeb.StatsView}),
+    do: %{
+      title: dgettext("seo", "State of transport open data in France")
+    }
+
+  def metadata(%{view_module: TransportWeb.AOMSView}),
+    do: %{
+      title: dgettext("seo", "State of transport open data for french AOMs")
+    }
+
+  def metadata(%{view_module: TransportWeb.PageView, page: "real_time.html"}),
+    do: %{
+      title: dgettext("seo", "Non standard real time transport open data")
+    }
+
+  def metadata(%{view_module: TransportWeb.ValidationView}),
+    do: %{
+      title: dgettext("seo", "GTFS data quality evaluation")
+    }
+
+  def metadata(_),
+    do: %{}
+end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -258,3 +258,7 @@ msgstr ""
 #, elixir-format
 msgid "This dataset only describes parking spaces accessible to the general public, with barrier entrance. Other datasets referenced here can have a broader definition and might include freely accessible car-parks, (ie. with no entrance barrier), in addition to the parking spaces with barrier entrance included in the “Base Nationale des Lieux de Stationnement” (BNLS)."
 msgstr ""
+
+#, elixir-format
+msgid "category"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
@@ -1,0 +1,60 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
+msgstr ""
+
+#, elixir-format
+msgid "Publish, improve and reuse French public transport data"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for %{type} %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for AOM %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for search %{q}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets on %{type} for %{spatial} - %{territory}%{formats}"
+msgstr ""
+
+#, elixir-format
+msgid "National Access Point for transport open data"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "GTFS data quality evaluation"
+msgstr ""
+
+#, elixir-format
+msgid "Non standard real time transport open data"
+msgstr ""
+
+#, elixir-format
+msgid "State of transport open data for french AOMs"
+msgstr ""
+
+#, elixir-format
+msgid "State of transport open data in France"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -258,3 +258,7 @@ msgstr "Les données concernant le stationnement hors-voirie en France sont prod
 #, elixir-format
 msgid "This dataset only describes parking spaces accessible to the general public, with barrier entrance. Other datasets referenced here can have a broader definition and might include freely accessible car-parks, (ie. with no entrance barrier), in addition to the parking spaces with barrier entrance included in the “Base Nationale des Lieux de Stationnement” (BNLS)."
 msgstr "Cette base ne référence que les parkings accessibles au public dont l’accès est limité par une barrière ; certaines bases locales référencées ici ont une définition plus larges et comprennent des parkings pour lesquelles l’accès est libre, sans barrière."
+
+#, elixir-format
+msgid "category"
+msgstr "catégorie"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
@@ -1,0 +1,60 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
+msgstr "Jeu de données ouvert %{format} - %{title} pour %{spatial} - %{territory}"
+
+#, elixir-format
+msgid "Publish, improve and reuse French public transport data"
+msgstr "Rendre disponible, valoriser et améliorer les données transports"
+
+#, elixir-format
+msgid "Transport open datasets for %{type} %{name}"
+msgstr "Jeux de données ouverts de la %{type} %{name}"
+
+#, elixir-format
+msgid "Transport open datasets for AOM %{name}"
+msgstr "Jeux de données ouverts de l'AOM %{name}"
+
+#, elixir-format
+msgid "Transport open datasets for search %{q}"
+msgstr "Jeux de données ouverts pour la recherche %{q}"
+
+#, elixir-format
+msgid "Transport open datasets on %{type} for %{spatial} - %{territory}%{formats}"
+msgstr "Jeux de données ouverts de %{spatial} - %{territory}%{formats}"
+
+#, elixir-format
+msgid "National Access Point for transport open data"
+msgstr "Le Point d’Accès National aux données ouvertes de transport"
+
+#, elixir-format
+msgid "Transport open datasets for city %{name}"
+msgstr "Jeux de données ouverts de la commune de %{name}"
+
+#, elixir-format
+msgid "GTFS data quality evaluation"
+msgstr "Évaluation de la qualité d’un jeu de données GTFS"
+
+#, elixir-format
+msgid "Non standard real time transport open data"
+msgstr "Liste des données temps-réel de transport en commun, non standardisées"
+
+#, elixir-format
+msgid "State of transport open data for french AOMs"
+msgstr "État de l’ouverture des données de transport en commun pour les AOMs françaises"
+
+#, elixir-format
+msgid "State of transport open data in France"
+msgstr "État de l’ouverture des données de transport en France"

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -258,3 +258,7 @@ msgstr ""
 #, elixir-format
 msgid "This dataset only describes parking spaces accessible to the general public, with barrier entrance. Other datasets referenced here can have a broader definition and might include freely accessible car-parks, (ie. with no entrance barrier), in addition to the parking spaces with barrier entrance included in the “Base Nationale des Lieux de Stationnement” (BNLS)."
 msgstr ""
+
+#, elixir-format
+msgid "category"
+msgstr ""

--- a/apps/transport/priv/gettext/seo.pot
+++ b/apps/transport/priv/gettext/seo.pot
@@ -1,0 +1,59 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-format
+msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
+msgstr ""
+
+#, elixir-format
+msgid "Publish, improve and reuse French public transport data"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for %{type} %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for AOM %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for search %{q}"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets on %{type} for %{spatial} - %{territory}%{formats}"
+msgstr ""
+
+#, elixir-format
+msgid "National Access Point for transport open data"
+msgstr ""
+
+#, elixir-format
+msgid "Transport open datasets for city %{name}"
+msgstr ""
+
+#, elixir-format
+msgid "GTFS data quality evaluation"
+msgstr ""
+
+#, elixir-format
+msgid "Non standard real time transport open data"
+msgstr ""
+
+#, elixir-format
+msgid "State of transport open data for french AOMs"
+msgstr ""
+
+#, elixir-format
+msgid "State of transport open data in France"
+msgstr ""

--- a/apps/transport/test/support/database_case.ex
+++ b/apps/transport/test/support/database_case.ex
@@ -31,7 +31,7 @@ defmodule TransportWeb.DatabaseCase do
           Sandbox.mode(Repo, {:shared, self()})
         end
 
-        Repo.insert(%Region{nom: "Pays de la Loire"})
+        Repo.insert(%Region{id: 12, nom: "Pays de la Loire"})
         Repo.insert(%Region{nom: "Auvergne-Rhône-Alpes"})
         Repo.insert(%Region{nom: "Île-de-France"})
 

--- a/apps/transport/test/support/database_case.ex
+++ b/apps/transport/test/support/database_case.ex
@@ -31,7 +31,7 @@ defmodule TransportWeb.DatabaseCase do
           Sandbox.mode(Repo, {:shared, self()})
         end
 
-        Repo.insert(%Region{id: 12, nom: "Pays de la Loire"})
+        Repo.insert(%Region{nom: "Pays de la Loire"})
         Repo.insert(%Region{nom: "Auvergne-Rhône-Alpes"})
         Repo.insert(%Region{nom: "Île-de-France"})
 

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -1,0 +1,109 @@
+defmodule TransportWeb.SeoMetadataTest do
+  @moduledoc """
+  test seo metadata
+  """
+  use TransportWeb.ConnCase, async: false
+  use TransportWeb.ExternalCase
+  use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  alias DB.{AOM, Dataset, Repo, Resource, Validation}
+
+  setup do
+    {:ok, _} =
+      %Dataset{
+        description: "Un jeu de données",
+        licence: "odc-odbl",
+        title: "Horaires et arrêts du réseau IRIGO - format GTFS",
+        spatial: "Horaires Angers",
+        type: "public-transit",
+        slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
+        datagouv_id: "5b4cd3a0b59508054dd496cd",
+        frequency: "yearly",
+        tags: [],
+        resources: [
+          %Resource{
+            url: "https://link.to/angers.zip",
+            validation: %Validation{
+              details: %{},
+              max_error: "Info"
+            },
+            description: "blabla on resource",
+            format: "GTFS",
+            metadata: %{"networks" => [], "modes" => []},
+            title: "angers.zip",
+            auto_tags: ["ferry"],
+            id: 1234
+          }
+        ],
+        aom: %AOM{id: 4242, nom: "Angers Métropôle"}
+      }
+      |> Repo.insert()
+
+    :ok
+  end
+
+  defp title(page) do
+    ~r|.*<title>(.*)</title>.*|
+    |> Regex.run(page)
+    |> case do
+      [_ | [title | _]] -> title
+      # if not found return all
+      _ -> page
+    end
+  end
+
+  test "GET / ", %{conn: conn} do
+    title = conn |> get("/") |> html_response(200) |> title
+    assert title =~ "Le Point d’Accès National aux données ouvertes de transport"
+  end
+
+  test "GET /datasets ", %{conn: conn} do
+    title = conn |> get(dataset_path(conn, :index)) |> html_response(200) |> title
+    assert title =~ "Le Point d’Accès National aux données ouvertes de transport"
+  end
+
+  test "GET /datasets/aom/4242 ", %{conn: conn} do
+    title = conn |> get("/datasets/aom/4242") |> html_response(200) |> title
+    assert title =~ "Jeux de données ouverts de l&#39;AOM Angers Métropôle"
+  end
+
+  test "GET /datasets/region/12 ", %{conn: conn} do
+    title = conn |> get("/datasets/region/12") |> html_response(200) |> title
+    assert title =~ "Jeux de données ouverts de la région Pays de la Loire"
+  end
+
+  test "GET /datasets/commune/36044 ", %{conn: conn} do
+    title = conn |> get("/datasets/commune/36044") |> html_response(200) |> title
+    assert title =~ "Jeux de données ouverts de la commune de Châteauroux"
+  end
+
+  test "GET /datasets?type=bike-sharing ", %{conn: conn} do
+    title = conn |> get("/datasets?type=bike-sharing") |> html_response(200) |> title
+    assert title =~ "Jeux de données ouverts de la catégorie Vélo partage"
+  end
+
+  test "GET /dataset/:id ", %{conn: conn} do
+    title = conn |> get("/datasets/horaires-et-arrets-du-reseau-irigo-format-gtfs") |> html_response(200) |> title
+    assert title =~ "Jeux de données ouverts de Horaires Angers - Angers Métropôle (GTFS)"
+  end
+
+  test "GET /resources/:id ", %{conn: conn} do
+    title = conn |> get("/resources/1234") |> html_response(200) |> title
+    assert title =~ "Jeu de données ouvert GTFS - angers.zip pour Horaires Angers - Angers Métropôle"
+  end
+
+  test "GET /real_time ", %{conn: conn} do
+    title = conn |> get("/real_time") |> html_response(200) |> title
+    assert title =~ "Liste des données temps-réel de transport en commun, non standardisées"
+  end
+
+  test "GET /aoms ", %{conn: conn} do
+    title = conn |> get("/aoms") |> html_response(200) |> title
+    assert title =~ "État de l’ouverture des données de transport en commun pour les AOMs françaises"
+  end
+
+  test "GET /validation ", %{conn: conn} do
+    title = conn |> get("/validation") |> html_response(200) |> title
+    assert title =~ "Évaluation de la qualité d’un jeu de données GTFS"
+  end
+
+end

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -67,7 +67,8 @@ defmodule TransportWeb.SeoMetadataTest do
   end
 
   test "GET /datasets/region/12 ", %{conn: conn} do
-    title = conn |> get("/datasets/region/12") |> html_response(200) |> title
+    region = Repo.get_by(Region, nom: "Pays de la Loire")
+    title = conn |> get("/datasets/region/#{region.id}") |> html_response(200) |> title
     assert title =~ "Jeux de données ouverts de la région Pays de la Loire"
   end
 
@@ -105,5 +106,4 @@ defmodule TransportWeb.SeoMetadataTest do
     title = conn |> get("/validation") |> html_response(200) |> title
     assert title =~ "Évaluation de la qualité d’un jeu de données GTFS"
   end
-
 end


### PR DESCRIPTION
closes #1184 
pour le moment je n'ai mis qu'un titre spécifique, il faut voir si on veut aussi modifier la `description` de la page.

Je veux bien une relecture attentive sur les fautes de français et d'anglais, vu l'exposition de ces textes :wink:

Pour voir ce que donne les titres, j'ai pushé sur [prochainement](https://prochainement-transport.cleverapps.io/), vous pouvez voir ce que ca donne (sachant que quand on aura amélioré les titres des jdd, ca sera encore mieux :stuck_out_tongue_winking_eye: ):
* [sur la home](https://prochainement-transport.cleverapps.io/)
* [sur la page d'un dataset](https://prochainement-transport.cleverapps.io/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bri-nva-m/)
* [sur la page d'un dataset non GTFS](https://prochainement-transport.cleverapps.io/datasets/parkings-relais-toulouse-metropole/)
* [sur la page d'une resource](https://prochainement-transport.cleverapps.io/resources/7790)
* [sur la page stats](https://prochainement-transport.cleverapps.io/stats)
* [sur la page d'une ville](https://prochainement-transport.cleverapps.io/datasets/commune/75056)

Sinon c'est pas mal de regarder [les tests](https://github.com/antoine-de/transport-site/blob/seo/apps/transport/test/transport_web/controllers/seo_test.exs#L54) 


#### Note
Comme effet de bord, j'ai un tout petit peu modifié le titre de la [page de recherche sur catégorie](https://prochainement-transport.cleverapps.io/datasets?type=public-transit) pour harmoniser avec ce qu'on faisait sur les villes/régions/aom:

Avant:
![image](https://user-images.githubusercontent.com/3987698/85046933-a4616d00-b180-11ea-8b53-581a2d661208.png)

Aprés:
![image](https://user-images.githubusercontent.com/3987698/85047036-d2df4800-b180-11ea-8a44-6eaf7a5ee5fb.png)
Je sais pas si ca vous va.

