### PR TITLE
Correction de la détection des ressources non disponibles

### DIFF
--- a/apps/shared/test/http_stream_v2_test.exs
+++ b/apps/shared/test/http_stream_v2_test.exs
@@ -25,79 +25,81 @@ defmodule HTTPStreamV2.Test do
     assert headers == [{"hello", "header"}]
   end
 
-  test "get a request status by streaming it", %{bypass: bypass} do
-    Bypass.expect(bypass, "GET", "/", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_header("hello", "header")
-      |> Plug.Conn.resp(200, "Contenu de la réponse")
-    end)
+  describe "get a request status by streaming it" do
+    test "simple 200 response", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("hello", "header")
+        |> Plug.Conn.resp(200, "Contenu de la réponse")
+      end)
 
-    url = "http://localhost:#{bypass.port}/"
+      url = "http://localhost:#{bypass.port}/"
 
-    result = HTTPStreamV2.fetch_status(url)
-    assert result == {:ok, %{status: 200}}
+      result = HTTPStreamV2.fetch_status(url)
+      assert result == {:ok, %{status: 200}}
 
-    result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
-    assert result_follow_redirect == {:ok, 200}
-  end
+      result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
+      assert result_follow_redirect == {:ok, 200}
+    end
 
-  test "get a redirect request status", %{bypass: bypass} do
-    url = "http://localhost:#{bypass.port}/"
+    test "redirect response", %{bypass: bypass} do
+      url = "http://localhost:#{bypass.port}/"
 
-    Bypass.expect(bypass, "GET", "/", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_header("Location", "#{url}here")
-      |> Plug.Conn.resp(301, "va voir ailleurs si j'y suis")
-    end)
+      Bypass.expect(bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("Location", "#{url}here")
+        |> Plug.Conn.resp(301, "va voir ailleurs si j'y suis")
+      end)
 
-    Bypass.expect_once(bypass, "GET", "/here", fn conn ->
-      conn
-      |> Plug.Conn.resp(200, "gagné")
-    end)
+      Bypass.expect_once(bypass, "GET", "/here", fn conn ->
+        conn
+        |> Plug.Conn.resp(200, "gagné")
+      end)
 
-    result = HTTPStreamV2.fetch_status(url)
-    assert result == {:ok, %{status: 301, location: "#{url}here"}}
+      result = HTTPStreamV2.fetch_status(url)
+      assert result == {:ok, %{status: 301, location: "#{url}here"}}
 
-    # get the status following redirection
-    result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
-    assert result_follow_redirect == {:ok, 200}
-  end
+      # get the status following redirection
+      result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
+      assert result_follow_redirect == {:ok, 200}
+    end
 
-  test "more redirects than allowed", %{bypass: bypass} do
-    url = "http://localhost:#{bypass.port}/"
+    test "more redirects than allowed", %{bypass: bypass} do
+      url = "http://localhost:#{bypass.port}/"
 
-    # setup a test with 2 successive redirects
-    Bypass.expect(bypass, "GET", "/", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_header("Location", "#{url}1")
-      |> Plug.Conn.resp(301, "")
-    end)
+      # setup a test with 2 successive redirects
+      Bypass.expect(bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("Location", "#{url}1")
+        |> Plug.Conn.resp(301, "")
+      end)
 
-    Bypass.expect(bypass, "GET", "/1", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_header("Location", "#{url}2")
-      |> Plug.Conn.resp(301, "")
-    end)
+      Bypass.expect(bypass, "GET", "/1", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("Location", "#{url}2")
+        |> Plug.Conn.resp(301, "")
+      end)
 
-    Bypass.expect(bypass, "GET", "/2", fn conn ->
-      conn
-      |> Plug.Conn.resp(404, "")
-    end)
+      Bypass.expect(bypass, "GET", "/2", fn conn ->
+        conn
+        |> Plug.Conn.resp(404, "")
+      end)
 
-    # test with 1 redirect allowed
-    assert {:error, "maximum number of redirect reached"} == HTTPStreamV2.fetch_status_follow_redirect(url, 1)
+      # test with 1 redirect allowed
+      assert {:error, "maximum number of redirect reached"} == HTTPStreamV2.fetch_status_follow_redirect(url, 1)
 
-    # test with 2 redirects allowed
-    assert {:ok, 404} == HTTPStreamV2.fetch_status_follow_redirect(url, 2)
-  end
+      # test with 2 redirects allowed
+      assert {:ok, 404} == HTTPStreamV2.fetch_status_follow_redirect(url, 2)
+    end
 
-  test "301 response, but location header not provided", %{bypass: bypass} do
-        Bypass.expect(bypass, "GET", "/", fn conn ->
-      conn
-      |> Plug.Conn.resp(301, "Mais ou est le header ?")
-    end)
+    test "redirect response, but location header not provided", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/", fn conn ->
+        conn
+        |> Plug.Conn.resp(301, "Mais ou est le header ?")
+      end)
 
