### PR TITLE
correct "duplicate" spelling

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -320,7 +320,7 @@ defmodule DB.Resource do
       "InvalidTransferDuration" => dgettext("validations", "Invalid transfer duration"),
       "MissingLanguage" => dgettext("validations", "Missing language"),
       "InvalidLanguage" => dgettext("validations", "Invalid language"),
-      "DupplicateObjectId" => dgettext("validations", "Dupplicate object id"),
+      "DuplicateObjectId" => dgettext("validations", "Duplicate object id"),
       "UnloadableModel" => dgettext("validations", "Not compliant with the GTFS specification"),
       "MissingMandatoryFile" => dgettext("validations", "Missing mandatory file"),
       "ExtraFile" => dgettext("validations", "Extra file"),

--- a/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
@@ -20,7 +20,7 @@ msgid "Duplicate stops"
 msgstr ""
 
 #, elixir-format
-msgid "Dupplicate object id"
+msgid "Duplicate object id"
 msgstr ""
 
 #, elixir-format

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -20,7 +20,7 @@ msgid "Duplicate stops"
 msgstr "Arrêts en double"
 
 #, elixir-format
-msgid "Dupplicate object id"
+msgid "Duplicate object id"
 msgstr "Identifiant d’objet en double"
 
 #, elixir-format

--- a/apps/db/priv/gettext/validations.pot
+++ b/apps/db/priv/gettext/validations.pot
@@ -19,7 +19,7 @@ msgid "Duplicate stops"
 msgstr ""
 
 #, elixir-format
-msgid "Dupplicate object id"
+msgid "Duplicate object id"
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
Petite faute d'orthographe qui nous empeche d'avoir le type de warning dans le validateur.

![image](https://user-images.githubusercontent.com/15341118/103528111-b20fe300-4e83-11eb-80b7-e79c6715052b.png)

https://transport.data.gouv.fr/resources/11876#issues