### PR TITLE
Correction erreur 500 resource#details

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -16,7 +16,7 @@ defmodule TransportWeb.ResourceController do
       |> Repo.get!(id)
       |> Repo.preload([:validation, dataset: [:resources]])
 
-    case Resource.has_metadata?(resource) do
+    case Resource.is_gtfs?(resource) and Resource.has_metadata?(resource) do
       false ->
         conn |> put_status(:not_found) |> put_view(ErrorView) |> render("404.html")
 


### PR DESCRIPTION
Correction de [cette erreur Sentry](https://sentry.io/organizations/betagouv-f7/issues/2798047776/events/6a9fd4940d574ccc81978b0ed2763e9b/?project=5687467). Les données GBFS ont des métadonnées mais ne sont pas affichées pour le moment sur cette page.

Visiblement on arrive cette page [depuis le controlleur Atom](https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport_web/controllers/atom_controller.ex), à modifier plus tard, c'est étonnant de linker vers des 404.