-    url = "http://localhost:#{bypass.port}/"
-    assert {:ok, 301} == HTTPStreamV2.fetch_status_follow_redirect(url)
+      url = "http://localhost:#{bypass.port}/"
+      assert {:ok, 301} == HTTPStreamV2.fetch_status_follow_redirect(url)
+    end
   end
 end

--- a/apps/shared/test/http_stream_v2_test.exs
+++ b/apps/shared/test/http_stream_v2_test.exs
@@ -50,12 +50,10 @@ defmodule HTTPStreamV2.Test do
       |> Plug.Conn.resp(301, "va voir ailleurs si j'y suis")
     end)
 
-
     Bypass.expect_once(bypass, "GET", "/here", fn conn ->
       conn
       |> Plug.Conn.resp(200, "gagné")
     end)
-
 
     result = HTTPStreamV2.fetch_status(url)
     assert result == {:ok, %{status: 301, location: "#{url}here"}}

--- a/apps/shared/test/http_stream_v2_test.exs
+++ b/apps/shared/test/http_stream_v2_test.exs
@@ -24,4 +24,82 @@ defmodule HTTPStreamV2.Test do
 
     assert headers == [{"hello", "header"}]
   end
+
+  test "get a request status by streaming it", %{bypass: bypass} do
+    Bypass.expect(bypass, "GET", "/", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("hello", "header")
+      |> Plug.Conn.resp(200, "Contenu de la réponse")
+    end)
+
+    url = "http://localhost:#{bypass.port}/"
+
+    result = HTTPStreamV2.fetch_status(url)
+    assert result == {:ok, %{status: 200}}
+
+    result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
+    assert result_follow_redirect == {:ok, 200}
+  end
+
+  test "get a redirect request status", %{bypass: bypass} do
+    url = "http://localhost:#{bypass.port}/"
+
+    Bypass.expect(bypass, "GET", "/", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("Location", "#{url}here")
+      |> Plug.Conn.resp(301, "va voir ailleurs si j'y suis")
+    end)
+
+
+    Bypass.expect_once(bypass, "GET", "/here", fn conn ->
+      conn
+      |> Plug.Conn.resp(200, "gagné")
+    end)
+
+
+    result = HTTPStreamV2.fetch_status(url)
+    assert result == {:ok, %{status: 301, location: "#{url}here"}}
+
+    # get the status following redirection
+    result_follow_redirect = HTTPStreamV2.fetch_status_follow_redirect(url)
+    assert result_follow_redirect == {:ok, 200}
+  end
+
+  test "more redirects than allowed", %{bypass: bypass} do
+    url = "http://localhost:#{bypass.port}/"
+
+    # setup a test with 2 successive redirects
+    Bypass.expect(bypass, "GET", "/", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("Location", "#{url}1")
+      |> Plug.Conn.resp(301, "")
+    end)
+
+    Bypass.expect(bypass, "GET", "/1", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("Location", "#{url}2")
+      |> Plug.Conn.resp(301, "")
+    end)
+
+    Bypass.expect(bypass, "GET", "/2", fn conn ->
+      conn
+      |> Plug.Conn.resp(404, "")
+    end)
+
+    # test with 1 redirect allowed
+    assert {:error, "maximum number of redirect reached"} == HTTPStreamV2.fetch_status_follow_redirect(url, 1)
+
+    # test with 2 redirects allowed
+    assert {:ok, 404} == HTTPStreamV2.fetch_status_follow_redirect(url, 2)
+  end
+
+  test "301 response, but location header not provided", %{bypass: bypass} do
+        Bypass.expect(bypass, "GET", "/", fn conn ->
+      conn
+      |> Plug.Conn.resp(301, "Mais ou est le header ?")
+    end)
+
+    url = "http://localhost:#{bypass.port}/"
+    assert {:ok, 301} == HTTPStreamV2.fetch_status_follow_redirect(url)
+  end
 end

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -1,0 +1,26 @@
+defmodule Transport.AvailabilityChecker do
+  @moduledoc """
+  A module used to check if a remote file is "available" through a GET a request.
+  Gives a response even if remote server does not support HEAD requests (405 response)
+  """
+
+  @spec available?(map() | binary()) :: boolean
+  def available?(target, use_stream_method \\ false)
+
+  def available?(%{"url" => url}, use_stream_method), do: available?(url, use_stream_method)
+
+  def available?(url, false) when is_binary(url) do
+    case HTTPoison.head(url, [], follow_redirect: true) do
+      {:ok, %HTTPoison.Response{status_code: 200}} -> true
+      {:ok, %HTTPoison.Response{status_code: 405}} -> available?(url, _use_stream_method = true)
+      _ -> false
+    end
+  end
+
+  def available?(url, _use_stream_method = true) do
+    case HTTPStreamV2.fetch_status_follow_redirect(url) do
+      {:ok, 200} -> true
+      _ -> false
+    end
+  end
+end

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -5,19 +5,19 @@ defmodule Transport.AvailabilityChecker do
   """
 
   @spec available?(map() | binary()) :: boolean
-  def available?(target, use_stream_method \\ false)
+  def available?(target, use_http_streaming \\ false)
 
-  def available?(%{"url" => url}, use_stream_method), do: available?(url, use_stream_method)
+  def available?(%{"url" => url}, use_http_streaming), do: available?(url, use_http_streaming)
 
   def available?(url, false) when is_binary(url) do
     case HTTPoison.head(url, [], follow_redirect: true) do
       {:ok, %HTTPoison.Response{status_code: 200}} -> true
-      {:ok, %HTTPoison.Response{status_code: 405}} -> available?(url, _use_stream_method = true)
+      {:ok, %HTTPoison.Response{status_code: 405}} -> available?(url, _use_http_streaming = true)
       _ -> false
     end
   end
 
-  def available?(url, true = _use_stream_method) do
+  def available?(url, true = _use_http_streaming) do
     case HTTPStreamV2.fetch_status_follow_redirect(url) do
       {:ok, 200} -> true
       _ -> false

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -17,7 +17,7 @@ defmodule Transport.AvailabilityChecker do
     end
   end
 
-  def available?(url, _use_stream_method = true) do
+  def available?(url, true = _use_stream_method) do
     case HTTPStreamV2.fetch_status_follow_redirect(url) do
       {:ok, 200} -> true
       _ -> false

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -1,0 +1,56 @@
+defmodule Transport.AvailabilityCheckerTest do
+  use ExUnit.Case
+  import Mock
+  alias Transport.AvailabilityChecker
+
+  test "head supported, 200", _ do
+    mock = fn _url, [], _options ->
+      {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
+    end
+
+    with_mock HTTPoison, head: mock do
+      assert AvailabilityChecker.available?(%{"url" => "url200"})
+      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
+    end
+  end
+
+  test "head supported, 400", _ do
+    mock = fn _url, [], _options ->
+      {:ok, %HTTPoison.Response{body: "{}", status_code: 400}}
+    end
+
+    with_mock HTTPoison, head: mock do
+      refute AvailabilityChecker.available?(%{"url" => "url400"})
+      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
+    end
+  end
+
+  test "head supported, 500", _ do
+    mock = fn _url, [], _options ->
+      {:ok, %HTTPoison.Response{body: "{}", status_code: 500}}
+    end
+
+    with_mock HTTPoison, head: mock do
+      refute AvailabilityChecker.available?(%{"url" => "url500"})
+      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
+    end
+  end
+
+  test "head NOT supported, fallback on stream method", _ do
+    httpoison_mock = fn _url, [], _options ->
+      {:ok, %HTTPoison.Response{body: "{}", status_code: 405}}
+    end
+
+    streamer_mock = fn _url ->
+      {:ok, 200}
+    end
+
+    with_mock HTTPoison, head: httpoison_mock do
+      with_mock HTTPStreamV2, fetch_status_follow_redirect: streamer_mock do
+        assert AvailabilityChecker.available?(%{"url" => "url405"})
+        assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
+        assert_called_exactly(HTTPStreamV2.fetch_status_follow_redirect(:_), 1)
+      end
+    end
+  end
+end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -274,24 +274,4 @@ defmodule Transport.ImportDataTest do
       end
     end
   end
-
-  test "the available? function with HTTP request", _ do
-    mock = fn url, [], options ->
-      # temporary fix for https://github.com/etalab/transport-site/issues/1564
-      assert options == [ssl: [versions: [:"tlsv1.2"]]]
-
-      case url do
-        'url200' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
-        'url300' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 300}}
-        'url400' -> {:ok, %HTTPoison.Response{body: "{}", status_code: 400}}
-      end
-    end
-
-    with_mock HTTPoison, head: mock do
-      assert ImportData.available?(%{"url" => 'url200'})
-      assert ImportData.available?(%{"url" => 'url300'})
-      refute ImportData.available?(%{"url" => 'url400'})
-      assert_called_exactly(HTTPoison.head(:_, :_, :_), 3)
-    end
-  end
 end


### PR DESCRIPTION
closes #1665
closes #1538 

L'idée est de supprimer tous les cas particuliers et de traiter toutes les ressources de la même manière : 

- on fait une requête head, en suivant les éventuelles redirections pour voir si la ressources est bien disponible
- en cas de réponse 405 (signifiant que la méthode HEAD n'est pas supportée), on passe au plan B : on fait un GET en streamant la réponse. Dès qu'on a l'information sur le statut de la réponse, on arrête le streaming pour gagner du temps.

Question à laquelle je viens de penser : quid des ressources sur ftp ? (voir #1409)