### PR TITLE
Répare démarrage worker

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,7 +55,7 @@ end
 base_oban_conf = [repo: DB.Repo]
 
 extra_oban_conf =
-  if worker || (iex_started? and config_env() == :prod) || config_env() == :test do
+  if not worker || (iex_started? and config_env() == :prod) || config_env() == :test do
     [queues: false, plugins: false]
   else
     [


### PR DESCRIPTION
Il manquait un petit `not` sur cette ligne pour que la configuration Oban ne soit pas vide. Dans l'état actuel, le seul moyen de lancer des jobs était de ne PAS démarrer en mode worker.