### PR TITLE
Refactoring de la fonction import_all_datasets

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -92,11 +92,12 @@ defmodule Transport.ImportData do
           error_msg: inspect(e)
         })
 
-      Logger.error("import of dataset #{dataset_id} has failed (datagouv_id #{datagouv_id})")
+      Logger.error("Import of dataset has failed (id:  #{dataset_id}, datagouv_id: #{datagouv_id})")
+
       Logger.error(Exception.format(:error, e, __STACKTRACE__))
 
       with {:error, msg} <- log_import_result do
-        Sentry.capture_message("import has failed, and failure log couldn't be inserted",
+        Sentry.capture_message("Import has failed, and failure log couldn't be inserted",
           level: "error",
           extra: %{dataset_id: dataset_id, datagouv_id: datagouv_id, msg: msg}
         )

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -104,8 +104,8 @@ defmodule Transport.ImportData do
     end
   end
 
-  @spec import_dataset(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
-  def import_dataset(dataset) do
+  @spec import_dataset_logged(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
+  def import_dataset_logged(dataset) do
     result = import_dataset!(dataset)
     generate_import_logs!(dataset, success: true)
     {:ok, result}

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -126,7 +126,7 @@ defmodule Transport.ImportData do
     })
 
     refresh_places()
-    result
+    {:ok, result}
   end
 
   @spec import_from_data_gouv!(binary, binary) :: map

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -113,7 +113,7 @@ defmodule Transport.ImportData do
       }) do
     now = DateTime.truncate(DateTime.utc_now(), :second)
 
