### PR TITLE
MAJ asdf Erlang 24.0.3 -> 24.0.4 + verrouillage plus complet de la version d'Erlang

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -13,6 +13,6 @@ elixir 1.12.2-otp-24
 # - https://github.com/erlang/otp/releases
 # - https://github.com/erlang/otp/blob/master/otp_versions.table
 # - `asdf list all erlang`
-erlang 24.0.3
+erlang 24.0.4
 
 nodejs 14.16.1

--- a/apps/transport/test/build_test.exs
+++ b/apps/transport/test/build_test.exs
@@ -10,9 +10,14 @@ defmodule TransportWeb.BuildTest do
     version
   end
 
-  def asdf_elixir_release do
-    [[_, version]] = Regex.scan(~r/erlang (\d+)\.\d/, tool_versions())
-    version
+  def asdf_erlang_version(return_full_version \\ false) do
+    [[_, full_version, major_version]] = Regex.scan(~r/erlang ((\d+)\.\d\.\d)/, tool_versions())
+
+    if return_full_version do
+      full_version
+    else
+      major_version
+    end
   end
 
   def asdf_nodejs_release do
@@ -24,8 +29,18 @@ defmodule TransportWeb.BuildTest do
     assert System.version() == asdf_elixir_version()
   end
 
-  test "make sure OTP version is same for asdf & CI" do
-    assert System.otp_release() == asdf_elixir_release()
+  test "make sure major OTP version is same for asdf & CI" do
+    assert System.otp_release() == asdf_erlang_version()
+  end
+
+  test "make sure full OTP version is same for asdf & Docker image" do
+    # NOTE: the previous tests only check the major + minor (24.0), not the build version (24.0.3)
+    # Getting the build version of OTP is tricky, but useful because in the past, we had differences.
+    # We really want to have the same version as much as possible to avoid complicated debugging stories.
+    content = File.read!("../../Dockerfile")
+    [[_, production_version]] = Regex.scan(~r/FROM.*erlang\-([\d\.]+)/, content)
+
+    assert asdf_erlang_version(true) == production_version
   end
 
   test "make sure NodeJS version is same for asdf & CI" do


### PR DESCRIPTION
Les tests présents sous https://github.com/etalab/transport-site/blob/master/apps/transport/test/build_test.exs (introduits cette année) nous ont bien aidé à identifier les versions utilisées (Elixir/Erlang/Node), à être sûr d'utiliser les bonnes versions en dév CI et prod et à les faire converger, ce qui a toujours beaucoup de valeur.

Suite à la mise à jour à 24.0.4 toutefois, j'ai vu que le système ne prévenait pas que le fichier ASDF et le Docker ne pointent pas exactement vers la même version (voir #1810).

En général c'est peu important, car OTP est très généralement bien stable et un numéro de build n'apporte pas d'incompatibilité pénible, toutefois le passage à `24.0.4` était un exemple où il y a un changement important (gestion SSL critique).

Des différences minimes peuvent aussi générer du débuggage par comparaison ratée, où on tire de mauvaises conclusions, et on perd du temps.

Dans cette PR je verrouille un peu plus la comparaison, pour que la version indiquée dans dans `.tool-versions` pour Erlang (`24.0.4`) soit exactement la même que dans le `Dockerfile`.

Cela fait un test qui échoue.

Juste derrière j'ai mis à jour OTP dans le manifeste asdf `.tool-versions` pour refléter la version de production.