### PR TITLE
encode url parameters for gtfs converter api call

### DIFF
--- a/apps/transport/lib/transport/gtfs_conversions.ex
+++ b/apps/transport/lib/transport/gtfs_conversions.ex
@@ -79,7 +79,8 @@ defmodule Transport.GtfsConversions do
   defp call_conversion_api(resource, endpoint) do
     Logger.info("calling #{endpoint} for #{resource.dataset.title} - #{resource.title} (#{resource.id})")
 
-    url = "#{@base_url}/#{endpoint}?url=#{resource.url}&datagouv_id=#{resource.dataset.datagouv_id}"
+    params = %{"url" => resource.url, "datagouv_id" => resource.dataset.datagouv_id}
+    url = "#{@base_url}/#{endpoint}?#{URI.encode_query(params)}"
 
     case HTTPoison.get(url) do
       {:ok, %{status_code: 200}} ->


### PR DESCRIPTION
Les parametres des appels au gtfs_converter n'étaient pas encodés, d'ou des taches qui échouaient si l'on passait comme paramètre une url contenant elle-même des caractères spéciaux, comme &.

Par exemple : https:// convertisseur.transport.data.gouv.fr/gtfs2geojson?url=http:// exs.itiniserev2.cityway.fr/gtfs.aspx?key=OPENDATA **&** operatorCode=CG38 **&** useCache=off&datagouv_id=5bb1caa6634f4136693d9053