### PR TITLE
Ignorer les datasets inactifs lors de l'import quotidien

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -14,9 +14,12 @@ defmodule Transport.ImportData do
 
   @spec import_all_datasets :: :ok
   def import_all_datasets do
-    Logger.info("reimporting all datasets")
+    Logger.info("reimporting all active datasets")
 
-    datasets = Repo.all(Dataset)
+    datasets =
+      Dataset
+      |> where([d], d.is_active == true)
+      |> Repo.all()
 
     results =
       ImportTaskSupervisor


### PR DESCRIPTION
Il existe dans la table dataset un champ `is_active`. Lorsque ce champ est à `true`, le dataset n'apparait plus dans les résultats de recherche du moteur du site, sa page dédiée est toujours accessible si l'on connait son url, mais elle s'affiche avec un bandeau rouge prévenant que le jeu a été supprimé de datagouv.
[exemple](https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-en-pays-de-la-loire-gtfs)

Il y a une tâche qui tourne quotidiennement `inactive_data` et qui détecte quels sont les jeux actifs et inactifs (un jeu inactif est un jeu dont la requête `head` chez data.gouv a retourné une 404). Un jeu peut-être actif, puis inactif, puis redevenir actif (s'il a été supprimé puis recréé sur data.gouv par exemple).

Lors d'un changement de statut (actif => inactif ou inactif => actif) un mail est envoyé à l'équipe avec le titre "Jeux de données qui disparaissent".

Cette petite PR propose de ne faire l'import quotidien que sur les jeux actifs.

En effet tous les jeux inactifs ont répondu une 404 dans les 24 dernières heures. Et même dans le cas où le jeu est flaggé en base comme inactif, mais que par chance celui-ci est redevenu actif entre temps, l'import se fera, mais le jeu restera flaggé inactif jusqu'au prochain run de la tâche `inactive_data`.

On ne perd donc pas grand chose. Par contre, cela économise du travail au serveur, et va nous éviter d'avoir des lignes entières de rouge dans notre dashboard du backoffice.

![image](https://user-images.githubusercontent.com/15341118/117958852-b8bfd280-b31b-11eb-96b5-1c09a6fafe16.png)

Reste la question de comment on veut gérer ces datasets inactifs, car le champ n'est pas historisé en base. On ne sait pas si a une date donnée, un jeu était actif ou non. Donc la on va avoir pour un dataset qui devient inactif des carrés verts avant, suivis de carrés marrons après, ce qui risque de cacher un carré marron plus "grave", comme par exemple un timeout.

On peut imaginer aussi n'afficher dans le dashboard que les datasets actifs, mais là on perd l'historique des jeux actuellement inactifs, mais actifs il y a quelques jours.

J'ai l'impression que le changement de la PR est logique, mais qu'il soulève d'autres questions, comme par exemple, ne devrait on pas historiser l'aspect actif ou pas d'un dataset ? On pourrait par exemple ajouter les champ "skipped" et "reason" à la table qui log les imports et mettre skipped à true aux datasets inactifs avec un message qui va bien.

Petite PR, grand roman qui va avec :P

