### PR TITLE
Map for validator

### DIFF
--- a/apps/db/lib/db/validation.ex
+++ b/apps/db/lib/db/validation.ex
@@ -18,6 +18,7 @@ defmodule DB.Validation do
     # content_hash of the validated resource
     # This makes it possible to check if we need to revalidate the resource
     field(:validation_latest_content_hash, :string)
+    field(:data_vis, :map)
 
     belongs_to(:resource, Resource)
   end

--- a/apps/db/priv/repo/migrations/20200818124059_add_geojson_to_validation_data.exs
+++ b/apps/db/priv/repo/migrations/20200818124059_add_geojson_to_validation_data.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddGeojsonToValidationData do
+  use Ecto.Migration
+
+  def change do
+    alter table(:validations) do
+      add(:data_vis, :map)
+    end
+  end
+end

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -1,0 +1,73 @@
+import L from 'leaflet'
+
+/**
+ * Represents a Mapbox object.
+ * @type {Object}
+ */
+const Mapbox = {
+    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    maxZoom: 20,
+    id: 'mapbox.light'
+}
+
+function initilizeMap (id) {
+    const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
+    L.tileLayer(Mapbox.url, {
+        accessToken: Mapbox.accessToken,
+        attribution: Mapbox.attribution,
+        maxZoom: Mapbox.maxZoom,
+        id: Mapbox.id
+    }).addTo(map)
+
+    const fg = L.featureGroup().addTo(map)
+    return { map, fg }
+}
+
+function getColor (severity) {
+    const severityColor = {
+        Error: 'red',
+        Warning: '#ff6600',
+        Information: 'orange'
+    }
+    return severityColor[severity] || 'blue'
+}
+
+function createValidationMap (divId, dataVis) {
+    const { map, fg } = initilizeMap(divId)
+    const gs = L.geoJSON(dataVis.geojson, {
+        pointToLayer (feature, latlng) {
+            const marker = L.circleMarker(latlng, { radius: 5, fillColor: 'white', fillOpacity: 1, color: getColor(dataVis.severity) })
+            marker.addTo(fg)
+            return marker
+        },
+        style (feature) {
+            if (feature.geometry.type === 'Point') {
+                return {}
+            } else {
+                return {
+                    color: 'black'
+                }
+            }
+        },
+        onEachFeature (feature, layer) {
+            layer.on('mouseover', () => { layer.setStyle({ weight: 5, radius: 7 }) })
+            layer.on('mouseout', () => { layer.setStyle({ weight: 3, radius: 5 }) })
+        }
+    }).addTo(map)
+    fg.bringToFront()
+    gs.bindPopup(layer => {
+        let popupContent = layer.feature.properties.name || layer.feature.properties.details
+        if (layer.feature.properties.id) {
+            popupContent += `<br>ID ${layer.feature.properties.id}`
+        }
+        return popupContent
+    })
+    const bounds = fg.getBounds()
+    if (bounds.isValid()) {
+        map.fitBounds(fg.getBounds())
+    }
+}
+
+window.createValidationMap = createValidationMap

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -355,6 +355,10 @@
   padding: 24px;
 }
 
+.p-6 {
+  padding: 6px;
+}
+
 .no-padding {
   padding: 0 !important;
 }

--- a/apps/transport/client/webpack.config.js
+++ b/apps/transport/client/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
         mapcsv: './javascripts/map-csv.js',
         mapgeojson: './javascripts/map-geojson.js',
         datasetmap: './javascripts/dataset-map.js',
+        validationmap: './javascripts/validation-map.js',
         utils: './javascripts/utils.js',
         autocomplete: './javascripts/autocomplete.js',
         scss: './stylesheets/app.scss'

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.ValidationController do
   @err HTTPoison.Error
   @timeout 180_000
 
-  @geojson_converter_url "http://localhost:8080/gtfs2geojson_sync"
+  @geojson_converter_url "https://convertisseur.transport.data.gouv.fr/gtfs2geojson_sync"
 
   defp endpoint, do: Application.get_env(:transport, :gtfs_validator_url) <> "/validate"
 

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -126,32 +126,38 @@ defmodule TransportWeb.ValidationController do
   def features_from_issue(issue, id, features_map) do
     # features contains a list of stops, related_stops and Linestrings
     # Linestrings are used to link a stop and its related stop
