### PR TITLE
Mise à jour comment désactiver page cache

### DIFF
--- a/apps/gbfs/lib/page_cache.ex
+++ b/apps/gbfs/lib/page_cache.ex
@@ -84,20 +84,25 @@ defmodule PageCache do
       status: conn.status
     }
 
-    Cachex.put(options |> Keyword.fetch!(:cache_name), page_cache_key, value, ttl: :timer.seconds(ttl_seconds(options)))
+    unless page_cache_disabled?() do
+      Cachex.put(options |> Keyword.fetch!(:cache_name), page_cache_key, value,
+        ttl: :timer.seconds(ttl_seconds(options))
+      )
+    end
 
     conn
   end
 
   @doc """
-  The purpose of this method is to help us set TTL to 0 during most tests, to disable cache for tests.
+  Determines if page cache is enabled.
 
-  A better way (to be implemented in the future) will be to use behaviours and alternate implementations
-  (like explained in https://dashbit.co/blog/mocks-and-explicit-contracts), but that will do for now.
+  Page cache is disabled during most tests.
   """
+  def page_cache_disabled? do
+    Application.get_env(:gbfs, :disable_page_cache, false)
+  end
+
   def ttl_seconds(options) do
-    ttl_seconds = options |> Keyword.fetch!(:ttl_seconds)
-    disable_page_cache = Application.get_env(:gbfs, :disable_page_cache, false)
-    if disable_page_cache, do: 0, else: ttl_seconds
+    options |> Keyword.fetch!(:ttl_seconds)
   end
 end


### PR DESCRIPTION
Depuis #1867, certains tests GBFS ne passent plus en particulier dans le controlleur smoove. Exemple

```
1) test Smoove GBFS conversion on station_status.json (GBFS.SmooveControllerTest)
   apps/gbfs/test/gbfs/controllers/smoove_controller_test.exs:30
   ** (RuntimeError) expected response with status 200, got: 502, with body:
   "{\"error\":\"smoove service unavailable\"}"
```

C'est étonnant car normalement il y a un mock qui est mis en place pour ce test spécifique. Je me suis donc demandé si `PageCache` ne pouvait pas avoir son rôle. Il semble que oui.

Actuellement, la logique pour désactiver le cache est de mettre un TTL à 0s.

https://github.com/etalab/transport-site/blob/bc33172585e2ac1c9dfaa3367aac65d6496a2c3d/apps/gbfs/lib/page_cache.ex#L92-L102

Ceci ne semble pas fonctionner

J'ai vérifié ça de 2 façons :
- dans iex
```
Cachex.put(:my_cache, "key", "value", ttl: :timer.seconds(0)); Cachex.get(:my_cache, "key")
{:ok, "value"}
```
- en mettant des `IO.puts` en cas de cache hit, et on voit ces logs apparaitre en exécutant les tests de Smoove

J'en déduis que mettre un TTL à 0s n'est pas suffisant. Le mécanisme de TTL est expliqué [dans la doc](https://github.com/whitfin/cachex/blob/master/docs/features/ttl-implementation.md) en détails.

Cette PR propose donc d'utiliser `Cachex.put` tant que le cache n'est pas explicitement désactivé.