### PR TITLE
Correction lancement des tests sub-app DB (correctif umbrella)

### DIFF
--- a/apps/db/mix.exs
+++ b/apps/db/mix.exs
@@ -46,7 +46,8 @@ defmodule Db.MixProject do
       {:ex_aws, ">= 0.0.0"},
       {:ex_aws_s3, ">= 0.0.0"},
       {:sentry, ">= 0.0.0"},
-      {:typed_ecto_schema, ">= 0.1.1"}
+      {:typed_ecto_schema, ">= 0.1.1"},
+      {:vex, "~> 0.8"}
     ]
   end
 end

--- a/apps/db/test/db_dataset_test.exs
+++ b/apps/db/test/db_dataset_test.exs
@@ -1,8 +1,8 @@
-defmodule TransportWeb.DatasetDBTest do
+defmodule DB.DatasetDBTest do
   @moduledoc """
   Tests on the Dataset schema
   """
-  use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  use DB.DatabaseCase, cleanup: [:datasets]
   alias DB.Repo
 
   test "delete_parent_dataset" do

--- a/apps/db/test/support/database_case.ex
+++ b/apps/db/test/support/database_case.ex
@@ -1,4 +1,4 @@
-defmodule TransportWeb.DatabaseCase do
+defmodule DB.DatabaseCase do
   @moduledoc """
   This module defines the test case to be used by
   tests interacting with database.

--- a/apps/db/test/support/database_case.ex
+++ b/apps/db/test/support/database_case.ex
@@ -1,0 +1,62 @@
+defmodule TransportWeb.DatabaseCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests interacting with database.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using(options) do
+    quote do
+      alias Ecto.Adapters.SQL.Sandbox
+      alias DB.{AOM, Commune, Dataset, Region, Repo}
+
+      import Ecto
+      import Ecto.Query
+
+      defp cleanup do
+        collections() |> Enum.each(&cleanup(&1))
+      end
+
+      defp cleanup(:datasets), do: Repo.delete_all(Dataset)
+
+      defp collections do
+        unquote(options)[:cleanup]
+      end
+
+      setup context do
+        :ok = Sandbox.checkout(Repo)
+
+        unless context[:async] do
+          Sandbox.mode(Repo, {:shared, self()})
+        end
+
+        Repo.insert(%Region{nom: "Pays de la Loire"})
+
+        Repo.insert(%AOM{
+          insee_commune_principale: "38185",
+          nom: "Grenoble",
+          region: Repo.get_by(Region, nom: "Auvergne-Rhône-Alpes"),
+          composition_res_id: 2
+        })
+
+        Repo.insert(%Commune{
+          insee: "38185",
+          nom: "Grenoble",
+          wikipedia: "fr:Grenoble",
+          surf_ha: 200_554.0,
+          aom_res_id: 2
+        })
+
+        cleanup()
+
+        on_exit(fn ->
+          :ok = Sandbox.checkout(Repo)
+          cleanup()
+        end)
+
+        :ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
Voir #1351, pour le cas de l'application `apps/db` (similaire à #1374).

On peut à présent lancer les tests DB seuls, ce qui est beaucoup plus rapide et ergonomique quand on travaille sur cette partie.