### PR TITLE
Correction hrefs cassées dans l'index GBFS json

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/index_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/index_controller.ex
@@ -12,7 +12,8 @@ defmodule GBFS.IndexController do
 
   @spec create_gbfs_links(binary(), Plug.Conn.t()) :: %{gbfs: %{name: binary(), _links: map()}}
   defp create_gbfs_links(network, conn) do
-    url = conn
+    url =
+      conn
       |> current_url()
       |> Path.join(network)
       |> Path.join("gbfs.json")

--- a/apps/gbfs/lib/gbfs/controllers/index_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/index_controller.ex
@@ -12,11 +12,16 @@ defmodule GBFS.IndexController do
 
   @spec create_gbfs_links(binary(), Plug.Conn.t()) :: %{gbfs: %{name: binary(), _links: map()}}
   defp create_gbfs_links(network, conn) do
+    url = conn
+      |> current_url()
+      |> Path.join(network)
+      |> Path.join("gbfs.json")
+
     %{
       gbfs: %{
         name: network,
         _links: %{
-          "gbfs.json" => %{href: current_url(conn) <> network <> "/gbfs.json"}
+          "gbfs.json" => %{href: url}
         }
       }
     }

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -2,18 +2,20 @@ defmodule GBFS.IndexControllerTest do
   use TransportWeb.ConnCase, async: true
 
   describe "GET /" do
-    test "returns properly formatted hrefs", %{conn: conn} do
+    test "returns correct absolute urls", %{conn: conn} do
       first_href = conn
         |> get("/gbfs")
         |> json_response(200)
         |> Enum.at(0)
         |> get_in(["gbfs", "_links", "gbfs.json", "href"])
-        |> URI.parse
-        |> Map.get(:path)
 
-      # NOTE: this order is deterministic & established via the code
+      port = Application.get_env(:transport, TransportWeb.Endpoint) |> Keyword.get(:http) |> Keyword.get(:port)
+
+      # NOTE: the order of "networks" is deterministic & established via the code,
+      # which means we can fix data for the test
       # see bottom of GBFS.Router for the static definition.
-      assert first_href == "/gbfs/vcub/gbfs.json"
+      # we're looking both to ensure we have a full url here, and that the path is as expected
+      assert first_href == "http://127.0.0.1:#{port}/gbfs/vcub/gbfs.json"
     end
   end
 end

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -1,0 +1,19 @@
+defmodule GBFS.IndexControllerTest do
+  use TransportWeb.ConnCase, async: true
+
+  describe "GET /" do
+    test "returns properly formatted hrefs", %{conn: conn} do
+      first_href = conn
+        |> get("/gbfs")
+        |> json_response(200)
+        |> Enum.at(0)
+        |> get_in(["gbfs", "_links", "gbfs.json", "href"])
+        |> URI.parse
+        |> Map.get(:path)
+
+      # NOTE: this order is deterministic & established via the code
+      # see bottom of GBFS.Router for the static definition.
+      assert first_href == "/gbfs/vcub/gbfs.json"
+    end
+  end
+end

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -3,7 +3,8 @@ defmodule GBFS.IndexControllerTest do
 
   describe "GET /" do
     test "returns correct absolute urls", %{conn: conn} do
-      first_href = conn
+      first_href =
+        conn
         |> get("/gbfs")
         |> json_response(200)
         |> Enum.at(0)

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -10,7 +10,9 @@ defmodule GBFS.IndexControllerTest do
         |> Enum.at(0)
         |> get_in(["gbfs", "_links", "gbfs.json", "href"])
 
-      port = Application.get_env(:transport, TransportWeb.Endpoint) |> Keyword.get(:http) |> Keyword.get(:port)
+      port = :transport
+        |> Application.get_env(TransportWeb.Endpoint)
+        |> get_in([:http, :port])
 
       # NOTE: the order of "networks" is deterministic & established via the code,
       # which means we can fix data for the test

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -10,7 +10,8 @@ defmodule GBFS.IndexControllerTest do
         |> Enum.at(0)
         |> get_in(["gbfs", "_links", "gbfs.json", "href"])
 
-      port = :transport
+      port =
+        :transport
         |> Application.get_env(TransportWeb.Endpoint)
         |> get_in([:http, :port])
 


### PR DESCRIPTION
Avant cette PR, l'[index JSON GBFS](https://transport.data.gouv.fr/gbfs) génère des urls incorrectes car il manque un `/` dans chacune d'entre elles:
* https://transport.data.gouv.fr/gbfsvcub/gbfs.json
* https://transport.data.gouv.fr/gbfsvlille/gbfs.json
* etc...

La PR présente ajoute un test autour de cette génération, et corrige la logique. Les liens doivent devenir:
* https://transport.data.gouv.fr/gbfs/vcub/gbfs.json
* https://transport.data.gouv.fr/gbfs/vlille/gbfs.json

Le test (un peu cracra avec la récupération du port par la config) vérifie que c'est une url complète, et que le chemin est conforme à ce qu'on attend.

