### PR TITLE
"warnings as errors" pour les tests transport

### DIFF
--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -12,3 +12,8 @@ ExUnit.start()
 ExVCR.Config.cassette_library_dir("test/fixture/cassettes")
 
 Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, :manual)
+
+# Temporary solution to consider warnings as errors during tests,
+# until `mix test --warning-as--errors` is available (Elixir 1.12+)
+# https://github.com/elixir-lang/elixir/issues/3223#issuecomment-751876927
+Code.put_compiler_option(:warnings_as_errors, true)

--- a/apps/transport/test/transport/comments_checker_test.exs
+++ b/apps/transport/test/transport/comments_checker_test.exs
@@ -28,7 +28,7 @@ defmodule Transport.CommentsCheckerTest do
     # when the dataset is created, no comment timestamp is stored
     assert_dataset_ts(dataset_id, nil)
 
-    get_mock = fn url, [], _ ->
+    get_mock = fn _url, [], _ ->
       {:ok,
        %{
          "data" => [
@@ -68,7 +68,7 @@ defmodule Transport.CommentsCheckerTest do
     end
 
     # we add a new comment
-    get_mock = fn url, [], _ ->
+    get_mock = fn _url, [], _ ->
       {:ok,
        %{
          "data" => [


### PR DESCRIPTION
Cette petite PR fait en sorte que si on laisse des warnings dans le code des tests de l'application "transport" (celle qu'on touche le plus souvent), le CI bloquera, pour qu'on pense à les enlever.

Voir https://github.com/elixir-lang/elixir/issues/3223#issuecomment-751876927

Je ne vais pas plus loin dans l'exercice, quand on aura migré vers Elixir 1.12 (https://hexdocs.pm/mix/1.12/Mix.Tasks.Test.html), on pourra directement utiliser `mix test --warning-as-errors`.

Je corrige aussi deux warnings qui étaient présent (objectif dépolluer l'output des tests, ce qui sera sympa aussi pour les futurs développeurs).