### PR TITLE
Filtre de davantage de datasets inactifs sur les stats (#1748)

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -239,7 +239,7 @@ defmodule TransportWeb.API.StatsController do
       geometry: aom.geom,
       id: aom.id,
       insee_commune_principale: aom.insee_commune_principale,
-      nb_datasets: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=?", aom.id),
+      nb_datasets: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND is_active=TRUE ", aom.id),
       dataset_formats: %{
         gtfs: count_aom_format(aom.id, "GTFS"),
         netex: count_aom_format(aom.id, "NeTEx"),
@@ -249,9 +249,13 @@ defmodule TransportWeb.API.StatsController do
       nom: aom.nom,
       forme_juridique: aom.forme_juridique,
       dataset_types: %{
-        pt: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit'", aom.id),
+        pt:
+          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit' AND is_active=TRUE", aom.id),
         bike_scooter_sharing:
-          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing'", aom.id)
+          fragment(
+            "SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing' AND is_active=TRUE",
+            aom.id
+          )
       },
       parent_dataset_slug: parent_dataset.slug,
       parent_dataset_name: parent_dataset.title
@@ -272,6 +276,7 @@ defmodule TransportWeb.API.StatsController do
           SELECT COUNT(*) FROM dataset
           JOIN dataset_geographic_view d_geo ON d_geo.dataset_id = dataset.id
           WHERE d_geo.region_id = ?
+          AND is_active=TRUE
           """,
           r.id
         ),
@@ -316,9 +321,13 @@ defmodule TransportWeb.API.StatsController do
       nom: aom.nom,
       forme_juridique: aom.forme_juridique,
       dataset_types: %{
-        pt: fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit'", aom.id),
+        pt:
+          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'public-transit' AND is_active=TRUE", aom.id),
         bike_scooter_sharing:
-          fragment("SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing'", aom.id)
+          fragment(
+            "SELECT COUNT(*) FROM dataset WHERE aom_id=? AND type = 'bike-scooter-sharing' AND is_active=TRUE",
+            aom.id
+          )
       },
       quality: %{
         # we get the number of day since the latest resource is expired


### PR DESCRIPTION
Dans #1748, il a été vu que la carte de disponibilité des horaires théoriques contenait une info incorrecte concernant le nombre de datasets.

Cette PR corrige en fait davantage de points où les datasets inactifs étaient comptabilisés par erreur:
- `nb_datasets` qui est affiché sur la carte mentionnée dans #1748
- `dataset_types`
- `region_features_query`
- `quality_features_query`

Je n'ai :warning: pas traité les points suivants, qui auraient pu l'être, car je n'étais pas sûr de l'impact à ce stade:
- `quality`
- `error_level`

Il serait bon d'avoir un mécanisme plus large, type "global scope" RubyOnRails, ou une vue filtrée par défaut (j'ai vu plusieurs mentions de cette technique pour gérer les "soft delete" avec Ecto), ou au moins une query composée de départ qui serait plus DRY, mais dans l'immédiat ça fera l'affaire.

### Avant/après sur le cas des AOM:

On avait initialement (avec `curl http://localhost:5000/api/stats | jq ".features[] | select(.properties.id == 114).properties"
`):

```json
{
  "completed": false,
  "dataset_count": 3,
  "dataset_formats": {
    "gtfs": 2,
    "netex": 2,
    "non_standard_rt": 0
  },
  "dataset_types": {
    "bike_scooter_sharing": 0,
    "pt": 3
  },
  "forme_juridique": "Communauté urbaine",
  "id": 114,
  "nom": "Grand Reims",
  "parent_dataset_name": null,
  "parent_dataset_slug": null,
  "quality": {
    "error_level": null,
    "expired_from": {
      "nb_days": null,
      "status": "unreadable"
    }
  }
}
```

Et on a à présent:

```json
{
  "completed": false,
  "dataset_count": 2,
  "dataset_formats": {
    "gtfs": 2,
    "netex": 2,
    "non_standard_rt": 0
  },
  "dataset_types": {
    "bike_scooter_sharing": 0,
    "pt": 2
  },
  "forme_juridique": "Communauté urbaine",
  "id": 114,
  "nom": "Grand Reims",
  "parent_dataset_name": null,
  "parent_dataset_slug": null,
  "quality": {
    "error_level": null,
    "expired_from": {
      "nb_days": null,
      "status": "unreadable"
    }
  }
}
```