### PR TITLE
fix bug on sanitize

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -260,11 +260,17 @@ defmodule TransportWeb.DatasetView do
 
   @spec description(%Dataset{} | %Resource{}) :: any
   def description(instance) do
-    {:safe, sanitized_md} = sanitize(instance.description)
+    instance.description
+    |> sanitize()
+    |> case do
+      {:safe, sanitized_md} ->
+        sanitized_md
+        |> Earmark.as_html!()
+        |> raw()
 
-    sanitized_md
-    |> Earmark.as_html!()
-    |> raw()
+      _raw ->
+        instance.description
+    end
   end
 
   @doc """


### PR DESCRIPTION
when the text cannot be sanitized the sanitizer returns a raw string.

I think in those cases it's better to not sanitize anything.

This was ausing a 500 for the route-500 dataset