### PR TITLE
Mise à jour de traductions manquantes

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -8,7 +8,7 @@
     <div>
       <% # See path explanation at https://elixirforum.com/t/scoped-live-view-does-not-seem-to-generate-a-live-path-helper/31162/4?u=thbar %>
       <a class="button" href="<%= backoffice_live_path(@conn, TransportWeb.Backoffice.ProxyConfigLive) %>">
-        <%= dgettext("backoffice", "Configuration du proxy") %>
+        <%= dgettext("backoffice", "Proxy configuration") %>
       </a>
     </div>
     <div>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -17,21 +17,21 @@ defmodule TransportWeb.BreadCrumbs do
   def crumbs(conn, :new_resource) do
     crumbs(conn, :espace_producteur) ++
       [
-        {dgettext("espace-producteurs", "Nouvelle ressource"), page_path(conn, :espace_producteur)}
+        {dgettext("espace-producteurs", "New resource"), page_path(conn, :espace_producteur)}
       ]
   end
 
   def crumbs(conn, :select_resource, id) do
     crumbs(conn, :espace_producteur) ++
       [
-        {dgettext("espace-producteurs", "Sélectionner une resource"), resource_path(conn, :resources_list, id)}
+        {dgettext("espace-producteurs", "Select a resource"), resource_path(conn, :resources_list, id)}
       ]
   end
 
   def crumbs(conn, :update_resource, id) do
     crumbs(conn, :select_resource, id) ++
       [
-        {dgettext("espace-producteurs", "Mettre à jour une ressource"), page_path(conn, :espace_producteur)}
+        {dgettext("espace-producteurs", "Update a resource"), page_path(conn, :espace_producteur)}
       ]
   end
 

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -224,3 +224,11 @@ msgstr ""
 #, elixir-format
 msgid "Show only datasets"
 msgstr ""
+
+#, elixir-format
+msgid "Proxy configuration"
+msgstr ""
+
+#, elixir-format
+msgid "Update all AOMs"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -223,3 +223,11 @@ msgstr ""
 #, elixir-format
 msgid "Show only datasets"
 msgstr ""
+
+#, elixir-format
+msgid "Proxy configuration"
+msgstr ""
+
+#, elixir-format
+msgid "Update all AOMs"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -84,9 +84,9 @@ msgid "You have no resource to update for the moment"
 msgstr ""
 
 #, elixir-format
-msgid "New resource"
+msgid "Select a resource"
 msgstr ""
 
 #, elixir-format
-msgid "Select a resource"
+msgid "New resource"
 msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -83,9 +83,9 @@ msgid "You have no resource to update for the moment"
 msgstr ""
 
 #, elixir-format
-msgid "New resource"
+msgid "Select a resource"
 msgstr ""
 
 #, elixir-format
-msgid "Select a resource"
+msgid "New resource"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -223,3 +223,11 @@ msgstr "Ayant plus de 1 GTFS"
 #, elixir-format
 msgid "Show only datasets"
 msgstr "Montrer seulement les jeux de données"
+
+#, elixir-format
+msgid "Proxy configuration"
+msgstr "Configuration du proxy"
+
+#, elixir-format
+msgid "Update all AOMs"
+msgstr "Mettre à jour toutes les AOMs"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -84,9 +84,9 @@ msgid "You have no resource to update for the moment"
 msgstr "Vous n'avez pas de ressource à mettre à jour pour le moment"
 
 #, elixir-format
-msgid "New resource"
-msgstr "Nouvelle ressource"
-
-#, elixir-format
 msgid "Select a resource"
 msgstr "Sélectionner une resource"
+
+#, elixir-format
+msgid "New resource"
+msgstr "Nouvelle ressource"


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/1739

- Traduction en anglais
- Ajout de chaines en français
- Suppression de doublons

Après ce commit, l'exécution de `mix gettext.extract --merge` ne change aucun fichier.