### PR TITLE
Tâche d'extraction de logs CleverCloud

### DIFF
--- a/apps/transport/lib/mix/tasks/logs.ex
+++ b/apps/transport/lib/mix/tasks/logs.ex
@@ -6,13 +6,18 @@ defmodule Mix.Tasks.Clever.Logs do
   1000 lines of logs per command invocation (https://github.com/CleverCloud/clever-tools/issues/429)
   and a lack of auto-pagination.
 
-  This task provides a minimal ability to fetch logs from the platform.
+  This mix task provides a minimal ability to fetch logs from the platform.
 
   How to use:
 
   ```
-  mix clever.logs --since "2021-01-25T04:00:00Z" --before "2021-01-25T04:10:00Z" --alias "transport-site"
+  mix clever.logs --since "2021-01-25T04:00:00Z" --before "2021-01-25T04:10:00Z" --alias "the-app"
   ```
+
+  The switches mimic the CleverCloud logs ones:
+  * `--since`: start time (ISO8601 Z). Defaults to "24 hours ago".
+  * `--before`: end time (ISO8601 Z). Defaults to "now".
+  * `--alias`: name of the CleverCloud app.
   """
 
   require Logger

--- a/apps/transport/lib/mix/tasks/logs.ex
+++ b/apps/transport/lib/mix/tasks/logs.ex
@@ -49,8 +49,14 @@ defmodule Mix.Tasks.Clever.Logs do
     logs
   end
 
-  def default_start_time,
-    do: DateTime.utc_now() |> DateTime.add((-1 * 60 * 60 * 24) |> round(), :second) |> DateTime.to_iso8601()
+  def default_start_time do
+    now = DateTime.utc_now()
+    span = round(-1 * 60 * 60 * 24)
+
+    now
+    |> DateTime.add(span, :second)
+    |> DateTime.to_iso8601()
+  end
 
   def default_end_time, do: DateTime.utc_now() |> DateTime.to_iso8601()
 

--- a/apps/transport/lib/mix/tasks/logs.ex
+++ b/apps/transport/lib/mix/tasks/logs.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Clever.Logs do
     ]
 
     Logger.info("Running clever #{cmd_args |> Enum.join(" ")}")
-    {output, _exit_code = 0} = System.cmd("clever", cmd_args)
+    {output, _exit_code = 0} = System.cmd("clever", cmd_args, stderr_to_stdout: true)
 
     logs = output |> String.split("\n")
 

--- a/apps/transport/lib/mix/tasks/logs.ex
+++ b/apps/transport/lib/mix/tasks/logs.ex
@@ -1,0 +1,71 @@
+defmodule Mix.Tasks.Clever.Logs do
+  @moduledoc """
+  The CleverCloud logs command currently has strong limitations, including a maximum of
+  1000 lines of logs per command invocation (https://github.com/CleverCloud/clever-tools/issues/429)
+  and a lack of auto-pagination.
+
+  This task provides a minimal ability to fetch logs from the platform.
+  """
+
+  require Logger
+  use Mix.Task
+
+  def fetch_logs(app, start_time, end_time) do
+    cmd_args = [
+      "logs",
+      "--alias",
+      app,
+      "--since",
+      start_time |> DateTime.to_iso8601(),
+      "--before",
+      end_time |> DateTime.to_iso8601()
+    ]
+
+    # Logger.info("Running clever #{cmd_args |> Enum.join(" ")}")
+    {output, _exit_code = 0} = System.cmd("clever", cmd_args)
+    output
+  end
+
+  def run(_args) do
+    start_time = DateTime.utc_now() |> DateTime.add((-1 * 60 * 60 * 24) |> round(), :second)
+    app = "transport-site"
+    span_size_in_seconds = 3 * 60
+
+    logs =
+      Stream.resource(
+        fn -> %{start_time: start_time, seen_lines: MapSet.new()} end,
+        fn state ->
+          case state.start_time > DateTime.utc_now() do
+            true ->
+              {:halt, nil}
+
+            false ->
+              end_time = DateTime.add(state.start_time, span_size_in_seconds, :second)
+              logs = fetch_logs(app, state.start_time, end_time) |> String.split("\n")
+
+              if Enum.count(logs) > 990 do
+                Mix.raise(
+                  "Fetching near or more than 1000 lines of logs at once means you are going to miss some data (https://github.com/CleverCloud/clever-tools/issues/429).\n\nPlease reduce the span_size_in_seconds!"
+                )
+              end
+
+              {seen, unseen} = logs |> Enum.split_with(&MapSet.member?(state.seen_lines, &1))
+
+              # Logger.info("#{seen |> Enum.count()} seen lines, #{unseen |> Enum.count()} unseen lines")
+
+              {
+                logs,
+                state
+                |> Map.put(:start_time, end_time)
+                |> Map.put(:seen_lines, state.seen_lines |> MapSet.union(MapSet.new(unseen)))
+              }
+          end
+        end,
+        fn _ -> nil end
+      )
+
+    logs
+    |> Stream.each(&IO.puts(&1))
+    |> Stream.run()
+  end
+end


### PR DESCRIPTION
Attention "beta", il pourrait y avoir des trous dans la raquette.

Actuellement la fonction `clever logs` ne fournit que 1000 lignes de logs (voir https://github.com/CleverCloud/clever-tools/issues/403 et https://github.com/CleverCloud/clever-tools/issues/429).

Ce n'est pas suffisant pour travailler correctement (ex: récupérer les logs d'import de la nuit précédente), et nous ne souhaitons pas pour l'instant utiliser un drain de logs.

En attentant d'avoir autre chose, j'ai porté le script Ruby réalisé avec @antoine-de l'autre jour lors de l'enquête sur #1465 en Elixir, et je l'ai rendu configurable.

La tâche réalise une auto-pagination vérifiée avec dédoublonnage des lignes déjà vues (à défaut de mieux).

### Usage 

```
mix clever.logs --since "2021-01-26T04:00:00Z" --before "2021-01-26T06:00:00Z" --alias "transport-site" | tee import.log
```

### Écran doc

<img width="917" alt="CleanShot 2021-01-25 at 18 48 23@2x" src="https://user-images.githubusercontent.com/10141/105744855-f13eca80-5f3d-11eb-8bee-ee390a50ecd2.png">
