### PR TITLE
Réparation des imports pour les datasets liés à une zone datagouv

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -228,7 +228,7 @@ defmodule Transport.ImportData do
   @spec fetch_data_gouv_zone_insee(binary()) :: [binary()]
   defp fetch_data_gouv_zone_insee(zone) do
     base_url = Application.fetch_env!(:transport, :datagouvfr_site)
-    url = "#{base_url}/api/1/spatial/zones/#{zone}"
+    url = "#{base_url}/api/1/spatial/zones/#{zone}/"
     Logger.info("getting zone (url = #{url})")
 
     with {:ok, response} <- HTTPoison.get(url, [], hackney: [follow_redirect: true]),

--- a/apps/transport/test/fixture/cassettes/client/datasets/sncf.json
+++ b/apps/transport/test/fixture/cassettes/client/datasets/sncf.json
@@ -124,7 +124,7 @@
         "follow_redirect": "true"
       },
       "request_body": "",
-      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/country:fr"
+      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/country:fr/"
     },
     "response": {
       "binary": false,

--- a/apps/transport/test/fixture/cassettes/dataset/dataset-with-multiple-cities-and-country.json.json
+++ b/apps/transport/test/fixture/cassettes/dataset/dataset-with-multiple-cities-and-country.json.json
@@ -108,7 +108,7 @@
         "follow_redirect": "true"
       },
       "request_body": "",
-      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/fr:commune:38185@1943-01-01"
+      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/fr:commune:38185@1943-01-01/"
     },
     "response": {
       "binary": false,

--- a/apps/transport/test/fixture/cassettes/dataset/dataset-with-multiple-cities.json.json
+++ b/apps/transport/test/fixture/cassettes/dataset/dataset-with-multiple-cities.json.json
@@ -108,7 +108,7 @@
         "follow_redirect": "true"
       },
       "request_body": "",
-      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/fr:commune:38185@1943-01-01"
+      "url": "https://demo.data.gouv.fr/api/1/spatial/zones/fr:commune:38185@1943-01-01/"
     },
     "response": {
       "binary": false,


### PR DESCRIPTION
closes #1790 

On a un problème avec HTTPoison (de Hackney en fait) qui ne gère pas les redirect pour les codes 308. Voir https://github.com/benoitc/hackney/issues/635
Ceci est juste un quick fix : je change l'url que l'on requête sur data.gouv.fr pour éviter d'avoir une 308 en retour et directement une 200. Mais ça ne règle pas le problème de la librairie en dessous, je vais créer une issue pour cela.