### PR TITLE
Permettre de lancer la MAJ des AOMs depuis le backoffice

### DIFF
--- a/apps/transport/lib/mix/tasks/transport/import_aom.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aom.ex
@@ -27,8 +27,10 @@ defmodule Mix.Tasks.Transport.ImportAom do
   alias DB.{AOM, Commune, Region, Repo}
   require Logger
 
-  @aom_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20201112-141547/base-aom-2020.csv"
-  @aom_insee_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20201112-142236/aom-insee.csv"
+  # Those 2 files are community resources published by transport for the following dataset :
+  # https://www.data.gouv.fr/fr/datasets/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/#community-resources
+  @aom_file "https://www.data.gouv.fr/fr/datasets/r/2668b0eb-2cfb-4f96-a359-d1b7876c13f4"
+  @aom_insee_file "https://www.data.gouv.fr/fr/datasets/r/00635634-065f-4008-b032-f5d5f7ba8617"
 
   @spec to_int(binary()) :: number() | nil
   def to_int(""), do: nil

--- a/apps/transport/lib/transport/import_aom.ex
+++ b/apps/transport/lib/transport/import_aom.ex
@@ -91,7 +91,7 @@ defmodule Transport.ImportAOMs do
   defp normalize_forme("EPL"), do: "Établissement public local"
   defp normalize_forme(f), do: f
 
-  def run() do
+  def run do
     aoms =
       AOM
       |> Repo.all()
@@ -104,18 +104,19 @@ defmodule Transport.ImportAOMs do
     # get all the aom to import, outside of the transaction to reduce the time in the transaction
     aom_to_add = get_aom_to_import()
 
-    {:ok, _} = Repo.transaction(
-      fn ->
-        # we load all aoms
-        import_aoms(aom_to_add)
+    {:ok, _} =
+      Repo.transaction(
+        fn ->
+          # we load all aoms
+          import_aoms(aom_to_add)
 
-        delete_old_aoms(aom_to_add, aoms)
+          delete_old_aoms(aom_to_add, aoms)
 
-        # we load the join on cities
-        import_insee_aom()
-      end,
-      timeout: 400_000
-    )
+          # we load the join on cities
+          import_insee_aom()
+        end,
+        timeout: 400_000
+      )
 
     # we can then compute the aom geometries (the union of each cities geometries)
     compute_geom()

--- a/apps/transport/lib/transport/import_aom.ex
+++ b/apps/transport/lib/transport/import_aom.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Transport.ImportAom do
+defmodule Transport.ImportAOMs do
   @moduledoc """
   Import the AOM files and updates the database
 
@@ -12,23 +12,14 @@ defmodule Mix.Tasks.Transport.ImportAom do
 
   This is a one shot import task, run when the aom have changed.
 
-  To run this script:
-  connect to the server, then run it as a mix task:
-  `mix Transport.ImportAom`
-
-  or run it in iex:
-  `iex -S mix`
-  then
-  `Mix.Tasks.Transport.ImportAom.run([])`
+  The import can be launched from the site backoffice
   """
 
-  use Mix.Task
   import Ecto.{Query}
   alias DB.{AOM, Commune, Region, Repo}
   require Logger
 
-  # Those 2 files are community resources published by transport for the following dataset :
-  # https://www.data.gouv.fr/fr/datasets/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/#community-resources
+  # The 2 community resources stable urls
   @aom_file "https://www.data.gouv.fr/fr/datasets/r/2668b0eb-2cfb-4f96-a359-d1b7876c13f4"
   @aom_insee_file "https://www.data.gouv.fr/fr/datasets/r/00635634-065f-4008-b032-f5d5f7ba8617"
 
@@ -100,10 +91,7 @@ defmodule Mix.Tasks.Transport.ImportAom do
   defp normalize_forme("EPL"), do: "Établissement public local"
   defp normalize_forme(f), do: f
 
-  @shortdoc "One shot update of AOM from a data.gouv.fr community ressource file"
-  def run(_) do
-    Mix.Task.run("app.start")
-
+  def run() do
     aoms =
       AOM
       |> Repo.all()
@@ -116,7 +104,7 @@ defmodule Mix.Tasks.Transport.ImportAom do
     # get all the aom to import, outside of the transaction to reduce the time in the transaction
     aom_to_add = get_aom_to_import()
 
