### PR TITLE
Add indices to speed up stats query

### DIFF
--- a/apps/db/priv/repo/migrations/20201209152013_add_indices.exs
+++ b/apps/db/priv/repo/migrations/20201209152013_add_indices.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddIndices do
+  use Ecto.Migration
+
+  def change do
+    # add some indices to speed up the stats query
+    create(index(:resource, [:format, :dataset_id]))
+    create(index(:dataset, [:aom_id]))
+  end
+end


### PR DESCRIPTION
the stats query was lasting several seconds (~3s) and was slowing the rendering of the /stats page.

Now the stat query is done in ~40ms.