### PR TITLE
Remplacement du trigger "refresh_places_resources_trigger"

### DIFF
--- a/apps/db/priv/repo/migrations/20210126172850_remove_refresh_places_resources_trigger.exs
+++ b/apps/db/priv/repo/migrations/20210126172850_remove_refresh_places_resources_trigger.exs
@@ -1,0 +1,17 @@
+defmodule DB.Repo.Migrations.RemoveRefreshPlacesResourcesTrigger do
+  use Ecto.Migration
+
+  def up do
+    execute("DROP TRIGGER refresh_places_resources_trigger ON resource;")
+  end
+
+  def down do
+    execute("""
+    CREATE TRIGGER refresh_places_resources_trigger
+    AFTER INSERT OR UPDATE OR DELETE
+    ON resource
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE refresh_places();
+    """)
+  end
+end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -67,6 +67,12 @@ defmodule Transport.ImportData do
     validate_all_resources()
   end
 
+  def refresh_places() do
+    Logger.info("Refreshing places...")
+    # NOTE: I could not find a way to call "refresh_places()" directly
+    {:ok, _result} = Repo.query("REFRESH MATERIALIZED VIEW places;")
+  end
+
   @spec import_dataset(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
   def import_dataset(%Dataset{
         id: dataset_id,
@@ -88,7 +94,11 @@ defmodule Transport.ImportData do
         dataset_id: dataset_id
       })
 
-      Repo.update(changeset)
+      result = Repo.update(changeset)
+
+      refresh_places()
+
+      result
     else
       {:error, error} ->
         Logger.error("Unable to import data of dataset #{datagouv_id}: #{inspect(error)}")

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -67,7 +67,7 @@ defmodule Transport.ImportData do
     validate_all_resources()
   end
 
-  def refresh_places() do
+  def refresh_places do
     Logger.info("Refreshing places...")
     # NOTE: I could not find a way to call "refresh_places()" directly
     {:ok, _result} = Repo.query("REFRESH MATERIALIZED VIEW places;")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,7 +22,8 @@ config :transport, Transport.Scheduler,
     # generate NeTEx / geojson files for all GTFS.
     # Note : this should be run before the import_validate_all for the NeTEx / geojson
     # to be created when the import is run
-    {"0 1 * * *", {Transport.GtfsConversions, :convert_all, []}}
+    {"0 1 * * *", {Transport.GtfsConversions, :convert_all, []}},
+    {"0 * * * *", {Transport.ImportData, :refresh_places, []}}
   ]
 
 config :db, DB.Repo,


### PR DESCRIPTION
### Exposé du problème traité

Comme vu dans #1473 et #1472, avant cette PR, l'import d'un dataset se traduisait par une transaction unique, qui met également à jour chacune de ses N ressources. Pour chaque ressource, le trigger `refresh_places_resources_trigger` est automatiquement appelé.

On a donc une forme de problème de N+1 mais avec un trigger, qui prend entre 500 et 1000 ms. Du coup l'import du dataset peut partir en timeout (> 15 secondes).

### Solution implémentée

Dans cette PR, on désactive le trigger, au profit d'un appel explicite pour rafraîchir la vue matérialisée, et on ne fait ce rafraîchissement qu'après chaque import de dataset (1 fois par dataset, plutôt que 1 fois par ressource du dataset).

Par sécurité j'ai ajouté un cron toutes les heures qui va également rafraîchir la vue matérialisée.

La PR devrait déjà bien aider à accélérer l'import mais surtout à réduire les soucis de timeout.

### Points à vérifier

Il faut nous assurer avant de merger que le trigger ne devrait pas être appelé ailleurs également. 

