### PR TITLE
Buckets : lecture des objets de l'organisation uniquement

### DIFF
--- a/apps/transport/lib/transport/history/backup.ex
+++ b/apps/transport/lib/transport/history/backup.ex
@@ -61,12 +61,12 @@ defmodule Transport.History.Backup do
 
   @spec get_already_backuped_resources(DB.Resource.t()) :: [map()]
   defp get_already_backuped_resources(resource) do
-    resource
-    |> Shared.resource_bucket_id()
-    |> ExAws.S3.list_objects(prefix: resource_title(resource))
-    |> Transport.Wrapper.ExAWS.impl().stream!()
+    bucket = Shared.resource_bucket_id(resource)
+
+    bucket
+    |> Transport.History.Shared.list_objects(resource_title(resource))
     |> Enum.map(fn o ->
-      metadata = Shared.fetch_history_metadata(Shared.resource_bucket_id(resource), o.key)
+      metadata = Shared.fetch_history_metadata(bucket, o.key)
 
       %{
         key: o.key,

--- a/apps/transport/lib/transport/history/fetcher_s3.ex
+++ b/apps/transport/lib/transport/history/fetcher_s3.ex
@@ -12,8 +12,7 @@ defmodule Transport.History.Fetcher.S3 do
     bucket = Transport.History.Shared.dataset_bucket_id(dataset)
 
     bucket
-    |> ExAws.S3.list_objects()
-    |> Transport.Wrapper.ExAWS.impl().stream!()
+    |> Transport.History.Shared.list_objects()
     |> Enum.to_list()
     |> Enum.map(fn f ->
       metadata = Transport.History.Shared.fetch_history_metadata(bucket, f.key)

--- a/apps/transport/lib/transport/history/shared.ex
+++ b/apps/transport/lib/transport/history/shared.ex
@@ -11,13 +11,13 @@ defmodule Transport.History.Shared do
   @spec resource_bucket_id(DB.Resource.t()) :: binary()
   def resource_bucket_id(%DB.Resource{} = resource), do: dataset_bucket_id(resource.dataset)
 
-  @spec list_objects(binary(), binary() | nil) :: Stream.t()
-  def list_objects(bucket, prefix \\ nil) do
+  @spec list_objects(binary(), binary()) :: Enum.t()
+  def list_objects(bucket, prefix \\ "") do
     bucket
     |> ExAws.S3.list_objects(prefix: prefix)
     |> Transport.Wrapper.ExAWS.impl().stream!()
     # Make sure objects belong to our organisation
-    |> Enum.filter(fn object ->
+    |> Stream.filter(fn object ->
       String.ends_with?(object[:owner][:display_name], Application.fetch_env!(:ex_aws, :cellar_organisation_id))
     end)
   end

--- a/apps/transport/test/transport/history_test.exs
+++ b/apps/transport/test/transport/history_test.exs
@@ -45,7 +45,7 @@ defmodule Transport.HistoryTest do
                path: "/"
              } = request
 
-      [%{key: "hello"}]
+      [%{key: "hello", owner: %{display_name: "foo@fake-cellar_organisation_id"}}]
     end)
     |> expect(:request!, fn request ->
       assert %{
@@ -88,7 +88,19 @@ defmodule Transport.HistoryTest do
                  path: "/"
                } = request
 
-        [%{key: "some-resource", last_modified: DateTime.add(DateTime.utc_now(), -60 * 60 * 24, :second)}]
+        [
+          %{
+            key: "some-resource",
+            last_modified: DateTime.add(DateTime.utc_now(), -60 * 60 * 24, :second),
+            owner: %{display_name: "foo@fake-cellar_organisation_id"}
+          },
+          # Resource *not* belonging to our organisation
+          %{
+            key: "other-resource",
+            last_modified: DateTime.add(DateTime.utc_now(), -60 * 60 * 24, :second),
+            owner: %{display_name: "foo@other-cellar_organisation_id"}
+          }
+        ]
       end)
       |> expect(:request!, fn request ->
         assert %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -111,6 +111,18 @@ config :transport,
 config :datagouvfr,
   community_resources_impl: Datagouvfr.Client.CommunityResources.API
 
+config :ex_aws,
+  access_key_id: System.get_env("CELLAR_ACCESS_KEY_ID"),
+  secret_access_key: System.get_env("CELLAR_SECRET_ACCESS_KEY"),
+  # The expected S3 owner of buckets/objects.
+  # For CleverCloud and the Cellar service, it looks like `orga-$UUID`
+  cellar_organisation_id: System.get_env("CELLAR_ORGANISATION_ID"),
+  s3: [
+    scheme: "https://",
+    host: "cellar-c2.services.clever-cloud.com",
+  ],
+  json_codec: Jason
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "datagouvfr.exs"
@@ -119,15 +131,6 @@ import_config "gtfs_validator.exs"
 import_config "mailjet.exs"
 import_config "mailchimp.exs"
 import_config "#{Mix.env}.exs"
-
-config :ex_aws,
-  access_key_id: System.get_env("CELLAR_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("CELLAR_SECRET_ACCESS_KEY"),
-  s3: [
-    scheme: "https://",
-    host: "cellar-c2.services.clever-cloud.com",
-  ],
-  json_codec: Jason
 
 config :transport,
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,6 +29,9 @@ config :transport,
   history_impl: Transport.History.Fetcher.Mock,
   gtfs_validator: Validation.Validator.Mock
 
+config :ex_aws,
+  cellar_organisation_id: "fake-cellar_organisation_id"
+
 config :datagouvfr,
   community_resources_impl: Datagouvfr.Client.CommunityResources.Mock
 


### PR DESCRIPTION
Une sécurité supplémentaire pour s'assurer qu'on lit uniquement les objets qui nous appartiennent dans les buckets Cellar de CleverCloud.

Voir https://github.com/etalab/transport_deploy/issues/31 pour les détails