### PR TITLE
[WIP] Amélioration/modernisation du setup de test

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -5,11 +5,6 @@
 # - GTFS_VALIDATOR_URL # for external?
 # - SECRET_KEY_BASE (to be generated)
 # 
-# MIX_ENV=dev can actually be removed, so that you don't have to type MIX_ENV=test
-# before each test run.
-
-# Set the mix_env to dev. Only for dev purpose.
-export MIX_ENV=dev
 
 # Configuration for the data.gouv.fr connection
 export DATAGOUVFR_SITE=https://www.demo.data.gouv.fr # This is data.gouv.fr test environment

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM betagouv/transport:0.4.3
+FROM betagouv/transport:0.4.5
 
 RUN apk add inotify-tools
 RUN apk add postgresql-client>=11

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,4 +19,9 @@ ADD mix.exs mix.lock /app/
 ADD config /app/config/
 ADD apps /app/apps/
 
+# files required for build test (verification of versions)
+ADD .tool-versions /app
+ADD Dockerfile.dev /app
+ADD Dockerfile /app
+
 CMD [ "/docker_phoenix_startup.sh" ]

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ Expect different behaviour with this method, because the version of ChromeDriver
 
 #### Running the tests
 
-Run the tests with `MIX_ENV=test mix test`
+Run the tests with `mix test`
 
 You can also:
 
-  * Run the integration tests with `MIX_ENV=test mix test --only integration`
-  * Run the solution tests with `MIX_ENV=test mix test --only solution`
-  * Run the external tests with `MIX_ENV=test mix test --only external`
-  * Run everything with `MIX_ENV=test RUN_ALL=1 mix test`
+  * Run the integration tests with `mix test --only integration`
+  * Run the solution tests with `mix test --only solution`
+  * Run the external tests with `mix test --only external`
+  * Run everything with `RUN_ALL=1 mix test`
 
 The application is an [umbrella app](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html). It means that it is split into several sub-projects (that you can see under `/apps`).
 
@@ -131,12 +131,12 @@ The following commands will launch the test and generate coverage:
 
 ```
 # Display overall (whole app) coverage for all tests in the console
-RUN_ALL=1 MIX_ENV=test mix coveralls --umbrella
+RUN_ALL=1 mix coveralls --umbrella
 # Same with a HTML report
-RUN_ALL=1 MIX_ENV=test mix coveralls.html --umbrella
+RUN_ALL=1 mix coveralls.html --umbrella
 
 # Display coverage for each umbrella component, rather
-MIX_ENV=test mix coveralls
+mix coveralls
 ```
 
 The coverage is written on screen by default, or in the `cover` subfolders for HTML output.
@@ -197,7 +197,7 @@ You can run any `mix` command with:
 
 For the tests you also need to add an environment variable:
 
-`docker-compose run -e MIX_ENV=test web mix test`
+`docker-compose run web mix test`
 
 ### Production
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ For the tests you also need to add an environment variable:
 
 `docker-compose run web mix test`
 
+If later you need to rebuild the containers (e.g. after pulling changes), you may need to run:
+`docker-compose up --build`
+
+See [`docker-compose up` documentation](https://docs.docker.com/compose/reference/up/) for more information.
+
 ### Production
 
   The Dockerfile needed to run the continuous integration is in the project:

--- a/apps/datagouvfr/mix.exs
+++ b/apps/datagouvfr/mix.exs
@@ -13,8 +13,14 @@ defmodule Datagouvfr.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       gettext: [{:write_reference_comments, false}],
-      compilers: [:gettext] ++ Mix.compilers,
-      test_coverage: [tool: ExCoveralls]
+      compilers: [:gettext] ++ Mix.compilers(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/apps/db/mix.exs
+++ b/apps/db/mix.exs
@@ -15,7 +15,13 @@ defmodule Db.MixProject do
       deps: deps(),
       gettext: [{:write_reference_comments, false}],
       compilers: [:gettext] ++ Mix.compilers(),
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/apps/gbfs/mix.exs
+++ b/apps/gbfs/mix.exs
@@ -14,7 +14,13 @@ defmodule GBFS.MixProject do
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/apps/helpers/mix.exs
+++ b/apps/helpers/mix.exs
@@ -13,7 +13,13 @@ defmodule Helpers.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -17,7 +17,11 @@ defmodule Transport.Mixfile do
         vcr: :test,
         "vcr.delete": :test,
         "vcr.check": :test,
-        "vcr.show": :test
+        "vcr.show": :test,
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
       ],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/apps/transport/test/build_test.exs
+++ b/apps/transport/test/build_test.exs
@@ -32,4 +32,15 @@ defmodule TransportWeb.BuildTest do
     {output, 0} = System.cmd("node", ["--version"])
     assert output |> String.trim() == "v" <> asdf_nodejs_release()
   end
+
+  def get_from(file) do
+    file
+    |> File.read!()
+    |> String.split("\n")
+    |> List.first()
+  end
+
+  test "make sure Dockerfile.dev base image is up to date" do
+    assert get_from("../../Dockerfile.dev") == get_from("../../Dockerfile")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,13 @@ defmodule Transport.MixProject do
       deps: deps(),
       aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
-      dialyzer: [plt_add_deps: :transitive, plt_add_apps: [:mix]]
+      dialyzer: [plt_add_deps: :transitive, plt_add_apps: [:mix]],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 


### PR DESCRIPTION
Ne pas merger! Il y a des points pas clair du tout (régressions sur les tests), je reviendrai dessus plus tard.

PR avec différentes améliorations, suite à une séance de pairing (#1445) avec @fchabouis.

Eléments traités:
* Meilleure gestion de `MIX_ENV`:
  * ⚠️ il faut supprimer `MIX_ENV=dev` des fichiers locaux `.envrc` après cette PR
  * Il n'y a plus besoin de taper `MIX_ENV=test` avant chaque opération liée aux tests (usage qui date de Elixir ~ v1.3 si j'ai compris)
  * La configuration recommandée par ExCoveralls a été adoptée pour forcer `MIX_ENV=test` pour les tâches de couvertures
* Verrou pour maintenir `Dockerfile.dev` (que j'ai découvert) à la même version d'image que la prod (vite fait, sous forme d'un petit test)
* Mise à jour de `Dockerfile.dev` pour utiliser `betagouv/transport:0.4.5` plutôt que la version `0.4.3` (abandonnée dans #1363).

Je ne fais qu'ouvrir en draft pour l'instant car il faudra que je vérifie avec du recul l'usage des DB, et passer en revue les différentes tâches, mais ça semble fonctionner à première vue.

En filigrane, ça nous amènera peut-être dans quelques temps à améliorer le temps de build sur le CI (éviter une double compilation dev/test), mais je n'en suis pas encore sûr.

- [ ] :warning:  tous les tests ne passent pas chez moi actuellement, il faudra que j'enquête