### PR TITLE
Count only active datasets for stats

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -147,7 +147,7 @@ defmodule TransportWeb.API.StatsController do
     quote do
       fragment("SELECT COUNT(format) FROM resource \
       WHERE dataset_id in \
-      (SELECT id FROM dataset WHERE aom_id=?) \
+      (SELECT id FROM dataset WHERE aom_id=? and is_active=TRUE) \
       AND format = ? GROUP BY format", unquote(aom), unquote(format))
     end
   end


### PR DESCRIPTION
Une petite correction que j'avais oublié de faire avant les vacances : la fonction count_aom_format sert dans la page de stats pour les données de la [carte](https://transport.data.gouv.fr/stats#public-transport-format) qui concerne les formats. Il faut ne compter que les datasets qui sont "actifs" pour avoir de bonnes statistiques. C'est pour cette raison que l'AOM du havre apparait en vert, à cause d'un dataset inactif, et donc invisible sur le reste du site.