### PR TITLE
add a test on aom foreign key constraints

### DIFF
--- a/apps/db/test/test_db_dataset.ex
+++ b/apps/db/test/test_db_dataset.ex
@@ -13,7 +13,7 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert not is_nil(linked_aom.parent_dataset_id)
 
     # it should be possible to delete a dataset even if it is an AOM's parent dataset
-    assert {:ok, _} = Repo.delete(parent_dataset)
+    Repo.delete!(parent_dataset)
 
     # after parent deletion, the aom should have a nil parent_dataset
     linked_aom = Repo.get!(AOM, linked_aom.id)

--- a/apps/db/test/test_db_dataset.ex
+++ b/apps/db/test/test_db_dataset.ex
@@ -1,0 +1,19 @@
+defmodule TransportWeb.BackofficeControllerTest do
+  use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  alias DB.Repo
+
+  test "delete_parent_dataset" do
+    parent_dataset = Repo.insert!(%Dataset{})
+    linked_aom = Repo.insert!(%AOM{parent_dataset_id: parent_dataset.id, nom: "Jolie AOM"})
+
+    # linked_aom is supposed to have a parent_dataset id
+    assert not is_nil(linked_aom.parent_dataset_id)
+
+    # it should be possible to delete a dataset even if it is an AOM's parent dataset
+    assert {:ok, _} = Repo.delete(parent_dataset)
+
+    # after parent deletion, the aom should have a nil parent_dataset
+    linked_aom = Repo.get!(AOM, linked_aom.id)
+    assert is_nil(linked_aom.parent_dataset_id)
+  end
+end

--- a/apps/db/test/test_db_dataset.ex
+++ b/apps/db/test/test_db_dataset.ex
@@ -1,4 +1,7 @@
 defmodule TransportWeb.BackofficeControllerTest do
+  @moduledoc """
+  Tests on the Dataset schema
+  """
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   alias DB.Repo
 


### PR DESCRIPTION
Ajout d'un petit test qui reproduit le scénario qui faisait planter la suppression d'un dataset par Nicolas : le fait que le dataset en question soit le parent_dataset d'une AOM.