### PR TITLE
Fix crash sur certaines pages de GBFS

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -270,11 +270,11 @@ defmodule TransportWeb.DatasetView do
   Builds a licence.
   ## Examples
       iex> %Dataset{licence: "fr-lo"}
-      ...> |> Dataset.licence
-      "Open Licence"
+      ...> |> TransportWeb.DatasetView.licence
+      "fr-lo"
       iex> %Dataset{licence: "Libertarian"}
-      ...> |> Dataset.licence
-      "Not specified"
+      ...> |> TransportWeb.DatasetView.licence
+      "notspecified"
   """
   @spec licence(%Dataset{}) :: String.t()
   def licence(%Dataset{licence: licence}) do
@@ -286,6 +286,32 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
+  @doc """
+  Returns the resources that need to be displayed on a map
+  ## Examples
+      iex> %Dataset{type: "carsharing-areas", resources: [
+      ...>   %DB.Resource{id: 1, format: "csv", last_update: "20201103T102030Z"},
+      ...>   %DB.Resource{id: 2, format: "csv", last_update: "20201105T102030Z"},
+      ...> ]}
+      ...> |> TransportWeb.DatasetView.get_resource_to_display
+      %DB.Resource{id: 2, format: "csv", last_update: "20201105T102030Z"}
+      iex> %Dataset{type: "public-transit", resources: [
+      ...>   %DB.Resource{id: 1, format: "gtfs", last_update: "20201103T102030Z"},
+      ...>   %DB.Resource{id: 2, format: "gtfs", last_update: "20201105T102030Z"},
+      ...> ]}
+      ...> |> TransportWeb.DatasetView.get_resource_to_display
+      nil
+      iex> %Dataset{type: "bike-sharing", resources: [
+      ...>   %DB.Resource{id: 1, url: "http://pouet.com/gbfs.json", last_update: "20201103T102030Z"},
+      ...>   %DB.Resource{id: 2, url: "http://pouet.com/gbfs.json", last_update: "20201105T102030Z"},
+      ...>   %DB.Resource{id: 3, url: "http://pouet.com/other_url.json", last_update: "20201107T102030Z"},
+      ...> ]}
+      ...> |> TransportWeb.DatasetView.get_resource_to_display
+      %DB.Resource{id: 2, url: "http://pouet.com/gbfs.json", last_update: "20201105T102030Z"}
+      iex> %Dataset{type: "carsharing-areas", resources: []}
+      ...> |> TransportWeb.DatasetView.get_resource_to_display
+      nil
+  """
   @spec get_resource_to_display(%Dataset{}) :: Resource.t() | nil
   def get_resource_to_display(%Dataset{type: type, resources: resources})
       when type == "carsharing-areas" or type == "private-parking" or type == "charging-stations" do

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -288,29 +288,6 @@ defmodule TransportWeb.DatasetView do
 
   @doc """
   Returns the resources that need to be displayed on a map
-  ## Examples
-      iex> %Dataset{type: "carsharing-areas", resources: [
-      ...>   %DB.Resource{id: 1, format: "csv", last_update: "20201103T102030Z"},
-      ...>   %DB.Resource{id: 2, format: "csv", last_update: "20201105T102030Z"},
-      ...> ]}
-      ...> |> TransportWeb.DatasetView.get_resource_to_display
-      %DB.Resource{id: 2, format: "csv", last_update: "20201105T102030Z"}
-      iex> %Dataset{type: "public-transit", resources: [
-      ...>   %DB.Resource{id: 1, format: "gtfs", last_update: "20201103T102030Z"},
-      ...>   %DB.Resource{id: 2, format: "gtfs", last_update: "20201105T102030Z"},
-      ...> ]}
-      ...> |> TransportWeb.DatasetView.get_resource_to_display
-      nil
-      iex> %Dataset{type: "bike-sharing", resources: [
-      ...>   %DB.Resource{id: 1, url: "http://pouet.com/gbfs.json", last_update: "20201103T102030Z"},
-      ...>   %DB.Resource{id: 2, url: "http://pouet.com/gbfs.json", last_update: "20201105T102030Z"},
-      ...>   %DB.Resource{id: 3, url: "http://pouet.com/other_url.json", last_update: "20201107T102030Z"},
-      ...> ]}
-      ...> |> TransportWeb.DatasetView.get_resource_to_display
-      %DB.Resource{id: 2, url: "http://pouet.com/gbfs.json", last_update: "20201105T102030Z"}
-      iex> %Dataset{type: "carsharing-areas", resources: []}
-      ...> |> TransportWeb.DatasetView.get_resource_to_display
-      nil
   """
   @spec get_resource_to_display(%Dataset{}) :: Resource.t() | nil
   def get_resource_to_display(%Dataset{type: type, resources: resources})

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -291,13 +291,13 @@ defmodule TransportWeb.DatasetView do
       when type == "carsharing-areas" or type == "private-parking" or type == "charging-stations" do
     resources
     |> Enum.filter(fn r -> r.format == "csv" end)
-    |> Enum.max_by(fn r -> r.last_update end)
+    |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end
 
   def get_resource_to_display(%Dataset{type: "bike-sharing", resources: resources}) do
     resources
     |> Enum.filter(fn r -> String.ends_with?(r.url, "gbfs.json") end)
-    |> Enum.max_by(fn r -> r.last_update end)
+    |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end
 
   def get_resource_to_display(%Dataset{}), do: nil

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -1,0 +1,7 @@
+defmodule TransportWeb.DatasetViewTest do
+  use TransportWeb.ConnCase, async: false
+  use TransportWeb.ExternalCase
+  use TransportWeb.DatabaseCase, cleanup: [:datasets]
+
+  doctest TransportWeb.DatasetView
+end


### PR DESCRIPTION
Enum.max_by jette une exception quand la liste est vide, ce qui causait une 500 sur certaines page (comme https://transport.data.gouv.fr/datasets/optymo-velo-en-libre-service/)