### PR TITLE
Compression et digest des static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN node --version
 ENV PORT 8080
 ENV MIX_ENV prod
 RUN mix deps.compile
-RUN mix phx.digest
 RUN cd apps/transport/client && yarn install && npm run build
+RUN mix phx.digest
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV PORT 8080
 ENV MIX_ENV prod
 RUN mix deps.compile
 RUN cd apps/transport/client && yarn install && npm run build
+# assets digest must happen after the npm build step
 RUN mix phx.digest
 
 EXPOSE 8080

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -18,7 +18,7 @@ defmodule TransportWeb.Endpoint do
   plug(Plug.Static,
     at: "/",
     from: :transport,
-    gzip: true,
+    gzip: Mix.env() == :prod,
     only:
       ~w(js css fonts images data favicon.ico robots.txt documents BingSiteAuth.xml google5be4b09db1274976.html demo_rt.html)
   )

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -18,7 +18,7 @@ defmodule TransportWeb.Endpoint do
   plug(Plug.Static,
     at: "/",
     from: :transport,
-    gzip: false,
+    gzip: true,
     only:
       ~w(js css fonts images data favicon.ico robots.txt documents BingSiteAuth.xml google5be4b09db1274976.html demo_rt.html)
   )

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :transport, TransportWeb.Endpoint,
-  http: [port: {:system, "PORT"}],
+  http: [port: {:system, "PORT"}, compress: true],
   url: [scheme: "https", host: System.get_env("DOMAIN_NAME") || "transport.data.gouv.fr", port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json",
   secret_key_base: System.get_env("SECRET_KEY_BASE"),


### PR DESCRIPTION
closes #1495

Oh zut alors, j'ai passé une bonne partie de la journée à essayer de comprendre pourquoi nos assets n'étaient pas compressés et pourquoi le digest n'était pas ajouté au nom de nos assets, et je vois que la réponse était en fait dans #1495 :sweat_smile: 

Voyons le bon côté des choses : j'ai appris des trucs et je suis arrivé à la même conclusion.

Qui était donc que l'on lançait dans le Dockerfile le `mix phx.digest` avant la phase de build de npm, et que par conséquent, webpack n'avait pas encore fait son travail, et les assets n'étaient pas encore là (voir le dossier priv/static n'existait même pas).

J'en profite pour activer la compression des documents html, via une option dans prod.exs. J'ai fait des tests sur prochainement, on passe de 2.27Mo transférés pour la page d'accueil à 1.44Mb, soit -36% c'est pas mal.

On note au passage que le assets demandés ont maintenant leur digest accolé à leurs noms.

![image](https://user-images.githubusercontent.com/15341118/131688771-efd120bb-d95e-4794-8c07-2fbfdd4bc1c2.png)
