### PR TITLE
[WIP] Simplification de la build (suppression du marquage "external")

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            mix test
+            mix test --warning-as-errors
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            mix test --warning-as-errors
+            mix test --warnings-as-errors
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,18 +182,6 @@ jobs:
           command: |
             mix test
 
-  test_external:
-    <<: *defaults_with_postgres
-
-    steps:
-      - attach_workspace:
-          at: ~/transport
-
-      - run:
-          name: Run tests
-          command: |
-            mix test --only external
-
 workflows:
   version: 2
   transport:
@@ -209,10 +197,6 @@ workflows:
             - build
 
       - test_unit:
-          requires:
-            - build
-
-      - test_external:
           requires:
             - build
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,6 @@ Run the server with `mix phx.server` and you can visit [`127.0.0.1:5000`](http:/
 
 Run the tests with `mix test`
 
-You can also:
-
-  * Run the "external" tests with `mix test --only external`
-  * Run everything with `RUN_ALL=1 mix test`
-
 The application is an [umbrella app](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html). It means that it is split into several sub-projects (that you can see under `/apps`).
 
 To run tests for a specific app, for example the `transport` or `gbfs` app, use this command:
@@ -107,9 +102,9 @@ The following commands will launch the test and generate coverage:
 
 ```
 # Display overall (whole app) coverage for all tests in the console
-MIX_ENV=test RUN_ALL=1 mix coveralls --umbrella
+MIX_ENV=test mix coveralls --umbrella
 # Same with a HTML report
-MIX_ENV=test RUN_ALL=1 mix coveralls.html --umbrella
+MIX_ENV=test mix coveralls.html --umbrella
 
 # Display coverage for each umbrella component, rather
 MIX_ENV=test mix coveralls

--- a/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
@@ -5,8 +5,6 @@ defmodule GBFS.JCDecauxControllerTest do
   import Mock
   import GBFS.Checker
 
-  @moduletag :external
-
   describe "JCDecaux GBFS conversion" do
     test "on gbfs.json", %{conn: conn} do
       conn = conn |> get(Routes.toulouse_path(conn, :index))

--- a/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
@@ -5,8 +5,6 @@ defmodule GBFS.VCubControllerTest do
   import Mock
   import GBFS.Checker
 
-  @moduletag :external
-
   describe "test VCub GBFS conversion" do
     test "test gbfs.json", %{conn: conn} do
       conn = conn |> get(Routes.v_cub_path(conn, :index))

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -1,7 +1,4 @@
-# Exclude all external tests from running (unless RUN_ALL is provided)
-run_all = System.get_env("RUN_ALL") == "1"
-excludes = if run_all, do: [], else: [:external]
-ExUnit.configure(exclude: excludes ++ [:pending])
+ExUnit.configure(exclude: [:pending])
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -9,8 +9,3 @@ ExUnit.start()
 ExVCR.Config.cassette_library_dir("test/fixture/cassettes")
 
 Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, :manual)
-
-# Temporary solution to consider warnings as errors during tests,
-# until `mix test --warning-as--errors` is available (Elixir 1.12+)
-# https://github.com/elixir-lang/elixir/issues/3223#issuecomment-751876927
-Code.put_compiler_option(:warnings_as_errors, true)

--- a/apps/transport/test/transport/import_data_service_test.exs
+++ b/apps/transport/test/transport/import_data_service_test.exs
@@ -4,8 +4,6 @@ defmodule Transport.ImportDataServiceTest do
   use TransportWeb.ExternalCase
   alias Transport.ImportData
 
-  @moduletag :external
-
   setup do
     Mox.stub_with(Datagouvfr.Client.CommunityResources.Mock, Datagouvfr.Client.StubCommunityResources)
     :ok

--- a/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
@@ -59,7 +59,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert html_response(conn, 200) =~ "Ajouter un jeu de données"
   end
 
-  @tag :external
   test "Add a dataset with a region and AOM", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -80,7 +79,6 @@ defmodule TransportWeb.BackofficeControllerTest do
              "%{region: [\"Vous devez remplir soit une région soit une AOM soit utiliser les zones data.gouv\"]}"
   end
 
-  @tag :external
   test "Add a dataset without a region nor aom", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -103,7 +101,6 @@ defmodule TransportWeb.BackofficeControllerTest do
              "%{region: [\"Vous devez remplir soit une région soit une AOM soit utiliser les zones data.gouv\"]}"
   end
 
-  @tag :external
   test "Add a dataset linked to a region", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -148,7 +145,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert get_flash(conn, :info) =~ "ajouté"
   end
 
-  @tag :external
   test "Add a dataset linked to aom", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -191,7 +187,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert get_flash(conn, :info) =~ "ajouté"
   end
 
-  @tag :external
   test "Add a dataset linked to cities", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -216,7 +211,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert get_flash(conn, :info) =~ "ajouté"
   end
 
-  @tag :external
   test "Add a dataset linked to cities and to the country", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -247,7 +241,6 @@ defmodule TransportWeb.BackofficeControllerTest do
              "Vous devez remplir soit une région soit une AOM soit utiliser les zones data.gouv"
   end
 
-  @tag :external
   test "Add a dataset linked to an AO and with an empty territory name", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -274,7 +267,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert get_flash(conn, :info) =~ "ajouté"
   end
 
-  @tag :external
   test "Add a dataset linked to a region and to the country", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do
@@ -301,7 +293,6 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert flash =~ "Un jeu de données ne pas pas être à la fois régional et national"
   end
 
-  @tag :external
   test "Add a dataset twice", %{conn: conn} do
     conn =
       use_cassette "session/create-2" do

--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule TransportWeb.ContactControllerTest do
-  use TransportWeb.ConnCase, async: true
+  # NOTE: going "async" false until https://github.com/etalab/transport-site/issues/1751 is solved,
+  # because other tests are using "with_mock" on Mailjet.Client
+  use TransportWeb.ConnCase, async: false
 
   test "Post contact form with honey pot filled", %{conn: conn} do
     conn
@@ -10,6 +12,7 @@ defmodule TransportWeb.ContactControllerTest do
     |> assert
   end
 
+  @tag :focus
   test "Post contact form without honey pot", %{conn: conn} do
     conn
     |> post(

--- a/apps/transport/test/transport_web/controllers/places_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/places_controller_test.exs
@@ -17,7 +17,6 @@ defmodule TransportWeb.API.PlacesControllerTest do
       |> Enum.sort()
       |> Enum.map(&Map.update!(&1, "url", fn v -> cleanup(v) end))
 
-  @tag :external
   test "Search a place", %{conn: conn} do
     r =
       conn
@@ -39,7 +38,6 @@ defmodule TransportWeb.API.PlacesControllerTest do
              ])
   end
 
-  @tag :external
   test "Search a place with accent", %{conn: conn} do
     r =
       conn
@@ -66,7 +64,6 @@ defmodule TransportWeb.API.PlacesControllerTest do
              ])
   end
 
-  @tag :external
   test "Search a place with multiple word", %{conn: conn} do
     r =
       conn
@@ -88,7 +85,6 @@ defmodule TransportWeb.API.PlacesControllerTest do
              ])
   end
 
-  @tag :external
   test "Search a unknown place", %{conn: conn} do
     r =
       conn

--- a/config/test.exs
+++ b/config/test.exs
@@ -57,9 +57,8 @@ config :db, DB.Repo,
 # temporary stuff, yet this is not DRY
 config :transport,
   datagouvfr_site: "https://demo.data.gouv.fr",
-  # NOTE: the tests are normally expected to be marked :external
-  # and rely on ExVCR cassettes at the moment. This provides the expected
-  # target host name for them, until we move to a behaviour-based testing instead.
+  # NOTE: some tests still rely on ExVCR cassettes at the moment. We configure the
+  # expected host here, until we move to a behaviour-based testing instead.
   gtfs_validator_url: "https://transport-validator.cleverapps.io"
 
 config :transport, TransportWeb.Endpoint,

--- a/learning_track.md
+++ b/learning_track.md
@@ -22,8 +22,7 @@ This guide tracks useful steps to learn how to maintain and modify this system.
 
 * Double-check `.envrc` values (this requirement will go away later)
 * Make sure to run ChromeDriver in a way or another
-* Run the default `mix test` suite (which excludes tests with special needs)
-* Run the full suite with `RUN_ALL` (see readme, this includes tests with special needs e.g. ChromeDriver)
+* Run the test suite with `mix test`
 * Learn how to run a single test (see readme), as this is very useful for debugging
 * :warning: All the tests should pass locally! If they don't, file an issue
 


### PR DESCRIPTION
Je continue petit à petit à simplifier le setup, car nous allons être bientôt 4 développeurs, et qu'il va falloir optimiser différents points (vérifier l'absence de dépendances circulaires via le CI, optimiser le cache pour ne pas attendre trop longtemps quand les branches vont se multiplier etc).

Dans ce cadre j'ai été supprimer le tag `:external`, qui marquait initialement l'usage des cassettes. En effet, ce tag n'était pas forcément synchro avec le besoin réel de cassette d'une part, et d'autre part ça force à avoir 2 lancements de tests, et je vais devoir modifier la façon de lancer les tests (pour les dépendances circulaires justement), donc autant simplifier.

En local, j'ai comparé le lancement complet avec le lancement sans "external", et au final on est sur des durées assez courtes (20 à 27 secondes), ce qui veut dire que le besoin de bypasser les tests external n'est pas vraiment nécessaire en local.

Je pense par contre que cette PR va nécessiter un peu de nettoyage (avant ou après merge, on va voit) du fait que certains tests utilisent `with_mock` et modifient l'état global (voir #1751 pour un exemple), et que ça ne se voyait pas forcément avant, donc je la crée mais il va falloir voir si la build passe.

Au moment de l'ouverture de cette PR, je rencontre également un souci lié `yarn install` mais qui n'a pas de rapport (normalement) avec la PR.