### PR TITLE
Suppresion de logs d'erreur aws

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -607,8 +607,7 @@ defmodule DB.Dataset do
         end)
         |> Enum.sort_by(fn f -> f.last_modified end, &Kernel.>=/2)
       rescue
-        e in ExAws.Error ->
-          Logger.error("error while accessing the S3 bucket: #{inspect(e)}")
+        _ in ExAws.Error ->
           []
       end
     end


### PR DESCRIPTION
Lorsque l'on accède à la page dataset sur le site, et que celui-ci n'est pas historisé, on log une erreur aws ["erreur while accessing the S3 bucket"](https://github.com/etalab/transport-site/blob/2adb7f8bde5531bd42af4c8053415ceab19a20cc/apps/db/lib/db/dataset.ex#L611).

Or pour le moment, il est fait le choix de n'historiser que les fichiers netex et gtfs (voir [ici](https://github.com/etalab/transport-site/blob/2adb7f8bde5531bd42af4c8053415ceab19a20cc/apps/transport/lib/transport/history.ex#L22) ), donc on s'attend à ce qu'un jeu de données qui est en csv par exemple n'ait pas de bucket à son nom.

On peut donc considérer que c'est un comportement normal de ne pas trouver de bucket s3 et enlever ces logs qui nous polluent   un peu (lors des tests et lorqu'on fouille dans les logs pour debugger).