### PR TITLE
Affichage de tous les GTFS, même indisponibles

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -91,13 +91,13 @@ defmodule DB.Dataset do
         latest_url: r.latest_url,
         content_hash: r.content_hash,
         is_community_resource: r.is_community_resource,
+        is_available: r.is_available,
         description: r.description,
         community_resource_publisher: r.community_resource_publisher,
         original_resource_url: r.original_resource_url,
         features: r.features,
         modes: r.modes
-      },
-      where: r.is_available
+      }
     )
   end
 

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -320,7 +320,10 @@ defmodule DB.Dataset do
 
   @spec valid_gtfs(DB.Dataset.t()) :: [Resource.t()]
   def valid_gtfs(%__MODULE__{resources: nil}), do: []
-  def valid_gtfs(%__MODULE__{resources: r, type: "public-transit"}), do: Enum.filter(r, &Resource.valid?/1)
+
+  def valid_gtfs(%__MODULE__{resources: r, type: "public-transit"}),
+    do: Enum.filter(r, &Resource.valid_and_available?/1)
+
   def valid_gtfs(%__MODULE__{resources: r}), do: r
 
   @spec link_to_datagouv(DB.Dataset.t()) :: any()

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -322,12 +322,12 @@ defmodule DB.Resource do
   @spec has_metadata?(__MODULE__.t()) :: boolean()
   def has_metadata?(%__MODULE__{} = r), do: r.metadata != nil
 
-  @spec valid?(__MODULE__.t()) :: boolean()
-  def valid?(%__MODULE__{is_available: available, metadata: %{"start_date" => s, "end_date" => e}})
+  @spec valid_and_available?(__MODULE__.t()) :: boolean()
+  def valid_and_available?(%__MODULE__{is_available: available, metadata: %{"start_date" => s, "end_date" => e}})
       when not is_nil(s) and not is_nil(e),
       do: available
 
-  def valid?(%__MODULE__{}), do: false
+  def valid_and_available?(%__MODULE__{}), do: false
 
   @spec is_outdated?(__MODULE__.t()) :: boolean
   def is_outdated?(%__MODULE__{metadata: %{"end_date" => nil}}), do: false

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -323,8 +323,9 @@ defmodule DB.Resource do
   def has_metadata?(%__MODULE__{} = r), do: r.metadata != nil
 
   @spec valid?(__MODULE__.t()) :: boolean()
-  def valid?(%__MODULE__{is_available: available, metadata: %{"start_date" => s, "end_date" => e}}) when not is_nil(s) and not is_nil(e),
-    do: available
+  def valid?(%__MODULE__{is_available: available, metadata: %{"start_date" => s, "end_date" => e}})
+      when not is_nil(s) and not is_nil(e),
+      do: available
 
   def valid?(%__MODULE__{}), do: false
 

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -323,8 +323,8 @@ defmodule DB.Resource do
   def has_metadata?(%__MODULE__{} = r), do: r.metadata != nil
 
   @spec valid?(__MODULE__.t()) :: boolean()
-  def valid?(%__MODULE__{metadata: %{"start_date" => s, "end_date" => e}}) when not is_nil(s) and not is_nil(e),
-    do: true
+  def valid?(%__MODULE__{is_available: available, metadata: %{"start_date" => s, "end_date" => e}}) when not is_nil(s) and not is_nil(e),
+    do: available
 
   def valid?(%__MODULE__{}), do: false
 

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -241,6 +241,10 @@
   }
 }
 
+.span-unavailable {
+  line-height: 1em;
+}
+
 .ml-05-em {
   margin-left: 0.5em;
 }

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -79,6 +79,14 @@
   color: var(--theme-label-text);
 }
 
