### PR TITLE
use right css class

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -173,8 +173,8 @@
   border: 1px solid var(--theme-warning-border);
 }
 .resource__summary--Information {
-  background: var(--theme-information-bg);
-  border: 1px solid var(--theme-information-border);
+  background: var(--theme-info-bg);
+  border: 1px solid var(--theme-info-border);
 }
 .resource__summary--Irrelevant {
   background: var(--theme-background-success);


### PR DESCRIPTION
for quite a long time we were using a non existent 'template.data.gouv.fr' css class, use the right one

the information were meant to be displayed as

![image](https://user-images.githubusercontent.com/3987698/92765109-93da2080-f384-11ea-8008-8927eae30880.png)


(before:
![image](https://user-images.githubusercontent.com/3987698/92765224-b2d8b280-f384-11ea-9fc9-a09ac54b2532.png)
)