### PR TITLE
remove deprecated `tag` filter handling

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -126,7 +126,7 @@ defmodule TransportWeb.DatasetController do
       |> clean_datasets_query("region")
       |> exclude(:order_by)
       |> join(:left, [d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id)
-      |> get_regions_select(params)
+      |> select([d, d_geo], %{id: d.id, region_id: d_geo.region_id})
 
     Region
     |> join(:left, [r], d in subquery(sub), on: d.region_id == r.id)
@@ -134,15 +134,6 @@ defmodule TransportWeb.DatasetController do
     |> select([r, d], %{nom: r.nom, id: r.id, count: count(d.id)})
     |> order_by([r], r.nom)
     |> Repo.all()
-  end
-
-  defp get_regions_select(query, %{"tags" => _tags}) do
-    # when there are some tags filters, the DatasetGeographicView is the third join, not the second.
-    query |> select([d, r, d_geo], %{id: d.id, region_id: d_geo.region_id})
-  end
-
-  defp get_regions_select(query, %{}) do
-    query |> select([d, d_geo], %{id: d.id, region_id: d_geo.region_id})
   end
 
   @spec get_types(map()) :: [%{type: binary(), msg: binary(), count: integer}]


### PR DESCRIPTION
le fitre par `tag` n’est plus supporté depuis un petit moment mais il restait un truc non desactivé qui faisait planter quand on appelait une route avec le filtre `tag` (inutile maintenant)

https://transport.data.gouv.fr/datasets?tags%5B%5D=bus&region=14 << ca plante maintenant et ca ne plante plus avec le fixe.

la mauvaise nouvelle c’est que quelqu’un a du sauvegarder cette url vu qu’on a eu le soucis en prod (et que ca ne fait pas la même chose que au moment où la personne a sauvegardé l’url), mais vu que ca ne fonctionne pas depuis un petit moment je vote pour fermer les yeux :grin: 