### PR TITLE
Patch pour faire en sorte qu'un timeout sur un import donnée ne bloque pas les imports suivants (fix #1626)

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -22,7 +22,8 @@ defmodule Transport.ImportData do
       ImportTaskSupervisor
       |> Task.Supervisor.async_stream_nolink(datasets, &import_dataset_logged/1,
         max_concurrency: @max_import_concurrent_jobs,
-        timeout: 180_000
+        timeout: 180_000,
+        on_timeout: :kill_task
       )
       |> Enum.to_list()
 


### PR DESCRIPTION
Voir #1626