### PR TITLE
Fix calcul sévérité JSON

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -405,7 +405,7 @@ defmodule DB.Resource do
   def get_max_severity_validation_number(%__MODULE__{id: id}) do
     """
       SELECT json_data.value#>'{0,severity}', json_array_length(json_data.value)
-      FROM validations, json_each(validations.details) json_data
+      FROM validations, json_each(validations.details::json) json_data
       WHERE validations.resource_id = $1
     """
     |> Repo.query([id])


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/1876

Lié à #1873

En local, l'erreur précédente était

```
ERROR:  function json_each(jsonb) does not exist
LINE 2:       FROM validations, json_each(validations.details) json_...
                                ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

Une solution rapide est de caster en JSON. Vérifié en local que ceci est suffisant.