### PR TITLE
Historisation des ressources à l'aide de jobs

### DIFF
--- a/apps/db/lib/db/resource_history.ex
+++ b/apps/db/lib/db/resource_history.ex
@@ -7,7 +7,6 @@ defmodule DB.ResourceHistory do
 
   typed_schema "resource_history" do
     field(:datagouv_id, :string)
-    field(:version, :integer)
     field(:payload, :map)
 
     timestamps(type: :utc_datetime_usec)

--- a/apps/db/lib/db/resource_history.ex
+++ b/apps/db/lib/db/resource_history.ex
@@ -1,0 +1,15 @@
+defmodule DB.ResourceHistory do
+  @moduledoc """
+  ResourceHistory stores metadata when resources are historicized.
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  typed_schema "resource_history" do
+    field(:datagouv_id, :string)
+    field(:version, :integer)
+    field(:payload, :map)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+end

--- a/apps/db/priv/repo/migrations/20211130094242_add_resource_history.exs
+++ b/apps/db/priv/repo/migrations/20211130094242_add_resource_history.exs
@@ -6,8 +6,8 @@ defmodule DB.Repo.Migrations.AddResourceHistory do
       # FIX ME
       # We should be able to add a foreign key to resource.datagouv_id
       # but for now datagouv_id is not unique
+      # See https://github.com/etalab/transport-site/issues/1930
       add :datagouv_id, :string, null: false
-      add :version, :integer, null: false
       add :payload, :jsonb, null: false
 
       timestamps([type: :utc_datetime_usec])

--- a/apps/db/priv/repo/migrations/20211130094242_add_resource_history.exs
+++ b/apps/db/priv/repo/migrations/20211130094242_add_resource_history.exs
@@ -1,0 +1,18 @@
+defmodule DB.Repo.Migrations.AddResourceHistory do
+  use Ecto.Migration
+
+  def change do
+    create table("resource_history") do
+      # FIX ME
+      # We should be able to add a foreign key to resource.datagouv_id
+      # but for now datagouv_id is not unique
+      add :datagouv_id, :string, null: false
+      add :version, :integer, null: false
+      add :payload, :jsonb, null: false
+
+      timestamps([type: :utc_datetime_usec])
+    end
+
+    create index("resource_history", [:datagouv_id])
+  end
+end

--- a/apps/db/test/support/factory.ex
+++ b/apps/db/test/support/factory.ex
@@ -42,6 +42,10 @@ defmodule DB.Factory do
     }
   end
 
+  def resource_history_factory do
+    %DB.ResourceHistory{version: "1"}
+  end
+
   def commune_factory do
     %DB.Commune{
       nom: "Ballans",

--- a/apps/db/test/support/factory.ex
+++ b/apps/db/test/support/factory.ex
@@ -43,7 +43,7 @@ defmodule DB.Factory do
   end
 
   def resource_history_factory do
-    %DB.ResourceHistory{version: "1"}
+    %DB.ResourceHistory{}
   end
 
   def commune_factory do

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -50,30 +50,58 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"datagouv_id" => datagouv_id}}) do
     Logger.info("Running ResourceHistoryJob for #{datagouv_id}")
+    resource = Resource |> where([r], r.datagouv_id == ^datagouv_id) |> Repo.one!()
 
-    {resource_path, headers} = download_resource(datagouv_id)
+    {resource_path, headers, body} = download_resource(resource)
 
-    data = %{
-      zip_metadata: Transport.ZipMetaDataExtractor.extract!(resource_path),
-      http_headers: headers
+    upload_filename = upload_to_s3!(resource, body)
+
+    zip_metadata = Transport.ZipMetaDataExtractor.extract!(resource_path)
+
+    _data = %{
+      zip_metadata: zip_metadata,
+      http_headers: headers,
+      resource_metadata: resource.metadata,
+      upload_filename: upload_filename,
+      filenames: zip_metadata |> Enum.map(& &1.file_name),
+      total_uncompressed_size: zip_metadata |> Enum.map(& &1.uncompressed_size) |> Enum.sum(),
+      total_compressed_size: zip_metadata |> Enum.map(& &1.compressed_size) |> Enum.sum()
     }
 
     :ok
   end
 
-  @spec download_resource(binary()) :: {binary(), map()}
-  defp download_resource(datagouv_id) do
-    resource = Resource |> where([r], r.datagouv_id == ^datagouv_id) |> Repo.one!()
-
+  defp download_resource(%Resource{datagouv_id: datagouv_id, url: url}) do
     file_path = System.tmp_dir!() |> Path.join("resource_#{datagouv_id}_download")
 
-    %{status: 200, body: body, headers: headers} = Unlock.HTTP.Client.impl().get!(resource.url, [])
+    %{status: 200, body: body, headers: headers} = Unlock.HTTP.Client.impl().get!(url, [])
     Logger.debug("Saving resource #{datagouv_id} to #{file_path}")
     File.write!(file_path, body)
 
-    relevant_headers = headers |> Enum.into(%{}) |> Map.take(relevant_http_headers)
+    relevant_headers = headers |> Enum.into(%{}) |> Map.take(relevant_http_headers())
 
-    {file_path, relevant_headers}
+    {file_path, relevant_headers, body}
+  end
+
+  defp upload_to_s3!(%Resource{} = resource, body) do
+    filename = upload_filename(resource)
+
+    :history
+    |> Transport.S3.bucket_name()
+    |> ExAws.S3.put_object(
+      filename,
+      body,
+      acl: "public-read"
+    )
+    |> Transport.Wrapper.ExAWS.impl().request!()
+
+    filename
+  end
+
+  defp upload_filename(%Resource{} = resource) do
+    d = DateTime.utc_now()
+    {microsecond, _} = d.microsecond
+    "#{resource.datagouv_id}/#{resource.datagouv_id}.#{d.year}#{d.month}#{d.minute}.#{microsecond}.zip"
   end
 
   defp relevant_http_headers do

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -1,0 +1,53 @@
+defmodule Transport.Jobs.ResourceHistoryDispatcherJob do
+  @moduledoc """
+  Job in charge of dispatching multiple `ResourceHistoryJob`
+  """
+  use Oban.Worker, unique: [period: 60 * 60 * 5]
+  import Ecto.Query
+  alias DB.{Repo, Resource}
+
+  @impl Oban.Worker
+  def perform(_job) do
+    duplicates =
+      Resource
+      |> where([r], not is_nil(r.datagouv_id))
+      |> group_by([r], r.datagouv_id)
+      |> having([r], count(r.datagouv_id) > 1)
+      |> select([r], r.datagouv_id)
+      |> Repo.all()
+
+    datagouv_ids =
+      Resource
+      |> where([r], not is_nil(r.url) and not is_nil(r.title) and not is_nil(r.datagouv_id))
+      |> where([r], r.format == "GTFS" or r.format == "NeTEx")
+      |> where([r], r.datagouv_id not in ^duplicates)
+      |> where([r], not r.is_community_resource)
+      |> select([r], r.datagouv_id)
+      |> Repo.all()
+
+    datagouv_ids
+    |> Enum.each(fn datagouv_id ->
+      %{datagouv_id: datagouv_id}
+      |> Transport.Jobs.ResourceHistoryJob.new()
+      |> Oban.insert()
+    end)
+
+    :ok
+  end
+end
+
+defmodule Transport.Jobs.ResourceHistoryJob do
+  @moduledoc """
+  Job historicising a single resource
+  """
+  use Oban.Worker, unique: [period: 60 * 60 * 5]
+  import Logger
+  alias DB.{Repo, Resource}
+
+  @impl Oban.Worker
+  def perform(%{id: id, args: %{"datagouv_id" => datagouv_id}}) do
+    Logger.info("Job for #{datagouv_id}")
+
+    :ok
+  end
+end

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -8,6 +8,8 @@ defmodule Transport.Jobs.ResourceHistoryDispatcherJob do
 
   @impl Oban.Worker
   def perform(_job) do
+    Transport.S3.create_bucket_if_needed!(:history)
+
     duplicates =
       Resource
       |> where([r], not is_nil(r.datagouv_id))

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -166,7 +166,14 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   defp upload_filename(%Resource{} = resource) do
     d = DateTime.utc_now()
     {microsecond, _} = d.microsecond
-    "#{resource.datagouv_id}/#{resource.datagouv_id}.#{d.year}#{d.month}#{d.minute}.#{microsecond}.zip"
+
+    parts = [
+      "#{d.year}#{d.month}#{d.day}",
+      "#{d.hour}#{d.minute}",
+      microsecond
+    ]
+
+    "#{resource.datagouv_id}/#{resource.datagouv_id}.#{parts |> Enum.join(".")}.zip"
   end
 
   defp relevant_http_headers do

--- a/apps/transport/lib/s3.ex
+++ b/apps/transport/lib/s3.ex
@@ -8,6 +8,11 @@ defmodule Transport.S3 do
     "transport-data-gouv-fr-#{Map.fetch!(config, feature)}"
   end
 
+  def permanent_url(feature, path \\ "") do
+    host = :io_lib.format(Application.fetch_env!(:ex_aws, :cellar_url), [bucket_name(feature)])
+    host |> to_string() |> URI.merge(path) |> URI.to_string()
+  end
+
   def create_bucket_if_needed!(feature, options \\ %{acl: "public-read"}) do
     buckets_response = ExAws.S3.list_buckets() |> Transport.Wrapper.ExAWS.impl().request!()
     bucket_names = buckets_response.body.buckets |> Enum.map(& &1.name)

--- a/apps/transport/lib/s3.ex
+++ b/apps/transport/lib/s3.ex
@@ -2,12 +2,10 @@ defmodule Transport.S3 do
   @moduledoc """
   This module contains common code related to S3 object storage.
   """
-  @buckets %{
-    history: "resource-history"
-  }
 
   def bucket_name(feature) do
-    "transport-data-gouv-fr-#{Map.fetch!(@buckets, feature)}-#{Mix.env()}"
+    config = Application.fetch_env!(:transport, :s3_buckets)
+    "transport-data-gouv-fr-#{Map.fetch!(config, feature)}"
   end
 
   def create_bucket_if_needed!(feature, options \\ %{acl: "public-read"}) do

--- a/apps/transport/lib/s3.ex
+++ b/apps/transport/lib/s3.ex
@@ -1,0 +1,25 @@
+defmodule Transport.S3 do
+  @moduledoc """
+  This module contains common code related to S3 object storage.
+  """
+  @buckets %{
+    history: "resource-history"
+  }
+
+  def bucket_name(feature) do
+    "transport-data-gouv-fr-#{Map.fetch!(@buckets, feature)}-#{Mix.env()}"
+  end
+
+  def create_bucket_if_needed!(feature, options \\ %{acl: "public-read"}) do
+    buckets_response = ExAws.S3.list_buckets() |> Transport.Wrapper.ExAWS.impl().request!()
+    bucket_names = buckets_response.body.buckets |> Enum.map(& &1.name)
+
+    bucket_name = bucket_name(feature)
+
+    if not Enum.member?(bucket_names, bucket_name) do
+      bucket_name
+      |> ExAws.S3.put_bucket("", options)
+      |> Transport.Wrapper.ExAWS.impl().request!()
+    end
+  end
+end

--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -4,6 +4,10 @@ defmodule Transport.ZipMetaDataExtractor do
   which is able to stream the content of each file, allowing us to easily compute a
   SHA256 for each entry.
   """
