### PR TITLE
Les visualisations carto ne s'appliquent qu'aux ressources officielles

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -64,7 +64,7 @@
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_rt_official_resources(@dataset), title: dgettext("page-dataset-details", "GTFS real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gbfs_official_resources(@dataset), title: dgettext("page-dataset-details", "GBFS resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
-      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Other resources") %>
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now")%>
       <% community_resources = community_resources(@dataset) %>
       <%= unless community_resources == [] do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -313,12 +313,14 @@ defmodule TransportWeb.DatasetView do
       when type == "carsharing-areas" or type == "private-parking" or type == "charging-stations" do
     resources
     |> Enum.filter(fn r -> r.format == "csv" end)
+    |> Enum.reject(fn r -> r.is_community_resource end)
     |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end
 
   def get_resource_to_display(%Dataset{type: "bike-sharing", resources: resources}) do
     resources
     |> Enum.filter(fn r -> String.ends_with?(r.url, "gbfs.json") end)
+    |> Enum.reject(fn r -> r.is_community_resource end)
     |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -179,10 +179,6 @@ msgid "NeTEx resources"
 msgstr ""
 
 #, elixir-format
-msgid "Other resources"
-msgstr ""
-
-#, elixir-format
 msgid "Reuses"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -179,10 +179,6 @@ msgid "NeTEx resources"
 msgstr "Ressources NeTEx"
 
 #, elixir-format
-msgid "Other resources"
-msgstr "Autres ressources"
-
-#, elixir-format
 msgid "Reuses"
 msgstr "Réutilisations"
 

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -179,10 +179,6 @@ msgid "NeTEx resources"
 msgstr ""
 
 #, elixir-format
-msgid "Other resources"
-msgstr ""
-
-#, elixir-format
 msgid "Reuses"
 msgstr ""
 


### PR DESCRIPTION
closes #1377 

J'en profite pour changer le "Autres ressources" sous lequel est listé la ressource de blablacar et le remplacer par "Ressources".
https://transport.data.gouv.fr/datasets/aires-de-covoiturage-en-france/

En effet, "autres ressources" a du sens lorsqu'il y a par exemple des ressources GTFS, et des "autres ressources" (un csv par exemple). Mais lorsque l'on a que un csv, ce "autres ressources" est embrouillant, car on ne sait pas à quoi ce "autre" se rapporte. Je me trompais moi-même en confondant ça avec les ressources communautaires !