### PR TITLE
Ajout d'un fil d'Ariane dans la mise à jour des ressources (espace producteurs)

### DIFF
--- a/apps/transport/client/stylesheets/components/_choose_file.scss
+++ b/apps/transport/client/stylesheets/components/_choose_file.scss
@@ -11,6 +11,8 @@
       display: flex;
       .panel {
         flex-basis: 40vw;
+        flex-grow: 1;
+        max-width: 800px;
       }
     }
     form {

--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -66,7 +66,7 @@
     flex-wrap: wrap;
     margin: 0 -24px;
     .panel {
-      margin: 0 24px;
+      margin: 0 24px 12px 24px;
       display: flex;
       align-items: center;
       img {

--- a/apps/transport/client/stylesheets/producteurs.scss
+++ b/apps/transport/client/stylesheets/producteurs.scss
@@ -189,3 +189,19 @@
     }
   }
 }
+
+.breadcrumbs {
+  display: flex;
+
+  .breadcrumbs-element {
+    list-style: none;
+    padding-right: 0.5em;
+  }
+  .breadcrumbs-element+.breadcrumbs-element {
+    &::before {
+      content: ">";
+      padding-right: 0.5em;
+    }
+  }
+
+}

--- a/apps/transport/client/stylesheets/producteurs.scss
+++ b/apps/transport/client/stylesheets/producteurs.scss
@@ -196,6 +196,10 @@
   .breadcrumbs-element {
     list-style: none;
     padding-right: 0.5em;
+    color: var(--dark-grey);
+    a {
+      color: var(--dark-grey);
+    }
   }
   .breadcrumbs-element+.breadcrumbs-element {
     &::before {

--- a/apps/transport/client/stylesheets/producteurs.scss
+++ b/apps/transport/client/stylesheets/producteurs.scss
@@ -207,5 +207,4 @@
       padding-right: 0.5em;
     }
   }
-
 }

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
@@ -1,6 +1,6 @@
 <div class="producer-space">
   <div class="pt-48">
-    <div class="container">
+    <div class="container pb-24">
       <%= breadcrumbs [@conn, :espace_producteur] %>
     </div>
   </div>

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
@@ -1,7 +1,7 @@
 <div class="producer-space">
   <div class="pt-48">
     <div class="container">
-      <%= render "_breadcrumbs.html" %>
+      <%= breadcrumbs [@conn, :espace_producteur] %>
     </div>
   </div>
   <section class="section producer-actions">

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -8,14 +8,14 @@
       <% else %>
         <%= breadcrumbs [@conn, :update_resource, @dataset["id"]] %>
       <% end %>
-      <h4 class="small-bottom-margin"><%= @dataset["title"] %></h4>
-      <%= link("Voir la page du jeu de données", to: "/datasets/#{@dataset["id"]}") %>
     </div>
   </section>
   <section class="choose-file">
-    <div class="container pt-48">
-      <div class="description">
-        <h4><%= title(@conn) %></h4>
+
+    <div class="container pt-24">
+      <strong><%= @dataset["title"] %></strong>
+      <div class="pt-24">
+        <h2><%= title(@conn) %></h2>
       </div>
       <div class="option-1">
         <div class="panel">

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -3,6 +3,11 @@
 <div class="add-update-resource">
   <section class="pt-48 pb-24">
     <div class="container">
+      <%= if new_resource do %>
+        <%= breadcrumbs [@conn, :new_resource] %>
+      <% else %>
+        <%= breadcrumbs [@conn, :update_resource, @dataset["id"]] %>
+      <% end %>
       <h4 class="small-bottom-margin"><%= @dataset["title"] %></h4>
       <%= link("Voir la page du jeu de données", to: "/datasets/#{@dataset["id"]}") %>
     </div>

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
@@ -1,5 +1,6 @@
 <section class="pt-48">
   <div class="container">
+      <%= breadcrumbs [@conn, :select_resource] %>
     <h3>
       <%= @dataset["title"] %>
     </h3>

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
@@ -1,6 +1,6 @@
 <section class="pt-48">
   <div class="container">
