### PR TITLE
Gestion d'une ressource CSV non UTF-8

### DIFF
--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -179,8 +179,8 @@ defmodule Opendatasoft.UrlExtractor do
         |> Enum.filter(&(&1 != nil))
     end
   rescue
-    e ->
-      # A non UTF-8 encoded CSV file can make CSV.decode() raise an exception
+    e in FunctionClauseError ->
+      # A non UTF-8 encoded CSV file can make CSV.decode() raises a FunctionClauseError exception
       # we skip the file to allow the import to continue
       Sentry.capture_exception(e,
         stacktrace: __STACKTRACE__,


### PR DESCRIPTION
closes #1834 

La librairie [CSV](https://github.com/beatrichartz/csv) lève une exception si on lui fait décoder un CSV qui a un encoding exotique. Cette PR résoud le problème en skipant la ressource en question. Je log un message dans Sentry, mais on ne saura pas directement de quel dataset il s'agit.