-    feature = features_map[id]
-    properties = Map.put(feature["properties"], "details", Map.get(issue, "details"))
-    stop = Map.put(feature, "properties", properties)
 
-    case issue["related_objects"] do
-      %{"id" => id, "name" => _name} ->
-        related_stop = features_map[id]
+    case features_map[id] do
+      nil ->
+        []
 
-        stops_link = %{
-          "type" => "Feature",
-          "properties" => %{
-            "details" => Map.get(issue, "details")
-          },
-          "geometry" => %{
-            "type" => "LineString",
-            "coordinates" => [
-              stop["geometry"]["coordinates"],
-              related_stop["geometry"]["coordinates"]
-            ]
-          }
-        }
+      feature ->
+        properties = Map.put(feature["properties"] || %{}, "details", Map.get(issue, "details"))
+        stop = Map.put(feature, "properties", properties)
 
-        [stop, related_stop, stops_link]
+        case issue["related_objects"] do
+          %{"id" => id, "name" => _name} ->
+            related_stop = features_map[id]
 
-      _ ->
-        [stop]
+            stops_link = %{
+              "type" => "Feature",
+              "properties" => %{
+                "details" => Map.get(issue, "details")
+              },
+              "geometry" => %{
+                "type" => "LineString",
+                "coordinates" => [
+                  stop["geometry"]["coordinates"],
+                  related_stop["geometry"]["coordinates"]
+                ]
+              }
+            }
+
+            [stop, related_stop, stops_link]
+
+          _ ->
+            [stop]
+        end
     end
   end
 

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -2,10 +2,14 @@ defmodule TransportWeb.ValidationController do
   use TransportWeb, :controller
   alias DB.{Repo, Validation}
 
+  import TransportWeb.ResourceView, only: [issue_type: 1]
+
   @client HTTPoison
   @res HTTPoison.Response
   @err HTTPoison.Error
   @timeout 180_000
+
+  @geojson_converter_url "https://convertisseur.transport.data.gouv.fr/gtfs2geojson_sync"
 
   defp endpoint, do: Application.get_env(:transport, :gtfs_validator_url) <> "/validate"
 
@@ -14,13 +18,36 @@ defmodule TransportWeb.ValidationController do
   end
 
   def validate(%Plug.Conn{} = conn, %{"upload" => upload_params}) do
-    with {:ok, gtfs} <- File.read(upload_params["file"].path),
-         {:ok, %@res{status_code: 200, body: body}} <- @client.post(endpoint(), gtfs, [], recv_timeout: @timeout),
-         {:ok, %{"validations" => validations, "metadata" => metadata}} <- Poison.decode(body) do
+    # geojson converter accepts only zip files
+    file_path = upload_params["file"].path
+    file_path_with_extension = file_path <> ".zip"
+    File.rename(file_path, file_path_with_extension)
+
+    geojson_converter_response =
+      @client.post(
+        @geojson_converter_url,
+        {:multipart, [{:file, file_path_with_extension}]},
+        [{"content-type", "multipart/form-data;"}],
+        recv_timeout: @timeout
+      )
+
+    geojson_encoded =
+      case geojson_converter_response do
+        {:ok, %@res{status_code: 200, body: geojson_encoded}} -> geojson_encoded
+        _ -> nil
+      end
+
+    with {:ok, gtfs} <- File.read(file_path_with_extension),
+         {:ok, %@res{status_code: 200, body: body}} <-
+           @client.post(endpoint(), gtfs, [], recv_timeout: @timeout),
+         {:ok, %{"validations" => validations, "metadata" => metadata}} <- Jason.decode(body) do
+      data_vis = validation_data_vis(geojson_encoded, validations)
+
       %Validation{
         date: DateTime.utc_now() |> DateTime.to_string(),
         details: validations,
-        on_the_fly_validation_metadata: metadata
+        on_the_fly_validation_metadata: metadata,
+        data_vis: data_vis
       }
       |> Repo.insert()
     else
