### PR TITLE
UrlExtractor : implémentation legacy pour get_gtfs_csv_resources

### DIFF
--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -53,7 +53,7 @@ defmodule Opendatasoft.UrlExtractor do
 
     gtfs_files =
       csv_resources
-      |> Enum.filter(fn r -> r["parsed_filename"] |> title_matches_type?("gtfs") end)
+      |> Enum.filter(fn r -> r["parsed_filename"] |> filename_matches_type?("gtfs") end)
 
     if Enum.empty?(gtfs_files) do
       # No GTFS files have been found, use the
@@ -74,55 +74,55 @@ defmodule Opendatasoft.UrlExtractor do
   def get_gtfs_rt_csv_resources(resources) do
     resources
     |> get_csv_resources
-    |> Enum.filter(fn r -> r["parsed_filename"] |> title_matches_type?("gtfs-rt") end)
+    |> Enum.filter(fn r -> r["parsed_filename"] |> filename_matches_type?("gtfs-rt") end)
   end
 
   @spec get_netex_csv_resources([any]) :: [any]
   def get_netex_csv_resources(resources) do
     resources
     |> get_csv_resources
-    |> Enum.filter(fn r -> r["parsed_filename"] |> title_matches_type?("netex") end)
+    |> Enum.filter(fn r -> r["parsed_filename"] |> filename_matches_type?("netex") end)
   end
 
-  @spec title_matches_type?(binary(), binary()) :: boolean()
-  defp title_matches_type?(csv_title, expected_type) do
-    title_to_type(csv_title) == expected_type
+  @spec filename_matches_type?(binary(), binary()) :: boolean()
+  defp filename_matches_type?(filename, expected_type) do
+    filename_to_type(filename) == expected_type
   end
 
   @doc ~S"""
-  Infers a resource's type from its title.
+  Infers a resource's type from its filename.
 
   ## Examples
-      iex> UrlExtractor.title_to_type("angers-gtfs-.zip")
+      iex> UrlExtractor.filename_to_type("angers-gtfs-.zip")
       "gtfs"
 
-      iex > UrlExtractor.title_to_type("angers-gtfs-rt-alerts.json")
+      iex > UrlExtractor.filename_to_type("angers-gtfs-rt-alerts.json")
       "gtfs-rt"
 
-      iex > UrlExtractor.title_to_type("angers gtfs-rt.json")
+      iex > UrlExtractor.filename_to_type("angers gtfs-rt.json")
       "gtfs-rt"
 
-      iex > UrlExtractor.title_to_type("angers gtfsrt.json")
+      iex > UrlExtractor.filename_to_type("angers gtfsrt.json")
       "gtfs-rt"
 
-      iex > UrlExtractor.title_to_type("description gtfs.pdf")
+      iex > UrlExtractor.filename_to_type("description gtfs.pdf")
       nil
 
-      iex > UrlExtractor.title_to_type("réseau NeTEx.zip")
+      iex > UrlExtractor.filename_to_type("réseau NeTEx.zip")
       "netex"
 
-      iex > UrlExtractor.title_to_type("foobar")
+      iex > UrlExtractor.filename_to_type("foobar")
       nil
   """
-  @spec title_to_type(binary()) :: nil | binary()
-  def title_to_type(title) do
-    title = String.downcase(title)
+  @spec filename_to_type(binary()) :: nil | binary()
+  def filename_to_type(filename) do
+    filename = String.downcase(filename)
 
     cond do
-      String.ends_with?(title, ".pdf") -> nil
-      String.match?(title, ~r/\bgtfs(-rt|rt| rt)\b/) -> "gtfs-rt"
-      String.contains?(title, "netex") -> "netex"
-      String.contains?(title, "gtfs") -> "gtfs"
+      String.ends_with?(filename, ".pdf") -> nil
+      String.match?(filename, ~r/\bgtfs(-rt|rt| rt)\b/) -> "gtfs-rt"
+      String.contains?(filename, "netex") -> "netex"
+      String.contains?(filename, "gtfs") -> "gtfs"
       true -> nil
     end
   end

--- a/apps/transport/test/transport/url_extractor_doc_test.exs
+++ b/apps/transport/test/transport/url_extractor_doc_test.exs
@@ -11,7 +11,7 @@ defmodule Transport.UrlExtractorDocTest do
       [{"name,file\ntoulouse,http", %{"id" => "bob"}}, {"stop,lon,lat\n1,48.8,2.3", %{"id" => "bobette"}}]
       |> UrlExtractor.get_resources_with_url_from_csv()
 
-    assert res == {:ok, [%{"url" => "http", "title" => "http", "id" => "bob"}]}
+    assert res == {:ok, [%{"url" => "http", "parsed_filename" => "http", "id" => "bob"}]}
   end
 
   test "get urls in CSV file : no url available" do


### PR DESCRIPTION
La PR #1885 a changé le comportement de `get_gtfs_csv_resources` pour le rendre plus strict.

- Avant : toutes les ressources avec des liens distants dont l'URL ne termine pas par `.pdf` ou ne contiennent pas `netex` (non sensible à la casse) sont considérées comme des GTFS
- Après : le nom du fichier doit contenir `gtfs` (non sensible à la casse)

Ceci a eu pour effet de supprimer des ressources de producteurs qui ne nommaient pas leurs fichiers ZIP d'une certaine façon. C'est apparemment commun [dans la région CVL](https://data.centrevaldeloire.fr/explore/dataset/ville-damboise-offre-theorique-mobilite-reseau-urbain/table/).

Reçu par email : 

> J’ai renommé le GTFS en bourges-gtfs.zip. sur notre site open data.
> Ce problème est lié au fait qu’il y a 2 enregistrement dans le jeu de données ? Car pour tous les autres GTFS publiés le nom du fichier est toujours « nom de l’AO ».zip sans mention du GTFS. Faut-il faire la même manip pour les autres ? car il ne me semble pas qu’il y est des soucis de téléchargement sur les autres jeux de données.

En attendant de modifier le code en profondeur et de donner des consignes aux producteurs, je rétablis l'ancien fonctionnement si la "nouvelle façon" ne trouve aucun GTFS.