### PR TITLE
add type public-transit filter

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.eex
@@ -38,7 +38,7 @@
                     <h3 class="text-center"><%= dgettext("page-index", "Public transit schedules") %></h3>
                     <p><%= dngettext("page-index", "dataset", "datasets", @count_by_type["public-transit"] || 0) %></p>
                 </a>
-                <a class="tile" href="<%= dataset_path(@conn, :index, filter: "has_realtime") %>">
+                <a class="tile" href="<%= dataset_path(@conn, :index, type: "public-transit", filter: "has_realtime") %>">
                     <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/bus-stop.svg") %>" alt="" />
                     <h3 class="text-center"><%= dgettext("page-index", "Realtime public transit") %></h3>
                     <p><%= dngettext("page-index", "dataset", "datasets", @count_has_realtime || 0) %></p>


### PR DESCRIPTION
Comme les GBFS sont maintenant considérés comme du real time, il faut mettre a jour la requete sur la page de garde pour les horaires de transports en commun real time.

closes #1327 