### PR TITLE
Correctifs pour le passage en mode umbrella (GBFS uniquement)

### DIFF
--- a/apps/gbfs/mix.exs
+++ b/apps/gbfs/mix.exs
@@ -30,12 +30,15 @@ defmodule GBFS.MixProject do
 
   defp deps do
     [
+      {:httpoison, "~> 1.5.0"},
       {:exshape, "~> 2.2.6"},
       {:phoenix, "~> 1.4"},
       {:iconv, "~> 1.0.10"},
       {:sweet_xml, ">= 0.0.0"},
       {:jason, ">= 0.0.0"},
-      {:cors_plug, "~> 2.0"}
+      {:cors_plug, "~> 2.0"},
+      {:sentry, "~> 7.1"},
+      {:exvcr, "~> 0.10", only: :test}
     ]
   end
 end

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -10,16 +10,11 @@ defmodule GBFS.IndexControllerTest do
         |> Enum.at(0)
         |> get_in(["gbfs", "_links", "gbfs.json", "href"])
 
-      port =
-        :transport
-        |> Application.get_env(TransportWeb.Endpoint)
-        |> get_in([:http, :port])
-
       # NOTE: the order of "networks" is deterministic & established via the code,
       # which means we can fix data for the test
       # see bottom of GBFS.Router for the static definition.
       # we're looking both to ensure we have a full url here, and that the path is as expected
-      assert first_href == "http://127.0.0.1:#{port}/gbfs/vcub/gbfs.json"
+      assert first_href == "http://localhost/gbfs/vcub/gbfs.json"
     end
   end
 end

--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule GBFS.IndexControllerTest do
-  use TransportWeb.ConnCase, async: true
+  use GBFS.ConnCase, async: true
 
   describe "GET /" do
     test "returns correct absolute urls", %{conn: conn} do

--- a/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule GBFS.VCubControllerTest do
-  use TransportWeb.ConnCase, async: true
-  use TransportWeb.ExternalCase
+  use GBFS.ConnCase, async: true
+  use GBFS.ExternalCase
   alias GBFS.Router.Helpers, as: Routes
 
   @moduletag :external

--- a/apps/gbfs/test/support/external_case.ex
+++ b/apps/gbfs/test/support/external_case.ex
@@ -1,0 +1,15 @@
+defmodule GBFS.ExternalCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  test that require to mock external API calls.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney, options: [clear_mock: true]
+      import Plug.Test
+    end
+  end
+end


### PR DESCRIPTION
Comme vu dans #1351, il est actuellement impossible de lancer les tests de façon isolé sur certaines applications.

Cela rend moins pratique le travail sur ces applications isolées (en plus d'être un code smell comme indiqué dans la codebase). Par exemple on peut vouloir lancer rapidement les tests avec [entr](htetp://entrproject.org) à chaque sauvegarde comme suit, pour itérer beaucoup plus vite :

```
cd apps/gbfs
find lib test | entr -c mix test
```

Dans la présente PR, je corrige les points de couplages qui empêchait de faire ça, mais uniquement sur la partie GBFS pour l'instant (car je bosse dessus et ça me gênait).

Dans le détail:
* GBFS dépend en fait de plusieurs [dépendances externes](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html#external-dependencies) comme `httpoison`. Elles manquaient dans le `mix.exs`, ce qui causait une erreur en lancement isolé. Il suffit de mettre la même contrainte de version qu'à la racine et l'application est ajoutée.
* Il manquait des helpers de tests ; j'ai adapté
* Un test était cassé car du coup je pense que le test fonctionne dans un contexte un peu différent au niveau lancement
* Les tests passent de façon isolée pour l'application, ou globalement en local et en CI

A priori je ne pense pas que ça impactera la production, mais à vérifier.

Je ferai la même chose dans le futur sur les autres parties qui présentent le même souci.

