### PR TITLE
Changer l'ordre des catégories des messages custom

### DIFF
--- a/apps/transport/priv/search_custom_messages.yml
+++ b/apps/transport/priv/search_custom_messages.yml
@@ -14,25 +14,6 @@
 #       - ferry
 
 
-- category: public-transit
-  search_params:
-    - key: type
-      value: public-transit
-  msg:
-    fr: |
-        Les jeux de données référencés dans cette catégorie contiennent des informations permettant de décrire les réseaux de transports en commun.
-
-        Ils nous renseignent notamment sur la position des arrêts, les parcours, les horaires de passage des véhicules.
-
-        Deux standards de données peuvent être utilisés : le format [GTFS](https://developers.google.com/transit/gtfs?hl=fr) ou le format [NeTEx](http://netex-cen.eu/).
-    en: |
-        The datasets referenced in this category contain information for describing public transport networks. 
-        
-        They inform us in particular about the position of the stops, the routes, the times of passage of the vehicles.
-        
-        Two data standards can be used: the [GTFS format](https://developers.google.com/transit/gtfs) or the [NeTEx format](http://netex-cen.eu/).
-
-
 - category: real-time
   search_params:
     - key: type
@@ -48,12 +29,28 @@
         Deux standards de données peuvent être utilisés : le format [GTFS-RT](https://developers.google.com/transit/gtfs-realtime?hl=fr) ou le format [SIRI](https://www.siri-cen.eu/).
     en: |
         The datasets referenced in this category contain information flows describing in real time the state of public transport networks.
-        
+
         They can tell us about traffic conditions, a vehicle's actual passage time or even its position in real time.
-        
+
         Two data standards can be used: the [GTFS-RT format](https://developers.google.com/transit/gtfs-realtime) or the [SIRI format](https://www.siri-cen.eu/).
 
+- category: public-transit
+  search_params:
+    - key: type
+      value: public-transit
+  msg:
+    fr: |
+        Les jeux de données référencés dans cette catégorie contiennent des informations permettant de décrire les réseaux de transports en commun.
 
+        Ils nous renseignent notamment sur la position des arrêts, les parcours, les horaires de passage des véhicules.
+
+        Deux standards de données peuvent être utilisés : le format [GTFS](https://developers.google.com/transit/gtfs?hl=fr) ou le format [NeTEx](http://netex-cen.eu/).
+    en: |
+        The datasets referenced in this category contain information for describing public transport networks.
+
+        They inform us in particular about the position of the stops, the routes, the times of passage of the vehicles.
+
+        Two data standards can be used: the [GTFS format](https://developers.google.com/transit/gtfs) or the [NeTEx format](http://netex-cen.eu/).
 
 - category: road-network
   search_params:
@@ -67,10 +64,10 @@
 
         L’équipe de transport.data.gouv.fr travaille au référencement de nouveaux jeux de données permettant de cartographier le réseau routier secondaire comme la [BD Topo de l’IGN](https://geoservices.ign.fr/documentation/donnees/vecteur/bdtopo).
     en: |
-        The mapping of the national road network is carried out by different organizations. 
-        
-        To date, only information is available in an open manner, information on the main road network (motorways and national roads). 
-        
+        The mapping of the national road network is carried out by different organizations.
+
+        To date, only information is available in an open manner, information on the main road network (motorways and national roads).
+
         The transport.data.gouv.fr team is working on referencing new datasets to map the secondary road network, such as the [IGN’s BD Topo](https://geoservices.ign.fr/documentation/donnees/vecteur/bdtopo).
 
 


### PR DESCRIPTION
Le message affiché correspond à la première catégorie qui match les critères rentrés.

Du coup il faut mettre la catégorie `real-time` avant la catégorie `public-transit` car elle est plus spécifique.

real-time : /datasets?type=public-transit&filter=has_realtime
public-transit : /datasets?type=public-transit