### PR TITLE
Quick-fix pour exclure les tests nécessitant gtfs-to-geojson (sauf sur le CI)

### DIFF
--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -1,5 +1,7 @@
 exclude = [:pending]
-extra_exclude = if System.get_env("CI") == "1", do: [], else: [:transport_tools]
+# NOTE: the CI variable is defined by CircleCI (and oftent by CI providers) here:
+# https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+extra_exclude = if System.get_env("CI") == "true", do: [], else: [:transport_tools]
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)
 

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -1,4 +1,7 @@
-ExUnit.configure(exclude: [:pending])
+exclude = [:pending]
+extra_exclude = if System.get_env("CI") == "1", do: [], else: [:transport_tools]
+
+ExUnit.configure(exclude: exclude ++ extra_exclude)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 

--- a/apps/transport/test/transport_web/controllers/geojson_conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/geojson_conversion_controller_test.exs
@@ -4,6 +4,11 @@ defmodule TransportWeb.GeojsonConversionControllerTest do
   doctest TransportWeb.GeojsonConversionController
 
   describe "test the gtfs to geojson conversion" do
+    # NOTE: the :transport_tools tag is just a quick fix to completely skip the tests outside CI, until
+    # we implement a better version of this, allowing to skip by default yet allow local runs
+    # with specific versions (either compiled locally, or Docker-pulled)
+    # See https://github.com/etalab/transport-site/issues/1820
+    @tag :transport_tools
     test "check the conversion binary is accessible" do
       {:error, msg} = GeojsonConversionController.call_geojson_converter("")
 
@@ -11,6 +16,7 @@ defmodule TransportWeb.GeojsonConversionControllerTest do
       assert msg != "rambo exited with 0"
     end
 
+    @tag :transport_tools
     test "we can convert a gtfs" do
       {:ok, msg} = GeojsonConversionController.call_geojson_converter("#{__DIR__}/../../fixture/files/gtfs.zip")
       assert String.contains?(msg, "FeatureCollection")


### PR DESCRIPTION
Voir #1820 ; ce n'est pas le correctif qu'il faudra à terme (où on voudra par défaut, pouvoir travailler sans ces tests en local, en ayant l'assurance qu'ils tourneront en CI, et en ayant la possibilité de travailler en local avec la version de l'outil que l'on souhaite, compilée en local ou pas), mais ça permettra de remettre au vert les suites de test en local, sans nécessiter de faire tourner l'outil.

Pour vérifier le fonctionnement et simuler un CI local:

```
CI=true mix cmd --app transport mix cmd --app transport mix test test/transport_web/controllers/geojson_conversion_controller_test.exs --color
```

Si on enlève `CI=1`, les tests tourneront à nouveau.