+  require Protocol
+
+  Protocol.derive(Jason.Encoder, Unzip.Entry)
+
   def extract!(file) do
     zip_file = Unzip.LocalFile.open(file)
     {:ok, unzip} = Unzip.new(zip_file)

--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -12,6 +12,21 @@ defmodule Transport.ZipMetaDataExtractor do
     unzip
     |> Unzip.list_entries()
     |> Enum.map(&enrich(&1, unzip))
+    |> Enum.map(fn m -> keep_keys(m, keys()) end)
+  end
+
+  def keep_keys(map, keys) do
+    Enum.into(keys, %{}, fn key -> {key, Map.fetch!(map, key)} end)
+  end
+
+  defp keys do
+    [
+      :compressed_size,
+      :file_name,
+      :last_modified_datetime,
+      :sha256,
+      :uncompressed_size
+    ]
   end
 
   def enrich(entry, unzip) do
@@ -22,7 +37,7 @@ defmodule Transport.ZipMetaDataExtractor do
       |> Unzip.file_stream!(entry.file_name)
       |> compute_checksum(algorithm)
 
-    entry |> Map.put(algorithm, checksum) |> Map.delete(:__struct__)
+    entry |> Map.put(algorithm, checksum)
   end
 
   def compute_checksum(stream, algorithm) do

