### PR TITLE
Ajustement redirect_path pour login

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -32,9 +32,9 @@ defmodule TransportWeb.PageController do
     ]
   end
 
-  def login(conn, %{"redirect_path" => redirect_path}) do
+  def login(conn, params) do
     conn
-    |> put_session(:redirect_path, redirect_path)
+    |> put_session(:redirect_path, Map.get(params, "redirect_path", "/"))
     |> render("login.html")
   end
 

--- a/apps/transport/priv/static/robots.txt
+++ b/apps/transport/priv/static/robots.txt
@@ -7,5 +7,5 @@ Disallow: /backoffice/
 User-agent: *
 Allow: /
 
-User-agent: SemrushBot
+User-agent: *
 Disallow: /login/*

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -23,6 +23,10 @@ defmodule TransportWeb.PageControllerTest do
       |> Floki.find(".mail__button .icon--envelope")
   end
 
+  test "GET login page without a redirect_path", %{conn: conn} do
+    conn |> get(page_path(conn, :login)) |> html_response(200)
+  end
+
   test "I can see a log-in link on home", %{conn: conn} do
     # go to the home page
     conn = conn |> get("/")
@@ -140,5 +144,9 @@ defmodule TransportWeb.PageControllerTest do
 
   test "security.txt page", %{conn: conn} do
     conn |> get("/.well-known/security.txt") |> text_response(200)
+  end
+
+  test "robots.txt page", %{conn: conn} do
+    conn |> get("robots.txt") |> text_response(200)
   end
 end


### PR DESCRIPTION
Correction de [cette erreur Sentry](https://sentry.io/organizations/betagouv-f7/issues/2586711595/?project=5687467&query=is%3Aunresolved)

- ajout d'un `redirect_path` par défaut
- ajustement du `robots.txt`
- ajout de tests