-    with {:ok, new_data} <- import_from_udata(datagouv_id, type),
+    with {:ok, new_data} <- import_from_data_gouv(datagouv_id, type),
          {:ok, changeset} <- Dataset.changeset(new_data) do
       # log the import success
       Repo.insert(%LogsImport{
@@ -148,8 +148,8 @@ defmodule Transport.ImportData do
     end
   end
 
-  @spec import_from_udata(binary, binary) :: {:error, any} | {:ok, map}
-  def import_from_udata(id, type) do
+  @spec import_from_data_gouv(binary, binary) :: map
+  def import_from_data_gouv(id, type) do
     base_url = Application.get_env(:transport, :datagouvfr_site)
     url = "#{base_url}/api/1/datasets/#{id}/"
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -80,7 +80,7 @@ defmodule Transport.ImportData do
   rescue
     e ->
       now = DateTime.truncate(DateTime.utc_now(), :second)
-      dataset_id = dataset.dataset.id
+      dataset_id = dataset.id
       datagouv_id = dataset.datagouv_id
 
       log_import_result =

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -20,7 +20,7 @@ defmodule Transport.ImportData do
 
     results =
       ImportTaskSupervisor
-      |> Task.Supervisor.async_stream_nolink(datasets, &import_dataset_logged/1,
+      |> Task.Supervisor.async_stream_nolink(datasets, &import_dataset/1,
         max_concurrency: @max_import_concurrent_jobs,
         timeout: 180_000,
         on_timeout: :kill_task
@@ -75,7 +75,7 @@ defmodule Transport.ImportData do
   end
 
   @spec import_dataset(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
-  def import_dataset_logged(dataset) do
+  def import_dataset(dataset) do
     import_dataset!(dataset)
   rescue
     e ->
@@ -103,7 +103,7 @@ defmodule Transport.ImportData do
   end
 
   @spec import_dataset!(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
-  def import_dataset(%Dataset{
+  def import_dataset!(%Dataset{
         id: dataset_id,
         datagouv_id: datagouv_id,
         type: type,

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -88,7 +88,8 @@ defmodule Transport.ImportData do
           datagouv_id: datagouv_id,
           timestamp: now,
           is_success: false,
-          dataset_id: dataset_id
+          dataset_id: dataset_id,
+          error_msg: inspect(e)
         })
 
       Logger.error("import of dataset #{dataset_id} has failed (datagouv_id #{datagouv_id})")
@@ -101,7 +102,7 @@ defmodule Transport.ImportData do
         )
       end
 
-      reraise e, __STACKTRACE__
+      {:error, inspect(e)}
   end
 
   @spec import_dataset!(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -76,7 +76,8 @@ defmodule Transport.ImportData do
 
   @spec import_dataset(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
   def import_dataset(dataset) do
-    import_dataset!(dataset)
+    result = import_dataset!(dataset)
+    {:ok, result}
   rescue
     e ->
       now = DateTime.truncate(DateTime.utc_now(), :second)
@@ -106,7 +107,7 @@ defmodule Transport.ImportData do
       {:error, inspect(e)}
   end
 
-  @spec import_dataset!(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()}
+  @spec import_dataset!(DB.Dataset.t()) :: Ecto.Schema.t()
   def import_dataset!(%Dataset{
         id: dataset_id,
         datagouv_id: datagouv_id,
@@ -127,7 +128,7 @@ defmodule Transport.ImportData do
     })
 
     refresh_places()
-    {:ok, result}
+    result
   end
 
   @spec import_from_data_gouv!(binary, binary) :: map

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -79,7 +79,7 @@ defmodule Transport.ImportData do
         options
       ) do
     success = options |> Keyword.fetch!(:success)
-    msg = options |> Keyword.get(:msg, "")
+    msg = options |> Keyword.get(:msg)
 
     now = DateTime.truncate(DateTime.utc_now(), :second)
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -124,7 +124,7 @@ defmodule Transport.ImportData do
         datagouv_id: datagouv_id,
         type: type
       }) do
-    dataset_map_from_data_gouv = import_from_data_gouv!(datagouv_id, type)
+    {:ok, dataset_map_from_data_gouv} = import_from_data_gouv(datagouv_id, type)
     {:ok, changeset} = Dataset.changeset(dataset_map_from_data_gouv)
     result = Repo.update!(changeset)
 
@@ -132,8 +132,8 @@ defmodule Transport.ImportData do
     result
   end
 
-  @spec import_from_data_gouv!(binary, binary) :: map
-  def import_from_data_gouv!(datagouv_id, type) do
+  @spec import_from_data_gouv(binary, binary) :: {:ok, map}
+  def import_from_data_gouv(datagouv_id, type) do
     base_url = Application.get_env(:transport, :datagouvfr_site)
     url = "#{base_url}/api/1/datasets/#{datagouv_id}/"
 
@@ -145,7 +145,7 @@ defmodule Transport.ImportData do
     json = Jason.decode!(response.body)
     {:ok, dataset} = prepare_dataset_from_data_gouv_response(json, type)
 
-    dataset
+    {:ok, dataset}
   end
 
   @spec prepare_dataset_from_data_gouv_response(map, binary) :: {:error, any} | {:ok, map}

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -112,7 +112,7 @@ defmodule Transport.ImportData do
       }) do
     now = DateTime.truncate(DateTime.utc_now(), :second)
 
-    {:ok, dataset_map_from_data_gouv} = import_from_data_gouv(datagouv_id, type)
+    dataset_map_from_data_gouv = import_from_data_gouv!(datagouv_id, type)
     {:ok, changeset} = Dataset.changeset(dataset_map_from_data_gouv)
     {:ok, result} = Repo.update(changeset)
 
@@ -128,8 +128,8 @@ defmodule Transport.ImportData do
     result
   end
 
-  @spec import_from_data_gouv(binary, binary) :: map
-  def import_from_data_gouv(datagouv_id, type) do
+  @spec import_from_data_gouv!(binary, binary) :: map
+  def import_from_data_gouv!(datagouv_id, type) do
     base_url = Application.get_env(:transport, :datagouvfr_site)
     url = "#{base_url}/api/1/datasets/#{datagouv_id}/"
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -108,10 +108,7 @@ defmodule Transport.ImportData do
   def import_dataset!(%Dataset{
         id: dataset_id,
         datagouv_id: datagouv_id,
-        type: type,
-        title: title,
-        slug: slug,
-        is_active: is_active
+        type: type
       }) do
     now = DateTime.truncate(DateTime.utc_now(), :second)
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -20,7 +20,7 @@ defmodule Transport.ImportData do
 
     results =
       ImportTaskSupervisor
-      |> Task.Supervisor.async_stream_nolink(datasets, &import_dataset/1,
+      |> Task.Supervisor.async_stream_nolink(datasets, &import_dataset_logged/1,
         max_concurrency: @max_import_concurrent_jobs,
         timeout: 180_000,
         on_timeout: :kill_task
@@ -99,7 +99,7 @@ defmodule Transport.ImportData do
         timestamp: now,
         is_success: success,
         dataset_id: dataset_id,
-        error_msg: "error message could not be logged"
+        error_msg: "Error message could not be logged"
       })
     end
   end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -105,7 +105,7 @@ defmodule Transport.ImportData do
       {:error, inspect(e)}
   end
 
-  @spec import_dataset!(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
+  @spec import_dataset!(DB.Dataset.t()) :: {:ok, Ecto.Schema.t()}
   def import_dataset!(%Dataset{
         id: dataset_id,
         datagouv_id: datagouv_id,

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -154,7 +154,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
     do: put_flash(conn, :error, "#{err} (#{message})")
 
   @spec import_data(Dataset.t() | nil) :: any()
-  defp import_data(%Dataset{} = dataset), do: ImportData.import_dataset(dataset)
+  defp import_data(%Dataset{} = dataset), do: ImportData.import_dataset_logged(dataset)
   defp import_data(nil), do: {:error, dgettext("backoffice", "Unable to find dataset")}
 
   defp redirect_to_index(conn),

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -20,7 +20,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
     }
 
     with datagouv_id when not is_nil(datagouv_id) <- Datasets.get_id_from_url(params["url"]),
-         {:ok, dg_dataset} <- ImportData.import_from_udata(datagouv_id, params["type"]),
+         {:ok, dg_dataset} <- ImportData.import_from_data_gouv(datagouv_id, params["type"]),
          params <- Map.merge(params, dg_dataset),
          {:ok, changeset} <- Dataset.changeset(params),
          {:ok, dataset} <- insert_dataset(changeset) do

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -82,7 +82,7 @@ defmodule TransportWeb.ResourceController do
     with {:ok, _} <- Resources.update(conn, params),
          dataset when not is_nil(dataset) <-
            Repo.get_by(Dataset, datagouv_id: params["dataset_id"]),
-         {:ok, _} <- ImportData.import_dataset(dataset),
+         {:ok, _} <- ImportData.import_dataset_logged(dataset),
          {:ok, _} <- Dataset.validate(dataset) do
       conn
       |> put_flash(:info, success_message)

--- a/apps/transport/test/transport/import_data_service_test.exs
+++ b/apps/transport/test/transport/import_data_service_test.exs
@@ -6,13 +6,13 @@ defmodule Transport.ImportDataServiceTest do
 
   @moduletag :external
 
-  describe "import_from_udata" do
+  describe "import_from_data_gouv" do
     test "import dataset with a zip" do
       url = "http://hstan.g-ny.org/grandnancy/data/public/gtfs_stan.zip"
 
       use_cassette "client/datasets/stan" do
         assert {:ok, dataset} =
-                 ImportData.import_from_udata(
+                 ImportData.import_from_data_gouv(
                    "arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs",
                    "public-transit"
                  )
@@ -25,7 +25,7 @@ defmodule Transport.ImportDataServiceTest do
       url = "https://si.metzmetropole.fr/fiches/opendata/gtfs_current.zip"
 
       use_cassette "client/datasets/metz" do
-        assert {:ok, dataset} = ImportData.import_from_udata("transport-donnees-gtfs", "public-transit")
+        assert {:ok, dataset} = ImportData.import_from_data_gouv("transport-donnees-gtfs", "public-transit")
         assert List.first(dataset["resources"])["url"] == url
       end
     end
@@ -35,7 +35,7 @@ defmodule Transport.ImportDataServiceTest do
         "https://ressources.data.sncf.com/api/v2/catalog/datasets/sncf-ter-gtfs/files/24e02fa969496e2caa5863a365c66ec2"
 
       use_cassette "client/datasets/sncf" do
-        assert {:ok, dataset} = ImportData.import_from_udata("horaires-des-lignes-ter-sncf", "public-transit")
+        assert {:ok, dataset} = ImportData.import_from_data_gouv("horaires-des-lignes-ter-sncf", "public-transit")
 
         assert length(dataset["resources"]) == 1
         resource = List.first(dataset["resources"])

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -72,7 +72,7 @@ defmodule Transport.ImportDataTest do
   end
 
   def http_stream_mock do
-    fn url ->
+    fn _url ->
       %{
         status: 200,
         hash: "resource1_hash"
@@ -81,7 +81,7 @@ defmodule Transport.ImportDataTest do
   end
 
   def http_head_mock do
-    fn url, _, _ ->
+    fn _url, _, _ ->
       {:ok, %HTTPoison.Response{status_code: 200}}
     end
   end
@@ -193,7 +193,7 @@ defmodule Transport.ImportDataTest do
         datagouv_id,
         generate_resources_payload(
           new_title,
-          new_url = "http://localhost:4321/resource1_new",
+          _new_url = "http://localhost:4321/resource1_new",
           new_datagouv_id
         )
       )

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -260,21 +260,17 @@ defmodule Transport.ImportDataTest do
         {:ok, %HTTPoison.Response{body: payload, status_code: 200}}
       end
 
-      with_mock Sentry, capture_message: fn _, _ -> nil end do
-        with_mock HTTPoison, get: mock do
-          logs =
-            capture_log([level: :warn], fn ->
-              ImportData.import_all_datasets()
-            end)
+      with_mock HTTPoison, get: mock do
+        logs =
+          capture_log([level: :warn], fn ->
+            ImportData.import_all_datasets()
+          end)
 
-          logs = logs |> String.split("\n")
-          assert logs |> Enum.at(0) =~ "Unmanaged exception during import"
-          # NOTE: for now, relying on a specific error that we're triggering due to missing key, but it's
-          # far from ideal and it would be better to have something more explicit
-          assert logs |> Enum.at(1) =~ "no function clause matching in Transport.ImportData.get_valid_resources/2"
-        end
-
-        assert_called_exactly(Sentry.capture_message(:_, :_), 1)
+        logs = logs |> String.split("\n")
+        assert logs |> Enum.at(0) =~ "Import of dataset has failed"
+        # NOTE: for now, relying on a specific error that we're triggering due to missing key, but it's
+        # far from ideal and it would be better to have something more explicit
+        assert logs |> Enum.at(1) =~ "no function clause matching in Transport.ImportData.get_valid_resources/2"
       end
     end
   end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -57,7 +57,7 @@ defmodule Transport.ImportDataTest do
 
       payload = payload || generate_dataset_payload(datagouv_id)
 
-      {:ok, %HTTPoison.Response{body: Jason.encode!(payload), status_code: 200}}
+      %HTTPoison.Response{body: Jason.encode!(payload), status_code: 200}
     end
   end
 
@@ -67,7 +67,7 @@ defmodule Transport.ImportDataTest do
       expected_url = "#{base_url}/api/1/datasets/#{datagouv_id}/"
       assert url == expected_url
 
-      {:ok, %HTTPoison.Response{body: "erreur 404, page non trouvée", status_code: 404}}
+      %HTTPoison.Response{body: "erreur 404, page non trouvée", status_code: 404}
     end
   end
 
@@ -96,12 +96,12 @@ defmodule Transport.ImportDataTest do
     assert db_count(DB.Dataset) == 1
     assert db_count(DB.Resource) == 0
 
-    with_mock HTTPoison, get: http_get_mock_200(datagouv_id), head: http_head_mock() do
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id), head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
           logs = capture_log([level: :info], fn -> ImportData.import_all_datasets() end)
 
-          assert_called_exactly(HTTPoison.get(:_, :_, :_), 1)
+          assert_called_exactly(HTTPoison.get!(:_, :_, :_), 1)
 
           # for each resource, 2 head requests are potentially made
           # one to check for availability, one to compute the resource hash.
@@ -125,11 +125,11 @@ defmodule Transport.ImportDataTest do
     assert db_count(DB.Dataset) == 1
     assert db_count(DB.Resource) == 0
 
-    with_mock HTTPoison, get: http_get_mock_404(datagouv_id), head: http_head_mock() do
+    with_mock HTTPoison, get!: http_get_mock_404(datagouv_id), head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
           logs = capture_log([level: :info], fn -> ImportData.import_all_datasets() end)
-          assert_called_exactly(HTTPoison.get(:_, :_, :_), 1)
+          assert_called_exactly(HTTPoison.get!(:_, :_, :_), 1)
           assert logs =~ "all datasets have been reimported (1 failures / 1)"
         end
       end
@@ -145,7 +145,7 @@ defmodule Transport.ImportDataTest do
     assert db_count(DB.Dataset) == 1
     assert db_count(DB.Resource) == 0
 
-    with_mock HTTPoison, get: http_get_mock_200(datagouv_id), head: http_head_mock() do
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id), head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
           ImportData.import_all_datasets()
@@ -170,7 +170,7 @@ defmodule Transport.ImportDataTest do
         )
       )
 
-    with_mock HTTPoison, get: http_get_mock_200(datagouv_id, payload_2), head: http_head_mock() do
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id, payload_2), head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
           ImportData.import_all_datasets()
@@ -198,7 +198,7 @@ defmodule Transport.ImportDataTest do
         )
       )
 