+.dataset__resources .resources-message {
+  color: var(--theme-label-text);
+}
+
+.dataset__resources .warning-red {
+  color: var(--theme-error-border);
+}
+
 .dataset__logo {
   img {
     max-height: 100px;
@@ -246,6 +254,10 @@
 }
 
 .resource--notvalid {
+  border-top: 75px solid var(--theme-error-bg);
+}
+
+.resource--unavailable {
   border-top: 75px solid var(--theme-error-bg);
 }
 

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -1,9 +1,10 @@
-<div class="panel resource <%= valid_panel_class(@resource) %>">
+<div class="panel resource <%= valid_panel_class(@resource) %>" title="<%= resource_title(@resource) %>">
   <% has_associated_geojson = ResourceView.has_associated_geojson(@dataset, @resource) %>
   <% has_associated_netex = ResourceView.has_associated_netex(@dataset, @resource) %>
   <h4>
     <%= @resource.title %>
   </h4>
+
   <%= if Resource.valid?(@resource) do %>
     <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
       <i class="icon icon--calendar-alt" aria-hidden="true"></i>
@@ -20,16 +21,21 @@
       <%= @resource.last_update |> format_datetime_to_date() %>
     <% end %>
   </div>
+
   <%= if Resource.is_gtfs?(@resource) do %>
     <div class="resource-status-corner <%= resource_class(@resource) %>">
       <span>
-        <%= unless Resource.valid?(@resource) do %>
-          <%= dgettext("page-dataset-details", "Impossible to read") %>
+        <%= unless @resource.is_available do %>
+          <%= dgettext("page-dataset-details", "Unavailable") %>
         <% else %>
-          <%= if Resource.is_outdated?(@resource) do %>
-            <%= dgettext("page-dataset-details", "Outdated") %>
+          <%= unless Resource.valid?(@resource) do %>
+            <%= dgettext("page-dataset-details", "Impossible to read") %>
           <% else %>
-            <%= dgettext("page-dataset-details", "Current dataset") %>
+            <%= if Resource.is_outdated?(@resource) do %>
+              <%= dgettext("page-dataset-details", "Outdated") %>
+            <% else %>
+              <%= dgettext("page-dataset-details", "Current dataset") %>
+            <% end %>
           <% end %>
         <% end %>
       </span>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -22,7 +22,7 @@
     <% end %>
   </div>
 
-  <%= if Resource.is_gtfs?(@resource) do %>
+  <%= if Resource.is_gtfs?(@resource) or not @resource.is_available do %>
     <div class="resource-status-corner <%= resource_class(@resource) %>">
       <span>
         <%= unless @resource.is_available do %>
@@ -40,6 +40,8 @@
         <% end %>
       </span>
     </div>
+  <% end %>
+  <%= if Resource.is_gtfs?(@resource) do %>
     <div class="pb-24">
       <a href="<%= resource_path(@conn, :details, @resource.id)<>"#issues" %>">
         <% r = Resource.get_max_severity_validation_number(@resource) %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -1,11 +1,11 @@
-<div class="panel resource <%= valid_panel_class(@resource) %>" title="<%= resource_title(@resource) %>">
+<div class="panel resource <%= valid_panel_class(@resource) %>" title="<%= resource_tooltip_content(@resource) %>">
   <% has_associated_geojson = ResourceView.has_associated_geojson(@dataset, @resource) %>
   <% has_associated_netex = ResourceView.has_associated_netex(@dataset, @resource) %>
   <h4>
     <%= @resource.title %>
   </h4>
 
-  <%= if Resource.valid?(@resource) do %>
+  <%= if Resource.valid_and_available?(@resource) do %>
     <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
       <i class="icon icon--calendar-alt" aria-hidden="true"></i>
       <span><%= format_date(@resource.metadata["start_date"]) %></span>
@@ -24,17 +24,18 @@
 
   <%= if Resource.is_gtfs?(@resource) or not @resource.is_available do %>
     <div class="resource-status-corner <%= resource_class(@resource) %>">
-      <span>
+      <span class="<%= resource_span_class(@resource) %>">
         <%= unless @resource.is_available do %>
-          <%= dgettext("page-dataset-details", "Unavailable") %>
+          <%= dgettext("page-dataset-details", "Not") %> <br>
+          <%= dgettext("page-dataset-details", "available") %>
         <% else %>
-          <%= unless Resource.valid?(@resource) do %>
+          <%= unless Resource.valid_and_available?(@resource) do %>
             <%= dgettext("page-dataset-details", "Impossible to read") %>
           <% else %>
             <%= if Resource.is_outdated?(@resource) do %>
               <%= dgettext("page-dataset-details", "Outdated") %>
             <% else %>
-              <%= dgettext("page-dataset-details", "Current dataset") %>
+              <%= dgettext("page-dataset-details", "Up to date") %>
             <% end %>
           <% end %>
         <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -1,6 +1,12 @@
 <%= unless is_nil(@resources) or @resources == [] do %>
   <section class="dataset__resources white">
     <h2><%= @title %></h2>
+    <%= unless is_nil(assigns[:message]) do %>
+      <div class="resources-message">
+        <i class="fa fa-exclamation-triangle warning-red"></i>
+        <%= assigns[:message] %>
+      </div>
+    <% end %>
     <div>
       <div class="ressources-list">
         <%= render_many order_resources_by_validity(@resources), TransportWeb.DatasetView, "_resource.html", as: :resource, conn: @conn, dataset: assigns[:dataset] %>
@@ -14,7 +20,7 @@
           a_end: "</a>"
           )
           |> raw()
