### PR TITLE
Clarification du log d'erreur lorsqu'on tente de charger une ressource FTP

### DIFF
--- a/apps/helpers/lib/hasher.ex
+++ b/apps/helpers/lib/hasher.ex
@@ -6,6 +6,18 @@ defmodule Hasher do
 
   @spec get_content_hash(String.t()) :: String.t()
   def get_content_hash(url) do
+    case scheme = URI.parse(url).scheme do
+      s when s in ["http", "https"] ->
+        get_content_hash_http(url)
+
+      _ ->
+        Logger.warn("Cannot process #{scheme |> inspect} url (#{url}) at the moment. Skipping.")
+        nil
+    end
+  end
+
+  @spec get_content_hash_http(String.t()) :: String.t()
+  def get_content_hash_http(url) do
     with {:ok, %{headers: headers}} <- HTTPoison.head(url),
          etag when not is_nil(etag) <- Enum.find_value(headers, &find_etag/1),
          content_hash <- String.replace(etag, "\"", "") do


### PR DESCRIPTION
Avant cette PR, l'application tente de télécharger les ressources FTP (qui ne sont pas supportées, voir #1033), et le message d'erreur était peu clair:

```
[error] error while computing content_hash %HTTPoison.Error{id: nil, reason: :nxdomain}
```

Cette PR affiche un message explicite pour tous les protocoles non HTTP/HTTPS, avec un niveau `warn`.

Le but de la PR est d'éviter qu'un développeur se mette à chercher pour rien.