### PR TITLE
Changement des liens vers schema

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -376,7 +376,7 @@ defmodule TransportWeb.DatasetView do
   end
 
   def schema_url(%{schema_name: schema_name, schema_version: schema_version}) when not is_nil(schema_version) do
-    "https://schema.data.gouv.fr/#{schema_name}/#{schema_version}.html"
+    "https://schema.data.gouv.fr/#{schema_name}/#{schema_version}/"
   end
 
   def schema_url(%{schema_name: schema_name}) do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/1816

Les URLs ont changé suite à la refonte graphique de schema.data.gouv.fr https://github.com/etalab/schema.data.gouv.fr/issues/195