### PR TITLE
Hasher: utiliser plusieurs versions de TLS

### DIFF
--- a/apps/shared/lib/hasher.ex
+++ b/apps/shared/lib/hasher.ex
@@ -18,9 +18,7 @@ defmodule Hasher do
 
   @spec get_content_hash_http(String.t()) :: String.t()
   def get_content_hash_http(url) do
-    # SSL config is a temporary fix for https://github.com/etalab/transport-site/issues/1564
-    # The better fix is to add proper tests around that and upgrade to OTP 23.
-    with {:ok, %{headers: headers}} <- HTTPoison.head(url, [], ssl: [versions: [:"tlsv1.2"]]),
+    with {:ok, %{headers: headers}} <- HTTPoison.head(url),
          etag when not is_nil(etag) <- Enum.find_value(headers, &find_etag/1),
          content_hash <- String.replace(etag, "\"", "") do
       content_hash


### PR DESCRIPTION
Voir https://github.com/etalab/transport-site/issues/1564 et https://github.com/etalab/transport-site/issues/1585

Ce fix temporaire était nécessaire à un moment donné suite à des problèmes de versions de SSL avec certains serveurs. Depuis, nous sommes en OTP 24 et on ne devrait pas avoir besoin de spécifier des versions spécifiques de TLS mais simplement de négocier la version appropriée.

Le code présent dans la PR initiale a déjà été remplacé ailleurs.