### PR TITLE
Permettre de faire des recherches approximatives dans la barre de recherche

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -19,6 +19,19 @@ defmodule TransportWeb.API.PlacesController do
 
   defp get_result_url(conn, %Place{:place_id => id, :type => "mode"}), do: dataset_path(conn, :index, "modes[]": id)
 
+  defp approx_search_query(query) do
+    Place
+    |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
+    |> order_by(asc: fragment("CASE type
+            when 'feature' then 1
+            when 'mode' then 2
+            when 'region' then 3
+            when 'aom' then 4
+            else 4 END"))
+    |> limit(10)
+    |> Repo.all()
+  end
+
   @spec autocomplete(Plug.Conn.t(), map) :: Plug.Conn.t()
   def autocomplete(%Plug.Conn{} = conn, %{"q" => query}) do
     query =
@@ -44,6 +57,10 @@ defmodule TransportWeb.API.PlacesController do
       |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
       |> limit(10)
       |> Repo.all()
+      |> case do
+        [] -> approx_search_query(query)
+        r -> r
+      end
 
     results =
       places

--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -22,12 +22,7 @@ defmodule TransportWeb.API.PlacesController do
   defp approx_search_query(query) do
     Place
     |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
-    |> order_by(asc: fragment("CASE type
-            when 'feature' then 1
-            when 'mode' then 2
-            when 'region' then 3
-            when 'aom' then 4
-            else 4 END"))
+    |> where([p], fragment("indexed_name % unaccent(?)", ^query))
     |> limit(10)
     |> Repo.all()
   end


### PR DESCRIPTION
closes #1464, #1520

Je fais un test simple pour rendre la recherche sur le site plus flexible. Si c'est trop couteux en temps de calcul et que les réponses sont lentes, il faudra y réfléchir plus.

![image](https://user-images.githubusercontent.com/15341118/129387188-1c040f2b-85f0-4ce4-92fe-a4f6e3a3e0b0.png)

Je commence par déployer sur prochainement.

# MAJ
Je trouve les résultats plutôt convaincants, et les requêtes sont vraiment raisonnables. Chapeau à Postgres :) Par exemple si je tape "Auxxerre", on aboutit à 2 requêtes : une première qui ne renvoit rien (basée sur ILIKE), puis une seconde basée sur des trigrammes et la notion de simalarity. L'ensemble de la requête GET se fait en local en 11ms.

![image](https://user-images.githubusercontent.com/15341118/129539000-0db44048-87ca-4566-89f9-24fc8dd81fdc.png)

# L'idée derrière la PR
On commence par une recherche exacte, basée sur une regex (sans les accents, sans la casse). Tant qu'on trouve des choses, on renvoit les résultats. Si la recherche ne renvoie rien, on fait une deuxième requête en base, cette fois si en utilisant la fonction `similarity` qui utilise les trigrammes et qui permet des recherches approximatives.