### PR TITLE
Ajout d'un TTL sur le cache de transport

### DIFF
--- a/apps/transport/lib/transport/cache.ex
+++ b/apps/transport/lib/transport/cache.ex
@@ -47,7 +47,7 @@ defmodule Transport.Cache.Cachex do
       end
     end
 
-    {operation, result} = Cachex.fetch(cache_name, cache_key, comp_fn, ttl: :timer.seconds(60))
+    {operation, result} = Cachex.fetch(cache_name, cache_key, comp_fn)
 
     case operation do
       :ok ->
@@ -55,6 +55,7 @@ defmodule Transport.Cache.Cachex do
         result
 
       :commit ->
+        Cachex.expire(cache_name, cache_key, :timer.seconds(60))
         Logger.info("Value for key #{cache_key} regenerated")
         result
 

--- a/apps/transport/test/transport/cache_cachex_test.exs
+++ b/apps/transport/test/transport/cache_cachex_test.exs
@@ -14,6 +14,8 @@ defmodule Transport.Cache.Cachex.Test do
 
     Transport.Cache.Cachex.fetch(unique_cache_key, fn -> "something else" end)
     assert Cachex.get!(:transport, unique_cache_key) == [hello: "world"]
+
+    assert_in_delta Cachex.ttl!(:transport, unique_cache_key), 60_000, 1000
   end
 
   test "it bubbles up errors occurring inside the computation function" do


### PR DESCRIPTION
closes #1565 

La fonction cachex.fetch ne prend pas en compte l'option ttl. Il faut donc ajouter un ttl à la main par la suite en cas de commit.

https://github.com/whitfin/cachex/issues/195