### PR TITLE
Création d'un behavior "Validator" pour la validation d'une resource

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -9,10 +9,6 @@ defmodule DB.Resource do
   import DB.Gettext
   require Logger
 
-  @client Transport.Shared.Wrapper.HTTPoison.impl()
-  @res HTTPoison.Response
-  @err HTTPoison.Error
-  @timeout 180_000
 
   typed_schema "resource" do
     field(:is_active, :boolean)
@@ -186,23 +182,6 @@ defmodule DB.Resource do
       })
 
       {:error, e}
-  end
-
-  @spec validate(__MODULE__.t()) :: {:error, any} | {:ok, map()}
-  def validate(%__MODULE__{url: nil}), do: {:error, "No url"}
-
-  def validate(%__MODULE__{url: url, format: "GTFS"}) do
-    case @client.get("#{endpoint()}?url=#{URI.encode_www_form(url)}", [], recv_timeout: @timeout) do
-      {:ok, %@res{status_code: 200, body: body}} -> Jason.decode(body)
-      {:ok, %@res{body: body}} -> {:error, body}
-      {:error, %@err{reason: error}} -> {:error, error}
-      _ -> {:error, "Unknown error in validation"}
-    end
-  end
-
-  def validate(%__MODULE__{format: f, id: id}) do
-    Logger.info("cannot validate resource id=#{id} because we don't know how to validate the #{f} format")
-    {:ok, %{"validations" => nil, "metadata" => nil}}
   end
 
   @spec save(__MODULE__.t(), map()) :: {:ok, any()} | {:error, any()}

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -9,7 +9,6 @@ defmodule DB.Resource do
   import DB.Gettext
   require Logger
 
-
   typed_schema "resource" do
     field(:is_active, :boolean)
     # real url

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -130,8 +130,10 @@ defmodule DB.Resource do
   def validate_and_save(%__MODULE__{id: resource_id} = resource, force_validation) do
     Logger.info("Validating #{resource.url}")
 
+    gtfs_transport_validator = DB.Resource.GtfsTransportValidator.Wrapper.impl()
+
     with {true, msg} <- __MODULE__.needs_validation(resource, force_validation),
