### PR TITLE
History.Backup : vérifie que meta ne contient pas de _

### DIFF
--- a/apps/transport/lib/transport/history/backup.ex
+++ b/apps/transport/lib/transport/history/backup.ex
@@ -127,11 +127,11 @@ defmodule Transport.History.Backup do
         url: resource.url,
         title: resource_title(resource),
         format: resource.format,
-        updated_at: resource |> modification_date() |> to_string()
+        "updated-at": resource |> modification_date() |> to_string()
       }
       |> maybe_put(:start, resource.metadata["start_date"])
       |> maybe_put(:end, resource.metadata["end_date"])
-      |> maybe_put(:content_hash, resource.content_hash)
+      |> maybe_put(:"content-hash", resource.content_hash)
 
     # NOTE: this call has a few drawbacks:
     # - redirects are not followed

--- a/apps/transport/test/transport/history_test.exs
+++ b/apps/transport/test/transport/history_test.exs
@@ -71,7 +71,7 @@ defmodule Transport.HistoryTest do
       # S3 metadata keys are usually transformed (_ are turned into -)
       %{headers: headers} = request
 
-      meta_headers_with_underscores = :maps.filter(fn k, _ -> String.match?(k, ~r/^x-amz-meta-\S+_\S+$/) end, headers)
+      meta_headers_with_underscores = :maps.filter(fn k, _ -> String.match?(k, ~r/^x-amz-meta-\S*_\S*$/) end, headers)
 
       :maps.map(
         fn k, _ -> raise ArgumentError, "`#{k}` header should not contain underscores" end,

--- a/apps/transport/test/transport/history_test.exs
+++ b/apps/transport/test/transport/history_test.exs
@@ -67,10 +67,21 @@ defmodule Transport.HistoryTest do
       }
     end)
     |> expect(:request!, fn request ->
+      # Check meta headers do not contain underscores
+      # S3 metadata keys are usually transformed (_ are turned into -)
+      %{headers: headers} = request
+
+      meta_headers_with_underscores = :maps.filter(fn k, _ -> String.match?(k, ~r/^x-amz-meta-\S+_\S+$/) end, headers)
+
+      :maps.map(
+        fn k, _ -> raise ArgumentError, "`#{k}` header should not contain underscores" end,
+        meta_headers_with_underscores
+      )
+
       assert %{
                service: :s3,
                bucket: "dataset-123",
-               headers: %{"x-amz-acl" => "public-read", "x-amz-meta-content_hash" => "fake_content_hash"},
+               headers: %{"x-amz-acl" => "public-read", "x-amz-meta-content-hash" => "fake_content_hash"},
                http_method: :put,
                body: "the-payload"
              } = request


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/1893

Voir l'issue pour l'explication du problème