### PR TITLE
Pas de 500 au lieu de 404

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -101,7 +101,7 @@ defmodule TransportWeb.DatasetController do
     conn
     |> put_status(:not_found)
     |> put_view(ErrorView)
-    |> assign(:reason, msg)
+    |> assign(:custom_message, msg)
     |> render("404.html")
   end
 

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -134,6 +134,22 @@ defmodule TransportWeb.Router do
     get("/legal", Redirect,
       external: "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/cadre-juridique-harmonise"
     )
+
+    # old static pages that have been moved to blog.transport
+    get("/blog/2019_04_26_interview_my_bus", Redirect,
+      external:
+        "https://blog.transport.data.gouv.fr/billets/entretien-avec-fr%C3%A9d%C3%A9ric-pacotte-co-fondateur-et-ceo-de-mybus/"
+    )
+
+    get("/blog/2019_10_24_itw-gueret", Redirect,
+      external:
+        "https://blog.transport.data.gouv.fr/billets/cr%C3%A9ation-dun-fichier-gtfs-interview-avec-le-grand-gu%C3%A9ret/"
+    )
+
+    get("/blog/2020_01_16_donnees_perimees.md", Redirect,
+      external:
+        "https://blog.transport.data.gouv.fr/billets/donn%C3%A9es-p%C3%A9rim%C3%A9es-donn%C3%A9es-inutilis%C3%A9es/"
+    )
   end
 
   # private

--- a/apps/transport/lib/transport_web/templates/error/not_found_error.html.eex
+++ b/apps/transport/lib/transport_web/templates/error/not_found_error.html.eex
@@ -1,5 +1,5 @@
 <section class="error">
   <h1><%= dgettext("errors", "404: Page not available") %></h1>
-  <h2><%= assigns[:reason] %></h2>
+  <h2><%= assigns[:custom_message] %></h2>
   <div class="error__background"></div>
 </section>

--- a/apps/transport/lib/transport_web/templates/layout/app.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.eex
@@ -13,7 +13,7 @@
 
     <link rel="stylesheet" media="all" href="<%= static_path(@conn, "/css/app.css") %>">
     <link rel="alternate" type="application/atom+xml"  href="<%= atom_url(@conn, :index) %>" title="Resources feed" >
-    <%= if @mix_env == :prod do %>
+    <%= if assigns[:mix_env] == :prod do %>
     <!-- Polyfill for css grid-->
     <script type="text/javascript">
     if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
@@ -44,16 +44,18 @@
     <%= render(LayoutView, "_header.html", assigns) %>
 
     <main class="layout-main" role="main">
-      <%= if get_flash(@conn, :info) do %>
-        <p class="notification"><%= get_flash(@conn, :info) %></p>
-      <% end %>
-      <%= if get_flash(@conn, :errors) do %>
-        <%= for error <- get_flash(@conn, :errors) do %>
-          <p class="message message--error"><%= error %></p>
+      <%= if has_flash(@conn) do %> 
+        <%= if get_flash(@conn, :info) do %>
+          <p class="notification"><%= get_flash(@conn, :info) %></p>
         <% end %>
-      <% end %>
-      <%= if get_flash(@conn, :error) do %>
-          <p class="message message--error"><%= get_flash(@conn, :error) %></p>
+        <%= if get_flash(@conn, :errors) do %>
+          <%= for error <- get_flash(@conn, :errors) do %>
+            <p class="message message--error"><%= error %></p>
+          <% end %>
+        <% end %>
+        <%= if get_flash(@conn, :error) do %>
+            <p class="message message--error"><%= get_flash(@conn, :error) %></p>
+        <% end %>
       <% end %>
 
       <%= render(@view_module, @view_template, assigns) %>

--- a/apps/transport/lib/transport_web/views/layout_view.ex
+++ b/apps/transport/lib/transport_web/views/layout_view.ex
@@ -6,4 +6,10 @@ defmodule TransportWeb.LayoutView do
   def current_path(conn) do
     Controller.current_path(conn)
   end
+
+  def has_flash(conn) do
+    # it's not nice to depend on some internal state, but it does not seems to have a better way
+    # to check if the `put_flash` function has been called, and it's important for error pages
+    not is_nil(conn.private[:phoenix_flash])
+  end
 end


### PR DESCRIPTION
closes #1228 

* redirection pour les anciens articles de blog
* meilleure gestion des erreurs, il y avait des soucis sur le temps `app.html.eex` qui le rendait impossible à rendre si on était pas passé dans le [pipeline :browser](https://github.com/etalab/transport-site/blob/89b6951dc002b7bb7f3edaa7498021e953e098e1/apps/transport/lib/transport_web/router.ex#L10).

Donc maintenant on a des 404 et non plus des 500