### PR TITLE
Suppression texte spécifique popup concernant l'Isère

### DIFF
--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -155,9 +155,6 @@ function addStaticPTMapRegions (id, view) {
                 ? 'Un jeu de données'
                 : `${count} jeux de données`
         let popupContent = `<strong>${name}</strong><br/><a href="/datasets/region/${id}?type=public-transit#datasets-results">${text}</a>`
-        if (id === 2) {
-            popupContent += '<br>Dans cette région seul le département de l\'Isère est partenaire du <acronym title="Point d\'accès national">PAN</acronym>.'
-        }
         layer.bindPopup(popupContent)
     }
 

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -154,7 +154,7 @@ function addStaticPTMapRegions (id, view) {
             : count === 1
                 ? 'Un jeu de données'
                 : `${count} jeux de données`
-        let popupContent = `<strong>${name}</strong><br/><a href="/datasets/region/${id}?type=public-transit#datasets-results">${text}</a>`
+        const popupContent = `<strong>${name}</strong><br/><a href="/datasets/region/${id}?type=public-transit#datasets-results">${text}</a>`
         layer.bindPopup(popupContent)
     }
 


### PR DESCRIPTION
Voir #1597, la région est passé au vert au complet à présent.

Après suppression du texte spécifique dans la popup, on voit ceci:

<img width="299" alt="CleanShot 2021-04-19 at 09 28 37@2x" src="https://user-images.githubusercontent.com/10141/115197743-a1f9d780-a0f1-11eb-87b6-ddfd2161b59d.png">
