### PR TITLE
Permettre d'importer des ressources Netex depuis un CSV

### DIFF
--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -59,6 +59,18 @@ defmodule Opendatasoft.UrlExtractor do
     end)
   end
 
+  @spec get_netex_csv_resources([any]) :: [any]
+  def get_netex_csv_resources(resources) do
+    resources
+    |> get_csv_resources
+    |> Enum.reject(fn r -> r["title"] |> String.ends_with?(".pdf") end)
+    |> Enum.filter(fn r ->
+      r["title"]
+      |> String.downcase()
+      |> String.contains?("netex")
+    end)
+  end
+
   @doc """
   filter csv http response
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -373,7 +373,7 @@ defmodule Transport.ImportData do
         true -> []
       end
 
-    resources |> Enum.map(fn r -> %{r | "format" => "NeTEx"} end)
+    resources |> Enum.map(fn r -> %{r | "format" => "netex"} end)
   end
 
   @spec get_valid_gtfs_rt_resources([map()]) :: [map()]

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -365,7 +365,15 @@ defmodule Transport.ImportData do
   end
 
   @spec get_valid_netex_resources([map()]) :: [map()]
-  def get_valid_netex_resources(resources), do: Enum.filter(resources, &is_netex?/1)
+  def get_valid_netex_resources(resources) do
+    resources =
+      cond do
+        !Enum.empty?(l = Enum.filter(resources, &is_netex?/1)) -> l
+        !Enum.empty?(l = UrlExtractor.get_netex_csv_resources(resources)) -> l
+      end
+
+    resources |> Enum.map(fn r -> %{r | "format" => "NeTEx"} end)
+  end
 
   @spec get_valid_gtfs_rt_resources([map()]) :: [map()]
   def get_valid_gtfs_rt_resources(resources), do: Enum.filter(resources, &is_gtfs_rt?/1)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -370,6 +370,7 @@ defmodule Transport.ImportData do
       cond do
         !Enum.empty?(l = Enum.filter(resources, &is_netex?/1)) -> l
         !Enum.empty?(l = UrlExtractor.get_netex_csv_resources(resources)) -> l
+        true -> []
       end
 
     resources |> Enum.map(fn r -> %{r | "format" => "NeTEx"} end)


### PR DESCRIPTION
Contexte : lorsque des jeux de données sont publiés sur opendatasoft, et qu'ils ne rentrent pas dans leurs cases (très limitées), une pratique courante est de publier un csv qui contient des url vers des ressources (GTFS, NeTEx).

C'est pas du tout pratique pour nous, et c'est pour l'instant quelque chose qu'on essaye en dernier recours lors d'un import : si c'est un jeu public-transit et que tu ne trouves aucune ressource GTFS dedans, alors essaye d'aller en chercher dans les ressources csv.

Cette logique n'était pas implémentée pour les NeTEx, je l'ai donc étendue pour https://transport.data.gouv.fr/datasets/horaires-des-lignes-transilien-1/