### PR TITLE
Bug dans la validation

### DIFF
--- a/apps/shared/lib/data_visualization.ex
+++ b/apps/shared/lib/data_visualization.ex
@@ -19,7 +19,7 @@ defmodule Transport.DataVisualization do
   def data_vis_per_issue_type(issues) do
     severity = issues |> Enum.at(0) |> Map.get("severity")
     geojson = issues
-      |> Enum.flat_map(fn issue -> issue["geojson"]["features"] end)
+      |> Enum.flat_map(fn issue -> get_in(issue, ["geojson", "features"]) || [] end)
       |> Enum.reject(&is_nil(&1))
 
     %{


### PR DESCRIPTION
Je découvre que la fonction flat_map ne gère pas les `nil`. Je croyais.

```
iex(9)> Enum.flat_map([[1,2], nil], fn l -> l end)  
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom
```

```
Enum.flat_map([[1,2], nil], fn l -> l || [] end)
[1, 2]
```

Ca faisait planter la validation du dataset des transiliens.