### PR TITLE
Réparation de la carte de visualisation des ressources, page dataset

### DIFF
--- a/apps/transport/client/.eslintrc
+++ b/apps/transport/client/.eslintrc
@@ -1,14 +1,13 @@
 {
   "extends": [
     "eslint:recommended",
-    "./apps/transport/client/node_modules/eslint-config-standard/eslintrc.json"
+    "standard"
   ],
   "rules": {
     "indent": [
       "error",
       4
-    ],
-    "no-multi-spaces": "off"
+    ]
   },
   "globals": {
     "fetch": true,

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -38,6 +38,10 @@ function initilizeMap (id) {
     return { map, fg }
 }
 
+function coordinatesAreCorrect (lat, lon) {
+    return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
+}
+
 function displayData (data, fg, { latField, lonField, nameField }) {
     const markerOptions = {
         fillColor: '#0066db',
@@ -46,7 +50,7 @@ function displayData (data, fg, { latField, lonField, nameField }) {
         fillOpacity: 0.15
     }
     for (const m of data) {
-        if (m[latField] && m[lonField]) {
+        if (coordinatesAreCorrect(m[latField], m[lonField])) {
             try {
                 L.circleMarker([m[latField], m[lonField]], markerOptions)
                     .bindPopup(m[nameField])

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -27,7 +27,7 @@ function getLabel (obj, labelsList) {
 }
 
 function initilizeMap (id) {
-    const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
+    const map = L.map(id, { preferCanvas: true }).setView([46.505, 2], 5)
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -87,6 +87,8 @@ function createCSVmap (id, resourceUrl) {
                 displayData(data.data, fg, { latField, lonField, nameField })
                 map.fitBounds(fg.getBounds())
                 setZoomEvents(map, fg)
+            } else {
+                removeViz('vizualisation of the resource has failed : not recognized column names')
             }
         }
     })
@@ -170,11 +172,19 @@ function createGBFSmap (id, resourceUrl) {
     setInterval(() => fillGBFSMap(resourceUrl, fg, availableDocks, map), 60000)
 }
 
+function removeViz (consoleMsg) {
+    const element = document.querySelector('#dataset-visualisation')
+    element.remove()
+    console.log(consoleMsg)
+}
+
 function createMap (id, resourceUrl) {
     if (resourceUrl.endsWith('.csv')) {
         createCSVmap(id, resourceUrl)
     } else if (resourceUrl.endsWith('gbfs.json')) {
         createGBFSmap(id, resourceUrl)
+    } else {
+        removeViz(`vizualisation of the resource ${resourceUrl} has failed : not recognized file extension`)
     }
 }
 

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -39,7 +39,7 @@ function initilizeMap (id) {
 }
 
 function coordinatesAreCorrect (lat, lon) {
-    return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
+    return !isNaN(lat) && !isNaN(lon) && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
 }
 
 function displayData (data, fg, { latField, lonField, nameField }) {

--- a/apps/transport/client/package.json
+++ b/apps/transport/client/package.json
@@ -8,7 +8,7 @@
     "watch": "webpack --watch-options-stdin --progress --color --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "errors": "webpack --display-error-details --config webpack.dev.js",
-    "linter:ecma": "eslint -c ../../../.eslintrc --resolve-plugins-relative-to ./apps/transport/client/node_modules --ext .js .",
+    "linter:ecma": "eslint -c .eslintrc --resolve-plugins-relative-to ./apps/transport/client/node_modules --ext .js .",
     "linter:sass": "stylelint --config '../../../.stylelintrc.json' 'stylesheets/**/*.scss'"
   },
   "dependencies": {

--- a/apps/transport/client/webpack.dev.js
+++ b/apps/transport/client/webpack.dev.js
@@ -5,5 +5,6 @@ console.log('webpack dev configuration is used')
 
 module.exports = merge(common, {
     mode: 'development',
+    watch: true,
     devtool: 'source-map'
 })


### PR DESCRIPTION
Ce qui était parti comme juste une réparation de la carte des IRVE est finalement plus large :

## IRVE

Ce fichier est d'une qualité assez médiocre (pour rester poli), il y a des décalages de colonnes dans tous les sens, des coordonnées qui contiennent tout et n'importe quoi. Ca arrivait meme a faire planter leaflet :)

Deja un premier fix pour remettre la carte sur pieds, ensuite je creuserai comment mieux gérer les erreurs des cartes.

https://transport.data.gouv.fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/

## Webpack code reloading
Je me suis rendu compte que ma migration vers webpack 5 avait cassé le code reloading, c'est réparé.

## Emplacement du fichier eslintrc
J'ai finalement compris pourquoi je n'arrivais pas à charger le plugin `eslint-plugin-standard` comme indiqué dans la doc depuis le fichier eslintrc : parce que ce dernier n'était pas dans le repertoire attendu. Au lieu de mettre ce fichier à la racine du projet, je le mets dans /apps/transport/client, ce qui fixe le problème

## ajout d'une règle eslint sur les espaces multiples
La règle avait été désactivée à la main, mais je la trouve plutot utile donc je la remets.

## Suppression de la carte en cas d'erreur de chargement des données
Plus de carte toute blanche, en cas de problème on supprime la section entière et on met un message dans la console.

