### PR TITLE
Ajout d'une action on_delete à la table dataset_communes

### DIFF
--- a/apps/db/priv/repo/migrations/20210622150648_dataset_communes_on_delete.exs
+++ b/apps/db/priv/repo/migrations/20210622150648_dataset_communes_on_delete.exs
@@ -1,0 +1,100 @@
+defmodule DB.Repo.Migrations.DatasetCommunesOnDelete do
+@moduledoc """
+  the on_delete action were misplaced in 20200116092044_link_dataset_commune.exs
+  but you cannot alter a table when a view depends on that table. So I need to delete the dataset_geographic_view and
+  its trigger, alter the table dataset_communes, and recreate the view.
+  The code to create the view is taken from the previous migration 20210622150648_dataset_communes_on_delete.exs
+"""
+  use Ecto.Migration
+
+  def up do
+    drop_materialized_view()
+
+    drop constraint(:dataset_communes, "dataset_communes_commune_id_fkey")
+    drop constraint(:dataset_communes, "dataset_communes_dataset_id_fkey")
+    alter table(:dataset_communes) do
+        modify :dataset_id, references(:dataset, on_delete: :delete_all)
+        modify :commune_id, references(:commune, on_delete: :delete_all)
+    end
+
+    recreate_materialized_view()
+  end
+
+  def down do
+    drop_materialized_view()
+
+    drop constraint(:dataset_communes, "dataset_communes_commune_id_fkey")
+    drop constraint(:dataset_communes, "dataset_communes_dataset_id_fkey")
+    alter table(:dataset_communes) do
+        modify :dataset_id, references(:dataset)
+        modify :commune_id, references(:commune)
+    end
+
+    recreate_materialized_view()
+  end
+
+  def drop_materialized_view() do
+    execute("DROP TRIGGER refresh_dataset_geographic_view_trigger ON dataset;")
+    execute("DROP FUNCTION refresh_dataset_geographic_view;")
+    execute("DROP MATERIALIZED VIEW dataset_geographic_view;")
+  end
+
+  def recreate_materialized_view() do
+    execute("""
+      CREATE MATERIALIZED VIEW dataset_geographic_view AS
+      SELECT
+        id as dataset_id,
+        COALESCE(
+          -- We take either directly the region
+          region_id,
+          -- Or the region of the aom
+          (SELECT region_id FROM aom WHERE aom.id = aom_id),
+          -- Or the region of a random city linked to the dataset
+          (SELECT c.region_id
+            FROM dataset_communes dc
+            LEFT JOIN commune c
+            ON dc.commune_id = c.id
+            WHERE dc.dataset_id = dataset.id
+            order BY aom_res_id desc
+            LIMIT 1
+          )
+        ) as region_id,
+        COALESCE(
+          (SELECT aom.geom FROM aom WHERE aom.id = aom_id),
+          (SELECT region.geom FROM region WHERE region.id = region_id),
+          -- If the dataset is linked to cities, we get the union of the cities's geometry
+          (SELECT
+            ST_UNION(commune.geom)
+            FROM commune
+            LEFT JOIN dataset_communes ON commune.id = dataset_communes.commune_id
+            WHERE dataset_communes.dataset_id = dataset.id
+          )
+        ) as geom
+      FROM dataset
+      WITH DATA;
+      """)
+
+    # Add an index on dataset_id since we'll often make a join on this
+    execute("CREATE INDEX dataset_id_idx ON dataset_geographic_view (dataset_id);")
+
+    # Define a trigger function to refresh the materialized view
+    execute("""
+      CREATE OR REPLACE FUNCTION refresh_dataset_geographic_view()
+      RETURNS trigger AS $$
+      BEGIN
+        REFRESH MATERIALIZED VIEW dataset_geographic_view;
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    # Call of the trigger
+    execute("""
+      CREATE TRIGGER refresh_dataset_geographic_view_trigger
+      AFTER INSERT OR UPDATE OR DELETE
+      ON dataset
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE refresh_dataset_geographic_view();
+    """)
+  end
+end

--- a/apps/db/priv/repo/migrations/20210622150648_dataset_communes_on_delete.exs
+++ b/apps/db/priv/repo/migrations/20210622150648_dataset_communes_on_delete.exs
@@ -33,13 +33,13 @@ defmodule DB.Repo.Migrations.DatasetCommunesOnDelete do
     recreate_materialized_view()
   end
 
-  def drop_materialized_view() do
+  def drop_materialized_view do
     execute("DROP TRIGGER refresh_dataset_geographic_view_trigger ON dataset;")
     execute("DROP FUNCTION refresh_dataset_geographic_view;")
     execute("DROP MATERIALIZED VIEW dataset_geographic_view;")
   end
 
-  def recreate_materialized_view() do
+  def recreate_materialized_view do
     execute("""
       CREATE MATERIALIZED VIEW dataset_geographic_view AS
       SELECT

--- a/apps/db/test/db_dataset_test.exs
+++ b/apps/db/test/db_dataset_test.exs
@@ -4,6 +4,7 @@ defmodule DB.DatasetDBTest do
   """
   use DB.DatabaseCase, cleanup: [:datasets]
   alias DB.Repo
+  import TransportWeb.Factory
 
   test "delete_parent_dataset" do
     parent_dataset = Repo.insert!(%Dataset{})
@@ -18,6 +19,24 @@ defmodule DB.DatasetDBTest do
     # after parent deletion, the aom should have a nil parent_dataset
     linked_aom = Repo.get!(AOM, linked_aom.id)
     assert is_nil(linked_aom.parent_dataset_id)
+  end
+
+  test "delete dataset associated to a commune" do
+    commune = insert(:commune)
+
+    dataset =
+      insert(:dataset)
+      |> Repo.preload(:communes)
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:communes, [commune])
+      |> Repo.update!()
+
+    # check the assoc succeeded
+    [associated_commune] = dataset.communes
+    assert associated_commune.id == commune.id
+
+    # the deletion will raise if no on_delete action is defined because of the presence of a foreign key
+    Repo.delete!(dataset)
   end
 
   describe "changeset of a dataset" do

--- a/apps/db/test/db_dataset_test.exs
+++ b/apps/db/test/db_dataset_test.exs
@@ -25,7 +25,8 @@ defmodule DB.DatasetDBTest do
     commune = insert(:commune)
 
     dataset =
-      insert(:dataset)
+      :dataset
+      |> insert()
       |> Repo.preload(:communes)
       |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:communes, [commune])

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -42,6 +42,13 @@ defmodule TransportWeb.Factory do
     }
   end
 
+  def commune_factory do
+    %DB.Commune{
+      nom: "Ballans",
+      insee: "17031"
+    }
+  end
+
   # Non-Ecto stuff, for now kept here for convenience
 
   def datagouv_api_get_factory do


### PR DESCRIPTION
La table dataset_communes permet de faire une relation many_to_many entre la table dataset et la table communes.
Sauf que lorsque celle-ci a été crée, il y a eu une coquille  dans l'emplacement du on_delete
```
      add(:dataset_id, references(:dataset), on_delete: :delete_all)
```

au lieu de 

```
      add(:dataset_id, references(:dataset, on_delete: :delete_all))
```
juste la parenthèse qui ferme au mauvais endroit.

Je fais donc ici une migration qui altère la table et qui rajoute le on_delete qui va bien.
Seul petit hic : on ne peut pas altérer une table lorsqu'une view en dépend.

Voir https://stackoverflow.com/questions/62793360/error-cannot-alter-type-of-a-column-used-by-a-view-or-rule-detail-rule-return par exemple.

Je vais donc récupérer le code qui a permis de créer la vue en question, je drop la vue, je modifie la table dataset_communes et je recréé la vue à l'identique.

J'ai testé en local et j'arrive à supprimer après migration le dataset récalcitrant, cf issue liée.

closes #1677