### PR TITLE
add pictos for stops-ref and informations categories

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -168,7 +168,6 @@ defmodule TransportWeb.DatasetView do
       "private-parking" => "/images/icons/parking.svg",
       "stops-ref" => "/images/icons/addresses.svg",
       "informations" => "/images/icons/infos.svg"
-
     }
 
     Map.get(icons, type)

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -165,7 +165,10 @@ defmodule TransportWeb.DatasetView do
       "air-transport" => "/images/icons/plane.svg",
       "road-network" => "/images/icons/map.svg",
       "addresses" => "/images/icons/addresses.svg",
-      "private-parking" => "/images/icons/parking.svg"
+      "private-parking" => "/images/icons/parking.svg",
+      "stops-ref" => "/images/icons/addresses.svg",
+      "informations" => "/images/icons/infos.svg"
+
     }
 
     Map.get(icons, type)


### PR DESCRIPTION
Ajout de pictos pour les datasets de type référentiels d'arrêts (un pins de carte comme pour les adresses) et pour les "autres informations"

J'en ai profité pour changer la catégorie du dataset https://transport.data.gouv.fr/datasets/cartographie-openstreetmap-des-gares-sncf-transilien-en-ile-de-france-1/ qui était en autre informations et que j'ai mis en référentiel d'arrêts.

![image](https://user-images.githubusercontent.com/15341118/89885136-e3350180-dbca-11ea-87ef-15075e2d7b3c.png)

![image](https://user-images.githubusercontent.com/15341118/89885160-eb8d3c80-dbca-11ea-8471-7f87c04e7506.png)
