### PR TITLE
add a better way to match geojson with gtfs

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -90,6 +90,7 @@ defmodule DB.Dataset do
         is_community_resource: r.is_community_resource,
         description: r.description,
         community_resource_publisher: r.community_resource_publisher,
+        original_resource_url: r.original_resource_url,
         auto_tags: r.auto_tags
       },
       where: r.is_available

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -32,9 +32,13 @@ defmodule DB.Resource do
     field(:conversion_latest_content_hash, :string)
 
     field(:is_community_resource, :boolean)
+
     # only relevant for community resources, name of the owner or the organization that published the resource
     field(:community_resource_publisher, :string)
     field(:description, :string)
+
+    # some community resources have been generated from another dataset (like the generated NeTEx / GeoJson)
+    field(:original_resource_url, :string)
 
     # we add 2 fields, that are already in the metadata json, in order to be able to add some indices
     field(:start_date, :date)
@@ -240,6 +244,7 @@ defmodule DB.Resource do
         :auto_tags,
         :is_community_resource,
         :community_resource_publisher,
+        :original_resource_url,
         :description,
         :filesize
       ]

--- a/apps/db/priv/repo/migrations/20200630154908_original_resource_url.exs
+++ b/apps/db/priv/repo/migrations/20200630154908_original_resource_url.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.OriginalResourceUrl do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      add(:original_resource_url, :string)
+    end
+  end
+end

--- a/apps/transport/lib/transport/gtfs_conversions.ex
+++ b/apps/transport/lib/transport/gtfs_conversions.ex
@@ -18,8 +18,8 @@ defmodule Transport.GtfsConversions do
     Resource
     |> where(
       [r],
-      not is_nil(r.url) and not is_nil(r.title) and r.format == "GTFS" and r.is_community_resource == false
-      and r.is_available
+      not is_nil(r.url) and not is_nil(r.title) and r.format == "GTFS" and r.is_community_resource == false and
+        r.is_available
     )
     |> preload(dataset: [:resources])
     |> Repo.all()

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -300,7 +300,8 @@ defmodule Transport.ImportData do
         "community_resource_publisher" => get_publisher(resource),
         "description" => resource["description"],
         "filesize" => resource["filesize"],
-        "content_hash" => Hasher.get_content_hash(resource["url"])
+        "content_hash" => Hasher.get_content_hash(resource["url"]),
+        "original_resource_url" => get_original_resource_url(resource)
       }
     end)
   end
@@ -559,6 +560,10 @@ defmodule Transport.ImportData do
     |> select([r], r.id)
     |> Repo.one()
   end
+
+  @spec get_original_resource_url(map()) :: binary() | nil
+  def get_original_resource_url(%{"extras" => %{"transport:original_resource_url" => url}}), do: url
+  def get_original_resource_url(_), do: nil
 
   @spec has_realtime?(map, binary) :: boolean
   def has_realtime?(dataset, "public-transit") do

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -63,14 +63,25 @@ defmodule TransportWeb.ResourceView do
   def dataset_creation,
     do: :transport |> Application.get_env(:datagouvfr_site) |> Path.join("/fr/admin/dataset/new/")
 
-  def get_associated_geojson(%DB.Resource{title: title, dataset: %{resources: resources}}) do
-    resources
-    |> Enum.find(fn r ->
-      title
-      |> String.downcase()
-      |> String.replace("_", "-")
-      |> Kernel.<>(".geojson") ==
-        r.title
-    end)
+  def get_associated_geojson(%DB.Resource{title: title, url: url, dataset: %{resources: resources}}) do
+    assoc =
+      resources
+      |> Enum.find(fn r -> r.original_resource_url == url end)
+
+    case assoc do
+      nil ->
+        # old way to match associated resource, we can remove this after a while
+        resources
+        |> Enum.find(fn r ->
+          title
+          |> String.downcase()
+          |> String.replace("_", "-")
+          |> Kernel.<>(".geojson") ==
+            r.title
+        end)
+
+      a ->
+        a
+    end
   end
 end


### PR DESCRIPTION
use the new metadata `transport:original_resource_url` on generated
geojson to match the corresponding GTFS