### PR TITLE
Force dataset validation

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -500,7 +500,7 @@ defmodule DB.Dataset do
     |> preload(:validation)
     |> where([r], r.dataset_id == ^id)
     |> Repo.all()
-    |> Enum.map(fn r -> Resource.validate_and_save(r, false) end)
+    |> Enum.map(fn r -> Resource.validate_and_save(r, true) end)
     |> Enum.any?(fn r -> match?({:error, _}, r) end)
     |> if do
       {:error, "Unable to validate dataset #{id}"}


### PR DESCRIPTION
Il y encore des soucis de hash et de validations qui ne veulent pas se lancer :(

Lorsque la tâche quotidienne est lancée, c'est une validation de toutes les ressources qui est demandée.

Par contre lorsque dans le backoffice, on lance une validation, c'est une validation du dataset qui se lance...et qui valide toutes les ressources associées. Je fais ici en sorte que lorsque l'on lance une validation du dataset, ce qui arrive à la création et quand on clique sur valider dans le backoffice, ce soit une validation "forcée". Cela me parait plus logique, car si on clique sur le bouton, à priori c'est qu'on a vraiment envie que les ressources soient validées. Au pire on revalide un peu pour rien.

On avait ici le cas sur https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tag/ d'une ressource qui avait été updatée par le producteur, mais dont la validation était bloquée car pour une raison que j'ignore, la validation périmée avait le hash de la nouvelle ressource.