### PR TITLE
Git ignore pour configuration CleverCloud CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ apps/transport/priv/static/js/*
 
 # the blog build folder
 /blog/public
+.clever.json


### PR DESCRIPTION
Le fichier est créé par la CLI de CleverCloud (`clever-tools`), décrite dans https://github.com/etalab/transport-site/blob/learning-track/learning_track.md#read-the-logs-from-the-database.