-      <%= breadcrumbs [@conn, :select_resource] %>
+      <%= breadcrumbs [@conn, :select_resource, @dataset["id"]] %>
     <h3>
       <%= @dataset["title"] %>
     </h3>

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
@@ -10,7 +10,7 @@
         <%= @dataset["title"] %>
       </strong>
       <div>
-        <%= link("Voir la page du jeu de données", to: "/datasets/#{@dataset["id"]}") %>
+        <%= link(dgettext("resource", "Visit the dataset page"), to: "/datasets/#{@dataset["id"]}") %>
       </div>
       <div class="pt-24">
         <%= dgettext("resource", "Choose the resource you want to update") %> :

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
@@ -1,15 +1,20 @@
 <section class="pt-48">
-  <div class="container">
-      <%= breadcrumbs [@conn, :select_resource, @dataset["id"]] %>
-    <h3>
-      <%= @dataset["title"] %>
-    </h3>
+  <div class="container pb-24">
+    <%= breadcrumbs [@conn, :select_resource, @dataset["id"]] %>
   </div>
 </section>
 <section class="resource-update-section">
   <div class="container">
-    <div class="pt-48">
-      <%= dgettext("resource", "Choose the resource you want to update") %> :
+    <div class="pt-24">
+      <strong>
+        <%= @dataset["title"] %>
+      </strong>
+      <div>
+        <%= link("Voir la page du jeu de données", to: "/datasets/#{@dataset["id"]}") %>
+      </div>
+      <div class="pt-24">
+        <%= dgettext("resource", "Choose the resource you want to update") %> :
+      </div>
     </div>
     <div class="resources-update-list pt-24">
       <%= for resource <- @dataset["resources"] do %>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -13,32 +13,41 @@ defmodule TransportWeb.BreadCrumbs do
     [{dgettext("espace-producteurs", "Your producer space"), page_path(conn, :espace_producteur)}]
   end
 
-  def crumbs(conn, :select_resource) do
-    crumbs(conn, :espace_producteur) ++
-    [{dgettext("espace-producteurs", "Sélectionner une resource"), page_path(conn, :espace_producteur)}]
-  end
-
   def crumbs(conn, :new_resource) do
     crumbs(conn, :espace_producteur) ++
     [{dgettext("espace-producteurs", "Nouvelle ressource"), page_path(conn, :espace_producteur)}]
   end
 
-  def crumbs(conn, :update_resource, _dataset_id) do
-    crumbs(conn, :select_resource) ++
+  def crumbs(conn, :select_resource, id) do
+    crumbs(conn, :espace_producteur) ++
+    [{dgettext("espace-producteurs", "Sélectionner une resource"), resource_path(conn, :resources_list, id)}]
+  end
+
+  def crumbs(conn, :update_resource, id) do
+    crumbs(conn, :select_resource, id) ++
     [{dgettext("espace-producteurs", "Mettre à jour une ressource"), page_path(conn, :espace_producteur)}]
   end
 
   def render_crumbs(crumbs_element) do
     content_tag :div, class: "breadcrumbs" do
-      render_crumbs_element(crumbs_element)
+      render_crumbs_elements_list(crumbs_element)
     end
   end
 
-  def render_crumbs_element([{text, link}]) do
+  def render_crumbs_element({text, link}, :list_element) do
     content_tag(:li, link(text, to: link), class: "breadcrumbs-element")
   end
 
