### PR TITLE
Resource conversion from backoffice

### DIFF
--- a/apps/transport/lib/transport/gtfs_conversions.ex
+++ b/apps/transport/lib/transport/gtfs_conversions.ex
@@ -16,11 +16,7 @@ defmodule Transport.GtfsConversions do
     Logger.info("generating NeTEx and geojson for all GTFS")
 
     Resource
-    |> where(
-      [r],
-      not is_nil(r.url) and not is_nil(r.title) and r.format == "GTFS" and r.is_community_resource == false and
-        r.is_available
-    )
+    |> filter_convertible_resources()
     |> preload(dataset: [:resources])
     |> Repo.all()
     |> Stream.filter(fn r -> force_update || update_needed?(r) end)
@@ -92,5 +88,14 @@ defmodule Transport.GtfsConversions do
     resource
     |> change(conversion_latest_content_hash: resource.content_hash)
     |> Repo.update()
+  end
+
+  defp filter_convertible_resources(query) do
+    query
+    |> where(
+      [r],
+      not is_nil(r.url) and not is_nil(r.title) and r.format == "GTFS" and r.is_community_resource == false and
+        r.is_available
+    )
   end
 end

--- a/apps/transport/lib/transport/gtfs_conversions.ex
+++ b/apps/transport/lib/transport/gtfs_conversions.ex
@@ -60,8 +60,8 @@ defmodule Transport.GtfsConversions do
     |> filter_convertible_resources()
     |> Repo.all()
     |> case do
-      nil ->
-        {:error, "no convertible resource"}
+      [] ->
+        {:error, "no eligible resource"}
 
       resources ->
         Enum.each(resources, &convert_resource/1)

--- a/apps/transport/lib/transport/gtfs_conversions.ex
+++ b/apps/transport/lib/transport/gtfs_conversions.ex
@@ -53,6 +53,22 @@ defmodule Transport.GtfsConversions do
     end
   end
 
+  def convert_resources_of_dataset(dataset_id) do
+    Resource
+    |> preload(dataset: [:resources])
+    |> where([r], r.dataset_id == ^dataset_id)
+    |> filter_convertible_resources()
+    |> Repo.all()
+    |> case do
+      nil ->
+        {:error, "no convertible resource"}
+
+      resources ->
+        Enum.each(resources, &convert_resource/1)
+        {:ok, ""}
+    end
+  end
+
   @spec generate_netex_and_geojson(Resource.t()) :: {:ok, Ecto.Schema.t()} | {:error, any()}
   defp generate_netex_and_geojson(resource), do: call_conversion_api(resource, "convert_to_netex_and_geojson")
 

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -3,7 +3,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
   alias Datagouvfr.Client.Datasets
 
   alias DB.{Dataset, ImportDataWorker, Repo}
-  alias Transport.{ImportData, ImportDataWorker}
+  alias Transport.{GtfsConversions, ImportData, ImportDataWorker}
   require Logger
 
   @spec post(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -111,6 +111,18 @@ defmodule TransportWeb.Backoffice.DatasetController do
     conn
     |> put_flash(:info, dgettext("backoffice_dataset", "validation of all datasets has been launch"))
     |> redirect_to_index()
+  end
+
+  @spec launch_resources_conversions(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def launch_resources_conversions(%Plug.Conn{} = conn, %{"id" => dataset_id}) do
+    # force the conversion of GTFS resources to GeoJSON and NeTEx format
+    GtfsConversions.convert_resources_of_dataset(dataset_id)
+    |> flash(
+      conn,
+      dgettext("backoffice_dataset", "resources conversion launched"),
+      dgettext("backoffice_dataset", "no resource can be converted")
+    )
+    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id))
   end
 
   ## Private functions

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -91,7 +91,10 @@ defmodule TransportWeb.Backoffice.DatasetController do
     ImportDataWorker.import_validate_all()
 
     conn
-    |> put_flash(:info, dgettext("backoffice_dataset", "Import and validation of all datasets have been launch"))
+    |> put_flash(
+      :info,
+      dgettext("backoffice_dataset", "Import and validation of all datasets have been launch")
+    )
     |> redirect_to_index()
   end
 