-    with_mock HTTPoison, get: http_get_mock_200(datagouv_id, payload_3), head: http_head_mock() do
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id, payload_3), head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
           ImportData.import_all_datasets()
@@ -227,7 +227,7 @@ defmodule Transport.ImportDataTest do
     community_resource_title = "a_community_resource"
 
     with_mock HTTPoison,
-      get: http_get_mock_200(datagouv_id, generate_dataset_payload(datagouv_id, [])),
+      get!: http_get_mock_200(datagouv_id, generate_dataset_payload(datagouv_id, [])),
       head: http_head_mock() do
       with_mock Datagouvfr.Client.CommunityResources,
         get: fn _ -> {:ok, generate_resources_payload(community_resource_title)} end do
@@ -257,10 +257,10 @@ defmodule Transport.ImportDataTest do
       payload = :datagouv_api_get |> build() |> Jason.encode!()
 
       mock = fn _, _, _ ->
-        {:ok, %HTTPoison.Response{body: payload, status_code: 200}}
+        %HTTPoison.Response{body: payload, status_code: 200}
       end
 
-      with_mock HTTPoison, get: mock do
+      with_mock HTTPoison, get!: mock do
         logs =
           capture_log([level: :warn], fn ->
             ImportData.import_all_datasets()


### PR DESCRIPTION
Cette fonction est celle qui est lancée quotidiennement pour importer les jeux de données venant de data.gouv.fr.

Maintenant qu'elle est mise un minimum sous test, l'idée de cette PR est de la retoucher pour modifier la philosophie de son fonctionnement. 

Étant donné qu'elle lance via `async_stream_nolink` une série de process qui vont chacun importer un jeu de données, le code d'import essaye désormais de faire toutes ses étapes sans se soucier du succès ou de l'échec de celles-ci. En cas de problème, nous laissons le code crasher, et nous avons mis autour de la fonction d'import d'un dataset un `rescue`.

Celui-ci nous permet, en cas de crash de logger l'erreur qui s'est produite, et d'insérer en base un log d'échec.
