### PR TITLE
Ajout d'un tag sur le transport à la demande

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -240,6 +240,7 @@ defmodule DB.Resource do
     |> base_tag()
     |> Enum.concat(has_fares_tag(metadata))
     |> Enum.concat(has_shapes_tag(metadata))
+    |> Enum.concat(has_odt_tag(metadata))
     |> Enum.uniq()
   end
 
@@ -255,6 +256,12 @@ defmodule DB.Resource do
   @spec has_shapes_tag(map()) :: [binary()]
   def has_shapes_tag(%{"has_shapes" => true}), do: ["tracés de lignes"]
   def has_shapes_tag(_), do: []
+
+  # check if the resource contains some On Demand Transport (odt) tags
+  @spec has_odt_tag(map()) :: [binary()]
+  def has_odt_tag(%{"some_stops_need_phone_agency" => true}), do: ["transport à la demande"]
+  def has_odt_tag(%{"some_stops_need_phone_driver" => true}), do: ["transport à la demande"]
+  def has_odt_tag(_), do: []
 
   @spec base_tag(__MODULE__.t()) :: [binary()]
   def base_tag(%__MODULE__{format: "GTFS"}), do: ["position des stations", "horaires théoriques", "topologie du réseau"]


### PR DESCRIPTION
closes https://github.com/etalab/transport-site/issues/1376

en fait j'ai regroupé les tranports soumis à reservation dans un tag TAD.
Ca ne couvre pour le moment pas tous les cas de TAD (lignes virtuelles, ...) mais j'ai l'impression qu'on pourra les rajouter, et que sinon ca va être trop précis.

On peut aussi mettre un `acronym` pour expliquer, mais en fait c'est pas que des données soumises à reservation sur le principe et je ne sais pas trop si on a vraiment besoin d'expliquer plus que ca