@@ -100,7 +103,10 @@ defmodule TransportWeb.Backoffice.DatasetController do
     ImportDataWorker.validate_all()
 
     conn
-    |> put_flash(:info, dgettext("backoffice_dataset", "validation of all datasets has been launched"))
+    |> put_flash(
+      :info,
+      dgettext("backoffice_dataset", "validation of all datasets has been launched")
+    )
     |> redirect_to_index()
   end
 
@@ -109,7 +115,10 @@ defmodule TransportWeb.Backoffice.DatasetController do
     ImportDataWorker.force_validate_all()
 
     conn
-    |> put_flash(:info, dgettext("backoffice_dataset", "validation of all datasets has been launch"))
+    |> put_flash(
+      :info,
+      dgettext("backoffice_dataset", "validation of all datasets has been launch")
+    )
     |> redirect_to_index()
   end
 
@@ -128,7 +137,9 @@ defmodule TransportWeb.Backoffice.DatasetController do
   ## Private functions
 
   @spec flash(:ok | {:ok, any} | {:error, any}, Plug.Conn.t(), binary, binary) :: Plug.Conn.t()
-  defp flash({:ok, _message}, conn, ok_message, err_message), do: flash(:ok, conn, ok_message, err_message)
+  defp flash({:ok, _message}, conn, ok_message, err_message),
+    do: flash(:ok, conn, ok_message, err_message)
+
   defp flash(:ok, conn, ok_message, _err_message), do: put_flash(conn, :info, ok_message)
 
   defp flash({:error, %{errors: errors}}, conn, _ok, err_message) do
@@ -137,7 +148,8 @@ defmodule TransportWeb.Backoffice.DatasetController do
     put_flash(conn, :error, Enum.join(messages, ", "))
   end
 
-  defp flash({:error, message}, conn, _ok, err), do: put_flash(conn, :error, "#{err} (#{message})")
+  defp flash({:error, message}, conn, _ok, err),
+    do: put_flash(conn, :error, "#{err} (#{message})")
 
   @spec import_data(Dataset.t() | nil) :: any()
   defp import_data(%Dataset{} = dataset), do: ImportData.import_dataset(dataset)

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -125,7 +125,9 @@ defmodule TransportWeb.Backoffice.DatasetController do
   @spec launch_resources_conversions(Plug.Conn.t(), map) :: Plug.Conn.t()
   def launch_resources_conversions(%Plug.Conn{} = conn, %{"id" => dataset_id}) do
     # force the conversion of GTFS resources to GeoJSON and NeTEx format
