### PR TITLE
Logger des métriques concernant la qualité d'une ressource

### DIFF
--- a/apps/db/lib/db/logs_resource_quality.ex
+++ b/apps/db/lib/db/logs_resource_quality.ex
@@ -12,6 +12,7 @@ defmodule DB.LogsResourceQuality do
     field(:log_date, :utc_datetime_usec)
     field(:resource_end_date, :date)
     field(:is_available, :boolean)
+    field(:resource_format, :string)
 
     belongs_to(:resource, Resource)
   end

--- a/apps/db/lib/db/logs_resource_quality.ex
+++ b/apps/db/lib/db/logs_resource_quality.ex
@@ -1,0 +1,18 @@
+defmodule DB.LogsResourceQuality do
+  @moduledoc """
+  A module for logging information about all the PAN resources "quality",
+  ie availability, freshness, correctness, etc
+  """
+
+  use Ecto.Schema
+  use TypedEctoSchema
+  alias DB.Resource
+
+  typed_schema "logs_resource_quality" do
+    field(:log_date, :utc_datetime_usec)
+    field(:resource_end_date, :date)
+    field(:is_available, :boolean)
+
+    belongs_to(:resource, Resource)
+  end
+end

--- a/apps/db/priv/repo/migrations/20210820145131_create_resource_quality_logs_table.exs
+++ b/apps/db/priv/repo/migrations/20210820145131_create_resource_quality_logs_table.exs
@@ -11,6 +11,7 @@ defmodule DB.Repo.Migrations.CreateResourceQualityLogsTable do
       add :log_date, :utc_datetime_usec
       add :resource_end_date, :date
       add :is_available, :boolean
+      add :resource_format, :string
     end
   end
 end

