### PR TITLE
Ajout APP_ENV en production

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -124,9 +124,7 @@ config :ex_aws,
   ],
   json_codec: Jason
 
-app_env = System.get_env("APP_ENV", "") |> String.to_atom()
 config :transport,
-  app_env: app_env,
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",
@@ -147,8 +145,3 @@ import_config "gbfs_validator.exs"
 import_config "mailjet.exs"
 import_config "mailchimp.exs"
 import_config "#{Mix.env}.exs"
-
-app_env_file = Path.join(__DIR__, "#{app_env}.exs")
-if File.exists?(app_env_file) do
-  import_config app_env_file
-end

--- a/config/config.exs
+++ b/config/config.exs
@@ -124,7 +124,9 @@ config :ex_aws,
   ],
   json_codec: Jason
 
+app_env = System.get_env("APP_ENV", "") |> String.to_atom()
 config :transport,
+  app_env: app_env,
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",
@@ -145,3 +147,8 @@ import_config "gbfs_validator.exs"
 import_config "mailjet.exs"
 import_config "mailchimp.exs"
 import_config "#{Mix.env}.exs"
+
+app_env_file = Path.join(__DIR__, "#{app_env}.exs")
+if File.exists?(app_env_file) do
+  import_config app_env_file
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,6 +52,15 @@ if config_env() == :prod && !iex_started? && worker && System.fetch_env!("INSTAN
   config :transport, Transport.Scheduler, jobs: Transport.Scheduler.scheduled_jobs()
 end
 
+# Make sure that APP_ENV is set in production to distinguish
+# production and staging (both running with MIX_ENV=prod)
+# See https://github.com/etalab/transport-site/issues/1945
+app_env_is_valid = Enum.member?([:production, :staging], Application.fetch_env!(:transport, :app_env))
+
+if config_env() == :prod and not app_env_is_valid do
+  raise("APP_ENV must be set to production or staging while in production")
+end
+
 base_oban_conf = [repo: DB.Repo]
 
 extra_oban_conf =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,10 +55,20 @@ end
 # Make sure that APP_ENV is set in production to distinguish
 # production and staging (both running with MIX_ENV=prod)
 # See https://github.com/etalab/transport-site/issues/1945
-app_env_is_valid = Enum.member?([:production, :staging], Application.fetch_env!(:transport, :app_env))
+app_env = System.get_env("APP_ENV", "") |> String.to_atom()
+app_env_is_valid = Enum.member?([:production, :staging], app_env)
 
 if config_env() == :prod and not app_env_is_valid do
   raise("APP_ENV must be set to production or staging while in production")
+end
+
+config :transport,
+  app_env: app_env
+
+app_env_file = Path.join(__DIR__, "#{app_env}.exs")
+
+if File.exists?(app_env_file) do
+  import_config app_env_file
 end
 
 base_oban_conf = [repo: DB.Repo]


### PR DESCRIPTION
Related to https://github.com/etalab/transport-site/issues/1945

Ajout de `APP_ENV` pour distinguer prochainement et la production. J'ai déjà ajouté les variables d'env nécessaires sur CleverCloud.