### PR TITLE
Ajout de l'id datagouv dans les ressources

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -86,6 +86,7 @@ defmodule DB.Dataset do
         url: r.url,
         metadata: r.metadata,
         id: r.id,
+        datagouv_id: r.datagouv_id,
         last_update: r.last_update,
         latest_url: r.latest_url,
         content_hash: r.content_hash,

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -256,7 +256,7 @@ defmodule DB.Resource do
         :filesize
       ]
     )
-    |> validate_required([:url])
+    |> validate_required([:url, :datagouv_id])
   end
 
   @spec issues_short_translation() :: %{binary() => binary()}

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -40,6 +40,11 @@ defmodule DB.Resource do
     # some community resources have been generated from another dataset (like the generated NeTEx / GeoJson)
     field(:original_resource_url, :string)
 
+    # Id of the datagouv resource. Note that several resources can have the same datagouv_id
+    # because one datagouv resource can be a CSV linking to several transport.data.gouv's resources
+    # (this is done for OpenDataSoft)
+    field(:datagouv_id, :string)
+
     # we add 2 fields, that are already in the metadata json, in order to be able to add some indices
     field(:start_date, :date)
     field(:end_date, :date)
@@ -238,6 +243,7 @@ defmodule DB.Resource do
         :title,
         :metadata,
         :id,
+        :datagouv_id,
         :last_update,
         :latest_url,
         :is_available,

--- a/apps/db/priv/repo/migrations/20200908085058_resource_datagouv_id.exs
+++ b/apps/db/priv/repo/migrations/20200908085058_resource_datagouv_id.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ResourceDatagouvId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      add(:datagouv_id, :string)
+    end
+  end
+end

--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -30,8 +30,8 @@ defmodule Opendatasoft.UrlExtractor do
 
   @doc """
   filter only the GTFS from an ODS csv file
-  we filter pdf and netex files,
-  based only with the title (eg. filename) since we do not have anything else.
+  we filter out pdf and netex files,
+  based only on with the title (eg. filename) since we do not have anything else.
   """
   @spec get_gtfs_csv_resources([any]) :: [any]
   def get_gtfs_csv_resources(resources) do

--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -35,8 +35,6 @@ defmodule Opendatasoft.UrlExtractor do
   """
   @spec get_gtfs_csv_resources([any]) :: [any]
   def get_gtfs_csv_resources(resources) do
-    IO.puts("gtfs csv")
-
     resources
     |> get_csv_resources
     |> Enum.reject(fn r -> r["title"] |> String.ends_with?(".pdf") end)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -295,6 +295,7 @@ defmodule Transport.ImportData do
         # (the 'latest' field is the stable data.gouv.fr url)
         "latest_url" => resource["latest"] || resource["url"],
         "id" => get_resource_id(resource, dataset["id"]),
+        "datagouv_id" => resource["id"],
         "is_available" => available?(resource),
         "is_community_resource" => is_community_resource,
         "community_resource_publisher" => get_publisher(resource),

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -385,7 +385,8 @@ defmodule Transport.ImportData do
     cond do
       is_gtfs_rt?(params["format"]) -> false
       is_gtfs?(params["format"]) -> true
-      is_format?(params["url"], ["json", "csv", "shp", "pdf"]) -> false
+      is_format?(params["url"], ["json", "csv", "shp", "pdf", "7z"]) -> false
+      is_format?(params["title"], "NeTEx") -> false
       is_gtfs?(params["description"]) -> true
       is_gtfs?(params["title"]) -> true
       true -> false

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -322,15 +322,15 @@ defmodule Transport.ImportData do
   end
 
   @spec get_valid_resources(map(), binary()) :: [map()]
-  def get_valid_resources(%{"resources" => resources}, type) do
-    if type == "public-transit" do
-      resources
-      |> get_valid_gtfs_resources()
-      |> Enum.concat(get_valid_netex_resources(resources))
-      |> Enum.concat(get_valid_gtfs_rt_resources(resources))
-    else
-      resources
-    end
+  def get_valid_resources(%{"resources" => resources}, "public-transit") do
+    resources
+    |> get_valid_gtfs_resources()
+    |> Enum.concat(get_valid_netex_resources(resources))
+    |> Enum.concat(get_valid_gtfs_rt_resources(resources))
+  end
+
+  def get_valid_resources(%{"resources" => resources}, _type) do
+    resources
   end
 
   @spec get_valid_gtfs_resources([map()]) :: [map()]
@@ -338,7 +338,7 @@ defmodule Transport.ImportData do
     cond do
       !Enum.empty?(l = Enum.filter(resources, &is_gtfs?/1)) -> l
       !Enum.empty?(l = Enum.filter(resources, &is_zip?/1)) -> l
-      !Enum.empty?(l = UrlExtractor.get_csv_resources(resources)) -> l
+      !Enum.empty?(l = UrlExtractor.get_gtfs_csv_resources(resources)) -> l
       true -> []
     end
   end

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -176,9 +176,11 @@ defmodule TransportWeb.API.DatasetController do
   defp transform_resource(resource),
     do:
       %{
+        "datagouv_id" => resource.datagouv_id,
         "title" => resource.title,
         "updated" => Helpers.format_datetime(resource.last_update),
         "url" => resource.latest_url,
+        "original_url" => resource.url,
         "end_calendar_validity" => resource.metadata["end_date"],
         "start_calendar_validity" => resource.metadata["start_date"],
         "format" => resource.format,

--- a/apps/transport/test/transport/import_data_service_test.exs
+++ b/apps/transport/test/transport/import_data_service_test.exs
@@ -36,7 +36,11 @@ defmodule Transport.ImportDataTest do
 
       use_cassette "client/datasets/sncf" do
         assert {:ok, dataset} = ImportData.import_from_udata("horaires-des-lignes-ter-sncf", "public-transit")
-        assert List.first(dataset["resources"])["url"] == url
+
+        assert length(dataset["resources"]) == 1
+        resource = List.first(dataset["resources"])
+        assert resource["url"] == url
+        assert resource["datagouv_id"] == "28a42d49-e9a8-4c6c-a999-b2b7ea8ce977"
       end
     end
 

--- a/apps/transport/test/transport/url_extractor_doc_test.exs
+++ b/apps/transport/test/transport/url_extractor_doc_test.exs
@@ -1,0 +1,5 @@
+defmodule Transport.UrlExtractorDocTest do
+  use ExUnit.Case, async: true
+  alias Opendatasoft.UrlExtractor
+  doctest UrlExtractor
+end


### PR DESCRIPTION
ca permettra de mieux nettoyer les ressources communautaires dans l'api de conversion.

J'en ai profité pour nettoyer et rebrancher certains test unitaires