### PR TITLE
History.Backup : correction comparaison dates

### DIFF
--- a/apps/transport/lib/transport/history/backup.ex
+++ b/apps/transport/lib/transport/history/backup.ex
@@ -79,7 +79,7 @@ defmodule Transport.History.Backup do
           |> Enum.map(fn r -> NaiveDateTime.from_iso8601!(r.updated_at) end)
           |> Enum.max()
 
-        max_last_modified < modification_date(resource)
+        NaiveDateTime.compare(max_last_modified, modification_date(resource)) == :lt
       end
     end
   end


### PR DESCRIPTION
Je me suis encore fait avoir par la comparaison des `NaiveDateTime` comme dans https://github.com/etalab/transport-site/pull/1892...

Le plus triste c'est que la PR précédente ne faisait pas apparaitre le problème car la comparaison des structures est "aléatoire". Je m'en suis rendu compte en vérifiant que le fix fonctionnait correctement en prod [pour un JDD précis](https://transport.data.gouv.fr/datasets/tisseo-offre-de-transport-gtfs/) (ce qui n'est pas le cas à cause de ce bug).

En utilisant les valeurs de production des dates :
```elixir
iex(1)> ~N[2020-08-31 07:10:03.159448] < ~N[2021-11-03 04:34:43.985516]
warning: invalid comparison with struct literal ~N[2020-08-31 07:10:03.159448]. Comparison operators (>, <, >=, <=, min, and max) perform structural and not semantic comparison. Comparing with a struct literal is unlikely to give a meaningful result. Struct modules typically define a compare/2 function that can be used for semantic comparison
  iex:1

false
iex(2)> NaiveDateTime.compare(~N[2020-08-31 07:10:03.159448], ~N[2021-11-03 04:34:43.985516])
:lt
```

Fingers crossed?