### PR TITLE
History.Backup: fix tri des dates

### DIFF
--- a/apps/transport/lib/transport/history/backup.ex
+++ b/apps/transport/lib/transport/history/backup.ex
@@ -51,7 +51,7 @@ defmodule Transport.History.Backup do
       end
 
     last_import = if resource.last_import == nil, do: nil, else: NaiveDateTime.from_iso8601!(resource.last_import)
-    [last_update, last_import] |> Enum.reject(&is_nil/1) |> Enum.max()
+    [last_update, last_import] |> Enum.reject(&is_nil/1) |> Enum.sort(NaiveDateTime) |> Enum.at(-1)
   end
 
   @doc """

--- a/apps/transport/test/transport/history_test.exs
+++ b/apps/transport/test/transport/history_test.exs
@@ -18,7 +18,12 @@ defmodule Transport.HistoryTest do
       dataset: insert(:dataset),
       # See https://github.com/etalab/transport-site/issues/1550
       # to understand why this has got a weird format
-      last_update: DateTime.utc_now() |> DateTime.to_iso8601(),
+      last_update:
+        DateTime.utc_now()
+        |> DateTime.add(-5 * 60 * 60 * 24, :second)
+        |> DateTime.to_iso8601()
+        |> String.replace(" ", "T"),
+      last_import: DateTime.utc_now() |> DateTime.add(-6 * 60 * 60, :second) |> DateTime.to_iso8601(),
       content_hash: "fake_content_hash"
     )
 


### PR DESCRIPTION
Suite de #1880

En vérifiant que mon fix fonctionnait correctement en production, j'ai eu une suprise. J'ai trouvé la source mon problème dans `modification_date`
```elixir
iex > [~N[2015-06-17 23:54:05], ~N[2021-11-01 04:32:48.819059]] |> Enum.max()
~N[2015-06-17 23:54:05]
iex > [~N[2015-06-17 23:54:05], ~N[2021-11-01 04:32:48.819059]] |> Enum.sort(NaiveDateTime) |> Enum.at(-1)
~N[2021-11-01 04:32:48.819059]
```

Bon, [la doc le dit](https://hexdocs.pm/elixir/1.12/NaiveDateTime.html#module-comparing-naive-date-times) mais je trouve ça surprenant.

Bref, voici une correction.