### PR TITLE
better explanation for backoffice AOM field

### DIFF
--- a/apps/transport/lib/transport_web/live/commune_field.ex
+++ b/apps/transport/lib/transport_web/live/commune_field.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.Live.CommuneField do
     ~L"""
     <div class="form__group">
         <input type="text" phx-keyup="suggest" list="matches" name="insee" value="<%= @insee %>"
-         autocomplete="off" id="communes_q" placeholder="Code INSEE (vous pouvez aussi chercher par nom)">
+         autocomplete="off" id="communes_q" placeholder="Commune faisant partie de l'AOM (code INSEE ou nom)">
         <datalist id="matches">
         <%= for match <- @matches do %>
             <option value="<%= match.insee %>"><%= "#{match.nom} #{match.insee}" %></option>


### PR DESCRIPTION
Il n'était pas très clair dans le backoffice que lorsque l'on veut lier un dataset à une AOM, il ne faut pas rechercher le nom de l'AOM mais le nom d'une des communes faisant partie de l'AOM.