--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -1,0 +1,34 @@
+defmodule Transport.ZipMetaDataExtractor do
+  @moduledoc """
+  A module to extract the metadata out of a zip file on disk. It relies on `unzip`
+  which is able to stream the content of each file, allowing us to easily compute a
+  SHA256 for each entry.
+  """
+  def extract!(file) do
+    zip_file = Unzip.LocalFile.open(file)
+    {:ok, unzip} = Unzip.new(zip_file)
+    # NOTE: `unzip.cd_list` contains crc + filenames & more info, if needed
+    unzip
+    |> Unzip.list_entries()
+    |> Enum.map(&enrich(&1, unzip))
+  end
+
+  def enrich(entry, unzip) do
+    algorithm = :sha256
+
+    checksum =
+      unzip
+      |> Unzip.file_stream!(entry.file_name)
+      |> compute_checksum(algorithm)
+
+    Map.put(entry, algorithm, checksum)
+  end
+
+  def compute_checksum(stream, algorithm) do
+    stream
+    |> Enum.reduce(:crypto.hash_init(algorithm), fn elm, acc -> :crypto.hash_update(acc, elm) end)
+    |> :crypto.hash_final()
+    |> Base.encode16()
+    |> String.downcase()
+  end
+end

--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -4,9 +4,6 @@ defmodule Transport.ZipMetaDataExtractor do
   which is able to stream the content of each file, allowing us to easily compute a
   SHA256 for each entry.
   """
-  require Protocol
-
-  Protocol.derive(Jason.Encoder, Unzip.Entry)
 
   def extract!(file) do
     zip_file = Unzip.LocalFile.open(file)
@@ -25,7 +22,7 @@ defmodule Transport.ZipMetaDataExtractor do
       |> Unzip.file_stream!(entry.file_name)
       |> compute_checksum(algorithm)
 
-    Map.put(entry, algorithm, checksum)
+    entry |> Map.put(algorithm, checksum) |> Map.delete(:__struct__)
   end
 
   def compute_checksum(stream, algorithm) do

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -87,7 +87,8 @@ defmodule Transport.Mixfile do
       {:mox, "~> 1.0.0", only: :test},
       {:rambo, "~> 0.3"},
       {:etag_plug, "~> 1.0"},
-      {:oban, "~> 2.9"}
+      {:oban, "~> 2.9"},
+      {:unzip, "~> 0.6.0"}
     ]
   end
 end

--- a/apps/transport/test/s3_test.exs
+++ b/apps/transport/test/s3_test.exs
@@ -14,6 +14,18 @@ defmodule Transport.S3Test do
     end
   end
 
+  describe "permanent_url" do
+    @bucket_name Transport.S3.bucket_name(:history)
+    test "no path" do
+      assert "https://#{@bucket_name}.cellar-c2.services.clever-cloud.com" == Transport.S3.permanent_url(:history)
+    end
+
+    test "with path" do
+      assert "https://#{@bucket_name}.cellar-c2.services.clever-cloud.com/foo/bar.zip" ==
+               Transport.S3.permanent_url(:history, "foo/bar.zip")
+    end
+  end
+
   test "create_bucket_if_needed! when bucket does not exist" do
     bucket_name = Transport.S3.bucket_name(:history)
 

--- a/apps/transport/test/s3_test.exs
+++ b/apps/transport/test/s3_test.exs
@@ -1,0 +1,62 @@
+defmodule Transport.S3Test do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  test "bucket_name" do
+    expected = "transport-data-gouv-fr-resource-history-test"
+    assert expected == Transport.S3.bucket_name(:history)
+
+    assert_raise KeyError, fn ->
+      Transport.S3.bucket_name(:foo)
+    end
+  end
+
+  test "create_bucket_if_needed! when bucket does not exist" do
+    bucket_name = Transport.S3.bucket_name(:history)
+
+    Transport.ExAWS.Mock
+    # Listing buckets
+    |> expect(:request!, fn request ->
+      assert %{
+               service: :s3,
+               http_method: :get,
+               path: "/"
+             } = request
+
+      %{body: %{buckets: [%{name: "foo"}]}}
+    end)
+
+    Transport.ExAWS.Mock
+    # Bucket creation
+    |> expect(:request!, fn request ->
+      assert %{
+               service: :s3,
+               http_method: :put,
+               path: "/",
+               bucket: ^bucket_name,
+               headers: %{"x-amz-acl" => "public-read"}
+             } = request
+    end)
+
+    Transport.S3.create_bucket_if_needed!(:history)
+  end
+
+  test "create_bucket_if_needed! when bucket exists" do
+    Transport.ExAWS.Mock
+    # listing buckets
+    |> expect(:request!, fn request ->
+      assert %{
+               service: :s3,
+               http_method: :get,
+               path: "/"
+             } = request
+
+      %{body: %{buckets: [%{name: Transport.S3.bucket_name(:history)}]}}
+    end)
+
+    Transport.S3.create_bucket_if_needed!(:history)
+  end
+end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -2,12 +2,15 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   use ExUnit.Case, async: true
   import DB.Factory
   use Oban.Testing, repo: DB.Repo
+  import Ecto.Query
   import Mox
 
   alias Transport.Jobs.{ResourceHistoryDispatcherJob, ResourceHistoryJob}
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+    DB.Repo.delete_all(DB.ResourceHistory)
+    :ok
   end
 
   setup :verify_on_exit!
@@ -71,7 +74,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     test "a simple successful case" do
       resource_url = "https://example.com/gtfs.zip"
 
-      %{datagouv_id: datagouv_id} =
+      %{datagouv_id: datagouv_id, metadata: resource_metadata} =
         insert(:resource,
           url: resource_url,
           format: "GTFS",
@@ -104,8 +107,94 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         assert String.starts_with?(path, "#{datagouv_id}/#{datagouv_id}.")
       end)
 
+      assert 0 == count_resource_history()
       assert :ok == perform_job(ResourceHistoryJob, %{datagouv_id: datagouv_id})
+      assert 1 == count_resource_history()
+
+      assert %DB.ResourceHistory{
+               datagouv_id: ^datagouv_id,
+               payload: %{
+                 "filenames" => [
+                   "ExportService.checksum.md5",
+                   "agency.txt",
+                   "calendar.txt",
+                   "calendar_dates.txt",
+                   "routes.txt",
+                   "stop_times.txt",
+                   "stops.txt",
+                   "transfers.txt",
+                   "trips.txt"
+                 ],
+                 "format" => "GTFS",
+                 "http_headers" => %{"content-type" => "application/octet-stream"},
+                 "resource_metadata" => ^resource_metadata,
+                 "total_compressed_size" => 2_370,
+                 "total_uncompressed_size" => 10_685,
+                 "upload_filename" => _upload_filename,
+                 "zip_metadata" => [
+                   %{
+                     "compressed_size" => 41,
+                     "file_name" => "ExportService.checksum.md5",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 47
+                   },
+                   %{
+                     "compressed_size" => 115,
+                     "file_name" => "agency.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 143
+                   },
+                   %{
+                     "compressed_size" => 179,
+                     "file_name" => "calendar.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 495
+                   },
+                   %{
+                     "compressed_size" => 215,
+                     "file_name" => "calendar_dates.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 1197
+                   },
+                   %{
+                     "compressed_size" => 82,
+                     "file_name" => "routes.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 102
+                   },
+                   %{
+                     "compressed_size" => 1038,
+                     "file_name" => "stop_times.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 5128
+                   },
+                   %{
+                     "compressed_size" => 251,
+                     "file_name" => "stops.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 607
+                   },
+                   %{
+                     "compressed_size" => 71,
+                     "file_name" => "transfers.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 102
+                   },
+                   %{
+                     "compressed_size" => 378,
+                     "file_name" => "trips.txt",
+                     "last_modified_datetime" => "2017-02-16T05:01:12",
+                     "uncompressed_size" => 2864
+                   }
+                 ]
+               },
+               version: 1
+             } = DB.ResourceHistory |> DB.Repo.one!()
     end
+  end
+
+  defp count_resource_history do
+    DB.Repo.one!(from(r in DB.ResourceHistory, select: count()))
   end
 
   defp s3_mocks_create_bucket do

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -175,6 +175,13 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     end
   end
 
+  describe "upload_filename" do
+    test "it works" do
+      assert "foo/foo.20211202.130534.393187.zip" ==
+               ResourceHistoryJob.upload_filename(%DB.Resource{datagouv_id: "foo"}, ~U[2021-12-02 13:05:34.393187Z])
+    end
+  end
+
   describe "ResourceHistoryJob" do
     test "a simple successful case" do
       resource_url = "https://example.com/gtfs.zip"
@@ -242,7 +249,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "filename" => filename,
                  "permanent_url" => permanent_url,
                  "zip_metadata" => ^expected_zip_metadata,
-                 "uuid" => _uuid
+                 "uuid" => _uuid,
+                 "download_datetime" => _download_datetime
                }
              } = DB.ResourceHistory |> DB.Repo.one!()
 

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -111,6 +111,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert :ok == perform_job(ResourceHistoryJob, %{datagouv_id: datagouv_id})
       assert 1 == count_resource_history()
 
+      ensure_no_tmp_files!()
+
       assert %DB.ResourceHistory{
                datagouv_id: ^datagouv_id,
                payload: %{
@@ -191,6 +193,11 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                version: 1
              } = DB.ResourceHistory |> DB.Repo.one!()
     end
+  end
+
+  defp ensure_no_tmp_files! do
+    tmp_files = System.tmp_dir!() |> File.ls!()
+    assert tmp_files |> Enum.filter(fn f -> String.starts_with?(f, "resource_") end) |> Enum.empty?()
   end
 
   defp count_resource_history do

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -2,15 +2,20 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   use ExUnit.Case, async: true
   import DB.Factory
   use Oban.Testing, repo: DB.Repo
+  import Mox
 
-  alias Transport.Jobs.{ResourceHistoryJob, ResourceHistoryDispatcherJob}
+  alias Transport.Jobs.{ResourceHistoryDispatcherJob, ResourceHistoryJob}
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
+  setup :verify_on_exit!
+
   describe "ResourceHistoryDispatcherJob" do
     test "a simple successful case" do
+      setup_s3_mocks()
+
       %{datagouv_id: datagouv_id} =
         insert(:resource,
           url: "https://example.com/gtfs.zip",
@@ -57,5 +62,33 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert [%{args: %{"datagouv_id" => ^datagouv_id}}] = all_enqueued(worker: ResourceHistoryJob)
       refute_enqueued(worker: ResourceHistoryDispatcherJob)
     end
+  end
+
+  defp setup_s3_mocks do
+    Transport.ExAWS.Mock
+    # Listing buckets
+    |> expect(:request!, fn request ->
+      assert %{
+               service: :s3,
+               http_method: :get,
+               path: "/"
+             } = request
+
+      %{body: %{buckets: []}}
+    end)
+
+    Transport.ExAWS.Mock
+    # Bucket creation
+    |> expect(:request!, fn request ->
+      bucket_name = Transport.S3.bucket_name(:history)
+
+      assert %{
+               service: :s3,
+               http_method: :put,
+               path: "/",
+               bucket: ^bucket_name,
+               headers: %{"x-amz-acl" => "public-read"}
+             } = request
+    end)
   end
 end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -89,18 +89,6 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       refute ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, zip_metadata())
     end
 
-    test "with the latest ResourceHistory matching but with a different version" do
-      %{datagouv_id: datagouv_id} =
-        insert(:resource_history,
-          datagouv_id: "1",
-          payload: %{"zip_metadata" => zip_metadata()},
-          version: 2
-        )
-
-      assert 1 == count_resource_history()
-      assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, zip_metadata())
-    end
-
     test "with the latest ResourceHistory matching but for a different datagouv_id" do
       %{datagouv_id: datagouv_id} =
         insert(:resource_history,
@@ -253,8 +241,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "total_uncompressed_size" => 10_685,
                  "upload_filename" => _upload_filename,
                  "zip_metadata" => ^expected_zip_metadata
-               },
-               version: 1
+               }
              } = DB.ResourceHistory |> DB.Repo.one!()
     end
 

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -1,0 +1,61 @@
+defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  use Oban.Testing, repo: DB.Repo
+
+  alias Transport.Jobs.{ResourceHistoryJob, ResourceHistoryDispatcherJob}
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "ResourceHistoryDispatcherJob" do
+    test "a simple successful case" do
+      %{datagouv_id: datagouv_id} =
+        insert(:resource,
+          url: "https://example.com/gtfs.zip",
+          format: "GTFS",
+          title: "title",
+          datagouv_id: "1",
+          is_community_resource: false
+        )
+
+      # Resources that should be ignored
+      insert(:resource,
+        url: "https://example.com/gtfs.zip",
+        format: "GTFS",
+        title: "Ignored because it's a community resource",
+        datagouv_id: "2",
+        is_community_resource: true
+      )
+
+      insert(:resource,
+        url: "https://example.com/gbfs",
+        format: "gbfs",
+        title: "Ignored because it's not GTFS or NeTEx",
+        datagouv_id: "3",
+        is_community_resource: false
+      )
+
+      insert(:resource,
+        url: "https://example.com/gtfs.zip",
+        format: "GTFS",
+        title: "Ignored because of duplicated datagouv_id",
+        datagouv_id: "4",
+        is_community_resource: false
+      )
+
+      insert(:resource,
+        url: "https://example.com/gtfs.zip",
+        format: "GTFS",
+        title: "Ignored because of duplicated datagouv_id",
+        datagouv_id: "4",
+        is_community_resource: false
+      )
+
+      assert :ok == perform_job(ResourceHistoryDispatcherJob, %{})
+      assert [%{args: %{"datagouv_id" => ^datagouv_id}}] = all_enqueued(worker: ResourceHistoryJob)
+      refute_enqueued(worker: ResourceHistoryDispatcherJob)
+    end
+  end
+end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -239,10 +239,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "resource_metadata" => ^resource_metadata,
                  "total_compressed_size" => 2_370,
                  "total_uncompressed_size" => 10_685,
-                 "upload_filename" => _upload_filename,
-                 "zip_metadata" => ^expected_zip_metadata
+                 "filename" => filename,
+                 "permanent_url" => permanent_url,
+                 "zip_metadata" => ^expected_zip_metadata,
+                 "uuid" => _uuid
                }
              } = DB.ResourceHistory |> DB.Repo.one!()
+
+      assert permanent_url == Transport.S3.permanent_url(:history, filename)
     end
 
     test "does not store resource again when it did not change" do

--- a/apps/transport/test/zip_test.exs
+++ b/apps/transport/test/zip_test.exs
@@ -1,0 +1,34 @@
+defmodule Transport.ZipMetaDataExtractorTest do
+  use ExUnit.Case, async: true
+
+  test "extract! with a valid zip" do
+    path = "#{__DIR__}/../../shared/test/validation/gtfs.zip"
+    results = Transport.ZipMetaDataExtractor.extract!(path)
+
+    assert 9 == Enum.count(results)
+
+    assert %{
+             __struct__: Unzip.Entry,
+             compressed_size: 251,
+             file_name: "stops.txt",
+             last_modified_datetime: ~N[2017-02-16 05:01:12],
+             sha256: "2685fb16434b396f277c7ad593b609574ed01592b48de7001c53beb36b926eca",
+             uncompressed_size: 607
+           } == results |> Enum.find(fn e -> e.file_name == "stops.txt" end)
+
+    assert %{
+             __struct__: Unzip.Entry,
+             compressed_size: 378,
+             file_name: "trips.txt",
+             last_modified_datetime: ~N[2017-02-16 05:01:12],
+             sha256: "dd79f0fb8d2fd0a70cc75f49c5f2cae56b9b2ef83670992d6b195e9806393c24",
+             uncompressed_size: 2864
+           } == results |> Enum.find(fn e -> e.file_name == "trips.txt" end)
+  end
+
+  test "extract! with a non existing file" do
+    assert_raise MatchError, fn ->
+      Transport.ZipMetaDataExtractor.extract!("foo")
+    end
+  end
+end

--- a/apps/transport/test/zip_test.exs
+++ b/apps/transport/test/zip_test.exs
@@ -8,7 +8,6 @@ defmodule Transport.ZipMetaDataExtractorTest do
     assert 9 == Enum.count(results)
 
     assert %{
-             __struct__: Unzip.Entry,
              compressed_size: 251,
              file_name: "stops.txt",
              last_modified_datetime: ~N[2017-02-16 05:01:12],
@@ -17,7 +16,6 @@ defmodule Transport.ZipMetaDataExtractorTest do
            } == results |> Enum.find(fn e -> e.file_name == "stops.txt" end)
 
     assert %{
-             __struct__: Unzip.Entry,
              compressed_size: 378,
              file_name: "trips.txt",
              last_modified_datetime: ~N[2017-02-16 05:01:12],

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,6 +118,7 @@ config :ex_aws,
   # The expected S3 owner of buckets/objects.
   # For CleverCloud and the Cellar service, it looks like `orga-$UUID`
   cellar_organisation_id: System.get_env("CELLAR_ORGANISATION_ID"),
+  cellar_url: "https://~s.cellar-c2.services.clever-cloud.com",
   s3: [
     scheme: "https://",
     host: "cellar-c2.services.clever-cloud.com",

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,6 +118,7 @@ config :ex_aws,
   # The expected S3 owner of buckets/objects.
   # For CleverCloud and the Cellar service, it looks like `orga-$UUID`
   cellar_organisation_id: System.get_env("CELLAR_ORGANISATION_ID"),
+  # ~s is a string parameter, it will be replaced by the bucket's name
   cellar_url: "https://~s.cellar-c2.services.clever-cloud.com",
   s3: [
     scheme: "https://",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -56,7 +56,10 @@ config :transport, TransportWeb.Endpoint,
   live_view: [
     # NOTE: unsure if this is actually great to reuse the same value
     signing_salt: secret_key_base
-  ]
+  ],
+  s3_buckets: %{
+    history: "resource-history-dev"
+  }
 
 datagouvfr_site = "https://demo.data.gouv.fr"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,7 +9,10 @@ config :transport, TransportWeb.Endpoint,
   live_view: [
     signing_salt: System.get_env("SECRET_KEY_BASE")
   ],
-  notifications_api_token: System.get_env("TRANSPORT_NOTIFICATIONS_API_TOKEN")
+  notifications_api_token: System.get_env("TRANSPORT_NOTIFICATIONS_API_TOKEN"),
+  s3_buckets: %{
+    history: "resource-history-prod"
+  }
 
 config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -79,7 +79,13 @@ extra_oban_conf =
   else
     [
       queues: [default: 2, heavy: 1],
-      plugins: [Oban.Plugins.Pruner]
+      plugins: [
+        {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
+        {Oban.Plugins.Cron,
+         crontab: [
+           {"* */6 * * *", Transport.Jobs.ResourceHistoryDispatcherJob}
+         ]}
+      ]
     ]
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -73,6 +73,18 @@ end
 
 base_oban_conf = [repo: DB.Repo]
 
+# Oban jobs that should be run in every environment
+oban_crontab_all_envs = []
+# Oban jobs that *should not* be run in staging by the crontab
+non_staging_crontab =
+  if app_env == :staging do
+    []
+  else
+    [
+      {"* */6 * * *", Transport.Jobs.ResourceHistoryDispatcherJob}
+    ]
+  end
+
 extra_oban_conf =
   if not worker || (iex_started? and config_env() == :prod) || config_env() == :test do
     [queues: false, plugins: false]
@@ -81,10 +93,7 @@ extra_oban_conf =
       queues: [default: 2, heavy: 1],
       plugins: [
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
-        {Oban.Plugins.Cron,
-         crontab: [
-           {"* */6 * * *", Transport.Jobs.ResourceHistoryDispatcherJob}
-         ]}
+        {Oban.Plugins.Cron, crontab: List.flatten(oban_crontab_all_envs, non_staging_crontab)}
       ]
     ]
   end

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :transport,
+  s3_buckets: %{
+    history: "resource-history-staging"
+  }

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,7 +32,10 @@ config :transport,
   gbfs_validator_impl: Shared.Validation.GBFSValidator.Mock,
   rambo_impl: Transport.Rambo.Mock,
   notifications_impl: Transport.Notifications.FetcherMock,
-  notifications_api_token: "secret"
+  notifications_api_token: "secret",
+  s3_buckets: %{
+    history: "resource-history-test"
+  }
 
 config :ex_aws,
   cellar_organisation_id: "fake-cellar_organisation_id"

--- a/mix.lock
+++ b/mix.lock
@@ -92,6 +92,7 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "unidecode": {:hex, :unidecode, "1.0.1", "d653e7e9777b7c1bcf48b923bbbb9167ecd21a2a90aabb5a3c65b32c6a359497", [:mix], [], "hexpm", "73b490342603a5b1083e0f8f8b9e9bee4149ada327d1b9cdbaf8259f04699611"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm", "6c7729a2d214806450d29766abc2afaa7a2cbecf415be64f36a6691afebb50e5"},
+  "unzip": {:hex, :unzip, "0.6.0", "8b32aaaeb35996ec8cf4c2c1ed36729dd22cae14b69505467502cb6622327ddb", [:mix], [], "hexpm", "e0a32d162fc696a51a71c2b08ab788d3b07442ca09d2cf7ef99c7488cb28182a"},
   "vex": {:git, "https://github.com/CargoSense/vex.git", "328a39f7688000e2746386eabe2f40e6c8e7796b", [ref: "328a39f7"]},
   "yamerl": {:hex, :yamerl, "0.8.1", "07da13ffa1d8e13948943789665c62ccd679dfa7b324a4a2ed3149df17f453a4", [:rebar3], [], "hexpm", "96cb30f9d64344fed0ef8a92e9f16f207de6c04dfff4f366752ca79f5bceb23f"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.8.0", "c7ff0034daf57279c2ce902788ce6fdb2445532eb4317e8df4b044209fae6832", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "4b674bd881e373d1ac6a790c64b2ecb69d1fd612c2af3b22de1619c15473830b"},


### PR DESCRIPTION
See https://github.com/etalab/transport-site/issues/1921

Cette PR ajoute des jobs en charge d'historiser des ressources :

- `Transport.Jobs.ResourceHistoryDispatcherJob` est un job à exécuter de manière régulière, qui ajoute d'autres jobs dans la file de traitement en charge d'historiser les ressources. La liste de ressources à historiser est obtenue à partie d'une requête en base de données.

- `Transport.Jobs.ResourceHistoryJob` est le job en charge d'historiser une ressource. Il doit
  - [x] télécharger une ressource depuis le web et l'enregistrer localement
  - [x] calculer des métadonnées sur le fichier ZIP
  - [x] enregistrer le fichier dans S3/Cellar
  - [x] enregistrer des métadonnées en BDD. Envisagé : métadonnées de la ressource à l'instant T, métadonnées ZIP, headers HTTP de la réponse
  - [x] ne pas historiser si la ressource est déjà présente sur S3/en BDD. En comparant la liste des fichiers/les checksums grâce aux métadonnées ZIP
  
 ----
 
 Les classes notables ajoutées pour faire ce travail
 
 - `Transport.ZipMetaDataExtractor` pour calculer les métadonnées ZIP, repris depuis #1918 
 - `Transport.S3` des helpers pour Cellar