### PR TITLE
Permettre le fonctionnement de transport en cas de downtime chez data.gouv

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -441,7 +441,7 @@ defmodule DB.Dataset do
 
   def get_territory(_), do: {:error, "Trying to find the territory of an unkown entity"}
 
-  @spec get_territory_or_nil(__MODULE__.t()) :: binary()
+  @spec get_territory_or_nil(__MODULE__.t()) :: binary() | nil
   def get_territory_or_nil(%__MODULE__{} = d) do
     case get_territory(d) do
       {:ok, t} -> t

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -512,3 +512,7 @@
   border: 0;
   box-shadow: none;
 }
+
+.reuses_not_available {
+  font-style: italic;
+}

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -79,6 +79,11 @@
     <%= unless is_nil(@reuses) or @reuses == [] do %>
       <section class="white pt-48" id="dataset-reuses">
         <h2><%= dgettext("page-dataset-details", "Reuses" )%></h2>
+        <%= if @fetch_reuses_error do %>
+          <div class="panel reuses_not_available">
+            🔌 <%= dgettext("page-dataset-details", "Reuses are temporarily unavailable") %>
+          </div>
+        <% end %>
         <div class="reuses">
           <%= for reuse <- @reuses do %>
             <div class="panel reuse">

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -369,3 +369,7 @@ msgstr ""
 #, elixir-format
 msgid "available"
 msgstr ""
+
+#, elixir-format
+msgid "Reuses are temporarily unavailable"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -369,3 +369,7 @@ msgstr "Non"
 #, elixir-format
 msgid "available"
 msgstr "disponible"
+
+#, elixir-format
+msgid "Reuses are temporarily unavailable"
+msgstr "Les réutilisations sont temporairement indisponibles"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -369,3 +369,7 @@ msgstr ""
 #, elixir-format
 msgid "available"
 msgstr ""
+
+#, elixir-format
+msgid "Reuses are temporarily unavailable"
+msgstr ""

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -27,9 +27,11 @@ defmodule TransportWeb.Factory do
   def dataset_factory do
     %DB.Dataset{
       title: "Hello",
+      slug: sequence("dataset_slug", fn i -> "dataset-#{i}" end),
       # NOTE: need to figure out how to pass aom/region together with changeset checks here
       datagouv_id: "123",
-      aom: build(:aom)
+      aom: build(:aom),
+      tags: []
     }
   end
 

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -2,11 +2,26 @@ defmodule TransportWeb.DatasetControllerTest do
   use TransportWeb.ConnCase, async: false
   use TransportWeb.ExternalCase
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  import TransportWeb.Factory
+
+  import Mock
 
   doctest TransportWeb.DatasetController
 
   test "GET /", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index))
     assert html_response(conn, 200) =~ "Jeux de données"
+  end
+
+  test "Datasets details page loads even when data.gouv is down", %{conn: conn} do
+    dataset = insert(:dataset, slug: "dataset-slug", tags: [], spatial: "dataset de test")
+
+    with_mocks [
+      {Datagouvfr.Client.Reuses, [], [get: fn dataset -> {:error, "data.gouv is down !"} end]},
+      {Datagouvfr.Client.Discussions, [], [get: fn id -> nil end]}
+    ] do
+      conn = conn |> get(dataset_path(conn, :details, dataset.slug))
+      assert html_response(conn, 200) =~ "dataset de test"
+    end
   end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -14,7 +14,7 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "Datasets details page loads even when data.gouv is down", %{conn: conn} do
-    dataset = insert(:dataset, spatial: "dataset de test")
+    dataset = insert(:dataset)
 
     with_mocks [
       {Datagouvfr.Client.Reuses, [], [get: fn dataset -> {:error, "data.gouv is down !"} end]},

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -21,7 +21,8 @@ defmodule TransportWeb.DatasetControllerTest do
       {Datagouvfr.Client.Discussions, [], [get: fn _id -> nil end]}
     ] do
       conn = conn |> get(dataset_path(conn, :details, dataset.slug))
-      assert html_response(conn, 200) =~ "dataset de test"
+      html = html_response(conn, 200)
+      assert html =~ "réutilisations sont temporairement indisponibles"
     end
   end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -17,8 +17,8 @@ defmodule TransportWeb.DatasetControllerTest do
     dataset = insert(:dataset)
 
     with_mocks [
-      {Datagouvfr.Client.Reuses, [], [get: fn dataset -> {:error, "data.gouv is down !"} end]},
-      {Datagouvfr.Client.Discussions, [], [get: fn id -> nil end]}
+      {Datagouvfr.Client.Reuses, [], [get: fn _dataset -> {:error, "data.gouv is down !"} end]},
+      {Datagouvfr.Client.Discussions, [], [get: fn _id -> nil end]}
     ] do
       conn = conn |> get(dataset_path(conn, :details, dataset.slug))
       assert html_response(conn, 200) =~ "dataset de test"

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -14,7 +14,9 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "Datasets details page loads even when data.gouv is down", %{conn: conn} do
-    dataset = insert(:dataset)
+    # NOTE: we just want a dataset, but the factory setup is not finished, so
+    # we have to provide an already built aom
+    dataset = insert(:dataset, aom: insert(:aom, composition_res_id: 157))
 
     with_mocks [
       {Datagouvfr.Client.Reuses, [], [get: fn _dataset -> {:error, "data.gouv is down !"} end]},

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -14,7 +14,7 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "Datasets details page loads even when data.gouv is down", %{conn: conn} do
-    dataset = insert(:dataset, slug: "dataset-slug", tags: [], spatial: "dataset de test")
+    dataset = insert(:dataset, spatial: "dataset de test")
 
     with_mocks [
       {Datagouvfr.Client.Reuses, [], [get: fn dataset -> {:error, "data.gouv is down !"} end]},


### PR DESCRIPTION
L'actualité nous a montré que lorsque data.gouv tombe, toutes nos pages de datasets passent en 404.

Ce qui pas nécessaire, puisque nous n'utilisons data.gouv lors de l'affichage d'un dataset que pour les réutilisations et les discussions.