-    GtfsConversions.convert_resources_of_dataset(dataset_id)
+    res = GtfsConversions.convert_resources_of_dataset(dataset_id)
+
+    res
     |> flash(
       conn,
       dgettext("backoffice_dataset", "resources conversion launched"),

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -99,6 +99,7 @@ defmodule TransportWeb.Router do
         post("/_all_/_force_validate", DatasetController, :force_validate_all)
         post("/:id/_import_validate", DatasetController, :import_validate_all)
         post("/:id/_validate", DatasetController, :validation)
+        post("/:id/_launch_resource_conversion", DatasetController, :launch_resources_conversions)
       end
 
       scope "/partners" do

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -100,6 +100,11 @@
           <% end %>
         </div>
       </div>
+      <div class="backoffice_dataset_actions_buttons">
+        <%= form_for @conn, backoffice_dataset_path(@conn, :generate_geojson, @dataset.id), [nodiv: true], fn _ -> %>
+          <%= submit dgettext("backoffice", "Generate community resources (GeoJSON and NeTEx)"), [class: "button"] %>
+        <% end %>
+      </div>
       <div class="dataset_import_validations_logs">
         <h3><%= dgettext("backoffice", "Imports history") %></h3>
         <table>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -101,7 +101,7 @@
         </div>
       </div>
       <div class="backoffice_dataset_actions_buttons">
-        <%= form_for @conn, backoffice_dataset_path(@conn, :generate_geojson, @dataset.id), [nodiv: true], fn _ -> %>
+        <%= form_for @conn, backoffice_dataset_path(@conn, :launch_resources_conversions, @dataset.id), [nodiv: true], fn _ -> %>
           <%= submit dgettext("backoffice", "Generate community resources (GeoJSON and NeTEx)"), [class: "button"] %>
         <% end %>
       </div>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -193,10 +193,6 @@ msgid "explanation"
 msgstr ""
 
 #, elixir-format
-msgid "resource id"
-msgstr ""
-
-#, elixir-format
 msgid "success"
 msgstr ""
 
@@ -205,9 +201,5 @@ msgid "validation needed"
 msgstr ""
 
 #, elixir-format
-msgid "resource page"
-msgstr ""
-
-#, elixir-format
-msgid "resource title"
+msgid "Generate community resources (GeoJSON and NeTEx)"
 msgstr ""

--- a/apps/transport/priv/gettext/backoffice_dataset.pot
+++ b/apps/transport/priv/gettext/backoffice_dataset.pot
@@ -65,3 +65,11 @@ msgstr ""
 #, elixir-format
 msgid "validation of all datasets has been launch"
 msgstr ""
+
+#, elixir-format
+msgid "no resource can be converted"
+msgstr ""
+
+#, elixir-format
+msgid "resources conversion launched"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -192,10 +192,6 @@ msgid "explanation"
 msgstr ""
 
 #, elixir-format
-msgid "resource id"
-msgstr ""
-
-#, elixir-format
 msgid "success"
 msgstr ""
 
@@ -203,10 +199,6 @@ msgstr ""
 msgid "validation needed"
 msgstr ""
 
-#, elixir-format, fuzzy
-msgid "resource page"
-msgstr ""
-
-#, elixir-format, fuzzy
-msgid "resource title"
+#, elixir-format
+msgid "Generate community resources (GeoJSON and NeTEx)"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
@@ -66,3 +66,11 @@ msgstr ""
 #, elixir-format
 msgid "validation of all datasets has been launch"
 msgstr ""
+
+#, elixir-format
+msgid "no resource can be converted"
+msgstr ""
+
+#, elixir-format
+msgid "resources conversion launched"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -231,6 +231,6 @@ msgstr ""
 msgid "Bicycle paths"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "Road works"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -192,10 +192,6 @@ msgid "explanation"
 msgstr "raison"
 
 #, elixir-format
-msgid "resource id"
-msgstr "id ressource"
-
-#, elixir-format
 msgid "success"
 msgstr "succès"
 
@@ -204,9 +200,5 @@ msgid "validation needed"
 msgstr "validation nécessaire"
 
 #, elixir-format
-msgid "resource page"
-msgstr "page ressource"
-
-#, elixir-format
-msgid "resource title"
-msgstr "titre ressource"
+msgid "Generate community resources (GeoJSON and NeTEx)"
+msgstr "Générer les ressources communautaires (GeoJSON et NeTEx)"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
@@ -66,3 +66,11 @@ msgstr "La validation de tous les jeux de données a été lancée."
 #, elixir-format
 msgid "validation of all datasets has been launch"
 msgstr "La validation de tous les jeux de données a été lancée."
+
+#, elixir-format
+msgid "no resource can be converted"
+msgstr "pas de ressource à convertir"
+
+#, elixir-format
+msgid "resources conversion launched"
+msgstr "la conversion des ressources est lancée"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -231,6 +231,6 @@ msgstr "Jeux de données"
 msgid "Bicycle paths"
 msgstr "Aménagements cyclables"
 
-#, elixir-format, fuzzy
+#, elixir-format
 msgid "Road works"
 msgstr "Travaux sur voirie"

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -226,3 +226,11 @@ msgstr ""
 #, elixir-format
 msgid "Datasets"
 msgstr ""
+
+#, elixir-format
+msgid "Bicycle paths"
+msgstr ""
+
+#, elixir-format
+msgid "Road works"
+msgstr ""


### PR DESCRIPTION
Permet de lancer la création de resources communautaires (GeoJSON et NeTEx) depuis le backoffice d'un dataset.

![image](https://user-images.githubusercontent.com/15341118/89919977-307d9700-dbfc-11ea-9a8d-f0411e558128.png)