-         {:ok, validations} <- validate(resource),
+         {:ok, validations} <- gtfs_transport_validator.validate(resource),
          {:ok, _} <- save(resource, validations) do
       # log the validation success
       Repo.insert(%LogsValidation{

--- a/apps/db/lib/db/resource_validator.ex
+++ b/apps/db/lib/db/resource_validator.ex
@@ -1,0 +1,56 @@
+defmodule DB.Resource.Validator do
+  alias DB.Resource
+
+  @doc """
+  Behavior for validating a resource
+  """
+  @callback validate(%Resource{}) :: {:ok, %{}} | {:error, binary()}
+end
+
+defmodule DB.Resource.GtfsTransportValidator.Wrapper do
+  def impl(), do: Application.get_env(:transport, :gtfs_transport_validator, DB.Resource.GtfsTransportValidator)
+end
+
+defmodule DB.Resource.Validator.Common do
+  defmacro __using__([]) do
+    quote do
+      def validate(%DB.Resource{url: nil}) do
+        {:error, "No Resource url provided"}
+      end
+    end
+  end
+end
+
+defmodule DB.Resource.GtfsTransportValidator do
+  @moduledoc """
+    Validator of GTFS files, based on the Rust Validator maintened by the team
+    https://github.com/etalab/transport-validator/
+  """
+
+  @behaviour DB.Resource.Validator
+  use DB.Resource.Validator.Common
+  alias DB.Resource
+
+  @httpClient Transport.Shared.Wrapper.HTTPoison.impl()
+  @httpRes HTTPoison.Response
+  @httpErr HTTPoison.Error
+  @timeout 180_000
+
+  @doc """
+    Endpoint of the gtfs validator
+  """
+  @spec endpoint() :: binary()
+  def endpoint, do: Application.fetch_env!(:transport, :gtfs_validator_url) <> "/validate"
+
+  @impl DB.Resource.Validator
+  def validate(%Resource{format: "GTFS", url: url}) do
+    case @httpClient.get("#{endpoint()}?url=#{URI.encode_www_form(url)}", [], recv_timeout: @timeout) do
+      {:ok, %@httpRes{status_code: 200, body: body}} -> Jason.decode(body)
+      {:ok, %@httpRes{body: body}} -> {:error, body}
+      {:error, %@httpErr{reason: error}} -> {:error, error}
+      _ -> {:error, "Unknown error in #{__MODULE__} validation"}
+    end
+  end
+
+  def validate(%Resource{}), do: {:error, "#{__MODULE__} can only validate GTFS resources"}
+end

--- a/apps/db/lib/db/resource_validator.ex
+++ b/apps/db/lib/db/resource_validator.ex
@@ -1,17 +1,23 @@
 defmodule DB.Resource.Validator do
+  @moduledoc """
+    Behavior for validating a resource
+  """
   alias DB.Resource
 
-  @doc """
-  Behavior for validating a resource
-  """
   @callback validate(%Resource{}) :: {:ok, %{}} | {:error, binary()}
 end
 
 defmodule DB.Resource.GtfsTransportValidator.Wrapper do
-  def impl(), do: Application.get_env(:transport, :gtfs_transport_validator, DB.Resource.GtfsTransportValidator)
+  @moduledoc """
+    Wrapper for the GTFS Validator, implementing the real module or a Mock during testing
+  """
+  def impl, do: Application.get_env(:transport, :gtfs_transport_validator, DB.Resource.GtfsTransportValidator)
 end
 
 defmodule DB.Resource.Validator.Common do
+  @moduledoc """
+    function in common to all validators
+  """
   defmacro __using__([]) do
     quote do
       def validate(%DB.Resource{url: nil}) do
@@ -31,9 +37,9 @@ defmodule DB.Resource.GtfsTransportValidator do
   use DB.Resource.Validator.Common
   alias DB.Resource
 
-  @httpClient Transport.Shared.Wrapper.HTTPoison.impl()
-  @httpRes HTTPoison.Response
-  @httpErr HTTPoison.Error
+  @http_client Transport.Shared.Wrapper.HTTPoison.impl()
+  @http_res HTTPoison.Response
+  @http_err HTTPoison.Error
   @timeout 180_000
 
   @doc """
@@ -44,10 +50,10 @@ defmodule DB.Resource.GtfsTransportValidator do
 
   @impl DB.Resource.Validator
   def validate(%Resource{format: "GTFS", url: url}) do
-    case @httpClient.get("#{endpoint()}?url=#{URI.encode_www_form(url)}", [], recv_timeout: @timeout) do
-      {:ok, %@httpRes{status_code: 200, body: body}} -> Jason.decode(body)
-      {:ok, %@httpRes{body: body}} -> {:error, body}
-      {:error, %@httpErr{reason: error}} -> {:error, error}
+    case @http_client.get("#{endpoint()}?url=#{URI.encode_www_form(url)}", [], recv_timeout: @timeout) do
+      {:ok, %@http_res{status_code: 200, body: body}} -> Jason.decode(body)
+      {:ok, %@http_res{body: body}} -> {:error, body}
+      {:error, %@http_err{reason: error}} -> {:error, error}
       _ -> {:error, "Unknown error in #{__MODULE__} validation"}
     end
   end

--- a/apps/db/test/resource_validator_test.exs
+++ b/apps/db/test/resource_validator_test.exs
@@ -1,0 +1,44 @@
+defmodule DB.ResourceValidatorTest do
+  use ExUnit.Case
+  import Mox
+
+  setup :verify_on_exit!
+
+  describe "the transport gtfs validator" do
+    test "with a validation going well" do
+      resource_url = "url"
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, 1, fn url, [], _ ->
+        assert url |> String.contains?(resource_url)
+        {:ok, %HTTPoison.Response{status_code: 200, body: "{\"is_valid\": true}"}}
+      end)
+
+      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate
+      assert {:ok, %{"is_valid" => true}} == validation
+    end
+
+    test "with a validation failing" do
+      resource_url = "url"
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, 1, fn url, [], _ ->
+        assert url |> String.contains?(resource_url)
+        {:ok, %HTTPoison.Response{status_code: 500, body: "internal server error"}}
+      end)
+
+      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate
+      assert {:error, "internal server error"} == validation
+    end
+
+    test "with a wrong format" do
+      {:error, msg} = %DB.Resource{format: "CSV", url: "url"} |> DB.Resource.GtfsTransportValidator.validate
+      assert msg |> String.contains?("can only validate GTFS resources")
+    end
+
+    test "with a missing url" do
+      {:error, msg} = %DB.Resource{format: "GTFS", url: nil} |> DB.Resource.GtfsTransportValidator.validate
+      assert msg == "No Resource url provided"
+    end
+  end
+end

--- a/apps/db/test/resource_validator_test.exs
+++ b/apps/db/test/resource_validator_test.exs
@@ -14,7 +14,7 @@ defmodule DB.ResourceValidatorTest do
         {:ok, %HTTPoison.Response{status_code: 200, body: "{\"is_valid\": true}"}}
       end)
 
-      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate
+      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate()
       assert {:ok, %{"is_valid" => true}} == validation
     end
 
@@ -27,17 +27,17 @@ defmodule DB.ResourceValidatorTest do
         {:ok, %HTTPoison.Response{status_code: 500, body: "internal server error"}}
       end)
 
-      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate
+      validation = %DB.Resource{format: "GTFS", url: resource_url} |> DB.Resource.GtfsTransportValidator.validate()
       assert {:error, "internal server error"} == validation
     end
 
     test "with a wrong format" do
-      {:error, msg} = %DB.Resource{format: "CSV", url: "url"} |> DB.Resource.GtfsTransportValidator.validate
+      {:error, msg} = %DB.Resource{format: "CSV", url: "url"} |> DB.Resource.GtfsTransportValidator.validate()
       assert msg |> String.contains?("can only validate GTFS resources")
     end
 
     test "with a missing url" do
-      {:error, msg} = %DB.Resource{format: "GTFS", url: nil} |> DB.Resource.GtfsTransportValidator.validate
+      {:error, msg} = %DB.Resource{format: "GTFS", url: nil} |> DB.Resource.GtfsTransportValidator.validate()
       assert msg == "No Resource url provided"
     end
   end

--- a/apps/db/test/test_helper.exs
+++ b/apps/db/test/test_helper.exs
@@ -2,3 +2,4 @@ ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, :manual)
 Mox.defmock(Transport.HTTPoison.Mock, for: HTTPoison.Base)
+Mox.defmock(DB.Resource.GtfsTransportValidator.Mock, for: DB.Resource.Validator)

--- a/apps/transport/test/support/mocks.ex
+++ b/apps/transport/test/support/mocks.ex
@@ -1,2 +1,3 @@
 Mox.defmock(Transport.ExAWS.Mock, for: ExAws.Behaviour)
 Mox.defmock(Transport.HTTPoison.Mock, for: HTTPoison.Base)
+Mox.defmock(DB.Resource.GtfsTransportValidator.Mock, for: DB.Resource.Validator)

--- a/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
@@ -11,7 +11,8 @@ defmodule TransportWeb.BackofficeControllerTest do
     Mox.stub_with(Datagouvfr.Client.CommunityResources.Mock, Datagouvfr.Client.StubCommunityResources)
 
     # ressource.db now uses DB.Resource.GtfsTransportValidatorinstead of HTTPoison directly
-    # we stub the 2 mocks with the real modules here to keep the tests of this file unchanged (ie make real validator calls !)
+    # we stub the 2 mocks with the real modules here to keep the tests of this file unchanged
+    # (ie make real validator calls !)
     Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
     Mox.stub_with(DB.Resource.GtfsTransportValidator.Mock, DB.Resource.GtfsTransportValidator)
 

--- a/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice_controller_test.exs
@@ -10,9 +10,11 @@ defmodule TransportWeb.BackofficeControllerTest do
   setup do
     Mox.stub_with(Datagouvfr.Client.CommunityResources.Mock, Datagouvfr.Client.StubCommunityResources)
 
-    # ressource.db now uses Transport.Shared.Wrapper.HTTPoison instead of HTTPoison directly
-    # we stub the mock with the real module here to keep the tests of this file unchanged.
+    # ressource.db now uses DB.Resource.GtfsTransportValidatorinstead of HTTPoison directly
+    # we stub the 2 mocks with the real modules here to keep the tests of this file unchanged (ie make real validator calls !)
     Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
+    Mox.stub_with(DB.Resource.GtfsTransportValidator.Mock, DB.Resource.GtfsTransportValidator)
+
     :ok
   end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,7 +26,8 @@ config :transport,
   cache_impl: Transport.Cache.Null,
   ex_aws_impl: Transport.ExAWS.Mock,
   httpoison_impl: Transport.HTTPoison.Mock,
-  history_impl: Transport.History.Fetcher.Mock
+  history_impl: Transport.History.Fetcher.Mock,
+  gtfs_transport_validator: DB.Resource.GtfsTransportValidator.Mock
 
 config :datagouvfr,
   community_resources_impl: Datagouvfr.Client.CommunityResources.Mock


### PR DESCRIPTION
Travail préparatoire pour ajouter la possibilité de brancher différents validateurs dans l'application. Au lieu d'appeler une fonction `validate`, on créé un behavior de Validator. Puis une implémentation de ce behavior qui utilise le validateur gtfs de transport.data.gouv.fr

Cela permet également de tester indépendamment l'appel au validateur GTFS.

Rajouter un nouveau validateur sera également plus facile.

Le travail en cours sur la nouvelle architecture de l'appli va peut-être venir encore modifier ce code par la suite, mais j'espère que le fait d'avoir défini des frontières plus claires entre le module Resource et la validation rendra l'arrivée de la nouvelle architecture plus simple. Typiquement le module Validator pourrait j'imagine se retrouver appelé côté "worker".

Le module Validator pourrait à terme changer d'app, pour le moment je l'ai laissée dans DB, à côté des ressources.