### PR TITLE
Ajout d'un lien vers la section "ressources historisées"

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -11,6 +11,14 @@
       <div class="ressources-list">
         <%= render_many order_resources_by_validity(@resources), TransportWeb.DatasetView, "_resource.html", as: :resource, conn: @conn, dataset: assigns[:dataset] %>
       </div>
+
+      <%= if assigns[:show_history_section_link] do %>
+        <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "History"), to: "#dataset-historic")) %>
+        <div class="pb-24" style="font-weight: bold">
+          <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the  %{link} section.", link: link_history)) %>
+        </div>
+      <% end %>
+
       <div class="reuser-message pb-48">
         <i class="fas fa-info-circle"></i>
         <%= dgettext(

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -13,7 +13,7 @@
       </div>
 
       <%= if assigns[:show_history_section_link] do %>
-        <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "History"), to: "#dataset-historic")) %>
+        <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
         <div class="pb-24" style="font-weight: bold">
           <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the  %{link} section.", link: link_history)) %>
         </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -15,7 +15,7 @@
       <%= if assigns[:show_history_section_link] do %>
         <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
         <div class="pb-24" style="font-weight: bold">
-          <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the  %{link} section.", link: link_history)) %>
+          <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.", link: link_history)) %>
         </div>
       <% end %>
 

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -26,7 +26,7 @@
       <% end %>
       <div class="menu-item"><a href="#dataset-discussions">Discussions (<%= count_discussions(@discussions) %>)</a></div>
       <%= unless @history_resources == [] do %>
-        <div class="menu-item"><a href="#dataset-historic"><%= dgettext("page-dataset-details", "History")%></a></div>
+        <div class="menu-item"><a href="#backed-up-resources"><%= dgettext("page-dataset-details", "Backed up resources")%></a></div>
       <% end %>
       <%= unless is_nil(@other_datasets) or @other_datasets == [] do %>
         <div class="menu-item"><a href="#dataset-other-datasets"><%= dgettext("page-dataset-details", "Other datasets")%> (<%= Enum.count(@other_datasets) %>)</a></div>
@@ -165,8 +165,8 @@
   </section>
 <% end %>
 <%= unless @history_resources == [] do %>
-  <section class="white pt-48" id="dataset-historic">
-    <h3><%= dgettext("page-dataset-details", "History")%></h3>
+  <section class="white pt-48" id="backed-up-resources">
+    <h3><%= dgettext("page-dataset-details", "Backed up resources")%></h3>
     <div class="">
       <div class="panel">
         <table class="table">

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -60,7 +60,11 @@
       </section>
     <% end %>
     <section id="dataset-resources" class="pt-48">
-      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources") %>
+
+      <% gtfs_official_resources= gtfs_official_resources(@dataset) %>
+      <% show_history_section_link= @history_resources !== [] and gtfs_official_resources !== [] %>
+
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_official_resources, dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources"), show_history_section_link: show_history_section_link %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gtfs_rt_official_resources(@dataset), title: dgettext("page-dataset-details", "GTFS real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: gbfs_official_resources(@dataset), title: dgettext("page-dataset-details", "GBFS resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -231,7 +231,7 @@ msgid "This dataset has been removed from data.gouv.fr"
 msgstr ""
 
 #, elixir-format
-msgid "History"
+msgid "Backed up resources"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -383,5 +383,5 @@ msgid "Resource declared schema"
 msgstr ""
 
 #, elixir-format
-msgid "Past versions of the dataset resources are available in the  %{link} section."
+msgid "Past versions of the dataset resources are available in the %{link} section."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -381,3 +381,7 @@ msgstr ""
 #, elixir-format
 msgid "Resource declared schema"
 msgstr ""
+
+#, elixir-format
+msgid "Past versions of the dataset resources are available in the  %{link} section."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -231,8 +231,8 @@ msgid "This dataset has been removed from data.gouv.fr"
 msgstr "Ce jeu de données a été supprimé de data.gouv.fr"
 
 #, elixir-format
-msgid "History"
-msgstr "Historique"
+msgid "Backed up resources"
+msgstr "Ressources historisées"
 
 #, elixir-format
 msgid "%{start} to %{end}"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -381,3 +381,7 @@ msgstr "Producteur de la donnée"
 #, elixir-format
 msgid "Resource declared schema"
 msgstr "La ressource déclare utiliser ce schéma"
+
+#, elixir-format
+msgid "Past versions of the dataset resources are available in the  %{link} section."
+msgstr "Des versions précédentes des ressources de ce dataset sont disponibles dans la section %{link}."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -383,5 +383,5 @@ msgid "Resource declared schema"
 msgstr "La ressource déclare utiliser ce schéma"
 
 #, elixir-format
-msgid "Past versions of the dataset resources are available in the  %{link} section."
-msgstr "Des versions précédentes des ressources de ce dataset sont disponibles dans la section %{link}."
+msgid "Past versions of the dataset resources are available in the %{link} section."
+msgstr "Des versions précédentes des ressources de ce jeu de données sont disponibles dans la section %{link}."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -231,7 +231,7 @@ msgid "This dataset has been removed from data.gouv.fr"
 msgstr ""
 
 #, elixir-format
-msgid "History"
+msgid "Backed up resources"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -383,5 +383,5 @@ msgid "Resource declared schema"
 msgstr ""
 
 #, elixir-format
-msgid "Past versions of the dataset resources are available in the  %{link} section."
+msgid "Past versions of the dataset resources are available in the %{link} section."
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -381,3 +381,7 @@ msgstr ""
 #, elixir-format
 msgid "Resource declared schema"
 msgstr ""
+
+#, elixir-format
+msgid "Past versions of the dataset resources are available in the  %{link} section."
+msgstr ""


### PR DESCRIPTION
closes #1619 

J'en profite pour renommer la section "historique" par "ressources historisées", ce qui me parait plus parlant.

Pour le moment j'ai mis le message uniquement pour les ressources GTFS, car il n'y a qu'elles qu'on historise.

![image](https://user-images.githubusercontent.com/15341118/141105506-aa94ad45-1d9a-4de8-8fcb-4ca96795ce85.png)