-  def render_crumbs_element([head | tail]) do
-    List.flatten([render_crumbs_element([head]), render_crumbs_element(tail)])
+  # last element does not need a link
+  def render_crumbs_element({text, _link}, :last_element) do
+    content_tag(:li, text, class: "breadcrumbs-element")
+  end
+
+  def render_crumbs_elements_list([element]) do
+    [render_crumbs_element(element, :last_element)]
+  end
+
+  def render_crumbs_elements_list([head | tail]) do
+    List.flatten([render_crumbs_element(head, :list_element), render_crumbs_elements_list(tail)])
   end
 end

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -1,0 +1,44 @@
+defmodule TransportWeb.BreadCrumbs do
+  use TransportWeb, :view
+
+  def breadcrumbs(args) do
+    IO.inspect(Enum.count(args))
+    IO.inspect(Enum.at(args, 0))
+    IO.inspect(Enum.at(args, 1))
+    apply(__MODULE__, :crumbs, args)
+    |> render_crumbs
+  end
+
+  def crumbs(conn, :espace_producteur) do
+    [{dgettext("espace-producteurs", "Your producer space"), page_path(conn, :espace_producteur)}]
+  end
+
+  def crumbs(conn, :select_resource) do
+    crumbs(conn, :espace_producteur) ++
+    [{dgettext("espace-producteurs", "Sélectionner une resource"), page_path(conn, :espace_producteur)}]
+  end
+
+  def crumbs(conn, :new_resource) do
+    crumbs(conn, :espace_producteur) ++
+    [{dgettext("espace-producteurs", "Nouvelle ressource"), page_path(conn, :espace_producteur)}]
+  end
+
+  def crumbs(conn, :update_resource, _dataset_id) do
+    crumbs(conn, :select_resource) ++
+    [{dgettext("espace-producteurs", "Mettre à jour une ressource"), page_path(conn, :espace_producteur)}]
+  end
+
+  def render_crumbs(crumbs_element) do
+    content_tag :div, class: "breadcrumbs" do
+      render_crumbs_element(crumbs_element)
+    end
+  end
+
+  def render_crumbs_element([{text, link}]) do
+    content_tag(:li, link(text, to: link), class: "breadcrumbs-element")
+  end
+
+  def render_crumbs_element([head | tail]) do
+    List.flatten([render_crumbs_element([head]), render_crumbs_element(tail)])
+  end
+end

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -31,24 +31,24 @@ defmodule TransportWeb.BreadCrumbs do
 
   def render_crumbs(crumbs_element) do
     content_tag :div, class: "breadcrumbs" do
-      render_crumbs_elements_list(crumbs_element)
+      render_crumbs_elements(crumbs_element)
     end
   end
 
-  def render_crumbs_element({text, link}, :list_element) do
+  def render_crumb_element({text, link}, :list_element) do
     content_tag(:li, link(text, to: link), class: "breadcrumbs-element")
   end
 
   # last element does not need a link
-  def render_crumbs_element({text, _link}, :last_element) do
+  def render_crumb_element({text, _link}, :last_element) do
     content_tag(:li, text, class: "breadcrumbs-element")
   end
 
-  def render_crumbs_elements_list([element]) do
-    [render_crumbs_element(element, :last_element)]
+  def render_crumbs_elements([element]) do
+    [render_crumb_element(element, :last_element)]
   end
 
-  def render_crumbs_elements_list([head | tail]) do
-    List.flatten([render_crumbs_element(head, :list_element), render_crumbs_elements_list(tail)])
+  def render_crumbs_elements([head | tail]) do
+    List.flatten([render_crumb_element(head, :list_element), render_crumbs_elements(tail)])
   end
 end

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -1,11 +1,12 @@
 defmodule TransportWeb.BreadCrumbs do
+  @moduledoc """
+  A module for creating breadcrumbs
+  """
   use TransportWeb, :view
 
   def breadcrumbs(args) do
-    IO.inspect(Enum.count(args))
-    IO.inspect(Enum.at(args, 0))
-    IO.inspect(Enum.at(args, 1))
-    apply(__MODULE__, :crumbs, args)
+    __MODULE__
+    |> apply(:crumbs, args)
     |> render_crumbs
   end
 

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -16,17 +16,23 @@ defmodule TransportWeb.BreadCrumbs do
 
   def crumbs(conn, :new_resource) do
     crumbs(conn, :espace_producteur) ++
-    [{dgettext("espace-producteurs", "Nouvelle ressource"), page_path(conn, :espace_producteur)}]
+      [
+        {dgettext("espace-producteurs", "Nouvelle ressource"), page_path(conn, :espace_producteur)}
+      ]
   end
 
   def crumbs(conn, :select_resource, id) do
     crumbs(conn, :espace_producteur) ++
