### PR TITLE
test of Ecto Plug.Exception

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -358,14 +358,13 @@ defmodule DB.Dataset do
 
   @spec get_by_slug(binary) :: {:ok, __MODULE__.t()} | {:error, binary()}
   def get_by_slug(slug) do
-    preload_without_validations()
-    |> where(slug: ^slug)
-    |> preload([:region, :aom, :communes])
-    |> Repo.one()
-    |> case do
-      nil -> {:error, "Dataset with slug #{slug} not found"}
-      dataset -> {:ok, dataset}
-    end
+    dataset =
+      preload_without_validations()
+      |> where(slug: ^slug)
+      |> preload([:region, :aom, :communes])
+      |> Repo.one!()
+
+    {:ok, dataset}
   end
 
   @spec get_other_datasets(__MODULE__.t()) :: [__MODULE__.t()]
@@ -400,19 +399,15 @@ defmodule DB.Dataset do
   def get_territory(%__MODULE__{aom: %{nom: nom}}), do: {:ok, nom}
 
   def get_territory(%__MODULE__{aom_id: aom_id}) when not is_nil(aom_id) do
-    case Repo.get(AOM, aom_id) do
-      nil -> {:error, "Could not find territory of AOM with id #{aom_id}"}
-      aom -> {:ok, aom.nom}
-    end
+    aom = Repo.get!(AOM, aom_id)
+    {:ok, aom.nom}
   end
 
   def get_territory(%__MODULE__{region: %{nom: nom}}), do: {:ok, nom}
 
   def get_territory(%__MODULE__{region_id: region_id}) when not is_nil(region_id) do
-    case Repo.get(Region, region_id) do
-      nil -> {:error, "Could not find territory of Region with id #{region_id}"}
-      region -> {:ok, region.nom}
-    end
+    region = Repo.get!(Region, region_id)
+    {:ok, region.nom}
   end
 
   def get_territory(%__MODULE__{associated_territory_name: associated_territory_name}),

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -31,7 +31,8 @@ defmodule Transport.Mixfile do
       extra_applications: [
         :logger,
         :mime,
-        :unidecode
+        :unidecode,
+        :phoenix_ecto
       ]
     ]
   end
@@ -76,7 +77,8 @@ defmodule Transport.Mixfile do
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_aws, "~> 2.1"},
       {:ex_aws_s3, "~> 2.0"},
-      {:unidecode, "~> 0.0.2"}
+      {:unidecode, "~> 0.0.2"},
+      {:phoenix_ecto, "~> 4.0"}
     ]
   end
 end


### PR DESCRIPTION
Attention, branche expérimentale :smiley: 

Tout est parti de rhho, on a encore des 500 quand on essaye d'atteindre une ressource qui n'existe pas https://transport.data.gouv.fr/resources/coucou

J'ai essayé de creuser cette histoire pour voir s'il y avait une manière automatique de gérer ça. Il s'avère que si on installe la dépendance [phoenix_ecto](https://hexdocs.pm/phoenix_ecto/main.html#usage), celle-ci nous donne accès à un truc que j'ai voulu tester : elle est sensée traduire automatiquement certaines exceptions qui peuvent être levées par Ecto en page d'erreurs adéquates. L'idée serait que dans le code on remplace un `Repo.get(Dataset, id)` (avec sa gestion des case, en fonction du résultat, du type si oui alors fais quelque chose et si nil alors renvoie une 404) 

par `Repo.get!(Dataset, id)`.

Du coup si la requête ne trouve pas de dataset correspondant, une erreur de type `Ecto.NoResultsError` est levée, attrapée automatiquement par le Plug et traduite en erreur 404.

J'ai du mal à savoir si c'est une bonne idée ou pas, est-ce que ça risque de nous faire passer à côté de problèmes, etc