### PR TITLE
Fix bike scooter map

### DIFF
--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -14,7 +14,7 @@ const Mapbox = {
 
 const regionsUrl = '/api/stats/regions'
 const aomsUrl = '/api/stats/'
-const bikesUrl = '/api/stats/bike-sharing'
+const bikeScooterUrl = '/api/stats/bike-scooter-sharing'
 const qualityUrl = '/api/stats/quality'
 
 const lightGreen = '#BCE954'
@@ -56,7 +56,7 @@ const getLegend = (title, colors, labels) => {
 // simple cache on stats
 let aomStats = null
 let regionStats = null
-let bikeStats = null
+let bikeScooterStats = null
 let qualityStats = null
 
 function getAomsFG (featureFunction, style, filter = null) {
@@ -96,13 +96,13 @@ function getRegionsFG (featureFunction, style) {
     return regionsFeatureGroup
 }
 
-function displayBikes (map, featureFunction) {
-    if (bikeStats == null) {
-        bikeStats = fetch(bikesUrl).then(response => {
+function displayBikeScooter (map, featureFunction) {
+    if (bikeScooterStats == null) {
+        bikeScooterStats = fetch(bikeScooterUrl).then(response => {
             return response.json()
         })
     }
-    bikeStats.then(response => {
+    bikeScooterStats.then(response => {
         const options = {
             fillColor: '#0066db',
             radius: 5,
@@ -605,10 +605,10 @@ function addPtFormatMap (id, view) {
     }
 }
 
-function addBikesMap (id, view) {
+function addBikeScooterMap (id, view) {
     const map = makeMapOnView(id, view)
 
-    displayBikes(map, (feature, layer) => {
+    displayBikeScooter(map, (feature, layer) => {
         const name = feature.properties.nom
         const slug = feature.properties.parent_dataset_slug
 
@@ -648,5 +648,5 @@ for (const [drom, view] of Object.entries(droms)) {
     addStaticPTQuality(`pt_quality_${drom}`, view)
     addPtFormatMap(`pt_format_map_${drom}`, view)
     addRealTimePTMap(`rt_map_${drom}`, view)
-    addBikesMap(`bikes_map_${drom}`, view)
+    addBikeScooterMap(`bike_scooter_map_${drom}`, view)
 }

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -101,7 +101,7 @@ defmodule Transport.StatsHandler do
   defp nb_bikes do
     bikes_datasets =
       from(d in Dataset,
-        where: d.type == "bike-sharing"
+        where: d.type == "bike-scooter-sharing"
       )
 
     Repo.aggregate(bikes_datasets, :count, :id)

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -36,13 +36,13 @@ defmodule TransportWeb.API.StatsController do
       }
     }
 
-  @spec bike_sharing_operation() :: Operation.t()
-  def bike_sharing_operation,
+  @spec bike_scooter_sharing_operation() :: Operation.t()
+  def bike_scooter_sharing_operation,
     do: %Operation{
-      tags: ["bike-sharing"],
-      summary: "Show bike sharing stats",
-      description: "Show bike sharing stats",
-      operationId: "API.StatsController.bike_sharing",
+      tags: ["bike-scooter-sharing"],
+      summary: "Show bike and scooter sharing stats",
+      description: "Show bike and scooter sharing stats",
+      operationId: "API.StatsController.bike_scooter_sharing",
       parameters: [],
       responses: %{
         200 => Operation.response("GeoJSON", "application/json", GeoJSONResponse)
@@ -188,8 +188,9 @@ defmodule TransportWeb.API.StatsController do
   @spec regions(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def regions(%Plug.Conn{} = conn, _params), do: render_features(conn, region_features_query(), "api-stats-regions")
 
-  @spec bike_sharing(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def bike_sharing(%Plug.Conn{} = conn, _params), do: render_features(conn, bike_sharing_features_query())
+  @spec bike_scooter_sharing(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def bike_scooter_sharing(%Plug.Conn{} = conn, _params),
+    do: render_features(conn, bike_scooter_sharing_features_query())
 
   @spec quality(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def quality(%Plug.Conn{} = conn, _params), do: render_features(conn, quality_features_query(), "api-stats-quality")
@@ -249,7 +250,8 @@ defmodule TransportWeb.API.StatsController do
       forme_juridique: aom.forme_juridique,
       dataset_types: %{
         pt: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit'", aom.id),
-        bike_sharing: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-sharing'", aom.id)
+        bike_scooter_sharing:
+          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing'", aom.id)
       },
       parent_dataset_slug: parent_dataset.slug,
       parent_dataset_name: parent_dataset.title
@@ -281,13 +283,13 @@ defmodule TransportWeb.API.StatsController do
       },
       dataset_types: %{
         pt: count_type_by_region(r.id, "public-transit"),
-        bike_sharing: count_type_by_region(r.id, "bike-sharing")
+        bike_scooter_sharing: count_type_by_region(r.id, "bike-scooter-sharing")
       }
     })
   end
 
-  @spec bike_sharing_features_query :: Ecto.Query.t()
-  defp bike_sharing_features_query do
+  @spec bike_scooter_sharing_features_query :: Ecto.Query.t()
+  def bike_scooter_sharing_features_query do
     DatasetGeographicView
     |> join(:left, [gv], dataset in Dataset, on: dataset.id == gv.dataset_id)
     |> select([gv, dataset], %{
@@ -296,7 +298,7 @@ defmodule TransportWeb.API.StatsController do
       nom: dataset.spatial,
       parent_dataset_slug: dataset.slug
     })
-    |> where([_gv, dataset], dataset.type == "bike-sharing")
+    |> where([_gv, dataset], dataset.type == "bike-scooter-sharing")
   end
 
   @spec quality_features_query :: Ecto.Query.t()
@@ -315,7 +317,8 @@ defmodule TransportWeb.API.StatsController do
       forme_juridique: aom.forme_juridique,
       dataset_types: %{
         pt: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit'", aom.id),
-        bike_sharing: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-sharing'", aom.id)
+        bike_scooter_sharing:
+          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing'", aom.id)
       },
       quality: %{
         # we get the number of day since the latest resource is expired

--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -24,7 +24,7 @@ defmodule TransportWeb.API.Router do
     scope "/stats" do
       get("/", TransportWeb.API.StatsController, :index)
       get("/regions", TransportWeb.API.StatsController, :regions)
-      get("/bike-sharing", TransportWeb.API.StatsController, :bike_sharing)
+      get("/bike-scooter-sharing", TransportWeb.API.StatsController, :bike_scooter_sharing)
       get("/quality", TransportWeb.API.StatsController, :quality)
     end
 

--- a/apps/transport/lib/transport_web/templates/page/real_time.html.md
+++ b/apps/transport/lib/transport_web/templates/page/real_time.html.md
@@ -40,7 +40,7 @@ Vous pouvez signaler à l'équipe du PAN un jeu de données à ajouter ci-dessus
 
 ## Velo en libre service
 
-Plusieurs jeux de données de données temps-réel de vélo en libre service sont [disponibles sur la plateforme](https://transport.data.gouv.fr/datasets?type=bike-sharing). Ces données sont standardisées en [BGFS](https://github.com/NABSA/gbfs/blob/master/gbfs.md).
+Plusieurs jeux de données de données temps-réel de vélo en libre service sont [disponibles sur la plateforme](https://transport.data.gouv.fr/datasets?type=bike-scooter-sharing). Ces données sont standardisées en [BGFS](https://github.com/NABSA/gbfs/blob/master/gbfs.md).
 
 ## Aérien
 

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -210,7 +210,7 @@
     <div class="domain bikes" id="real-time-bikes">
       <h2>Vélos libre service</h2>
       <div class="domain-stats">
-        <%= render("_maps.html", droms: @droms, prefix: "bikes_map") %>
+        <%= render("_maps.html", droms: @droms, prefix: "bike_scooter_map") %>
         <div class="panel">
           <div class="description">
             <span class="stat-link">
@@ -229,7 +229,7 @@
           <div class="tile-numbers">
             <div class="tile">
               <h3><%= @nb_bikes_datasets %></h3>
-              <div> <a href="/datasets?type=bike-sharing">Jeux de données disponibles</a></div>
+              <div> <a href="/datasets?type=bike-scooter-sharing">Jeux de données disponibles</a></div>
             </div>
             <div class="rt-viz">
               <%= for _i <- 1..@nb_bikes_datasets do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -330,7 +330,7 @@ defmodule TransportWeb.DatasetView do
     |> Enum.max_by(fn r -> r.last_update end, fn -> nil end)
   end
 
-  def get_resource_to_display(%Dataset{type: "bike-sharing", resources: resources}) do
+  def get_resource_to_display(%Dataset{type: "bike-scooter-sharing", resources: resources}) do
     resources
     |> Enum.filter(fn r -> r.format == "gbfs" or String.ends_with?(r.url, "gbfs.json") end)
     |> Enum.reject(fn r -> r.is_community_resource end)

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -33,7 +33,7 @@ defmodule TransportWeb.API.StatsControllerTest do
   end
 
   test "Get the bike and scooter stats", %{conn: _conn} do
-    _dataset = :dataset |> insert(%{type: "bike-scooter-sharing"})
+    _dataset = :dataset |> insert(%{type: "bike-scooter-sharing", aom: nil})
     result = TransportWeb.API.StatsController.bike_scooter_sharing_features_query() |> DB.Repo.all()
     assert length(result) == 1
   end

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -2,6 +2,7 @@ defmodule TransportWeb.API.StatsControllerTest do
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   use TransportWeb.ConnCase
   import Mock
+  import TransportWeb.Factory
 
   @cached_features_routes [
     {"/api/stats", "api-stats-aoms"},
@@ -29,5 +30,11 @@ defmodule TransportWeb.API.StatsControllerTest do
         assert json_response(conn, 200) == %{"hello" => 123}
       end
     end
+  end
+
+  test "Get the bike and scooter stats", %{conn: _conn} do
+    _dataset = :dataset |> insert(%{type: "bike-scooter-sharing"})
+    result = TransportWeb.API.StatsController.bike_scooter_sharing_features_query() |> DB.Repo.all()
+    assert length(result) == 1
   end
 end


### PR DESCRIPTION
En renommant la catégorie bike-sharing en bike-scooter-sharing, j'ai oublié la partie statistiques du site.
Cette fois ci j'ai vraiment reporté la modif partout, et j'ai rajouté un (premier) test sur la page de stats.
La carte de stats est réparée.

closes #1735 