### PR TITLE
Correctif proxy GBFS (arithmetic error)

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
@@ -97,7 +97,7 @@ defmodule GBFS.JCDecauxController do
                is_installed: if(s["status"] == "OPEN", do: 1, else: 0),
                is_renting: if(s["status"] == "OPEN", do: 1, else: 0),
                is_returning: if(s["status"] == "OPEN", do: 1, else: 0),
-               last_reported: if(last_update = s["last_update"], do: last_update / 1000, else: nil)
+               last_reported: if(last_update = s["last_update"], do: div(last_update, 1000), else: nil)
              }
            end)
        }}

--- a/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/jcdecaux_controller.ex
@@ -97,7 +97,7 @@ defmodule GBFS.JCDecauxController do
                is_installed: if(s["status"] == "OPEN", do: 1, else: 0),
                is_renting: if(s["status"] == "OPEN", do: 1, else: 0),
                is_returning: if(s["status"] == "OPEN", do: 1, else: 0),
-               last_reported: s["last_update"] / 1000
+               last_reported: if(last_update = s["last_update"], do: last_update / 1000, else: nil)
              }
            end)
        }}


### PR DESCRIPTION
Il peut arriver que le flux JCDecaux remonte le `last_update` d'une station à `null`. C'est le cas depuis plusieurs jours (voir #1653).

Cette PR rend le code plus défensif par rapport à l'input fourni par l'API JCDecaux, et gère le cas `null` correctement.

L'explication du besoin de diviser par 1000 est ici https://github.com/etalab/transport-site/issues/898 (secondes plutôt que millisecondes).

La sortie était en flottant `1622454039.0` car `x / 1000` donne un flottant. J'ai modifié ce point pour utiliser une division entière.

### Point d'attention

On note que ce ticket montre bien que "faire proxy" impose un soin plus important: suivi des ops (#1654) et des erreurs, code plus défensif, car en faisant ici une conversion, et en introduisant une erreur à l'intérieur, on crée une indisponibilité là où elle n'existe pas chez le fournisseur.
