### PR TITLE
create a log table for import tasks

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -7,7 +7,7 @@ defmodule DB.Dataset do
   so the search vector is up-to-date.
   """
   alias Datagouvfr.Client.User
-  alias DB.{AOM, Commune, DatasetGeographicView, Region, Repo, Resource}
+  alias DB.{AOM, Commune, DatasetGeographicView, LogsImport, Region, Repo, Resource}
   alias ExAws.S3
   alias Phoenix.HTML.Link
   import Ecto.{Changeset, Query}

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -50,6 +50,7 @@ defmodule DB.Dataset do
     many_to_many(:communes, Commune, join_through: "dataset_communes", on_replace: :delete)
 
     has_many(:resources, Resource, on_replace: :delete, on_delete: :delete_all)
+    has_many(:logs_import, LogsImport, on_replace: :delete, on_delete: :delete_all)
   end
 
   @spec type_to_str_map() :: %{binary() => binary()}

--- a/apps/db/lib/db/logs_import.ex
+++ b/apps/db/lib/db/logs_import.ex
@@ -1,0 +1,16 @@
+defmodule DB.LogsImport do
+  @moduledoc """
+  LogsImport schema
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+  alias DB.Dataset
+
+  typed_schema "logs_import" do
+    field(:datagouv_id, :string)
+    field(:timestamp, :utc_datetime)
+    field(:is_success, :boolean)
+    field(:error_msg, :string)
+    belongs_to(:dataset, Dataset)
+  end
+end

--- a/apps/db/priv/repo/migrations/20200622141231_create_import_logs_table.exs
+++ b/apps/db/priv/repo/migrations/20200622141231_create_import_logs_table.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.CreateImportLogsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:logs_import) do
+      add(:dataset_id, references(:dataset))
+      add(:datagouv_id, :string)
+      add(:timestamp, :utc_datetime)
+      add(:is_success, :boolean)
+      add(:error_msg, :string)
+    end
+  end
+end


### PR DESCRIPTION
Création d'une table qui log les imports de datasets, avec un timestamp, un résultat (succes/echec) et un éventuel message d'erreur.

Je pense que ça peut nous servir à debugger, et à afficher sur le site et dans le backoffice la date du dernier import d'un dataset.

Je pensais par la suite faire une table similaire pour les logs des validations, mais je voulais t'en parler avant @antoine-de .

![image](https://user-images.githubusercontent.com/15341118/85306199-6fba2200-b4ae-11ea-8375-fa311b83fa0c.png)
