### PR TITLE
mieux gérer la visualisation des gbfs 

### DIFF
--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -184,10 +184,10 @@ function removeViz (consoleMsg) {
     console.log(consoleMsg)
 }
 
-function createMap (id, resourceUrl) {
+function createMap (id, resourceUrl, resourceFormat) {
     if (resourceUrl.endsWith('.csv')) {
         createCSVmap(id, resourceUrl)
-    } else if (resourceUrl.endsWith('gbfs.json')) {
+    } else if (resourceFormat === 'gbfs' || resourceUrl.endsWith('gbfs.json')) {
         createGBFSmap(id, resourceUrl)
     } else {
         removeViz(`vizualisation of the resource ${resourceUrl} has failed : not recognized file extension`)

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -173,8 +173,14 @@ function createGBFSmap (id, resourceUrl) {
 }
 
 function removeViz (consoleMsg) {
-    const element = document.querySelector('#dataset-visualisation')
-    element.remove()
+    const vis = document.querySelector('#dataset-visualisation')
+    if (vis) {
+        vis.remove()
+    }
+    const menu = document.querySelector('#menu-item-visualisation')
+    if (menu) {
+        menu.remove()
+    }
     console.log(consoleMsg)
 }
 

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -160,7 +160,7 @@ function fillGBFSMap (resourceUrl, fg, availableDocks, map, fitBounds = false) {
                 setGBFSMarkerStyle(stations, station, 'num_docks_available')
             }
         })
-        .catch(_ => console.log('invalid geojson'))
+        .catch(e => removeViz(e))
 }
 
 function createGBFSmap (id, resourceUrl) {

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -46,15 +46,15 @@
         <div class="panel">
           <div id='map' class='leaflet-map'></div>
           <%= if displayResource.format == "gbfs" do %>
-            <div class="is-centered"><%= dgettext("page-dataset-details", "Real-time visualization of ")%> "<%= get_resource_to_display(@dataset).title %>".</div>
+            <div class="is-centered"><%= dgettext("page-dataset-details", "Real-time visualization of ")%> "<%= displayResource.title %>".</div>
           <% else %>
-            <div class="is-centered"><%= dgettext("page-dataset-details", "Visualization of the resource")%> "<%= get_resource_to_display(@dataset).title %>".</div>
+            <div class="is-centered"><%= dgettext("page-dataset-details", "Visualization of the resource")%> "<%= displayResource.title %>".</div>
           <% end %>
         </div>
         <script src="<%= static_path(@conn, "/js/resourceviz.js") %>"></script>
         <script>
           document.addEventListener("DOMContentLoaded", function() {
-            createMap('map', "<%= get_resource_to_display(@dataset).url %>")
+            createMap('map', "<%= displayResource.url %>", "<%= displayResource.format %>")
           })
         </script>
       </section>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -18,7 +18,7 @@
     <div class="dataset-menu">
       <div class="menu-item"><a href="#dataset-top">Description</a></div>
       <%= if not is_nil(get_resource_to_display(@dataset)) do %>
-        <div class="menu-item"><a href="#dataset-visualisation"><%= dgettext("page-dataset-details", "Visualization")%></a></div>
+        <div id="menu-item-visualisation" class="menu-item"><a href="#dataset-visualisation"><%= dgettext("page-dataset-details", "Visualization")%></a></div>
       <% end %>
       <div class="menu-item"><a href="#dataset-resources"><%= dgettext("page-dataset-details", "Resources")%></a></div>
       <%= unless is_nil(@reuses) or @reuses == [] do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -320,7 +320,7 @@ defmodule TransportWeb.DatasetView do
 
   def get_resource_to_display(%Dataset{type: "bike-sharing", resources: resources}) do
     resources
-    |> Enum.filter(fn r -> String.ends_with?(r.url, "gbfs.json") end)
+    |> Enum.filter(fn r -> r.format == "gbfs" or String.ends_with?(r.url, "gbfs.json") end)
     |> Enum.reject(fn r -> r.is_community_resource end)
     |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end


### PR DESCRIPTION
Suite au commentaire de @Miryad3108 , je règle quelques points concernant la visualisation des gbfs :
- en cas de soucis d'affichage avec un gbfs, on avait une carte vide. Maintenant je supprime la carte en entier.
- il restait la rubrique visualisation dans le menu à gauche de la page dataset en question, je supprime aussi la ligne "visualisation" du menu
- un fichier était reconnu comme étant un gbfs si son url se terminait par "gbfs.json", puisque c'est le nom du fichier décrit dans la spec. On a ici un cas de fichier gbfs.json qui est servi depuis une url qui ne se termine pas comme ça. On peut donc aussi se servir du type de fichier déclaré dans data.gouv (type gbfs)

Ensuite malheureusement, ces fix ne règlent pas le problème du dataset https://transport.data.gouv.fr/datasets/velyceos-electriques-en-libre-service-sur-la-carene/ , car leur serveur d'API n'inclut pas les headers `Acces-Control-Allow-Origin`, ce qui fait que nous ne pouvons pas faire de requête depuis le navigateur de la personne qui navigue sur notre site. Il faudrait leur demander de rajouter ce header pour autoriser les requêtes venant de n'importe quelle origine.