### PR TITLE
mise à jour de libring pour résoudre #1500

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -49,7 +49,7 @@
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm", "fc3499fed7a726995aa659143a248534adc754ebd16ccd437cd93b649a95091f"},
   "jumper": {:hex, :jumper, "1.0.1", "3c00542ef1a83532b72269fab9f0f0c82bf23a35e27d278bfd9ed0865cecabff", [:mix], [], "hexpm", "318c59078ac220e966d27af3646026db9b5a5e6703cb2aa3e26bcfaba65b7433"},
-  "libring": {:hex, :libring, "1.4.0", "41246ba2f3fbc76b3971f6bce83119dfec1eee17e977a48d8a9cfaaf58c2a8d6", [:mix], [], "hexpm", "1feaf05ee886815ad047cad7ede17d6910710986148ae09cf73eee2989717b81"},
+  "libring": {:hex, :libring, "1.5.0", "44313eb6862f5c9168594a061e9d5f556a9819da7c6444706a9e2da533396d70", [:mix], [], "hexpm", "04e843d4fdcff49a62d8e03778d17c6cb2a03fe2d14020d3825a1761b55bd6cc"},
   "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm", "d34f013c156db51ad57cc556891b9720e6a1c1df5fe2e15af999c84d6cebeb1a"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},


### PR DESCRIPTION
Ce répertoire est open-source, mais je ne sais pas s'il est open-contribution :thinking: 
J'essaye et puis on verra bien ! :shrug: 

Voici une petite PR pour résoudre https://github.com/etalab/transport-site/issues/1500 où j'ai simplement mis à jour `libring` pour se débarrasser de l'avertissement de déprécation concernant la stratégie `:simple_one_for_one`.

Dans votre propre base de code, vous n'utilisez jamais cette stratégie, alors j'ai recherché dans le dossier `deps` contenant toutes vos dépendances et j'ai vu que `libring 1.4` utilisait la stratégie `:simple_one_for_one`. Vu que ca faisait longtemps que cette stratégie a été abandonné, je me suis dit que mettre à jour `libring` devrait enlever les avertissements. 

Et c'est le cas ! 
On peut voir [ici](https://diff.hex.pm/diff/libring/1.4.0..1.5.0) que la version 1.5.0 de libring se débarasse de l'ancienne stratégie de supervision.

Avant : 
![image](https://user-images.githubusercontent.com/46972947/116763263-7e059280-aa1d-11eb-86df-f1dc26542465.png)

Après : 
![image](https://user-images.githubusercontent.com/46972947/116763304-a55c5f80-aa1d-11eb-8413-86fe86c74e24.png)


:warning: 
Je ne suis pas encore familier avec la base de code et je n'ai pas pu faire tourner la suite de test : il faut que je configure PostGIS 
:warning: 