### PR TITLE
Changer le calcul de la qualité des données pour une AOM

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -303,7 +303,7 @@ defmodule TransportWeb.API.StatsController do
             aom.id,
             parent_dataset.id
           ),
-        # we get the most serious error of the valid resources
+        # we get the least serious error of the valid resources
         error_level:
           fragment(
             """
@@ -319,12 +319,12 @@ defmodule TransportWeb.API.StatsController do
               resource.is_available
             ORDER BY (
               CASE max_error::text
-                WHEN 'Fatal' THEN 6
-                WHEN 'Error' THEN 5
-                WHEN 'Warning' THEN 4
-                WHEN 'Information' THEN 3
-                WHEN 'Irrelevant' THEN 2
-                WHEN 'NoError' THEN 1
+                WHEN 'Fatal' THEN 1
+                WHEN 'Error' THEN 2
+                WHEN 'Warning' THEN 3
+                WHEN 'Information' THEN 4
+                WHEN 'Irrelevant' THEN 5
+                WHEN 'NoError' THEN 6
               END
             ) DESC
             LIMIT 1


### PR DESCRIPTION
closes #1408

Une manière facile de colorier une carte en vert :)

Précédemment c'est le niveau d'erreur maximal qui déterminait la couleur d'une aom sur la carte de [qualité des données](https://transport.data.gouv.fr/stats#public-transport-quality). C'est maintenant le niveau minimal.

Avant :
![image](https://user-images.githubusercontent.com/15341118/103355570-d8fa9d80-4aae-11eb-8d5c-591b15e67bdc.png)


Après :
![image](https://user-images.githubusercontent.com/15341118/103355602-e879e680-4aae-11eb-8574-99e6aaa7e155.png)
