### PR TITLE
Réduction du nombre d'évènements envoyés à Sentry

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
@@ -79,7 +79,6 @@ defmodule GBFS.JCDecauxController do
     else
       e ->
         Logger.error("impossible to query jcdecaux: #{inspect(e)}")
-        Sentry.capture_message("impossible to query jcdecaux")
         {:error, "jcdecaux service unavailable"}
     end
   end

--- a/apps/gbfs/lib/gbfs/controllers/vcub_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/vcub_controller.ex
@@ -127,7 +127,6 @@ defmodule GBFS.VCubController do
     else
       e ->
         Logger.error("impossible to query vcub: #{inspect(e)}")
-        Sentry.capture_message("impossible to query vcub", extra: %{error: e})
         {:error, "service vcub unavailable"}
     end
   end

--- a/apps/gbfs/lib/gbfs/views/error_view.ex
+++ b/apps/gbfs/lib/gbfs/views/error_view.ex
@@ -7,11 +7,6 @@ defmodule GBFS.ErrorView do
   end
 
   def render("error.json", %{error: error}) do
-    Sentry.capture_message("GBFS error",
-      level: "error",
-      extra: %{details: error}
-    )
-
     %{error: error}
   end
 end

--- a/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
@@ -3,7 +3,6 @@ defmodule GBFS.JCDecauxControllerTest do
   use GBFS.ExternalCase
   alias GBFS.Router.Helpers, as: Routes
   import Mock
-  import AppConfigHelper
   import GBFS.Checker
 
   @moduletag :external
@@ -43,18 +42,6 @@ defmodule GBFS.JCDecauxControllerTest do
           {:ok, %HTTPoison.Response{body: "{}", status_code: 500}}
         end
       end
-
-      # we also mock Sentry, but using bypass since we don't want to mock sentry's internal
-      bypass = Bypass.open()
-
-      Bypass.expect(bypass, fn conn ->
-        {:ok, _body, conn} = Plug.Conn.read_body(conn)
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      change_app_config_temporarily(:sentry, :dsn, "http://public:secret@localhost:#{bypass.port}/1")
-      change_app_config_temporarily(:sentry, :included_environments, [:test])
-      change_app_config_temporarily(:sentry, :send_result, :sync)
 
       with_mock HTTPoison, get: mock do
         conn = conn |> get(Routes.toulouse_path(conn, :station_status))

--- a/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
@@ -3,7 +3,6 @@ defmodule GBFS.VCubControllerTest do
   use GBFS.ExternalCase
   alias GBFS.Router.Helpers, as: Routes
   import Mock
-  import AppConfigHelper
   import GBFS.Checker
 
   @moduletag :external
@@ -48,21 +47,10 @@ defmodule GBFS.VCubControllerTest do
         {:ok, %HTTPoison.Response{body: "{}", status_code: 500}}
       end
 
-      # we also mock Sentry, but using bypass since we don't want to mock sentry's internal
-      bypass = Bypass.open()
-
-      Bypass.expect(bypass, fn conn ->
-        {:ok, _body, conn} = Plug.Conn.read_body(conn)
-        Plug.Conn.resp(conn, 200, ~s<{"id": "340"}>)
-      end)
-
-      change_app_config_temporarily(:sentry, :dsn, "http://public:secret@localhost:#{bypass.port}/1")
-      change_app_config_temporarily(:sentry, :included_environments, [:test])
-      change_app_config_temporarily(:sentry, :send_result, :sync)
-
       with_mock HTTPoison, get: mock do
         conn = conn |> get(Routes.v_cub_path(conn, :station_status))
         assert %{"error" => "service vcub unavailable"} == json_response(conn, 502)
+
         assert_called_exactly(HTTPoison.get(:_), 1)
       end
     end

--- a/apps/helpers/lib/sentry_exception_filter.ex
+++ b/apps/helpers/lib/sentry_exception_filter.ex
@@ -1,0 +1,33 @@
+defmodule Transport.Shared.SentryExceptionFilter do
+  @moduledoc """
+  This module is used to avoid spamming our Sentry server
+  and thus consuming our events quota.
+
+  See https://hexdocs.pm/sentry/Sentry.html#module-filtering-exceptions.
+
+  Implementation based on
+  https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/default_event_filter.ex
+  """
+  @behaviour Sentry.EventFilter
+
+  @ignored_plug_exceptions [
+    # default ones
+    Phoenix.Router.NoRouteError,
+    Plug.Parsers.RequestTooLarge,
+    Plug.Parsers.BadEncodingError,
+    Plug.Parsers.ParseError,
+    Plug.Parsers.UnsupportedMediaTypeError,
+    # our additions
+    Ecto.NoResultsError,
+    Phoenix.NotAcceptableError
+  ]
+
+  def exclude_exception?(%x{}, :plug) when x in @ignored_plug_exceptions do
+    true
+  end
+
+  # "Ignore Plug route not found exception"
+  def exclude_exception?(%FunctionClauseError{function: :do_match, arity: 4}, :plug), do: true
+
+  def exclude_exception?(_exception, _source), do: false
+end

--- a/apps/transport/priv/static/robots.txt
+++ b/apps/transport/priv/static/robots.txt
@@ -6,3 +6,6 @@ Disallow: /backoffice/
 
 User-agent: *
 Allow: /
+
+User-agent: SemrushBot
+Disallow: /login/*

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,6 +79,7 @@ config :sentry,
   included_environments: [:prod, :staging],
   enable_source_code_context: true,
   root_source_code_path: File.cwd!,
+  filter: Transport.Shared.SentryExceptionFilter,
   # the key must be there for overriding during tests,
   # so we set it to the default based on source code for now
   send_result: :none


### PR DESCRIPTION
Voir #1567 il faut réduire le nombre d'évènements.

Je déploie cette PR graduellement sur la production (sans la merger) pour itérer dessus.
