### PR TITLE
update copy-webpack-plugin to latest version

### DIFF
--- a/apps/transport/client/package.json
+++ b/apps/transport/client/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/fontawesome-free": "^5.1.0",
     "@tarekraafat/autocomplete.js": "^7.2.0",
     "babel-loader": "^8.0.5",
-    "copy-webpack-plugin": "^5.0.0",
+    "copy-webpack-plugin": "^6.0.0",
     "core-js": "3",
     "css-loader": "^3.4.0",
     "exports-loader": "^0.7.0",

--- a/apps/transport/client/webpack.config.js
+++ b/apps/transport/client/webpack.config.js
@@ -46,24 +46,24 @@ module.exports = {
     devtool: 'source-map',
     module: {
         rules: [{ test: /\.css$/, use: ['style-loader', 'css-loader'] },
-        {
-            test: /\.(js|scss)$/,
-            exclude: [/node_modules/],
-            enforce: 'pre',
-            loader: 'import-glob-loader'
-        }, {
-            test: /\.js$/,
-            exclude: [/node_modules/],
-            use: {
-                loader: 'babel-loader',
-                options: {
-                    presets: ['@babel/preset-env']
+            {
+                test: /\.(js|scss)$/,
+                exclude: [/node_modules/],
+                enforce: 'pre',
+                loader: 'import-glob-loader'
+            }, {
+                test: /\.js$/,
+                exclude: [/node_modules/],
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-env']
+                    }
                 }
-            }
-        }, {
-            test: /\.scss$/,
-            exclude: [/node_modules/],
-            use:
+            }, {
+                test: /\.scss$/,
+                exclude: [/node_modules/],
+                use:
                 [
                     MiniCssExtractPlugin.loader,
                     {
@@ -78,25 +78,25 @@ module.exports = {
                         }
                     }
                 ]
-        }, {
-            test: /\.(jpe?g|png|gif|svg)$/,
-            exclude: [/font-awesome/],
-            use: [{
-                loader: 'file-loader',
-                options: {
-                    name: '[name].[ext]',
-                    outputPath: '../images/'
-                }
+            }, {
+                test: /\.(jpe?g|png|gif|svg)$/,
+                exclude: [/font-awesome/],
+                use: [{
+                    loader: 'file-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: '../images/'
+                    }
+                }]
+            }, {
+                test: /\.(eot|ttf|otf|woff|woff2|svg)(\?v=\d+\.\d+\.\d+)?$/,
+                use: [{
+                    loader: 'file-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: '../fonts/'
+                    }
+                }]
             }]
-        }, {
-            test: /\.(eot|ttf|otf|woff|woff2|svg)(\?v=\d+\.\d+\.\d+)?$/,
-            use: [{
-                loader: 'file-loader',
-                options: {
-                    name: '[name].[ext]',
-                    outputPath: '../fonts/'
-                }
-            }]
-        }]
     }
 }

--- a/apps/transport/client/webpack.config.js
+++ b/apps/transport/client/webpack.config.js
@@ -3,7 +3,7 @@ const devMode = process.env.NODE_ENV !== 'production'
 const webpack = require('webpack')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const extractImages = new CopyWebpackPlugin([{ from: 'images', to: '../images' }])
+const extractImages = new CopyWebpackPlugin({ patterns: [{ from: 'images', to: '../images' }] })
 const extractSass = new MiniCssExtractPlugin({ filename: '../css/app.css', allChunks: true })
 const fetchPolyfill = new webpack.ProvidePlugin({ fetch: 'exports-loader?self.fetch!whatwg-fetch/dist/fetch.umd' })
 const promisePolyfill = new webpack.ProvidePlugin({ Promise: 'core-js/es/promise' })
@@ -46,57 +46,57 @@ module.exports = {
     devtool: 'source-map',
     module: {
         rules: [{ test: /\.css$/, use: ['style-loader', 'css-loader'] },
-            {
-                test: /\.(js|scss)$/,
-                exclude: [/node_modules/],
-                enforce: 'pre',
-                loader: 'import-glob-loader'
-            }, {
-                test: /\.js$/,
-                exclude: [/node_modules/],
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: ['@babel/preset-env']
-                    }
+        {
+            test: /\.(js|scss)$/,
+            exclude: [/node_modules/],
+            enforce: 'pre',
+            loader: 'import-glob-loader'
+        }, {
+            test: /\.js$/,
+            exclude: [/node_modules/],
+            use: {
+                loader: 'babel-loader',
+                options: {
+                    presets: ['@babel/preset-env']
                 }
-            }, {
-                test: /\.scss$/,
-                exclude: [/node_modules/],
-                use:
-                    [
-                        MiniCssExtractPlugin.loader,
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                sourceMap: true
-                            }
-                        }, {
-                            loader: 'sass-loader',
-                            options: {
-                                sourceMap: true
-                            }
+            }
+        }, {
+            test: /\.scss$/,
+            exclude: [/node_modules/],
+            use:
+                [
+                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: true
                         }
-                    ]
-            }, {
-                test: /\.(jpe?g|png|gif|svg)$/,
-                exclude: [/font-awesome/],
-                use: [{
-                    loader: 'file-loader',
-                    options: {
-                        name: '[name].[ext]',
-                        outputPath: '../images/'
+                    }, {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: true
+                        }
                     }
-                }]
-            }, {
-                test: /\.(eot|ttf|otf|woff|woff2|svg)(\?v=\d+\.\d+\.\d+)?$/,
-                use: [{
-                    loader: 'file-loader',
-                    options: {
-                        name: '[name].[ext]',
-                        outputPath: '../fonts/'
-                    }
-                }]
+                ]
+        }, {
+            test: /\.(jpe?g|png|gif|svg)$/,
+            exclude: [/font-awesome/],
+            use: [{
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]',
+                    outputPath: '../images/'
+                }
             }]
+        }, {
+            test: /\.(eot|ttf|otf|woff|woff2|svg)(\?v=\d+\.\d+\.\d+)?$/,
+            use: [{
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]',
+                    outputPath: '../fonts/'
+                }
+            }]
+        }]
     }
 }


### PR DESCRIPTION
for security reasons.

Nous avons eu une alerte sécurité à cause du package serialize-javascript qui est utilisé par le plugin webpack copy-webpack-plugin. La faille de sécurité est corrigée dans les versions >v6.0.1 du plugin.

![image](https://user-images.githubusercontent.com/15341118/90512689-cfefdc00-e15e-11ea-9689-ebcd9bafe93f.png)
