### PR TITLE
Augmentation du pool_size de Ecto

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -36,7 +36,7 @@ config :db, DB.Repo,
   url:
     System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||
       "" |> String.replace_prefix("postgresql", "ecto"),
-  pool_size: 2,
+  pool_size: 10,
   pool_timeout: 15_000,
   timeout: 15_000
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,18 +7,24 @@ config :transport, TransportWeb.Endpoint,
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
 
-config :gbfs, GBFSWeb.Endpoint,
-  secret_key_base: System.get_env("SECRET_KEY_BASE")
+config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :transport, Transport.Scheduler,
   jobs: [
-    {"0 4 * * *", {Transport.ImportData, :import_validate_all, []}}, # Every day at 4am UTC
-    {"@daily", {Transport.DataChecker, :outdated_data, []}}, # Send email for outdated data
-    {"@daily", {Transport.DataChecker, :inactive_data, []}}, # Set inactive data
-    {"@daily", {Transport.History, :backup_resources, []}}, # backup all resources
-    {"0 3 * * *", {Transport.LogCleaner, :clean_old_logs, []}}, # clean old logs
-    {"0 2 * * *", {Transport.ValidationCleaner, :clean_old_validations, []}}, # clean old validations
-    {"0 20 * * *", {Transport.StatsHandler, :store_stats, []}}, # compute some global stats and store them in the DB
+    # Every day at 4am UTC
+    {"0 4 * * *", {Transport.ImportData, :import_validate_all, []}},
+    # Send email for outdated data
+    {"@daily", {Transport.DataChecker, :outdated_data, []}},
+    # Set inactive data
+    {"@daily", {Transport.DataChecker, :inactive_data, []}},
+    # backup all resources
+    {"@daily", {Transport.History, :backup_resources, []}},
+    # clean old logs
+    {"0 3 * * *", {Transport.LogCleaner, :clean_old_logs, []}},
+    # clean old validations
+    {"0 2 * * *", {Transport.ValidationCleaner, :clean_old_validations, []}},
+    # compute some global stats and store them in the DB
+    {"0 20 * * *", {Transport.StatsHandler, :store_stats, []}},
     # generate NeTEx / geojson files for all GTFS.
     # Note : this should be run before the import_validate_all for the NeTEx / geojson
     # to be created when the import is run
@@ -27,7 +33,9 @@ config :transport, Transport.Scheduler,
   ]
 
 config :db, DB.Repo,
-  url: System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") || "" |> String.replace_prefix("postgresql", "ecto"),
+  url:
+    System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||
+      "" |> String.replace_prefix("postgresql", "ecto"),
   pool_size: 2,
   pool_timeout: 15_000,
   timeout: 15_000


### PR DESCRIPTION
Pour améliorer la tenue en charge de l'application, j'augmente la taille du pool Ecto de 2 à 10.

(Au passage mon éditeur a reformaté le fichier, ce qui rend le diff un peu moins lisible).

Voir #1502 pour les benchmarks.

@fchabouis je vais devoir déployer pour tester en production, car pas de possibilité apparemment de déployer une branche dans notre configuration CleverCloud.

Je pense qu'au final il faudra peut-être ajuster différemment pour `prochainement`, mais je cherche à tester d'abord en privilégiant la production donc je vais merger en l'état.