### PR TITLE
Ajout test détection logos cassés et correctif logo

### DIFF
--- a/apps/transport/priv/reusers.csv
+++ b/apps/transport/priv/reusers.csv
@@ -21,7 +21,7 @@ cityway.png;Cityway;https://www.cityway.fr
 api_tux.jpg;APITUX;http://www.apitux.com/
 les-voitures-com-logo.png;Les Voitures.Com;https://lesvoitures.fr/
 metis.png;Metis;https://www.metis-reseaux.fr
-mobireport.svg;Mobireport;https://www.mobireport.fr/
+mobireport-logo.svg;Mobireport;https://www.mobireport.fr/
 comparabus.png;Comparabus;https://www.comparabus.com
 1km_a_pied.gif;1km à Pied;https://www.1kmapied.com/
 karos.png;Karos;https://www.karos.fr

--- a/apps/transport/test/transport/csv_documents_test.exs
+++ b/apps/transport/test/transport/csv_documents_test.exs
@@ -1,0 +1,15 @@
+defmodule Transport.CSVDocumentsTest do
+  use ExUnit.Case
+
+  test "ensures that all referenced logos do exist" do
+    Transport.CSVDocuments.reusers()
+    |> Enum.each(fn %{"image" => image} ->
+      path =
+        __DIR__
+        |> Path.join("/../../client/images/logos")
+        |> Path.join(image)
+
+      assert File.exists?(path)
+    end)
+  end
+end


### PR DESCRIPTION
J'ai introduit un chemin incorrect suite à un commit non poussé dans #1716.

Cette PR ajoute un test rapide qui détectera ces soucis dès la PR, pour éviter que ça ne se reproduise.