-      %>
+        %>
       </div>
     </div>
   </section>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -61,11 +61,11 @@
     <% end %>
     <section id="dataset-resources" class="pt-48">
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources") %>
-      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable GTFS resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now")%>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_rt_official_resources(@dataset), title: dgettext("page-dataset-details", "GTFS real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gbfs_official_resources(@dataset), title: dgettext("page-dataset-details", "GBFS resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Other resources") %>
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now")%>
       <% community_resources = community_resources(@dataset) %>
       <%= unless community_resources == [] do %>
         <section class="dataset__resources white">

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -61,6 +61,7 @@
     <% end %>
     <section id="dataset-resources" class="pt-48">
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources") %>
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable GTFS resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now")%>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_rt_official_resources(@dataset), title: dgettext("page-dataset-details", "GTFS real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gbfs_official_resources(@dataset), title: dgettext("page-dataset-details", "GBFS resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -200,7 +200,7 @@ defmodule TransportWeb.DatasetView do
   end
 
   def valid_panel_class(%Resource{} = r) do
-    case {Resource.is_gtfs?(r), Resource.valid?(r), Resource.is_outdated?(r)} do
+    case {Resource.is_gtfs?(r), Resource.valid_and_available?(r), Resource.is_outdated?(r)} do
       {true, false, _} -> "invalid-resource-panel"
       {true, _, true} -> "invalid-resource-panel"
       _ -> ""
@@ -324,15 +324,18 @@ defmodule TransportWeb.DatasetView do
 
   def get_resource_to_display(%Dataset{}), do: nil
 
-  def resource_title(%DB.Resource{is_available: false}),
+  def resource_tooltip_content(%DB.Resource{is_available: false}),
     do: dgettext("dataset", "The resource is not available (maybe temporarily)")
 
-  def resource_title(%DB.Resource{}), do: nil
+  def resource_tooltip_content(%DB.Resource{}), do: nil
+
+  def resource_span_class(%DB.Resource{is_available: false}), do: "span-unavailable"
+  def resource_span_class(%DB.Resource{}), do: nil
 
   def resource_class(%DB.Resource{is_available: false}), do: "resource--unavailable"
 
   def resource_class(%DB.Resource{} = r) do
-    case DB.Resource.valid?(r) do
+    case DB.Resource.valid_and_available?(r) do
       false ->
         "resource--notvalid"
 
@@ -347,6 +350,6 @@ defmodule TransportWeb.DatasetView do
   def order_resources_by_validity(resources) do
     resources
     |> Enum.sort_by(& &1.metadata["end_date"], &>=/2)
-    |> Enum.sort_by(&Resource.valid?(&1), &>=/2)
+    |> Enum.sort_by(&Resource.valid_and_available?(&1), &>=/2)
   end
 end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -207,41 +207,45 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
+  def official_available_resources(dataset),
+    do:
+      dataset
+      |> Dataset.official_resources()
+      |> Enum.filter(fn r -> r.is_available end)
+
   def gtfs_official_resources(dataset),
     do:
       dataset
-      |> Dataset.official_resources()
+      |> official_available_resources()
       |> Enum.filter(&Resource.is_gtfs?/1)
-      |> Enum.filter(fn r -> r.is_available end)
 
-  def gtfs_official_unavailable_resources(dataset),
+  def unavailable_resources(dataset),
     do:
       dataset
       |> Dataset.official_resources()
-      |> Enum.filter(&Resource.is_gtfs?/1)
       |> Enum.reject(fn r -> r.is_available end)
 
   def gtfs_rt_official_resources(dataset),
     do:
       dataset
-      |> Dataset.official_resources()
+      |> official_available_resources()
       |> Enum.filter(&Resource.is_gtfs_rt?/1)
 
   def gbfs_official_resources(dataset),
     do:
       dataset
-      |> Dataset.official_resources()
+      |> official_available_resources()
       |> Enum.filter(&Resource.is_gbfs?/1)
 
   def netex_official_resources(dataset),
     do:
       dataset
-      |> Dataset.official_resources()
+      |> official_available_resources()
       |> Enum.filter(&Resource.is_netex?/1)
 
   def other_official_resources(dataset) do
     dataset
-    |> Dataset.official_resources()
+    |> official_available_resources()
     |> Stream.reject(&Resource.is_gtfs?/1)
     |> Stream.reject(&Resource.is_gtfs_rt?/1)
     |> Stream.reject(&Resource.is_gbfs?/1)

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -212,14 +212,14 @@ defmodule TransportWeb.DatasetView do
       dataset
       |> Dataset.official_resources()
       |> Enum.filter(&Resource.is_gtfs?/1)
-      |> Enum.filter(&Resource.is_available?/1)
+      |> Enum.filter(fn r -> r.is_available end)
 
   def gtfs_official_unavailable_resources(dataset),
     do:
       dataset
       |> Dataset.official_resources()
       |> Enum.filter(&Resource.is_gtfs?/1)
-      |> Enum.reject(&Resource.is_available?/1)
+      |> Enum.reject(fn r -> r.is_available end)
 
   def gtfs_rt_official_resources(dataset),
     do:
@@ -320,10 +320,13 @@ defmodule TransportWeb.DatasetView do
 
   def get_resource_to_display(%Dataset{}), do: nil
 
-  def resource_title(%DB.Resource{is_available: false}), do: dgettext("dataset", "The resource is not available (maybe temporarily)")
+  def resource_title(%DB.Resource{is_available: false}),
+    do: dgettext("dataset", "The resource is not available (maybe temporarily)")
+
   def resource_title(%DB.Resource{}), do: nil
 
   def resource_class(%DB.Resource{is_available: false}), do: "resource--unavailable"
+
   def resource_class(%DB.Resource{} = r) do
     case DB.Resource.valid?(r) do
       false ->

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -212,6 +212,14 @@ defmodule TransportWeb.DatasetView do
       dataset
       |> Dataset.official_resources()
       |> Enum.filter(&Resource.is_gtfs?/1)
+      |> Enum.filter(&Resource.is_available?/1)
+
+  def gtfs_official_unavailable_resources(dataset),
+    do:
+      dataset
+      |> Dataset.official_resources()
+      |> Enum.filter(&Resource.is_gtfs?/1)
+      |> Enum.reject(&Resource.is_available?/1)
 
   def gtfs_rt_official_resources(dataset),
     do:
@@ -312,6 +320,10 @@ defmodule TransportWeb.DatasetView do
 
   def get_resource_to_display(%Dataset{}), do: nil
 
+  def resource_title(%DB.Resource{is_available: false}), do: dgettext("dataset", "The resource is not available (maybe temporarily)")
+  def resource_title(%DB.Resource{}), do: nil
+
+  def resource_class(%DB.Resource{is_available: false}), do: "resource--unavailable"
   def resource_class(%DB.Resource{} = r) do
     case DB.Resource.valid?(r) do
       false ->

--- a/apps/transport/priv/gettext/dataset.pot
+++ b/apps/transport/priv/gettext/dataset.pot
@@ -67,3 +67,7 @@ msgstr ""
 #, elixir-format
 msgid "other-open"
 msgstr ""
+
+#, elixir-format
+msgid "The resource is not available (maybe temporarily)"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -67,3 +67,7 @@ msgstr ""
 #, elixir-format
 msgid "other-open"
 msgstr ""
+
+#, elixir-format
+msgid "The resource is not available (maybe temporarily)"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -195,10 +195,6 @@ msgid "Specific usage conditions"
 msgstr ""
 
 #, elixir-format
-msgid "Current dataset"
-msgstr ""
-
-#, elixir-format
 msgid "and "
 msgstr ""
 
@@ -359,13 +355,21 @@ msgid "Modes available in the resource:"
 msgstr ""
 
 #, elixir-format
-msgid "Unavailable"
-msgstr ""
-
-#, elixir-format
 msgid "unavailable resources"
 msgstr ""
 
 #, elixir-format
 msgid "Those resources are listed by the provider but are unreachable for now"
+msgstr ""
+
+#, elixir-format
+msgid "Up to date"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Not"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "available"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -357,3 +357,15 @@ msgstr ""
 #, elixir-format
 msgid "Modes available in the resource:"
 msgstr ""
+
+#, elixir-format
+msgid "Unavailable"
+msgstr ""
+
+#, elixir-format
+msgid "unavailable GTFS resources"
+msgstr ""
+
+#, elixir-format
+msgid "Those resources are listed by the provider but are unreachable for now"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -363,7 +363,7 @@ msgid "Unavailable"
 msgstr ""
 
 #, elixir-format
-msgid "unavailable GTFS resources"
+msgid "unavailable resources"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -67,3 +67,7 @@ msgstr "ODbL"
 #, elixir-format
 msgid "other-open"
 msgstr "Autre ouverte"
+
+#, elixir-format
+msgid "The resource is not available (maybe temporarily)"
+msgstr "La ressource est indisponible (peut-être temporairement)"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -357,3 +357,15 @@ msgstr "Données présentes dans la ressource :"
 #, elixir-format
 msgid "Modes available in the resource:"
 msgstr "Modes de transport disponibles dans la ressource :"
+
+#, elixir-format
+msgid "Unavailable"
+msgstr "Non dispo."
+
+#, elixir-format
+msgid "unavailable GTFS resources"
+msgstr "Ressources GTFS non disponibles"
+
+#, elixir-format
+msgid "Those resources are listed by the provider but are unreachable for now"
+msgstr "Ces ressources sont référencées, mais ne semblent pas accessibles pour le moment"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -363,8 +363,8 @@ msgid "Unavailable"
 msgstr "Non dispo."
 
 #, elixir-format
-msgid "unavailable GTFS resources"
-msgstr "Ressources GTFS non disponibles"
+msgid "unavailable resources"
+msgstr "Ressources non disponibles"
 
 #, elixir-format
 msgid "Those resources are listed by the provider but are unreachable for now"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -195,10 +195,6 @@ msgid "Specific usage conditions"
 msgstr "Conditions Particulières d'utilisation"
 
 #, elixir-format
-msgid "Current dataset"
-msgstr "À jour !"
-
-#, elixir-format
 msgid "and "
 msgstr "et "
 
@@ -359,13 +355,21 @@ msgid "Modes available in the resource:"
 msgstr "Modes de transport disponibles dans la ressource :"
 
 #, elixir-format
-msgid "Unavailable"
-msgstr "Non dispo."
-
-#, elixir-format
 msgid "unavailable resources"
 msgstr "Ressources non disponibles"
 
 #, elixir-format
 msgid "Those resources are listed by the provider but are unreachable for now"
 msgstr "Ces ressources sont référencées, mais ne semblent pas accessibles pour le moment"
+
+#, elixir-format
+msgid "Up to date"
+msgstr "À jour"
+
+#, elixir-format, fuzzy
+msgid "Not"
+msgstr "Non"
+
+#, elixir-format, fuzzy
+msgid "available"
+msgstr "disponible"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -357,3 +357,15 @@ msgstr ""
 #, elixir-format
 msgid "Modes available in the resource:"
 msgstr ""
+
+#, elixir-format
+msgid "Unavailable"
+msgstr ""
+
+#, elixir-format
+msgid "unavailable GTFS resources"
+msgstr ""
+
+#, elixir-format
+msgid "Those resources are listed by the provider but are unreachable for now"
+msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -363,7 +363,7 @@ msgid "Unavailable"
 msgstr ""
 
 #, elixir-format
-msgid "unavailable GTFS resources"
+msgid "unavailable resources"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -195,10 +195,6 @@ msgid "Specific usage conditions"
 msgstr ""
 
 #, elixir-format
-msgid "Current dataset"
-msgstr ""
-
-#, elixir-format
 msgid "and "
 msgstr ""
 
@@ -359,13 +355,21 @@ msgid "Modes available in the resource:"
 msgstr ""
 
 #, elixir-format
-msgid "Unavailable"
-msgstr ""
-
-#, elixir-format
 msgid "unavailable resources"
 msgstr ""
 
 #, elixir-format
 msgid "Those resources are listed by the provider but are unreachable for now"
+msgstr ""
+
+#, elixir-format
+msgid "Up to date"
+msgstr ""
+
+#, elixir-format
+msgid "Not"
+msgstr ""
+
+#, elixir-format
+msgid "available"
 msgstr ""


### PR DESCRIPTION
Pour le moment on filtrait les GTFS non dispo (en 404).

Ca permettait de ne pas alourdir les pages comme [celle de la bretagne](https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-mobibreizh) où un seul GTFS est encore la, mais tout plein de GTFS sont encore référencés sur data.gouv (surement un bug de moissonneur).

Le problème c'est que de temps en temps on se retrouve avec des dataset vides (toutes les ressources sont non dispo), sauf les ressources communautaires qui ont été générées quand les ressources étaient ok.

bref ca porte à confusion.

Pour info, il y a 126 ressources non dispo dont  89 GTFS (pour 59 datasets).

Cette PR réaffiche les ressources non dispo, en les marquant comme telle. Je savais pas trop comment faire apparaitre ca, et j'ai peur que la notion prete un peu à confusion alors j'ai essayé de blinder le message.

J'ai pour le moment mis les ressources dans un bloc à part, avec un message d'explication, et un bandeau sur la ressource.
Le bandeau fait qu'on ne peut plus voir si l'ancien JDD aurait été valide à la date courante, mais j'ai l'impression que c'est plutot une bonne chose, sinon ca aurait pu encore plus porter à confusion.

Ca donne ca:
![image](https://user-images.githubusercontent.com/3987698/99554810-890cbf00-29b7-11eb-83d9-ca675d43c8d6.png)


C'est quand meme un peu relou, typiquement pour la bretagne ca fait 11 GTFS non dispo qu'on affiche, ca spamme un peu la page, mais j'ai l'impression que c'est un moindre mal.

Pour les ressources non GTFS ca donne:
![image](https://user-images.githubusercontent.com/3987698/99555390-2831b680-29b8-11eb-89a6-175888b1b637.png)

Comme c'est un même bloc en vrac pour toutes les ressources non dispo (GTFS ou non) ca peut aussi donner ca: (mais j'ai pas l'impression que ca soit grave)
![image](https://user-images.githubusercontent.com/3987698/99555560-5a431880-29b8-11eb-8aee-0431f539eaa0.png)


Note: j'ai mis une abréviation ("Non dispo.') car un texte plus long ne rentrerait pas, mais je trouve ca pas dingue d'avoir une abréviation la. Vous en pensez quoi ?

J'ai vraiment aucune sensibilité sur l'UI, n'hésitez pas à proposer des amélio :stuck_out_tongue_winking_eye: 