### PR TITLE
Une ressource disponible via une redirection HTTP est quand meme available

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -312,7 +312,7 @@ defmodule Transport.ImportData do
 
   def available?(%{"url" => url}) do
     case HTTPoison.head(url) do
-      {:ok, %HTTPoison.Response{status_code: 200}} -> true
+      {:ok, %HTTPoison.Response{status_code: code}} when code >= 200 and code < 400 -> true
       _ -> false
     end
   end

--- a/apps/transport/test/transport/import_data_doc_test.exs
+++ b/apps/transport/test/transport/import_data_doc_test.exs
@@ -1,5 +1,0 @@
-defmodule Transport.ImportDataDocTest do
-  use ExUnit.Case, async: true
-  alias Transport.ImportData
-  doctest ImportData
-end

--- a/apps/transport/test/transport/import_data_service_test.exs
+++ b/apps/transport/test/transport/import_data_service_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.ImportDataTest do
+defmodule Transport.ImportDataServiceTest do
   use ExUnit.Case, async: true
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   use TransportWeb.ExternalCase

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -6,7 +6,7 @@ defmodule Transport.ImportDataTest do
   doctest ImportData
 
   test "the available? function with HTTP request", _ do
-    mock = fn(url) ->
+    mock = fn url ->
       case url do
         'url200' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
         'url300' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 300}}

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -1,0 +1,24 @@
+defmodule Transport.ImportDataTest do
+  use ExUnit.Case, async: true
+  alias Transport.ImportData
+  import Mock
+
+  doctest ImportData
+
+  test "the available? function with HTTP request", _ do
+    mock = fn(url) ->
+      case url do
+        'url200' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
+        'url300' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 300}}
+        'url400' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 400}}
+      end
+    end
+
+    with_mock HTTPoison, head: mock do
+      assert ImportData.available?(%{"url" => 'url200'})
+      assert ImportData.available?(%{"url" => 'url300'})
+      refute ImportData.available?(%{"url" => 'url400'})
+      assert_called_exactly(HTTPoison.head(:_), 3)
+    end
+  end
+end


### PR DESCRIPTION
Il y a un bug, par exemple sur le réseau [TAG](https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tag/).

Sa ressource principale apparait comme indisponible, alors qu'elle est disponible. La ressource est juste dispo via une redirection (HTTP 300), pour le moment tout ce qui n'était pas du 200 était considéré comme non dispo.