### PR TITLE
Petites modifs dans les tests de la fonction send_mail

### DIFF
--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule TransportWeb.ContactControllerTest do
+  use TransportWeb.ConnCase, async: true
+
+  test "Post contact form with honey pot filled", %{conn: conn} do
+    conn
+    |> post(contact_path(conn, :send_mail, %{email: "spammer@internet.com", name: "John Doe"}))
+    |> get_flash(:info)
+    # only spammers get a fox emoji in their flash message
+    |> Kernel.=~("🦊")
+    |> assert
+  end
+
+  test "Post contact form without honey pot", %{conn: conn} do
+    conn
+    |> post(
+      contact_path(conn, :send_mail, %{email: "human@user.fr", topic: "question", demande: "where is my dataset?"})
+    )
+    |> get_flash(:info)
+    |> case do
+      nil -> assert true
+      msg -> refute msg =~ "🦊"
+    end
+  end
+end

--- a/apps/transport/test/transport_web/integrations/contact_test.exs
+++ b/apps/transport/test/transport_web/integrations/contact_test.exs
@@ -14,29 +14,4 @@ defmodule TransportWeb.Integration.ContactTest do
     |> find_within_element(:class, "icon--envelope")
     |> assert
   end
-
-  @tag :integration
-  test "Post contact form with honey pot filled", %{conn: conn} do
-    conn
-    |> post("/send_mail", email: "spammer@internet.com", name: "John Doe")
-    |> get_flash(:info)
-    # only spammers get a fox emoji in their flash message
-    |> Kernel.=~("🦊")
-    |> assert
-  end
-
-  @tag :integration
-  test "Post contact form without honey pot", %{conn: conn} do
-    conn
-    |> post("/send_mail",
-      email: "human@user.fr",
-      topic: "question",
-      demande: "where is my dataset?"
-    )
-    |> get_flash(:info)
-    |> case do
-      nil -> assert true
-      msg -> refute msg =~ "🦊"
-    end
-  end
 end


### PR DESCRIPTION
Après avoir lu la review de @thbar sur ma PR précédente, j'ai compris des petits trucs sur les tests qui m'avaient échappés.

- les tests que j'avais écrits n'étaient pas des tests d'intégration
- j'ai compris comment utiliser le Helper contact_path, je ne sais pas pourquoi je n'avais pas réussi la dernière fois...