### PR TITLE
Correctifs warning Phoenix

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/vlille_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/vlille_controller.ex
@@ -48,7 +48,8 @@ defmodule GBFS.VLilleController do
       {:error, msg} ->
         conn
         |> assign(:error, msg)
-        |> render(GBFS.ErrorView, "error.json")
+        |> put_view(GBFS.ErrorView)
+        |> render("error.json")
     end
   end
 

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -122,7 +122,8 @@ defmodule TransportWeb.ResourceController do
           conn
           |> put_flash(:error, dgettext("resource", "Resource is not available on remote server"))
           |> put_status(:not_found)
-          |> render(ErrorView, "404.html")
+          |> put_view(ErrorView)
+          |> render("404.html")
       end
     end
   end


### PR DESCRIPTION
Les logs de tests étaient pollués par plusieurs gros logs de ce type:

```
warning: Elixir.Phoenix.Controller.render/4 with a view is deprecated, see the documentation for render/3 for an alternative
  (phoenix 1.5.9) lib/phoenix/controller.ex:763: Phoenix.Controller.render/4
  (transport 0.0.1) lib/transport_web/controllers/resource_controller.ex:1: TransportWeb.ResourceController.action/2
  (transport 0.0.1) lib/transport_web/controllers/resource_controller.ex:1: TransportWeb.ResourceController.phoenix_controller_pipeline/2
  (phoenix 1.5.9) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
  (transport 0.0.1) lib/transport_web/router.ex:1: TransportWeb.Router.call/2
  (transport 0.0.1) lib/plug/router.ex:280: anonymous fn/4 in TransportWeb.Plugs.Router.dispatch/2
  (telemetry 0.4.3) /Users/thbar/git/transport/transport-site/deps/telemetry/src/telemetry.erl:272: :telemetry.span/3
  (transport 0.0.1) lib/plug/router.ex:276: TransportWeb.Plugs.Router.dispatch/2
  (transport 0.0.1) lib/transport_web/plugs/router.ex:1: TransportWeb.Plugs.Router.plug_builder_call/2
  (transport 0.0.1) lib/transport_web/endpoint.ex:1: TransportWeb.Endpoint.plug_builder_call/2
  (transport 0.0.1) lib/transport_web/endpoint.ex:1: TransportWeb.Endpoint."call (overridable 3)"/2
  (transport 0.0.1) lib/transport_web/endpoint.ex:1: TransportWeb.Endpoint.call/2
```

J'ai vérifié le fonctionnement des deux correctifs manuellement (en forçant à passer dans le code concerné), car après vérification de la couverture de test un des deux cas n'était pas couvert, et sur l'autre j'avais un petit doute. Tout semble marcher à l'identique.
