### PR TITLE
SECRET_KEY_BASE n'est pas une variable requise

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -4,14 +4,14 @@ config :transport, TransportWeb.Endpoint,
   http: [port: {:system, "PORT"}, compress: true],
   url: [scheme: "https", host: System.get_env("DOMAIN_NAME") || "transport.data.gouv.fr", port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   live_view: [
-    signing_salt: System.fetch_env!("SECRET_KEY_BASE")
+    signing_salt: System.get_env("SECRET_KEY_BASE")
   ],
   notifications_api_token: System.fetch_env!("TRANSPORT_NOTIFICATIONS_API_TOKEN")
 
-config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :db, DB.Repo,
   url:


### PR DESCRIPTION
https://github.com/etalab/transport-site/pull/1920 avait rendu cette variable d'environnement obligatoire. Celle-ci est obligatoire au runtime mais non au build et ceci a créé des problèmes sur CleverCloud.

~~Navré.~~ -> edit @thbar aucun souci !