### PR TITLE
Désactiver la page détails pour les ressources non gtfs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -16,7 +16,7 @@ defmodule TransportWeb.ResourceController do
       |> Repo.get!(id)
       |> Repo.preload([:validation, dataset: [:resources]])
 
-      # for the moment, only gtfs have a dedicated resource details page
+    # for the moment, only gtfs have a dedicated resource details page
     case Resource.has_metadata?(resource) && Resource.is_gtfs?(resource) do
       false ->
         conn |> put_status(:not_found) |> put_view(ErrorView) |> render("404.html")

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -16,7 +16,8 @@ defmodule TransportWeb.ResourceController do
       |> Repo.get!(id)
       |> Repo.preload([:validation, dataset: [:resources]])
 
-    case Resource.has_metadata?(resource) do
+      # for the moment, only gtfs have a dedicated resource details page
+    case Resource.has_metadata?(resource) && Resource.is_gtfs?(resource) do
       false ->
         conn |> put_status(:not_found) |> put_view(ErrorView) |> render("404.html")
 


### PR DESCRIPTION
On s'appuyait implicitement sur le fait que seules les ressources GTFS avaient des métadatas. Mais depuis que les GBFS en ont aussi, on se retrouve avec des erreurs 500 sur les pages de détails des ressources GBFS ([ex](https://transport.data.gouv.fr/resources/58740)) et ça fait un peu de bruit dans [Sentry](https://sentry.io/organizations/betagouv-f7/issues/2798047776/?environment=prod&project=5687467&query=is%3Aunresolved&sort=freq&statsPeriod=7d).

Donc maintenant on est explicite : seules les ressources GTFS ont le droit à une page de détail pour le moment.