### PR TITLE
Correctif régression SECRET_KEY_BASE

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,7 +20,7 @@ config :gbfs, GBFS.Endpoint,
 # Configures the endpoint
 config :transport, TransportWeb.Endpoint,
   url: [host: "127.0.0.1"],
-  secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   render_errors: [
     view: TransportWeb.ErrorView,
     layout: {TransportWeb.LayoutView, "app.html"},
@@ -29,7 +29,7 @@ config :transport, TransportWeb.Endpoint,
   pubsub: [name: Transport.PubSub,
            adapter: Phoenix.PubSub.PG2],
   live_view: [
-    signing_salt: System.fetch_env!("SECRET_KEY_BASE")
+    signing_salt: System.get_env("SECRET_KEY_BASE")
   ]
 
 config :phoenix, :json_library, Jason


### PR DESCRIPTION
Dans #1431 j'ai durci la vérification du chargement de `SECRET_KEY_BASE`, toutefois au déploiement la compilation échoue. Je pense que la variable est temporairement non disponible.

On voit pourtant plus haut `Inject SECRET_KEY_BASE`, mais peut-être que le processus plus bas n'en profite pas.

Je reviens juste en arrière, sachant que de toute façon Phoenix lèvera une erreur au boot si la variable n'est pas settée.

```
2021-01-07T19:01:25+01:00 #7 [4/13] RUN mkdir phoenixapp
2021-01-07T19:01:25+01:00 #6 DONE 1.1s
2021-01-07T19:01:26+01:00 #10 [6/13] COPY ./ /phoenixapp
2021-01-07T19:01:26+01:00 #7 DONE 0.3s
2021-01-07T19:01:26+01:00 #8 [5/13] WORKDIR /phoenixapp
2021-01-07T19:01:26+01:00 #8 DONE 0.1s
2021-01-07T19:01:26+01:00 #11 [7/13] RUN mix do deps.get --only prod
2021-01-07T19:01:26+01:00 #10 DONE 0.5s
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:680: :erl_eval.do_apply/6
2021-01-07T19:01:27+01:00 #11 1.304 (elixir 1.10.4) lib/system.ex:520: System.fetch_env!/1
2021-01-07T19:01:27+01:00 #11 1.304 ** (ArgumentError) could not fetch environment variable "SECRET_KEY_BASE" because it is not set
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:240: :erl_eval.expr/5
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:888: :erl_eval.expr_list/6
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:232: :erl_eval.expr/5
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:888: :erl_eval.expr_list/6
2021-01-07T19:01:27+01:00 #11 1.304 (stdlib 3.12.1) erl_eval.erl:233: :erl_eval.expr/5
```