### PR TITLE
Suppression erreur Sentry

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -12,9 +12,7 @@ defmodule TransportWeb.ValidationController do
     render(conn, "index.html")
   end
 
-  def validate(%Plug.Conn{} = conn, %{"upload" => upload_params}) do
-    file_path = upload_params["file"].path
-
+  def validate(%Plug.Conn{} = conn, %{"upload" => %{"file" => %{path: file_path}}}) do
     with {:ok, gtfs} <- File.read(file_path),
          {:ok, %{"validations" => validations, "metadata" => metadata}} <- GtfsValidator.validate(gtfs) do
       data_vis = DataVisualization.validation_data_vis(validations)
@@ -39,6 +37,13 @@ defmodule TransportWeb.ValidationController do
         |> put_flash(:error, dgettext("validations", "Unable to validate file"))
         |> redirect(to: validation_path(conn, :index))
     end
+  end
+
+  def validate(conn, _) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(ErrorView)
+    |> render("400.html")
   end
 
   def show(%Plug.Conn{} = conn, %{} = params) do


### PR DESCRIPTION
Pour je ne sais quelle raison, quelqu'un nous appelle quotidiennement sur l'url de validation des GTFS mais en nous passant un "faux upload" qui s'appelle test_file.txt.

Ca fait des erreurs [Sentry](https://sentry.io/organizations/betagouv-f7/issues/2586794539/events/d1fbda4344f4401395e9ac6c342c5b97/events/?project=5687467&statsPeriod=14d).

Maintenant ça va renvoyer des réponses bad request ([400](https://http.cat/400))