-    [{dgettext("espace-producteurs", "Sélectionner une resource"), resource_path(conn, :resources_list, id)}]
+      [
+        {dgettext("espace-producteurs", "Sélectionner une resource"), resource_path(conn, :resources_list, id)}
+      ]
   end
 
   def crumbs(conn, :update_resource, id) do
     crumbs(conn, :select_resource, id) ++
-    [{dgettext("espace-producteurs", "Mettre à jour une ressource"), page_path(conn, :espace_producteur)}]
+      [
+        {dgettext("espace-producteurs", "Mettre à jour une ressource"), page_path(conn, :espace_producteur)}
+      ]
   end
 
   def render_crumbs(crumbs_element) do

--- a/apps/transport/lib/transport_web/views/page_view.ex
+++ b/apps/transport/lib/transport_web/views/page_view.ex
@@ -2,6 +2,7 @@ defmodule TransportWeb.PageView do
   use TransportWeb, :view
   import Phoenix.Controller, only: [current_path: 1]
   import TransportWeb.ResourceView, only: [dataset_creation: 0]
+  import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
 
   def class("y"), do: "good"
   def class(_), do: "bad"

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -3,6 +3,7 @@ defmodule TransportWeb.ResourceView do
   import TransportWeb.PaginationHelpers
   import DB.Validation
   import Phoenix.Controller, only: [current_url: 2]
+  import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
 
   def format_related_objects(nil), do: ""
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -82,3 +82,11 @@ msgstr ""
 #, elixir-format
 msgid "You have no resource to update for the moment"
 msgstr ""
+
+#, elixir-format
+msgid "New resource"
+msgstr ""
+
+#, elixir-format
+msgid "Select a resource"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -112,3 +112,7 @@ msgstr ""
 #, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr ""
+
+#, elixir-format
+msgid "Visit the dataset page"
+msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -81,3 +81,11 @@ msgstr ""
 #, elixir-format
 msgid "You have no resource to update for the moment"
 msgstr ""
+
+#, elixir-format
+msgid "New resource"
+msgstr ""
+
+#, elixir-format
+msgid "Select a resource"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -82,3 +82,11 @@ msgstr "Que souhaitez-vous faire ?"
 #, elixir-format
 msgid "You have no resource to update for the moment"
 msgstr "Vous n'avez pas de ressource à mettre à jour pour le moment"
+
+#, elixir-format
+msgid "New resource"
+msgstr "Nouvelle ressource"
+
+#, elixir-format
+msgid "Select a resource"
+msgstr "Sélectionner une resource"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -91,7 +91,7 @@ msgstr "Option 2 : pour plus d'options, éditer la ressource sur data.gouv.fr"
 
 #, elixir-format
 msgid "Resource modification"
-msgstr "Modification de la ressource"
+msgstr "Modification d'une ressource"
 
 #, elixir-format
 msgid "Give a link for the resource"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -112,3 +112,7 @@ msgstr "Cette option vous permet d'ajouter la ressource sur data.gouv.fr depuis 
 #, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr "exemple : Horaires au format GTFS"
+
+#, elixir-format
+msgid "Visit the dataset page"
+msgstr ""Voir la page du jeu de données""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -115,4 +115,4 @@ msgstr "exemple : Horaires au format GTFS"
 
 #, elixir-format
 msgid "Visit the dataset page"
-msgstr ""Voir la page du jeu de données""
+msgstr "Voir la page du jeu de données"

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -112,3 +112,7 @@ msgstr ""
 #, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr ""
+
+#, elixir-format
+msgid "Visit the dataset page"
+msgstr ""


### PR DESCRIPTION
Suivant les recommandations de Aurélie, ajout d'un fil d'Ariane (breadcrumbs) dans l'espace producteur pour mieux s'y retrouver lors de l'ajout ou de la modification de ressources.

![image](https://user-images.githubusercontent.com/15341118/108528065-4f5b9500-72d3-11eb-9f2b-78e6a04f9572.png)
