### PR TITLE
Gestion du header lorsque le nom de l'utilisateur est vide

### DIFF
--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -182,3 +182,8 @@ nav.navigation input {
 .input__group .button {
   margin-left: var(--space-s) !important;
 }
+
+.user-name-display {
+  display: flex;
+  align-items: center;
+}

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.eex
@@ -38,12 +38,18 @@
           <%= if assigns[:current_user] do %>
             <li class="nav__item">
               <div class="dropdown">
-                <%= if assigns[:current_user]["avatar_thumbnail"] do %>
+                <div class="user-name-display">
                   <span class="nav__username">
-                    <%= assigns[:current_user]["first_name"] %> <%= assigns[:current_user]["last_name"] %>
+                    <%= if assigns[:current_user]["first_name"] || assigns[:current_user]["last_name"] do %>
+                        <%= assigns[:current_user]["first_name"] %> <%= assigns[:current_user]["last_name"] %>
+                    <% else %>
+                        <%= gettext("My account") %>
+                    <% end %>
                   </span>
-                  <img src="<%= assigns[:current_user]["avatar_thumbnail"] %>" alt="" class="nav__avatar"> </img>
-              <% end %>
+                  <%= if assigns[:current_user]["avatar_thumbnail"] do %>
+                    <img src="<%= assigns[:current_user]["avatar_thumbnail"] %>" alt="" class="nav__avatar"> </img>
+                  <% end %>
+                </div>
               <div class="dropdown-content">
                 <%= if admin?(assigns[:current_user]) do %>
                   <%= link("Administration", to: "/backoffice") %>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -80,3 +80,7 @@ msgstr ""
 #, elixir-format
 msgid "Producer infos"
 msgstr ""
+
+#, elixir-format
+msgid "My account"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -80,3 +80,7 @@ msgstr ""
 #, elixir-format
 msgid "Producer infos"
 msgstr ""
+
+#, elixir-format
+msgid "My account"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -80,3 +80,7 @@ msgstr "Voir les infos producteurs"
 #, elixir-format
 msgid "Producer infos"
 msgstr "Infos producteurs"
+
+#, elixir-format
+msgid "My account"
+msgstr "Mon compte"


### PR DESCRIPTION
closes #1551 

J'en profite pour mieux aligner le nom qui etait un peu au dessus des autres éléments de la navigation (a cause du thumbnail de l'utilisateur)

Si le nom n'est pas connu, on affiche juste "Mon compte"