### PR TITLE
WIP Amélioration: bloquage de la build dès qu'une référence circulaire est détectée

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,8 +179,19 @@ jobs:
 
       - run:
           name: Run tests
+          # Why running `mix cmd mix test` ? The answer is at
+          # https://github.com/smartlogic/smartlogic.io/blob/main/podcast/elixir-wizards/transcripts/s4e11_Johanna_Larsson.txt
+          #
+          # "One great trick is using ‘mix CMD mix test’. So normally in an umbrella, if you run
+          # mix tests, it loads all of the apps and the runs of tests for each app through all of the apps.
+          # The problem there is that all of the apps are loaded and each app will load all of its dependencies.
+          # So a dependency of one app is available to another app even if it doesn’t explicitly find it.
+          # If you use mix CMD mix test’, it loads each app separately into its own relying VM.
+          # So it doesn’t have access to the other apps or the other apps dependencies. And that sort of 
+          # enforces the separation of the apps. You can’t accidentally call into a different app, at least
+          # not in your test and lose that separation of concern.
           command: |
-            mix test --warnings-as-errors
+            mix cmd mix test --warnings-as-errors
 
 workflows:
   version: 2

--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -12,6 +12,7 @@ defmodule TransportWeb.ContactControllerTest do
     |> assert
   end
 
+  @tag :focus
   test "Post contact form without honey pot", %{conn: conn} do
     conn
     |> post(

--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -12,7 +12,6 @@ defmodule TransportWeb.ContactControllerTest do
     |> assert
   end
 
-  @tag :focus
   test "Post contact form without honey pot", %{conn: conn} do
     conn
     |> post(


### PR DESCRIPTION
(Hat-tip to @LostKobrakai who provided this better version of what I used before (iterating over `/apps` and running myself) via the Elixir lang slack, and to @joladev who (as I found out looking for information) mentioned that in a [podcast](https://github.com/smartlogic/smartlogic.io/blob/main/podcast/elixir-wizards/transcripts/s4e11_Johanna_Larsson.txt), thanks to both of you for disseminating that information around!).

Durant les mois passés, j'ai petit à petit amélioré la codebase pour que chaque app sous `/apps` (ex: `db`, `transport`) puisse être testée de façon autonome (avec `mix cmd --app db mix test --color` par exemple).

Il y avait plusieurs cas où une application "enfant" (`db` par exemple) dépendait de l'application principale `transport`, mais ça ne se voyait pas en CI, ni au lancement réel de l'application (ce qui est déjà pratique), et je les ai supprimé.

J'en ai par contre a priori réintroduit, et donc dans la présente PR, j'ajoute un mécanisme, après quelques recherches, qui va bloquer la build dès lors qu'on a une référence circulaire, comme ça on sera prévenu dans le futur.
