### PR TITLE
Ajout d'informations supplémentaires dans le dashboard du backoffice

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -122,14 +122,17 @@
   a:hover {
     text-decoration: underline;
   }
-  .crash {
+  .no_import {
+    background-color: rgb(71, 32, 32);
+  }
+  .only_failures {
     background-color: red;
   }
-  .failure {
+  .some_failures {
     background-color:orange;
   }
-  .success {
-    background-color: rgb(231, 255, 217);
+  .only_successes {
+    background-color: rgb(0, 255, 0);
   }
   /* I used class to work around linter error here */
   .dataset {

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -109,6 +109,11 @@
   padding-left: 3px;
 }
 
+.dashboard-description {
+  margin: 0 auto;
+  max-width: 700px;
+}
+
 .dashboard-heatmap {
   border-spacing: 1px;
   border-collapse: separate;

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -122,11 +122,14 @@
   a:hover {
     text-decoration: underline;
   }
-  .ko {
+  .crash {
     background-color: red;
   }
-  .unknown {
-    background-color:#eee;
+  .failure {
+    background-color:orange;
+  }
+  .success {
+    background-color: rgb(231, 255, 217);
   }
   /* I used class to work around linter error here */
   .dataset {

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -110,7 +110,7 @@
 }
 
 .dashboard-heatmap {
-  border-spacing: 0.5px;
+  border-spacing: 1px;
   border-collapse: separate;
   margin: 0 auto;
   margin-bottom: 2em;

--- a/apps/transport/lib/queries/dashboard_import_count.sql
+++ b/apps/transport/lib/queries/dashboard_import_count.sql
@@ -1,5 +1,7 @@
 /*
-  Return the "count" of logs_import for each dataset and each day of a recent date range.
+  Return :
+  - the "count" of logs_import for each dataset and each day of a recent date range (import_counts)
+  - the count of logs_import full success for each dataset and each day of a recent date range (success_counts)
 
   NOTE: If we need to parameterize the date range, but still work with a raw SQL like here
   (easier to test with SQL tooling, without having to rewrite into Ecto SQL), we can have
@@ -15,7 +17,7 @@ from
 	generate_series(current_date - interval '30 day', current_date, '1 day') as day,
 	dataset d),
 
-counts as (
+import_counts as (
 select
 	dataset_id,
 	timestamp::date as date,
@@ -24,13 +26,30 @@ from
 	logs_import
 group by
 	dataset_id,
+	date),
+
+  success_counts as (
+select
+	dataset_id,
+	timestamp::date as date,
+	count(*) as count
+from
+	logs_import
+  WHERE is_success = TRUE
+
+group by
+	dataset_id,
 	date)
 
 select
 	dates.*,
-	coalesce(counts.count, 0) as count
+	coalesce(import_counts.count, 0) as import_counts,
+  coalesce(success_counts.count, 0) as success_counts
 from
 	dates
-left join counts on
-	dates.day = counts.date
-	and dates.dataset_id = counts.dataset_id;
+left join import_counts on
+	dates.day = import_counts.date
+	and dates.dataset_id = import_counts.dataset_id
+left join success_counts on
+	dates.day = success_counts.date
+	and dates.dataset_id = success_counts.dataset_id;

--- a/apps/transport/lib/transport_web/controllers/backoffice/dashboard_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dashboard_controller.ex
@@ -15,10 +15,10 @@ defmodule TransportWeb.Backoffice.DashboardController do
     import_count_by_dataset_and_by_day =
       data.rows
       |> Enum.group_by(
-        fn [dataset_id, _, _] -> dataset_id end,
-        fn [_, date, count] -> {date, count} end
+        fn [dataset_id, _, _, _] -> dataset_id end,
+        fn [_, date, import_count, success_count] -> {date, import_count, success_count} end
       )
-      |> Enum.sort_by(fn {key, value} -> key end)
+      |> Enum.sort_by(fn {key, _} -> key end)
 
     conn
     |> render("index.html", import_count_by_dataset_and_by_day: import_count_by_dataset_and_by_day)

--- a/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
@@ -6,15 +6,16 @@
     - que le dataset n'existait pas encore à l'instant t<br>
     - que les imports n'ont pas tourné du tout à une date donnée<br>
     <br>
-    La couleur grise n'indique pas qu'il y a eu succès, mais simplement que <br>
-    le système a été assez loin pour noter le résultat de l'import (OK ou KO), sans être interrompu.
+    La couleur orange signifie qu'un import a tourné et qu'une erreur (gérée) s'est produite.
+    <br>
+    La couleur claire indique un import réalisé avec succès !
 </p>
 
 <table class="dashboard-heatmap">
 <tbody>
 <%= for {dataset_id, counts} <- @import_count_by_dataset_and_by_day do %>
     <tr class="dataset">
-        <th class="heatmap-header"><%= link to: backoffice_page_path(@conn, :edit, dataset_id) do %><%= dataset_id %><% end %></th>
+        <th class="heatmap-header"><%= link to: "#{backoffice_page_path(@conn, :edit, dataset_id)}#imports_history" ,target: "_blank" do %><%= dataset_id %><% end %></th>
         <%= for {date, import_count, success_count} <- counts do %>
             <% import_crash = (import_count == 0) %>
             <% import_failure = (success_count == 0) %>

--- a/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
@@ -15,10 +15,10 @@
 <%= for {dataset_id, counts} <- @import_count_by_dataset_and_by_day do %>
     <tr class="dataset">
         <th class="heatmap-header"><%= link to: backoffice_page_path(@conn, :edit, dataset_id) do %><%= dataset_id %><% end %></th>
-        <%= for {date, count} <- counts do %>
-            <% failure = (count == 0) %>
-            <% cell_class = if failure, do: "ko", else: "unknown" %>
-            <%= content_tag :td, title: date, class: cell_class do %><% end %>
+        <%= for {date, import_count, success_count} <- counts do %>
+            <% import_crash = (import_count == 0) %>
+            <% import_failure = (success_count == 0) %>
+            <%= content_tag :td, title: date, class: cell_class({import_crash, import_failure}) do %><% end %>
         <% end %>
     </tr>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
@@ -1,25 +1,31 @@
 <h2 class="is-centered">Rapport de complétude des imports (<%= @import_count_by_dataset_and_by_day |> length %> datasets).</h2>
 
-<p class="is-centered">
-    La couleur rouge dénote l'absence de trace d'au moins 1 log d'import pour une date donnée, c'est à dire:<br>
-    - qu'une erreur non gérée s'est produite (ex: <a href="https://sentry.io/organizations/betagouv-f7/issues/?environment=prod&project=5687467&query=is%3Aunresolved+unmanaged_exception_during_import&statsPeriod=14d">unmanaged_exception_during_import</a>)<br>
-    - que le dataset n'existait pas encore à l'instant t<br>
-    - que les imports n'ont pas tourné du tout à une date donnée<br>
-    <br>
-    La couleur orange signifie qu'un import a tourné et qu'une erreur (gérée) s'est produite.
-    <br>
-    La couleur claire indique un import réalisé avec succès !
-</p>
+<div class="container pt-24">
+<div style="margin: 0 auto; max-width: 700px;">
+  <ul>
+    <li>
+        La couleur rouge foncée dénote l'absence de trace d'au moins 1 log d'import pour une date donnée, c'est à dire:
+      <ul>
+        <li>qu'une erreur non gérée s'est produite (ex: <a href="https://sentry.io/organizations/betagouv-f7/issues/?environment=prod&project=5687467&query=is%3Aunresolved+unmanaged_exception_during_import&statsPeriod=14d">unmanaged_exception_during_import</a>)</li>
+        <li>que le dataset n'existait pas encore à l'instant t</li>
+        <li>que les imports n'ont pas tourné du tout à une date donnée</li>
+      </ul>
+    </li>
+    <li>La couleur rouge signifie qu'au moins un import a tourné et que tous ont donné lieu à une erreur</li>
+    <li>La couleur orange indique la présence d'au moins un succès et un échec d'import au cours de la journée</li>
+    <li>La couleur verte indique que tous les imports de la journée sont des succès !</li>
+  </ul>
+</div>
 
-<table class="dashboard-heatmap">
+</div>
+
+<table class="dashboard-heatmap mt-48">
 <tbody>
 <%= for {dataset_id, counts} <- @import_count_by_dataset_and_by_day do %>
     <tr class="dataset">
         <th class="heatmap-header"><%= link to: "#{backoffice_page_path(@conn, :edit, dataset_id)}#imports_history" ,target: "_blank" do %><%= dataset_id %><% end %></th>
         <%= for {date, import_count, success_count} <- counts do %>
-            <% import_crash = (import_count == 0) %>
-            <% import_failure = (success_count == 0) %>
-            <%= content_tag :td, title: date, class: cell_class({import_crash, import_failure}) do %><% end %>
+            <%= content_tag :td, title: date, class: cell_class({import_count, success_count}) do %><% end %>
         <% end %>
     </tr>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/dashboard/index.html.eex
@@ -1,7 +1,7 @@
 <h2 class="is-centered">Rapport de complétude des imports (<%= @import_count_by_dataset_and_by_day |> length %> datasets).</h2>
 
 <div class="container pt-24">
-<div style="margin: 0 auto; max-width: 700px;">
+<div class="dashboard-description">
   <ul>
     <li>
         La couleur rouge foncée dénote l'absence de trace d'au moins 1 log d'import pour une date donnée, c'est à dire:

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -105,7 +105,7 @@
           <%= submit dgettext("backoffice", "Generate community resources (GeoJSON and NeTEx)"), [class: "button"] %>
         <% end %>
       </div>
-      <div class="dataset_import_validations_logs">
+      <div class="dataset_import_validations_logs" id="imports_history">
         <h3><%= dgettext("backoffice", "Imports history") %></h3>
         <table>
           <tr>

--- a/apps/transport/lib/transport_web/views/backoffice/dashboard_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/dashboard_view.ex
@@ -1,3 +1,13 @@
 defmodule TransportWeb.Backoffice.DashboardView do
   use TransportWeb, :view
+
+  @spec cell_class({boolean(), boolean()}) :: binary()
+  def cell_class({true, _import_failure}), do: "crash"
+
+  def cell_class({false, import_failure}) do
+    case import_failure do
+      true -> "failure"
+      false -> "success"
+    end
+  end
 end

--- a/apps/transport/lib/transport_web/views/backoffice/dashboard_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/dashboard_view.ex
@@ -2,12 +2,11 @@ defmodule TransportWeb.Backoffice.DashboardView do
   use TransportWeb, :view
 
   @spec cell_class({boolean(), boolean()}) :: binary()
-  def cell_class({true, _import_failure}), do: "crash"
+  def cell_class({_import_count = 0, _success_count}), do: "no_import"
 
-  def cell_class({false, import_failure}) do
-    case import_failure do
-      true -> "failure"
-      false -> "success"
-    end
-  end
+  def cell_class({import_count, _success_count = 0}) when import_count > 0, do: "only_failures"
+
+  def cell_class({import_count, success_count}) when import_count != success_count, do: "some_failures"
+
+  def cell_class({import_count, success_count}) when import_count == success_count, do: "only_successes"
 end


### PR DESCRIPTION
Ajout de plusieurs couleurs:
- rouge foncé pour crash non géré
- rouge pour uniquement des erreurs
- orange pour mix d'erreurs et de succès
- vert pour full succès

![image](https://user-images.githubusercontent.com/15341118/117144944-d8eb1100-adb2-11eb-8759-c7fe9b8a2c53.png)

(bon la y'a beaucoup de rouge, mais c'est la base de tests :P)