-    Repo.transaction(
+    {:ok, _} = Repo.transaction(
       fn ->
         # we load all aoms
         import_aoms(aom_to_add)
@@ -131,6 +119,8 @@ defmodule Mix.Tasks.Transport.ImportAom do
 
     # we can then compute the aom geometries (the union of each cities geometries)
     compute_geom()
+
+    :ok
   end
 
   defp get_aom_to_import do

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -192,6 +192,17 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render("form_dataset.html")
   end
 
+  def import_all_aoms(%Plug.Conn{} = conn, _params) do
+    try do
+      Transport.ImportAOMs.run()
+      conn |> put_flash(:info, "AOMs successfully imported")
+    rescue
+      e ->
+        conn |> put_flash(:error, "AOMs import failed. #{inspect(e)}")
+    end
+    |> redirect(to: backoffice_page_path(conn, :index))
+  end
+
   ## Private functions
   @spec render_index(Ecto.Queryable.t(), Plug.Conn.t(), map()) :: Plug.Conn.t()
   defp render_index(datasets, conn, params) do

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -193,14 +193,16 @@ defmodule TransportWeb.Backoffice.PageController do
   end
 
   def import_all_aoms(%Plug.Conn{} = conn, _params) do
-    try do
-      Transport.ImportAOMs.run()
-      conn |> put_flash(:info, "AOMs successfully imported")
-    rescue
-      e ->
-        conn |> put_flash(:error, "AOMs import failed. #{inspect(e)}")
-    end
-    |> redirect(to: backoffice_page_path(conn, :index))
+    conn =
+      try do
+        Transport.ImportAOMs.run()
+        conn |> put_flash(:info, "AOMs successfully imported")
+      rescue
+        e ->
+          conn |> put_flash(:error, "AOMs import failed. #{inspect(e)}")
+      end
+
+    conn |> redirect(to: backoffice_page_path(conn, :index))
   end
 
   ## Private functions

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -102,6 +102,7 @@ defmodule TransportWeb.Router do
         layout: {TransportWeb.LayoutView, :app},
         session: {TransportWeb.Backoffice.ProxyConfigLive, :build_session, []}
       )
+
       get("/import_aoms", PageController, :import_all_aoms)
 
       scope "/datasets" do

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -102,6 +102,7 @@ defmodule TransportWeb.Router do
         layout: {TransportWeb.LayoutView, :app},
         session: {TransportWeb.Backoffice.ProxyConfigLive, :build_session, []}
       )
+      get("/import_aoms", PageController, :import_all_aoms)
 
       scope "/datasets" do
         get("/new", PageController, :new)

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -24,7 +24,7 @@
         <%= submit dgettext("backoffice", "validate all") %>
       <% end %>
     </div>
-    <a class="button" href="" title="Télécharge depuis data.gouv la dernière version de la liste des AOMs, puis les importe dans notre base.">
+    <a class="button" href="<%= backoffice_page_path(@conn, :import_all_aoms) %>" title="Télécharge depuis data.gouv la dernière version de la liste des AOMs, puis les importe dans notre base.">
       <%= dgettext("backoffice", "Update all AOMs") %>
     </a>
   <h1 class="pt-48">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -24,6 +24,9 @@
         <%= submit dgettext("backoffice", "validate all") %>
       <% end %>
     </div>
+    <a class="button" href="" title="Télécharge depuis data.gouv la dernière version de la liste des AOMs, puis les importe dans notre base.">
+      <%= dgettext("backoffice", "Update all AOMs") %>
+    </a>
   <h1 class="pt-48">
     <a name="list_datasets" href="#list_datasets" class="anchor"></a>
     <%= dgettext("backoffice", "Valid datasets available") %>


### PR DESCRIPTION
closes #1727 , #1711, #1710

Je n'ai pas touché au code d'import des AOMs, qui n'est pas testé. De plus, il y a des choses que je trouve étranges dans la manière dont sont liés en base les AOMs et les Datasets, il faudrait peut-être le changer, et ça pourrait avoir des conséquences sur la manière de mettre à jour les AOMs.

Tout ça pour dire que l'import des AOMs était auparavant une Task à lancer depuis mix, ce qui n'était pas très pratique car il fallait se connecter sur le serveur de prod et lancer la ligne de commande. J'ai donc rajouté un bouton dans le backoffice qui permet de mettre à jour les AOMs.