@@ -38,19 +65,115 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
+  @spec validation_data_vis(any, any) :: nil | map
+  def validation_data_vis(nil, _), do: nil
+
+  def validation_data_vis(geojson_encoded, validations) do
+    case Jason.decode(geojson_encoded) do
+      {:ok, geojson} ->
+        validations
+        |> Map.new(fn {issue_name, issues_list} ->
+          # create a map with stops id as keys and issue description as values
+          issues_map =
+            Map.new(issues_list, fn issue ->
+              # keep only on related stop in related objects
+              simplified_issue =
+                issue
+                |> Map.update("related_objects", [], fn related_objects ->
+                  related_objects |> Enum.filter(fn o -> o["object_type"] == "Stop" end) |> List.first()
+                end)
+
+              {issue["object_id"], simplified_issue}
+            end)
+
+          # create a map with with stop id as keys and geojson features as values
+          features_map =
+            geojson["features"]
+            |> Map.new(fn feature -> {feature["properties"]["id"], feature} end)
+
+          # create a geojson for each issue type
+          # features contains a list of stops, related_stops and Linestrings
+          # Linestrings are used to link a stop and its related stop
+          issues_geojson =
+            Map.update(geojson, "features", [], fn _features ->
+              issues_map
+              |> Enum.flat_map(fn {id, issue} ->
+                feature = features_map[id]
+                properties = Map.put(feature["properties"], "details", Map.get(issue, "details"))
+                stop = Map.put(feature, "properties", properties)
+
+                case issue["related_objects"] do
+                  %{"id" => id, "name" => _name} ->
+                    related_stop = features_map[id]
+
+                    stops_link = %{
+                      "type" => "Feature",
+                      "properties" => %{
+                        "details" => Map.get(issue, "details")
+                      },
+                      "geometry" => %{
+                        "type" => "LineString",
+                        "coordinates" => [
+                          stop["geometry"]["coordinates"],
+                          related_stop["geometry"]["coordinates"]
+                        ]
+                      }
+                    }
+
+                    [stop, related_stop, stops_link]
+
+                  _ ->
+                    [stop]
+                end
+              end)
+            end)
+
+          severity = issues_map |> Map.values() |> Enum.at(0) |> Map.get("severity")
+          # severity is used to customize the markers color in leaflet
+          {issue_name, %{"severity" => severity, "geojson" => issues_geojson}}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
   def show(%Plug.Conn{} = conn, %{} = params) do
     config = make_pagination_config(params)
     validation = Repo.get(Validation, params["id"])
 
-    current_issues = Validation.get_issues(validation, params)
+    case validation do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(TransportWeb.ErrorView)
+        |> render(:"404")
 
-    conn
-    |> assign(:validation_id, params["id"])
-    |> assign(:other_resources, [])
-    |> assign(:issues, Scrivener.paginate(current_issues, config))
-    |> assign(:validation_summary, Validation.summary(validation))
-    |> assign(:severities_count, Validation.count_by_severity(validation))
-    |> assign(:metadata, validation.on_the_fly_validation_metadata)
-    |> render("show.html")
+      validation ->
+        current_issues = Validation.get_issues(validation, params)
+
+        issue_type =
+          case params["issue_type"] do
+            nil -> issue_type(current_issues)
+            issue_type -> issue_type
+          end
+
+        encoded_data_vis =
+          case Jason.encode(validation.data_vis[issue_type]) do
+            {:ok, "null"} -> nil
+            {:ok, data_vis} -> data_vis
+            _ -> nil
+          end
+
+        conn
+        |> assign(:validation_id, params["id"])
+        |> assign(:other_resources, [])
+        |> assign(:issues, Scrivener.paginate(current_issues, config))
+        |> assign(:validation_summary, Validation.summary(validation))
+        |> assign(:severities_count, Validation.count_by_severity(validation))
+        |> assign(:metadata, validation.on_the_fly_validation_metadata)
+        |> assign(:data_vis, encoded_data_vis)
+        |> render("show.html")
+    end
   end
 end

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -181,10 +181,13 @@ defmodule TransportWeb.ValidationController do
             issue_type -> issue_type
           end
 
+        data_vis = validation.data_vis[issue_type]
+        has_features = not (data_vis["geojson"]["features"] == [])
+
         encoded_data_vis =
-          case Jason.encode(validation.data_vis[issue_type]) do
-            {:ok, "null"} -> nil
-            {:ok, data_vis} -> data_vis
+          case {has_features, Jason.encode(data_vis)} do
+            {false, _} -> nil
+            {true, {:ok, encoded_data_vis}} -> encoded_data_vis
             _ -> nil
           end
 

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.ValidationController do
   @err HTTPoison.Error
   @timeout 180_000
 
-  @geojson_converter_url "https://convertisseur.transport.data.gouv.fr/gtfs2geojson_sync"
+  @geojson_converter_url "http://localhost:8080/gtfs2geojson_sync"
 
   defp endpoint, do: Application.get_env(:transport, :gtfs_validator_url) <> "/validate"
 
@@ -71,70 +71,87 @@ defmodule TransportWeb.ValidationController do
   def validation_data_vis(geojson_encoded, validations) do
     case Jason.decode(geojson_encoded) do
       {:ok, geojson} ->
-        validations
-        |> Map.new(fn {issue_name, issues_list} ->
-          # create a map with stops id as keys and issue description as values
-          issues_map =
-            Map.new(issues_list, fn issue ->
-              # keep only on related stop in related objects
-              simplified_issue =
-                issue
-                |> Map.update("related_objects", [], fn related_objects ->
-                  related_objects |> Enum.filter(fn o -> o["object_type"] == "Stop" end) |> List.first()
-                end)
-
-              {issue["object_id"], simplified_issue}
-            end)
-
-          # create a map with with stop id as keys and geojson features as values
-          features_map =
-            geojson["features"]
-            |> Map.new(fn feature -> {feature["properties"]["id"], feature} end)
-
-          # create a geojson for each issue type
-          # features contains a list of stops, related_stops and Linestrings
-          # Linestrings are used to link a stop and its related stop
-          issues_geojson =
-            Map.update(geojson, "features", [], fn _features ->
-              issues_map
-              |> Enum.flat_map(fn {id, issue} ->
-                feature = features_map[id]
-                properties = Map.put(feature["properties"], "details", Map.get(issue, "details"))
-                stop = Map.put(feature, "properties", properties)
-
-                case issue["related_objects"] do
-                  %{"id" => id, "name" => _name} ->
-                    related_stop = features_map[id]
-
-                    stops_link = %{
-                      "type" => "Feature",
-                      "properties" => %{
-                        "details" => Map.get(issue, "details")
-                      },
-                      "geometry" => %{
-                        "type" => "LineString",
-                        "coordinates" => [
-                          stop["geometry"]["coordinates"],
-                          related_stop["geometry"]["coordinates"]
-                        ]
-                      }
-                    }
-
-                    [stop, related_stop, stops_link]
-
-                  _ ->
-                    [stop]
-                end
-              end)
-            end)
-
-          severity = issues_map |> Map.values() |> Enum.at(0) |> Map.get("severity")
-          # severity is used to customize the markers color in leaflet
-          {issue_name, %{"severity" => severity, "geojson" => issues_geojson}}
-        end)
+        data_vis_content(geojson, validations)
 
       _ ->
         %{}
+    end
+  end
+
+  def data_vis_content(geojson, validations) do
+    validations
+    |> Map.new(fn {issue_name, issues_list} ->
+      issues_map = get_issues_map(issues_list)
+
+      # create a map with with stop id as keys and geojson features as values
+      features_map =
+        geojson["features"]
+        |> Map.new(fn feature -> {feature["properties"]["id"], feature} end)
+
+      issues_geojson = get_issues_geojson(geojson, issues_map, features_map)
+
+      severity = issues_map |> Map.values() |> Enum.at(0) |> Map.get("severity")
+      # severity is used to customize the markers color in leaflet
+      {issue_name, %{"severity" => severity, "geojson" => issues_geojson}}
+    end)
+  end
+
+  def get_issues_map(issues_list) do
+    # create a map with stops id as keys and issue description as values
+    Map.new(issues_list, fn issue ->
+      simplified_issue = simplified_issue(issue)
+
+      {issue["object_id"], simplified_issue}
+    end)
+  end
+
+  def simplified_issue(issue) do
+    # keep only on related stop in related objects
+    issue
+    |> Map.update("related_objects", [], fn related_objects ->
+      related_objects |> Enum.filter(fn o -> o["object_type"] == "Stop" end) |> List.first()
+    end)
+  end
+
+  def get_issues_geojson(geojson, issues_map, features_map) do
+    # create a geojson for each issue type
+    Map.update(geojson, "features", [], fn _features ->
+      issues_map
+      |> Enum.flat_map(fn {id, issue} ->
+        features_from_issue(issue, id, features_map)
+      end)
+    end)
+  end
+
+  def features_from_issue(issue, id, features_map) do
+    # features contains a list of stops, related_stops and Linestrings
+    # Linestrings are used to link a stop and its related stop
+    feature = features_map[id]
+    properties = Map.put(feature["properties"], "details", Map.get(issue, "details"))
+    stop = Map.put(feature, "properties", properties)
+
+    case issue["related_objects"] do
+      %{"id" => id, "name" => _name} ->
+        related_stop = features_map[id]
+
+        stops_link = %{
+          "type" => "Feature",
+          "properties" => %{
+            "details" => Map.get(issue, "details")
+          },
+          "geometry" => %{
+            "type" => "LineString",
+            "coordinates" => [
+              stop["geometry"]["coordinates"],
+              related_stop["geometry"]["coordinates"]
+            ]
+          }
+        }
+
+        [stop, related_stop, stops_link]
+
+      _ ->
+        [stop]
     end
   end
 

--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -22,8 +22,14 @@
       <% end %>
 
       <%= if has_errors?(@validation_summary) do %>
+        <div id="issues" class="validation-navigation">
+          <nav class="issues-list validation" role="navigation">
+            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
+          </nav>
+        </div>
+
         <%= unless is_nil(@data_vis) do %>
-          <div id="issues" class="panel p-6">
+          <div class="panel p-6">
             <div id='map' class='mapcsv'></div>
             <script src="<%= static_path(@conn, "/js/validationmap.js") %>"></script>
             <script>
@@ -33,12 +39,6 @@
             </script>
           </div>
         <% end %>
-
-        <div class="validation-navigation">
-          <nav class="issues-list validation" role="navigation">
-            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
-          </nav>
-        </div>
       <% end %>
 
 

--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -14,14 +14,33 @@
 
   <div class="validation-content">
     <div class="container">
-      <div class="panel validation-metadata">
+
+      <%= unless is_nil(@metadata) do %>
+        <div class="panel validation-metadata">
           <%= render "_resources_details.html", metadata: @metadata %>
-      </div>
-      <div class="validation-navigation">
-        <nav class="issues-list validation" role="navigation">
-          <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
-        </nav>
-      </div>
+        </div>
+      <% end %>
+
+      <%= if has_errors?(@validation_summary) do %>
+        <%= unless is_nil(@data_vis) do %>
+          <div id="issues" class="panel p-6">
+            <div id='map' class='mapcsv'></div>
+            <script src="<%= static_path(@conn, "/js/validationmap.js") %>"></script>
+            <script>
+              document.addEventListener("DOMContentLoaded", function() {
+              createValidationMap('map', <%= raw(@data_vis) %>)
+              })
+            </script>
+          </div>
+        <% end %>
+
+        <div class="validation-navigation">
+          <nav class="issues-list validation" role="navigation">
+            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues %>
+          </nav>
+        </div>
+      <% end %>
+
 
       <div class="validation-content-details">
         <div class="panel" style="overflow-x:auto;">
@@ -29,6 +48,10 @@
             <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
                 path: &validation_path/4, action: :show %>
             <%= render template(@issues), issues: @issues || [] , conn: @conn %>
+            <div class="pt-24">
+              <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
+                path: &validation_path/4, action: :show %>
+            </div>
           <% else %>
             <h2><%= dgettext("validations", "Nice work, there are no issues!")%></h2>
           <% end %>


### PR DESCRIPTION
Pour facilier le debug, la validation à la volée de GTFS inclut maintenant une carte.

https://prochainement-transport.cleverapps.io/validation/99732?issue_type=ExcessiveSpeed#issues

![image](https://user-images.githubusercontent.com/15341118/90769039-df525f00-e2ef-11ea-9636-a8038c89afa8.png)

Point à discuter :
- Est-ce une bonne idée de faire un appel synchrone au convertisseur gtfs2geojson ?
- On stocke maintenant en base le geojson de chaque validation. Est-ce que ça prend trop de place ?
- Est-ce qu'on devrait directement intégrer la conversion en geojson au validateur rust plutôt que de faire 2 appels différents (un pour la validation un pour la conversion ?)

