### PR TITLE
Do not preload all resources / validation while revalidating all

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -114,7 +114,15 @@ defmodule DB.Resource do
     {true, "no previous validation"}
   end
 
-  @spec validate_and_save(__MODULE__.t(), boolean()) :: {:error, any} | {:ok, nil}
+  @spec validate_and_save(__MODULE__.t() | integer(), boolean()) :: {:error, any} | {:ok, nil}
+  def validate_and_save(resource_id, force_validation) when is_integer(resource_id),
+    do:
+      __MODULE__
+      |> where([r], r.id == ^resource_id)
+      |> preload(:validation)
+      |> Repo.one!()
+      |> validate_and_save(force_validation)
+
   def validate_and_save(%__MODULE__{id: resource_id} = resource, force_validation) do
     Logger.info("Validating #{resource.url}")
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -37,18 +37,18 @@ defmodule Transport.ImportData do
   def validate_all_resources(force \\ false) do
     Logger.info("Validating all resources")
 
-    resources =
+    resources_id =
       Resource
-      |> preload(:validation)
+      |> select([r], r.id)
       |> Repo.all()
 
-    Logger.info("launching #{Enum.count(resources)} validations")
+    Logger.info("launching #{Enum.count(resources_id)} validations")
 
     validation_results =
       ImportTaskSupervisor
       |> Task.Supervisor.async_stream_nolink(
-        resources,
-        fn r -> Resource.validate_and_save(r, force) end,
+        resources_id,
+        fn r_id -> Resource.validate_and_save(r_id, force) end,
         max_concurrency: @max_import_concurrent_jobs,
         timeout: 180_000
       )

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,7 @@ config :gbfs, GBFSWeb.Endpoint,
 
 config :transport, Transport.Scheduler,
   jobs: [
-    {"0 7 * * *", {Transport.ImportData, :import_validate_all, []}}, # Every day at 7am
+    {"0 4 * * *", {Transport.ImportData, :import_validate_all, []}}, # Every day at 4am UTC
     {"@daily", {Transport.DataChecker, :outdated_data, []}}, # Send email for outdated data
     {"@daily", {Transport.DataChecker, :inactive_data, []}}, # Set inactive data
     {"@daily", {Transport.History, :backup_resources, []}}, # backup all resources


### PR DESCRIPTION
The import/validate process seems to consume too much memory.

This reduce the memory footprint by not loading in memory all resources
and their validation.

With a dump test on my computer the `maxresident` of `/usr/bin/time`
says that the validate process is now 397_428 compared to 1_836_576
before.

I also changed the time to 4am, this way no user should be impacted if
some stuff slow down