### PR TITLE
Correctif statistiques Bretagne (fixes #1355)

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -315,6 +315,8 @@ defmodule TransportWeb.API.StatsController do
               (dataset.aom_id = ? OR dataset.id = ?)
               AND
               resource.end_date >= TO_DATE(?, 'YYYY-MM-DD')
+              AND
+              resource.is_available
             ORDER BY (
               CASE max_error::text
                 WHEN 'Fatal' THEN 6


### PR DESCRIPTION
Voir #1355, la Bretagne était en rouge car nous prenions en compte les ressources non disponibles de [ce dataset](https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-mobibreizh/).

Ces ressources non disponibles sont d'anciennes versions des données "MOBIBREIZHBRET", qui sont sur [data.gouv](https://www.data.gouv.fr/fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-mobibreizh/) mais sont indiquées "non disponibles peut-être temporaire":

<img width="886" alt="CleanShot 2020-11-16 at 10 26 20@2x" src="https://user-images.githubusercontent.com/10141/99235468-2ddf9e80-27f6-11eb-96a5-99cb50e5f0da.png">

On va pour l'instant filtrer les ressources non disponibles pour les exclure de la statistiques (dans le cas présent ça reflètera mieux la qualité réelle de la donnée, qui est en fait bien à jour).

Avant le correctif, la carte qualité ressemblait à ceci:

<img width="689" alt="CleanShot 2020-11-16 at 10 27 05@2x" src="https://user-images.githubusercontent.com/10141/99235576-523b7b00-27f6-11eb-86ff-5413f64b18dc.png">

Après le correctif (qui ne semble pas impacter les autres cartes, j'ai fait une comparaison), on obtient:

<img width="705" alt="CleanShot 2020-11-16 at 10 28 14@2x" src="https://user-images.githubusercontent.com/10141/99235689-7434fd80-27f6-11eb-85ca-4adb523f8cca.png">

