### PR TITLE
Modification "carsharing-area" en "carpooling-area"

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -59,7 +59,7 @@ defmodule DB.Dataset do
   def type_to_str_map,
     do: %{
       "public-transit" => dgettext("dataset", "Public transit timetable"),
-      "carsharing-areas" => dgettext("dataset", "Carsharing areas"),
+      "carpooling-areas" => dgettext("dataset", "Carpooling areas"),
       "stops-ref" => dgettext("dataset", "Stops referential"),
       "charging-stations" => dgettext("dataset", "Charging stations"),
       "micro-mobility" => dgettext("dataset", "Micro mobility"),

--- a/apps/db/priv/gettext/dataset.pot
+++ b/apps/db/priv/gettext/dataset.pot
@@ -19,7 +19,7 @@ msgid "Bike sharing"
 msgstr ""
 
 #, elixir-format
-msgid "Carsharing areas"
+msgid "Carpooling areas"
 msgstr ""
 
 #, elixir-format

--- a/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -20,7 +20,7 @@ msgid "Bike sharing"
 msgstr ""
 
 #, elixir-format
-msgid "Carsharing areas"
+msgid "Carpooling areas"
 msgstr ""
 
 #, elixir-format

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -20,7 +20,7 @@ msgid "Bike sharing"
 msgstr "Vélo partage"
 
 #, elixir-format
-msgid "Carsharing areas"
+msgid "Carpooling areas"
 msgstr "Lieux de covoiturage"
 
 #, elixir-format

--- a/apps/db/priv/repo/migrations/20190130145745_rename_transit_types.exs
+++ b/apps/db/priv/repo/migrations/20190130145745_rename_transit_types.exs
@@ -4,14 +4,14 @@ defmodule DB.Repo.Migrations.RenameTransitTypes do
   def up do
     execute "UPDATE dataset set type='public-transit' where type='DB-statique'"
     execute "UPDATE dataset set type='micro-mobility' where type='bike sharing'"
-    execute "UPDATE dataset set type='carsharing-areas' where type='aires-covoiturage'"
+    execute "UPDATE dataset set type='carpooling-areas' where type='aires-covoiturage'"
     execute "UPDATE dataset set type='charging-stations' where type='borne-recharge'"
   end
 
   def down do
     execute "UPDATE dataset set type='DB-statique' where type='public-transit'"
     execute "UPDATE dataset set type='bike sharing' where type='micro-mobility'"
-    execute "UPDATE dataset set type='aires-covoiturage' where type='carsharing-areas'"
+    execute "UPDATE dataset set type='aires-covoiturage' where type='carpooling-areas'"
     execute "UPDATE dataset set type='borne-recharge' where type='charging-stations'"
   end
 end

--- a/apps/db/priv/repo/migrations/20190130145745_rename_transit_types.exs
+++ b/apps/db/priv/repo/migrations/20190130145745_rename_transit_types.exs
@@ -4,14 +4,14 @@ defmodule DB.Repo.Migrations.RenameTransitTypes do
   def up do
     execute "UPDATE dataset set type='public-transit' where type='DB-statique'"
     execute "UPDATE dataset set type='micro-mobility' where type='bike sharing'"
-    execute "UPDATE dataset set type='carpooling-areas' where type='aires-covoiturage'"
+    execute "UPDATE dataset set type='carsharing-areas' where type='aires-covoiturage'"
     execute "UPDATE dataset set type='charging-stations' where type='borne-recharge'"
   end
 
   def down do
     execute "UPDATE dataset set type='DB-statique' where type='public-transit'"
     execute "UPDATE dataset set type='bike sharing' where type='micro-mobility'"
-    execute "UPDATE dataset set type='aires-covoiturage' where type='carpooling-areas'"
+    execute "UPDATE dataset set type='aires-covoiturage' where type='carsharing-areas'"
     execute "UPDATE dataset set type='borne-recharge' where type='charging-stations'"
   end
 end

--- a/apps/db/priv/repo/migrations/20210615132842_charsharing_to_carpooling.exs
+++ b/apps/db/priv/repo/migrations/20210615132842_charsharing_to_carpooling.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.CharsharingToCarpooling do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE dataset set type='carpooling-areas' where type='carsharing-areas'"
+  end
+
+  def down do
+    execute "UPDATE dataset set type='carsharing-areas' where type='carpooling-areas'"
+  end
+end

--- a/apps/transport/lib/transport_web/templates/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.eex
@@ -103,11 +103,11 @@
         <div><%= dngettext("page-index", "dataset", "datasets", @count_by_type["bike-sharing"] || 0) %></div>
       </div>
     </a>
-    <a class="tile" href="<%= dataset_path(@conn, :index, type: "carsharing-areas") %>">
+    <a class="tile" href="<%= dataset_path(@conn, :index, type: "carpooling-areas") %>">
                           <img class="tile__icon" src="<%= static_path(@conn, "/images/icons/car.svg") %>" alt="" />
     <div class="tile__text">
       <h4 class=""><%= dgettext("page-index", "Car-sharing areas") %></h4>
-      <div><%= dngettext("page-index", "dataset", "datasets", @count_by_type["carsharing-areas"] || 0) %></div>
+      <div><%= dngettext("page-index", "dataset", "datasets", @count_by_type["carpooling-areas"] || 0) %></div>
     </div>
   </a>
   <a class="tile" href="<%= dataset_path(@conn, :index, type: "charging-stations") %>">

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -171,7 +171,7 @@ defmodule TransportWeb.DatasetView do
       "public-transit" => "/images/icons/bus.svg",
       "bike-sharing" => "/images/icons/bicycle.svg",
       "bike-path" => "/images/icons/bike-path.svg",
-      "carsharing-areas" => "/images/icons/car.svg",
+      "carpooling-areas" => "/images/icons/car.svg",
       "charging-stations" => "/images/icons/charge-station.svg",
       "air-transport" => "/images/icons/plane.svg",
       "road-network" => "/images/icons/map.svg",
@@ -308,7 +308,7 @@ defmodule TransportWeb.DatasetView do
   """
   @spec get_resource_to_display(%Dataset{}) :: Resource.t() | nil
   def get_resource_to_display(%Dataset{type: type, resources: resources})
-      when type == "carsharing-areas" or type == "private-parking" or type == "charging-stations" do
+      when type == "carpooling-areas" or type == "private-parking" or type == "charging-stations" do
     resources
     |> Enum.filter(fn r -> r.format == "csv" end)
     |> Enum.reject(fn r -> r.is_community_resource end)

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -38,7 +38,7 @@ msgstr ""
 msgid "public-transit"
 msgstr ""
 
-msgid "carsharing-areas"
+msgid "carpooling-areas"
 msgstr ""
 
 msgid "stops-ref"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "public-transit"
 msgstr "Public transit"
 
-msgid "carsharing-areas"
+msgid "carpooling-areas"
 msgstr "Car sharing areas"
 
 msgid "stops-ref"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -37,7 +37,7 @@ msgstr "Échec à l’ajout du jeu de données"
 msgid "public-transit"
 msgstr "Transport en communs"
 
-msgid "carsharing-areas"
+msgid "carpooling-areas"
 msgstr "Lieux de covoiturage"
 
 msgid "stops-ref"


### PR DESCRIPTION
Modification "carsharing-area" en "carpooling-area" pour éviter les confusions quand il y aura des données d'autopartage 