### PR TITLE
Mise à jour de la page uptime robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project brings a mobility focus on data hosted on [data.gouv.fr](https://ww
 
 You will find user documentation at [doc.transport.data.gouv.fr](https://doc.transport.data.gouv.fr).
 
-A status dashboard is available at [https://status.transport.data.gouv.fr](https://status.transport.data.gouv.fr) for a part of the project.
+A status dashboard is available at [https://stats.uptimerobot.com/q7nqyiO9yQ](https://stats.uptimerobot.com/q7nqyiO9yQ) for a part of the project.
 
 # Glossary
 

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.eex
@@ -25,7 +25,7 @@
               Outils
               <div class="dropdown-content">
                 <%= link(gettext("Check a GTFS file's quality"), to: "/validation") %>
-                <%= link(gettext("Service status"), to: "https://status.transport.data.gouv.fr", target: "_blank") %>
+                <%= link(gettext("Service status"), to: "https://stats.uptimerobot.com/q7nqyiO9yQ", target: "_blank") %>
               </div>
             </div>
           </li>


### PR DESCRIPTION
J'ai reçu un mail : les pages de status uptime robot sur notre nom de domaine ne sont plus comprises dans le plan gratuit à partir de demain. Apparemment, j'avais déjà reçu un mail le 27 avril, que je n'avais pas vu.

Pour le moment, je mets juste à jour avec l'url qui reste gratuite, puis on pourra se demander si on reste chez eux ou pas.