### PR TITLE
desactivation temporaire du prefiltre datagouv sur l'indisponibilité

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -303,7 +303,8 @@ defmodule Transport.ImportData do
   end
 
   @spec available?(map()) :: boolean
-  def available?(%{"extras" => %{"check:available" => available}}), do: available
+  # Temporarily disabled since data.gouv.fr has been blocked by ODS
+  # def available?(%{"extras" => %{"check:available" => available}}), do: available
   def available?(%{"url" => "https://static.data.gouv.fr/" <> _}), do: true
   def available?(%{"url" => "https://demo.data.gouv.fr/" <> _}), do: true
   def available?(%{"format" => "csv"}), do: true


### PR DESCRIPTION
data.gouv.fr a visiblement été bloqué par OpenDataSoft, leur sonde ne
remontent plus correctement si une ressource est dispo ou non. Du coup
on a perdu tout plein de ressources hébérgées sur ODS (genre IDFM,
Nantes, ...)