### PR TITLE
fetch_env! vers get_env

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,7 +9,7 @@ config :transport, TransportWeb.Endpoint,
   live_view: [
     signing_salt: System.get_env("SECRET_KEY_BASE")
   ],
-  notifications_api_token: System.fetch_env!("TRANSPORT_NOTIFICATIONS_API_TOKEN")
+  notifications_api_token: System.get_env("TRANSPORT_NOTIFICATIONS_API_TOKEN")
 
 config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 


### PR DESCRIPTION
Comme dans #1942. 

Le support CC indique que les variables d'env sont bien disponibles lors du build, mais il faut sûrement [ajuster notre Dockerfile](https://github.com/etalab/transport-site/blob/master/Dockerfile) pour partager des variables d'env lors de la phase de build du container.