### PR TITLE
Gestion des discussions : mieux gérer l'échec d'un post qui échoue

### DIFF
--- a/apps/transport/lib/transport_web/controllers/discussion_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/discussion_controller.ex
@@ -34,7 +34,7 @@ defmodule TransportWeb.DiscussionController do
         |> put_flash(:info, dgettext("page-dataset-details", "Answer published"))
 
       {:error, error} ->
-        Logger.error("When publishing an answer: #{error}")
+        Logger.error("When publishing an answer: #{inspect(error)}")
 
         conn
         |> put_flash(:error, dgettext("page-dataset-details", "Unable to publish the answer"))


### PR DESCRIPTION
Il manquait un `inspect()`, ce qui nous faisait une 500.

Je me demande quand même pourquoi le post a échoué, mais ça a aussi pu venir de data.gouv.fr

closes #1652 