### PR TITLE
Add the paging feature for Community Resources API.

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -119,7 +119,7 @@ defmodule Datagouvfr.Client.API do
   def fetch_all_pages!(path, method \\ :get) do
     path
     |> Datagouvfr.Client.API.stream(method)
-    |> Stream.map(fn element ->
+    |> Stream.flat_map(fn element ->
       case element do
         {:ok, %{"data" => data}} ->
           data

--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -7,6 +7,9 @@ defmodule Datagouvfr.Client.API do
 
   @type response :: {:ok, any} | {:error, any}
 
+  # HTTP client injection. Allow mock injection in tests
+  defp http_client, do: Application.get_env(:transport, :httpoison_impl)
+
   def api_key_headers do
     {"X-API-KEY", Application.get_env(:transport, :datagouvfr_apikey)}
   end
@@ -71,7 +74,7 @@ defmodule Datagouvfr.Client.API do
     options = Keyword.put_new(options, :follow_redirect, true)
 
     method
-    |> HTTPoison.request(url, body, headers, options)
+    |> http_client().request(url, body, headers, options)
     |> decode_body()
     |> post_process()
   end

--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -115,12 +115,12 @@ defmodule Datagouvfr.Client.API do
     )
   end
 
-  @spec fetch_all_pages!(path(), method()) :: Enumerable.t()
+  @spec fetch_all_pages!(path(), method()) :: [any()]
   def fetch_all_pages!(path, method \\ :get) do
     path
     |> Datagouvfr.Client.API.stream(method)
-    |> Stream.map(fn item ->
-      case item do
+    |> Stream.map(fn element ->
+      case element do
         {:ok, %{"data" => data}} ->
           data
 
@@ -137,7 +137,7 @@ defmodule Datagouvfr.Client.API do
     |> Enum.to_list()
   end
 
-  @spec fetch_all_pages(path(), method()) :: {:ok, Enumerable.t()} | {:error, binary()}
+  @spec fetch_all_pages(path(), method()) :: {:ok, [any()]} | {:error, any()}
   def fetch_all_pages(path, method \\ :get) do
     {:ok, fetch_all_pages!(path, method)}
   rescue

--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -114,4 +114,35 @@ defmodule Datagouvfr.Client.API do
       fn _ -> nil end
     )
   end
+
+  @spec fetch_all_pages!(path(), method()) :: Enumerable.t()
+  def fetch_all_pages!(path, method \\ :get) do
+    path
+    |> Datagouvfr.Client.API.stream(method)
+    |> Stream.map(fn item ->
+      case item do
+        {:ok, %{"data" => data}} ->
+          data
+
+        {:ok, response} ->
+          raise "Request was ok but the response didn't contain data. Response : #{response}"
+
+        {:error, %{reason: reason}} ->
+          raise reason
+
+        {:error, error} ->
+          raise error
+      end
+    end)
+    |> Enum.to_list()
+  end
+
+  @spec fetch_all_pages(path(), method()) :: {:ok, Enumerable.t()} | {:error, binary()}
+  def fetch_all_pages(path, method \\ :get) do
+    {:ok, fetch_all_pages!(path, method)}
+  rescue
+    error ->
+      Logger.error(error)
+      {:error, error}
+  end
 end

--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -9,7 +9,7 @@ defmodule Datagouvfr.Client.API do
   @type method :: :delete | :get | :head | :options | :patch | :post | :put
 
   # HTTP client injection. Allow mock injection in tests
-  defp http_client, do: Application.get_env(:transport, :httpoison_impl)
+  defp http_client, do: Application.fetch_env!(:transport, :httpoison_impl)
 
   def api_key_headers do
     {"X-API-KEY", Application.get_env(:transport, :datagouvfr_apikey)}

--- a/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
@@ -25,28 +25,10 @@ defmodule Datagouvfr.Client.CommunityResources.API do
 
   @spec get(binary) :: Datagouvfr.Client.API.response()
   def get(id) when is_binary(id) do
-    "#{@endpoint}?dataset=#{id}"
-    |> Datagouvfr.Client.API.stream()
-    |> Stream.map(fn item ->
-      case item do
-        {:ok, %{"data" => data}} ->
-          data
-
-        {:ok, data} ->
-          raise "When getting community_ressources for id #{id}: request was ok but the response didn't contain data #{data}"
-
-        {:error, %{reason: reason}} ->
-          raise "When getting community_ressources for id #{id}: #{reason}"
-
-        {:error, error} ->
-          raise "When getting community_ressources for id #{id}: #{error}"
-      end
-    end)
-    |> Enum.to_list()
-  rescue
-    error ->
-      Logger.error(error)
-      {:error, []}
+    case Datagouvfr.Client.API.fetch_all_pages("#{@endpoint}?dataset=#{id}") do
+      {:ok, pages} -> pages
+      {:error, error} -> {:error, []}
+    end
   end
 
   def delete(dataset_datagouv_id, resource_datagouv_id) do

--- a/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
@@ -5,7 +5,7 @@ defmodule Datagouvfr.Client.CommunityResources do
   """
   alias Datagouvfr.Client.API
 
-  @callback get(dataset_id :: binary()) :: API.response()
+  @callback get(dataset_id :: binary()) :: {:ok, [any()]} | {:error, []}
   @callback delete(dataset_id :: binary(), resource_id :: binary()) ::
               {:ok, any()} | {:error, any()}
 
@@ -23,10 +23,10 @@ defmodule Datagouvfr.Client.CommunityResources.API do
   @behaviour Datagouvfr.Client.CommunityResources
   @endpoint "/datasets/community_resources/"
 
-  @spec get(binary) :: Datagouvfr.Client.API.response()
-  def get(id) when is_binary(id) do
-    case Datagouvfr.Client.API.fetch_all_pages("#{@endpoint}?dataset=#{id}") do
-      {:ok, pages} -> pages
+  @spec get(dataset_id :: binary()) :: {:ok, [any()]} | {:error, []}
+  def get(dataset_id) when is_binary(dataset_id) do
+    case Datagouvfr.Client.API.fetch_all_pages("#{@endpoint}?dataset=#{dataset_id}") do
+      {:ok, pages} -> {:ok, pages}
       {:error, error} -> {:error, []}
     end
   end

--- a/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
@@ -3,7 +3,6 @@ defmodule Datagouvfr.Client.CommunityResources do
     This behaviour defines the API for interacting with data.gouv community resources
     , with alternative implementations.
   """
-  alias Datagouvfr.Client.API
 
   @callback get(dataset_id :: binary()) :: {:ok, [any()]} | {:error, []}
   @callback delete(dataset_id :: binary(), resource_id :: binary()) ::
@@ -27,7 +26,7 @@ defmodule Datagouvfr.Client.CommunityResources.API do
   def get(dataset_id) when is_binary(dataset_id) do
     case Datagouvfr.Client.API.fetch_all_pages("#{@endpoint}?dataset=#{dataset_id}") do
       {:ok, pages} -> {:ok, pages}
-      {:error, error} -> {:error, []}
+      {:error, _error} -> {:error, []}
     end
   end
 

--- a/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/community_resources.ex
@@ -27,10 +27,10 @@ defmodule Datagouvfr.Client.CommunityResources.API do
   def get(id) when is_binary(id) do
     "#{@endpoint}?dataset=#{id}"
     |> Datagouvfr.Client.API.stream()
-    |> Stream.transform([], fn item, acc ->
+    |> Stream.map(fn item ->
       case item do
         {:ok, %{"data" => data}} ->
-          {[data], [data | acc]}
+          data
 
         {:ok, data} ->
           raise "When getting community_ressources for id #{id}: request was ok but the response didn't contain data #{data}"

--- a/apps/datagouvfr/test/datagouvfr/client/api_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/api_test.exs
@@ -1,0 +1,67 @@
+defmodule Datagouvfr.Client.APITest do
+  use ExUnit.Case, async: true
+
+  doctest Datagouvfr.Client.API
+
+  import Datagouvfr.ApiFixtures
+  import Mox
+
+  alias Datagouvfr.Client.API
+
+  setup :verify_on_exit!
+
+  describe "Stream a data.gouv.fr resource" do
+    test "when resource is NOT paginated" do
+      resource_to_stream = "resource"
+
+      resource_to_stream
+      |> API.process_url()
+      |> expect_request_called_with_only_one_page("page 1 data")
+
+      assert_stream_return_pages(resource_to_stream, [{:ok, "page 1 data"}])
+    end
+
+    test "when resource is paginated" do
+      resource_to_stream = "resource"
+
+      resource_to_stream
+      |> API.process_url()
+      |> expect_request_called_and_return_next_page("page 1 data")
+      |> expect_request_called_and_return_next_page("page 2 data")
+      |> expect_request_called_without_next_page("page 3 data")
+
+      assert_stream_return_pages(resource_to_stream, [
+        {:ok, "page 1 data"},
+        {:ok, "page 2 data"},
+        {:ok, "page 3 data"}
+      ])
+    end
+
+    test "when resource's page return an error" do
+      resource_to_stream = "resource"
+
+      resource_to_stream
+      |> API.process_url()
+      |> expect_request_called_and_return_next_page("page 1 data")
+      |> expect_request_called_and_return_an_error("error page")
+
+      assert_stream_return_pages(
+        resource_to_stream,
+        [
+          {:ok, "page 1 data"},
+          {:error, "error page"}
+        ]
+      )
+    end
+  end
+
+  defp assert_stream_return_pages(resource_to_stream, expected_pages_data) do
+    obtained_pages_data =
+      resource_to_stream
+      |> API.stream()
+      |> Stream.map(fn {response_status, %{"data" => data}} -> {response_status, data} end)
+      |> Enum.to_list()
+
+    assert obtained_pages_data == expected_pages_data
+  end
+end

--- a/apps/datagouvfr/test/datagouvfr/client/api_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/api_test.exs
@@ -19,7 +19,7 @@ defmodule Datagouvfr.Client.APITest do
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_with_only_one_page(@data_containing_1_element)
+      |> given_request_return_only_one_page(@data_containing_1_element)
 
       assert_stream_return_pages(resource_to_stream, [{:ok, @data_containing_1_element}])
     end
@@ -29,9 +29,9 @@ defmodule Datagouvfr.Client.APITest do
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
-      |> expect_request_called_and_return_next_page(@data_containing_1_element)
-      |> expect_request_called_without_next_page(@data_containing_2_elements)
+      |> given_request_return_response_with_next_page(@data_containing_2_elements)
+      |> given_request_return_response_with_next_page(@data_containing_1_element)
+      |> given_request_return_response_without_next_page(@data_containing_2_elements)
 
       assert_stream_return_pages(resource_to_stream, [
         {:ok, @data_containing_2_elements},
@@ -45,8 +45,8 @@ defmodule Datagouvfr.Client.APITest do
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
-      |> expect_request_called_and_return_an_error("error page")
+      |> given_request_return_response_with_next_page(@data_containing_2_elements)
+      |> given_request_return_an_error("error page")
 
       assert_stream_return_pages(
         resource_to_stream,

--- a/apps/datagouvfr/test/datagouvfr/client/api_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/api_test.exs
@@ -10,15 +10,18 @@ defmodule Datagouvfr.Client.APITest do
 
   setup :verify_on_exit!
 
+  @data_containing_1_element ["data_containing_1_element #1"]
+  @data_containing_2_elements ["data_containing_2_elements #1", "data_containing_2_elements #2"]
+
   describe "Stream a data.gouv.fr resource" do
     test "when resource is NOT paginated" do
       resource_to_stream = "resource"
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_with_only_one_page("page 1 data")
+      |> expect_request_called_with_only_one_page(@data_containing_1_element)
 
-      assert_stream_return_pages(resource_to_stream, [{:ok, "page 1 data"}])
+      assert_stream_return_pages(resource_to_stream, [{:ok, @data_containing_1_element}])
     end
 
     test "when resource is paginated" do
@@ -26,14 +29,14 @@ defmodule Datagouvfr.Client.APITest do
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_and_return_next_page("page 1 data")
-      |> expect_request_called_and_return_next_page("page 2 data")
-      |> expect_request_called_without_next_page("page 3 data")
+      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
+      |> expect_request_called_and_return_next_page(@data_containing_1_element)
+      |> expect_request_called_without_next_page(@data_containing_2_elements)
 
       assert_stream_return_pages(resource_to_stream, [
-        {:ok, "page 1 data"},
-        {:ok, "page 2 data"},
-        {:ok, "page 3 data"}
+        {:ok, @data_containing_2_elements},
+        {:ok, @data_containing_1_element},
+        {:ok, @data_containing_2_elements}
       ])
     end
 
@@ -42,13 +45,13 @@ defmodule Datagouvfr.Client.APITest do
 
       resource_to_stream
       |> API.process_url()
-      |> expect_request_called_and_return_next_page("page 1 data")
+      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
       |> expect_request_called_and_return_an_error("error page")
 
       assert_stream_return_pages(
         resource_to_stream,
         [
-          {:ok, "page 1 data"},
+          {:ok, @data_containing_2_elements},
           {:error, "error page"}
         ]
       )

--- a/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
@@ -1,0 +1,65 @@
+defmodule Datagouvfr.Client.CommunityResources.APITest do
+  use ExUnit.Case, async: true
+  doctest Datagouvfr.Client.CommunityResources.API
+
+  import Datagouvfr.ApiFixtures
+  import Mox
+
+  alias Datagouvfr.Client.CommunityResources.API
+
+  setup :verify_on_exit!
+
+  describe "Fetch community resources by dataset id" do
+    test "when resource is NOT paginated" do
+      a_dataset_id = "a_dataset_id"
+
+      a_dataset_id
+      |> build_expected_community_resource_base_url()
+      |> expect_request_called_with_only_one_page("page 1 data")
+
+      assert_stream_return_data(a_dataset_id, ["page 1 data"])
+    end
+
+    test "when resource is paginated" do
+      a_dataset_id = "a_dataset_id"
+
+      a_dataset_id
+      |> build_expected_community_resource_base_url()
+      |> expect_request_called_and_return_next_page("page 1 data")
+      |> expect_request_called_with_only_one_page("page 2 data")
+
+      assert_stream_return_data(a_dataset_id, ["page 1 data", "page 2 data"])
+    end
+
+    test "when resource return a page in error" do
+      a_dataset_id = "a_dataset_id"
+
+      a_dataset_id
+      |> build_expected_community_resource_base_url()
+      |> expect_request_called_and_return_next_page("page 1 data")
+      |> expect_request_called_and_return_next_page("page 2 data")
+      |> expect_request_called_and_return_an_error("community resource error")
+
+      assert_stream_return_an_error(a_dataset_id)
+    end
+  end
+
+  defp assert_stream_return_data(resource_to_stream, expected_pages_data) do
+    obtained_pages_data =
+      resource_to_stream
+      |> API.get()
+      |> Enum.to_list()
+
+    assert obtained_pages_data == expected_pages_data
+  end
+
+  defp assert_stream_return_an_error(resource_to_stream) do
+    result = resource_to_stream |> API.get()
+    assert result == {:error, []}
+  end
+
+  defp build_expected_community_resource_base_url(community_resource_id),
+    do:
+      "/datasets/community_resources?dataset=#{community_resource_id}"
+      |> process_url()
+end

--- a/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
@@ -45,17 +45,13 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
   end
 
   defp assert_stream_return_data(resource_to_stream, expected_pages_data) do
-    obtained_pages_data =
-      resource_to_stream
-      |> API.get()
-      |> Enum.to_list()
-
+    {:ok, obtained_pages_data} = API.get(resource_to_stream)
     assert obtained_pages_data == expected_pages_data
   end
 
   defp assert_stream_return_an_error(resource_to_stream) do
-    result = resource_to_stream |> API.get()
-    assert result == {:error, []}
+    {:error, data} = API.get(resource_to_stream)
+    assert data == []
   end
 
   defp build_expected_community_resource_base_url(community_resource_id),

--- a/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
@@ -9,15 +9,18 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
 
   setup :verify_on_exit!
 
+  @data_containing_1_element ["data_containing_1_element #1"]
+  @data_containing_2_elements ["data_containing_2_elements #1", "data_containing_2_elements #2"]
+
   describe "Fetch community resources by dataset id" do
     test "when resource is NOT paginated" do
       a_dataset_id = "a_dataset_id"
 
       a_dataset_id
       |> build_expected_community_resource_base_url()
-      |> expect_request_called_with_only_one_page("page 1 data")
+      |> expect_request_called_with_only_one_page(@data_containing_2_elements)
 
-      assert_stream_return_data(a_dataset_id, ["page 1 data"])
+      assert_stream_return_data(a_dataset_id, @data_containing_2_elements)
     end
 
     test "when resource is paginated" do
@@ -25,10 +28,10 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
 
       a_dataset_id
       |> build_expected_community_resource_base_url()
-      |> expect_request_called_and_return_next_page("page 1 data")
-      |> expect_request_called_with_only_one_page("page 2 data")
+      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
+      |> expect_request_called_with_only_one_page(@data_containing_1_element)
 
-      assert_stream_return_data(a_dataset_id, ["page 1 data", "page 2 data"])
+      assert_stream_return_data(a_dataset_id, @data_containing_2_elements ++ @data_containing_1_element)
     end
 
     test "when resource return a page in error" do
@@ -36,8 +39,8 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
 
       a_dataset_id
       |> build_expected_community_resource_base_url()
-      |> expect_request_called_and_return_next_page("page 1 data")
-      |> expect_request_called_and_return_next_page("page 2 data")
+      |> expect_request_called_and_return_next_page(@data_containing_2_elements)
+      |> expect_request_called_and_return_next_page(@data_containing_1_element)
       |> expect_request_called_and_return_an_error("community resource error")
 
       assert_stream_return_an_error(a_dataset_id)

--- a/apps/datagouvfr/test/datagouvfr/client/datasets_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/datasets_test.exs
@@ -6,6 +6,11 @@ defmodule Datagouvfr.Client.DatasetsTest do
 
   doctest Client
 
+  setup do
+    Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
+    :ok
+  end
+
   test "get one dataset" do
     use_cassette "client/datasets/one-0" do
       assert "5387f0a0a3a7291cb367549e" == Datasets.get_id_from_url("horaires-et-arrets-du-reseau-irigo-format-gtfs")

--- a/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
+++ b/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
@@ -3,7 +3,6 @@ defmodule Datagouvfr.ApiFixtures do
   Utility module for mocking Data.Gouv.Fr API.
   """
 
-  alias Datagouvfr.Client.API
   alias HTTPoison.Response
 
   import Mox
@@ -15,39 +14,23 @@ defmodule Datagouvfr.ApiFixtures do
   Mock Data.Gouv.Fr API request and wrap exepected_data into the mocked response.
   Assert that it's called only one time, that the given expected_url is called.
   """
-  def expect_request_called_with_only_one_page(expected_url, expected_data),
-    do: expect_request_called_without_next_page(expected_url, expected_data)
+  def given_request_return_only_one_page(expected_url, expected_data),
+    do: given_request_return_response_without_next_page(expected_url, expected_data)
 
   @doc """
   Mock Data.Gouv.Fr API request and wrap exepected_data into the mocked response.
   Also generate a "next_page" url and return it into the mocked response.
   Assert that it's called only one time, that the given expected_url is called.
   """
-  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page? \\ true)
+  def given_request_return_response_with_next_page(expected_url, expected_data)
 
-  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page?)
+  def given_request_return_response_with_next_page(expected_url, expected_data)
       when not is_list(expected_data),
-      do: expect_request_called_and_return_next_page(expected_url, [expected_data], has_next_page?)
+      do: given_request_return_response_with_next_page(expected_url, [expected_data])
 
-  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page?) do
-    next_page =
-      case has_next_page? do
-        true -> expected_url <> "_next"
-        false -> nil
-      end
-
-    mocked_response = {
-      :ok,
-      %Response{
-        status_code: 200,
-        body:
-          Jason.encode!(%{
-            next_page: next_page,
-            data: expected_data
-          })
-      }
-    }
-
+  def given_request_return_response_with_next_page(expected_url, expected_data) do
+    next_page = expected_url <> "_next"
+    mocked_response = build_mocked_response(:ok, expected_data, 200, next_page)
     mock_httpoison_request(expected_url, mocked_response)
 
     next_page
@@ -58,18 +41,8 @@ defmodule Datagouvfr.ApiFixtures do
   Assert that it's called only one time, that the given expected_url is called.
   An error response does not contains next_page property.
   """
-  def expect_request_called_and_return_an_error(expected_url, error \\ "error") do
-    mocked_response = {
-      :ok,
-      %Response{
-        status_code: 500,
-        body:
-          Jason.encode!(%{
-            data: error
-          })
-      }
-    }
-
+  def given_request_return_an_error(expected_url, error \\ "error") do
+    mocked_response = build_mocked_response(:error, expected_url, error)
     mock_httpoison_request(expected_url, mocked_response)
   end
 
@@ -78,8 +51,9 @@ defmodule Datagouvfr.ApiFixtures do
   Since the resource only have one page, then the mocked response is set with "next_page" property to nil.
   Assert that it's called only one time, that the given expected_url is called.
   """
-  def expect_request_called_without_next_page(expected_url, expected_data) do
-    expect_request_called_and_return_next_page(expected_url, expected_data, false)
+  def given_request_return_response_without_next_page(expected_url, expected_data) do
+    mocked_response = build_mocked_response(:ok, expected_data, 200, nil)
+    mock_httpoison_request(expected_url, mocked_response)
     nil
   end
 
@@ -94,4 +68,29 @@ defmodule Datagouvfr.ApiFixtures do
       end
     )
   end
+
+  defp build_mocked_response(:ok, expected_data, expected_status_code, expected_next_page),
+    do: {
+      :ok,
+      %Response{
+        status_code: expected_status_code,
+        body:
+          Jason.encode!(%{
+            next_page: expected_next_page,
+            data: expected_data
+          })
+      }
+    }
+
+  defp build_mocked_response(:error, expected_status_code, expected_data),
+    do: {
+      :ok,
+      %Response{
+        status_code: expected_status_code,
+        body:
+          Jason.encode!(%{
+            data: expected_data
+          })
+      }
+    }
 end

--- a/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
+++ b/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
@@ -23,7 +23,13 @@ defmodule Datagouvfr.ApiFixtures do
   Also generate a "next_page" url and return it into the mocked response.
   Assert that it's called only one time, that the given expected_url is called.
   """
-  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page? \\ true) do
+  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page? \\ true)
+
+  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page?)
+      when not is_list(expected_data),
+      do: expect_request_called_and_return_next_page(expected_url, [expected_data], has_next_page?)
+
+  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page?) do
     next_page =
       case has_next_page? do
         true -> expected_url <> "_next"

--- a/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
+++ b/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
@@ -1,0 +1,91 @@
+defmodule Datagouvfr.ApiFixtures do
+  @moduledoc """
+  Utility module for mocking Data.Gouv.Fr API.
+  """
+
+  alias Datagouvfr.Client.API
+  alias HTTPoison.Response
+
+  import Mox
+  import ExUnit.Assertions
+
+  use Datagouvfr.Client
+
+  @doc """
+  Mock Data.Gouv.Fr API request and wrap exepected_data into the mocked response.
+  Assert that it's called only one time, that the given expected_url is called.
+  """
+  def expect_request_called_with_only_one_page(expected_url, expected_data),
+    do: expect_request_called_without_next_page(expected_url, expected_data)
+
+  @doc """
+  Mock Data.Gouv.Fr API request and wrap exepected_data into the mocked response.
+  Also generate a "next_page" url and return it into the mocked response.
+  Assert that it's called only one time, that the given expected_url is called.
+  """
+  def expect_request_called_and_return_next_page(expected_url, expected_data, has_next_page? \\ true) do
+    next_page =
+      case has_next_page? do
+        true -> expected_url <> "_next"
+        false -> nil
+      end
+
+    mocked_response = {
+      :ok,
+      %Response{
+        status_code: 200,
+        body:
+          Jason.encode!(%{
+            next_page: next_page,
+            data: expected_data
+          })
+      }
+    }
+
+    mock_httpoison_request(expected_url, mocked_response)
+
+    next_page
+  end
+
+  @doc """
+  Mock Data.Gouv.Fr API request to return an error.
+  Assert that it's called only one time, that the given expected_url is called.
+  An error response does not contains next_page property.
+  """
+  def expect_request_called_and_return_an_error(expected_url, error \\ "error") do
+    mocked_response = {
+      :ok,
+      %Response{
+        status_code: 500,
+        body:
+          Jason.encode!(%{
+            data: error
+          })
+      }
+    }
+
+    mock_httpoison_request(expected_url, mocked_response)
+  end
+
+  @doc """
+  Mock Data.Gouv.Fr API request and wrap exepected_data into the mocked response.
+  Since the resource only have one page, then the mocked response is set with "next_page" property to nil.
+  Assert that it's called only one time, that the given expected_url is called.
+  """
+  def expect_request_called_without_next_page(expected_url, expected_data) do
+    expect_request_called_and_return_next_page(expected_url, expected_data, false)
+    nil
+  end
+
+  def mock_httpoison_request(expected_url, expected_response) do
+    Transport.HTTPoison.Mock
+    |> expect(
+      :request,
+      1,
+      fn _method, requested_url, _body, _headers, _options ->
+        assert expected_url == requested_url
+        expected_response
+      end
+    )
+  end
+end

--- a/apps/datagouvfr/test/support/mocks.ex
+++ b/apps/datagouvfr/test/support/mocks.ex
@@ -1,1 +1,2 @@
 Mox.defmock(Datagouvfr.Client.CommunityResources.Mock, for: Datagouvfr.Client.CommunityResources)
+Mox.defmock(Transport.HTTPoison.Mock, for: HTTPoison.Base)

--- a/apps/transport/test/transport_web/controllers/nav_test.exs
+++ b/apps/transport/test/transport_web/controllers/nav_test.exs
@@ -16,6 +16,8 @@ defmodule TransportWeb.NavTest do
       aom: build(:aom)
     )
 
+    Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
+
     :ok
   end
 

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -38,6 +38,8 @@ defmodule TransportWeb.SeoMetadataTest do
       }
       |> Repo.insert()
 
+    Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
+
     :ok
   end
 


### PR DESCRIPTION
Après refacto, la pagination de l'API Data.Gouv.Fr est géré à partir de la propriété "next_page" fournie dans l'enveloppe de la réponse.

👉 Gestion des erreurs dans Datagouvfr.Client.API :
Le stream s'arrête à la première erreur rencontrée
Le dernier élément du stream est un tuple {:error, error} où error contient le détail de l'erreur fournie par l'API.
ex : si la 3e page d'un stream est en erreur, alors le résultat sera

> Datagouvfr.Client.API.stream(resource) |> Enum.to_list()

[
  {:ok, page1},
  {:ok, page2},
  {:erreur, "cannot access resource"} 
]
👉 Gestion des erreurs dans CommunityResources.API :
Le stream s'arrête à la première erreur rencontrée
Retourne le tuple {:error, []} (comportement identique au précédent - avant streaming)
