### PR TITLE
Tentative de réparation du CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
           keys:
             - elixir-<< parameters.base_image >>-{{ .Branch }}-{{ checksum "mix.lock" }}
             - elixir-<< parameters.base_image >>-{{ .Branch }}
-            - elixir-<< parameters.base_image >>
       - run:
           name: Install hex
           command: mix local.hex --force
@@ -81,14 +80,6 @@ jobs:
       # Intermediate
       - save_cache:
           key: elixir-<< parameters.base_image >>-{{ .Branch }}
-          paths:
-            - ~/transport/_build
-            - ~/transport/deps
-            - ~/.mix
-
-      # Least specific
-      - save_cache:
-          key: elixir-<< parameters.base_image >>
           paths:
             - ~/transport/_build
             - ~/transport/deps


### PR DESCRIPTION
Voir https://app.circleci.com/pipelines/github/etalab/transport-site/1515/workflows/44c43865-9683-44c5-a27d-ffd498d7195a/jobs/25774/parallel-runs/0/steps/0-102, je me demande si l'erreur provient d'une restauration partielle du cache mix.