### PR TITLE
change mapbox map at least temporarily

### DIFF
--- a/apps/transport/client/javascripts/dataset-map.js
+++ b/apps/transport/client/javascripts/dataset-map.js
@@ -16,7 +16,7 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
+        maxZoom: Mapbox.maxZoom
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/dataset-map.js
+++ b/apps/transport/client/javascripts/dataset-map.js
@@ -5,11 +5,10 @@ import L from 'leaflet'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 18,
-    id: 'mapbox.light'
+    maxZoom: 20
 }
 
 function initilizeMap (id) {
@@ -18,7 +17,6 @@ function initilizeMap (id) {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
         maxZoom: Mapbox.maxZoom,
-        id: Mapbox.id
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -5,11 +5,10 @@ import L from 'leaflet'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 18,
-    id: 'mapbox.light'
+    maxZoom: 20
 }
 
 function initilizeMap (id) {
@@ -18,7 +17,6 @@ function initilizeMap (id) {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
         maxZoom: Mapbox.maxZoom,
-        id: Mapbox.id
     }).addTo(map)
 
     const markersfg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -16,7 +16,7 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
+        maxZoom: Mapbox.maxZoom
     }).addTo(map)
 
     const markersfg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -31,7 +31,7 @@ const makeMapOnView = (id, view) => {
     Leaflet.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
+        maxZoom: Mapbox.maxZoom
     }).addTo(map)
 
     return map

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -6,11 +6,10 @@ import 'leaflet.pattern'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 18,
-    id: 'mapbox.light'
+    maxZoom: 20
 }
 
 const regionsUrl = '/api/stats/regions'
@@ -33,7 +32,6 @@ const makeMapOnView = (id, view) => {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
         maxZoom: Mapbox.maxZoom,
-        id: Mapbox.id
     }).addTo(map)
 
     return map

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -1,7 +1,6 @@
 import L from 'leaflet'
 import Papa from 'papaparse'
 
-
 /**
  * Represents a Mapbox object.
  * @type {Object}
@@ -32,7 +31,7 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
+        maxZoom: Mapbox.maxZoom
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -1,16 +1,16 @@
 import L from 'leaflet'
 import Papa from 'papaparse'
 
+
 /**
  * Represents a Mapbox object.
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 18,
-    id: 'mapbox.light'
+    maxZoom: 20
 }
 
 // possible field names in csv files
@@ -33,7 +33,6 @@ function initilizeMap (id) {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
         maxZoom: Mapbox.maxZoom,
-        id: Mapbox.id
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -16,7 +16,7 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
+        maxZoom: Mapbox.maxZoom
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -5,11 +5,10 @@ import L from 'leaflet'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoibC12aW5jZW50LWwiLCJhIjoiY2pzMWtlNG90MXA5cTQ5dGYwNDRyMDRvayJ9.RhYAa9O0Qla5zhJAb9iwJA',
+    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    id: 'mapbox.light'
+    maxZoom: 20
 }
 
 function initilizeMap (id) {
@@ -18,7 +17,6 @@ function initilizeMap (id) {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
         maxZoom: Mapbox.maxZoom,
-        id: Mapbox.id
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)


### PR DESCRIPTION
https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4

Le fond de carte que nous utilisions n'est plus dispo. Je corrige au moins pour aujourd'hui avec un fond de carte lié à mon compte mapbox.

@l-vincent-l nous informe de l'existence de https://openmaptiles.geo.data.gouv.fr/, mais ce sont des tuiles colorées et vectorielles, ce que leaflet ne gère pas par défaut.