--- a/apps/db/priv/repo/migrations/20210820145131_create_resource_quality_logs_table.exs
+++ b/apps/db/priv/repo/migrations/20210820145131_create_resource_quality_logs_table.exs
@@ -1,0 +1,16 @@
+defmodule DB.Repo.Migrations.CreateResourceQualityLogsTable do
+  @moduledoc """
+  A table for logging information about all the PAN resources "quality",
+  ie availability, freshness, correctness, etc
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:logs_resource_quality) do
+      add :resource_id,  references(:resource)
+      add :log_date, :utc_datetime_usec
+      add :resource_end_date, :date
+      add :is_available, :boolean
+    end
+  end
+end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -72,7 +72,7 @@ defmodule Transport.ImportData do
   def import_validate_all do
     import_all_datasets()
     validate_all_resources()
-    Transport.ResourceQualityLogger.inserts_all_resources_logs()
+    Transport.ResourceQualityLogger.insert_all_resources_logs()
   end
 
   def refresh_places do

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -72,6 +72,7 @@ defmodule Transport.ImportData do
   def import_validate_all do
     import_all_datasets()
     validate_all_resources()
+    Transport.ResourceQualityLogger.inserts_all_resources_logs()
   end
 
   def refresh_places do

--- a/apps/transport/lib/transport/resource_quality_logger.ex
+++ b/apps/transport/lib/transport/resource_quality_logger.ex
@@ -5,7 +5,7 @@ defmodule Transport.ResourceQualityLogger do
 
   alias DB.{LogsResourceQuality, Repo, Resource}
 
-  def inserts_all_resources_logs do
+  def insert_all_resources_logs do
     stream = Resource |> Repo.stream()
 
     Repo.transaction(fn ->

--- a/apps/transport/lib/transport/resource_quality_logger.ex
+++ b/apps/transport/lib/transport/resource_quality_logger.ex
@@ -1,7 +1,11 @@
 defmodule Transport.ResourceQualityLogger do
+  @moduledoc """
+  A module to launch the insertion in the DB of quality metrics about the resources
+  """
+
   alias DB.{LogsResourceQuality, Repo, Resource}
 
-  def inserts_all_resources_logs() do
+  def inserts_all_resources_logs do
     stream = Resource |> Repo.stream()
 
     Repo.transaction(fn ->

--- a/apps/transport/lib/transport/resource_quality_logger.ex
+++ b/apps/transport/lib/transport/resource_quality_logger.ex
@@ -1,0 +1,22 @@
+defmodule Transport.ResourceQualityLogger do
+  alias DB.{LogsResourceQuality, Repo, Resource}
+
+  def inserts_all_resources_logs() do
+    stream = Resource |> Repo.stream()
+
+    Repo.transaction(fn ->
+      stream
+      |> Stream.map(fn resource ->
+        %{
+          resource_id: resource.id,
+          is_available: resource.is_available,
+          resource_end_date: resource.end_date,
+          log_date: DateTime.utc_now()
+        }
+      end)
+      |> Stream.chunk_every(500)
+      |> Stream.each(fn changesets -> Repo.insert_all(LogsResourceQuality, changesets) end)
+      |> Enum.to_list()
+    end)
+  end
+end

--- a/apps/transport/lib/transport/resource_quality_logger.ex
+++ b/apps/transport/lib/transport/resource_quality_logger.ex
@@ -14,6 +14,7 @@ defmodule Transport.ResourceQualityLogger do
         %{
           resource_id: resource.id,
           is_available: resource.is_available,
+          resource_format: resource.format,
           resource_end_date: resource.end_date,
           log_date: DateTime.utc_now()
         }

--- a/apps/transport/test/transport/resource_quality_logger_test.exs
+++ b/apps/transport/test/transport/resource_quality_logger_test.exs
@@ -1,0 +1,35 @@
+defmodule Transport.ResourceQualityLoggerTest do
+  @moduledoc """
+  A test module for Transport.ResourceQualityLogger.
+  """
+  use ExUnit.Case
+  import TransportWeb.Factory
+  alias DB.{LogsResourceQuality, Resource}
+  alias Transport.ResourceQualityLogger
+  doctest Transport.ResourceQualityLogger
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "log resources quality metrics" do
+    resource1 = insert(:resource, %{is_available: true, end_date: %Date{year: 2021, month: 8, day: 23}})
+    resource2 = insert(:resource, %{is_available: false, end_date: %Date{year: 2020, month: 8, day: 23}})
+
+    assert Resource |> DB.Repo.all() |> length == 2
+
+    ResourceQualityLogger.insert_all_resources_logs()
+
+    logs = LogsResourceQuality |> DB.Repo.all()
+
+    assert logs |> length == 2
+
+    resource1_log = logs |> Enum.find(&(&1.resource_id == resource1.id))
+    assert resource1_log |> Map.fetch!(:resource_end_date) == resource1.end_date
+    assert resource1_log |> Map.fetch!(:is_available) == resource1.is_available
+
+    resource2_log = logs |> Enum.find(&(&1.resource_id == resource2.id))
+    assert resource2_log |> Map.fetch!(:resource_end_date) == resource2.end_date
+    assert resource2_log |> Map.fetch!(:is_available) == resource2.is_available
+  end
+end

--- a/apps/transport/test/transport/resource_quality_logger_test.exs
+++ b/apps/transport/test/transport/resource_quality_logger_test.exs
@@ -13,8 +13,10 @@ defmodule Transport.ResourceQualityLoggerTest do
   end
 
   test "log resources quality metrics" do
-    resource1 = insert(:resource, %{is_available: true, end_date: %Date{year: 2021, month: 8, day: 23}})
-    resource2 = insert(:resource, %{is_available: false, end_date: %Date{year: 2020, month: 8, day: 23}})
+    resource1 = insert(:resource, %{is_available: true, format: "csv", end_date: %Date{year: 2021, month: 8, day: 23}})
+
+    resource2 =
+      insert(:resource, %{is_available: false, format: "gtfs", end_date: %Date{year: 2020, month: 8, day: 23}})
 
     assert Resource |> DB.Repo.all() |> length == 2
 
@@ -27,9 +29,11 @@ defmodule Transport.ResourceQualityLoggerTest do
     resource1_log = logs |> Enum.find(&(&1.resource_id == resource1.id))
     assert resource1_log |> Map.fetch!(:resource_end_date) == resource1.end_date
     assert resource1_log |> Map.fetch!(:is_available) == resource1.is_available
+    assert resource1_log |> Map.fetch!(:resource_format) == resource1.format
 
     resource2_log = logs |> Enum.find(&(&1.resource_id == resource2.id))
     assert resource2_log |> Map.fetch!(:resource_end_date) == resource2.end_date
     assert resource2_log |> Map.fetch!(:is_available) == resource2.is_available
+    assert resource2_log |> Map.fetch!(:resource_format) == resource2.format
   end
 end


### PR DESCRIPTION
Je lance la balle sur un sujet dont nous avons souvent parlé : être capable d'avoir (et de montrer) des statistiques temporelles concernant le niveau de qualité d'un dataset.

Pour cela, je commence par une brique de base : le fait de logger après chaque import journalier 2 informations pour chaque ressource que nous avons en base : sa disponibilité et sa date (si elle est connue) de péremption.

L'occasion pour moi d'aller jeter un oeil sur le streaming (en général) et dans Ecto en particulier.

Ce n'est pas une grosse PR, mais avant d'aller plus loin, il sera intéressant d'en discuter ensemble !

# Edit
Finalement je me dis que ça peut être pas mal de juste merger cette première brique, histoire que de l'historique commence à se remplir, et je ferai une seconde PR pour en faire quelque chose côté backoffice et/ou site publique.