### PR TITLE
Filtres supplémentaires pour ResourceHistory

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -43,6 +43,8 @@ defmodule Transport.Jobs.ResourceHistoryDispatcherJob do
     |> where([r], r.format == "GTFS" or r.format == "NeTEx")
     |> where([r], r.datagouv_id not in ^duplicates)
     |> where([r], not r.is_community_resource)
+    |> where([r], r.is_active)
+    |> where([r], like(r.url, "http%"))
     |> select([r], r.datagouv_id)
     |> Repo.all()
   end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -19,51 +19,17 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   @gtfs_content File.read!(@gtfs_path)
 
   describe "ResourceHistoryDispatcherJob" do
+    test "resources_to_historise" do
+      datagouv_id = create_resources_for_history()
+      assert 7 == count_resources()
+      assert [datagouv_id] == ResourceHistoryDispatcherJob.resources_to_historise()
+    end
+
     test "a simple successful case" do
       s3_mocks_create_bucket()
+      datagouv_id = create_resources_for_history()
 
-      %{datagouv_id: datagouv_id} =
-        insert(:resource,
-          url: "https://example.com/gtfs.zip",
-          format: "GTFS",
-          title: "title",
-          datagouv_id: "1",
-          is_community_resource: false
-        )
-
-      # Resources that should be ignored
-      insert(:resource,
-        url: "https://example.com/gtfs.zip",
-        format: "GTFS",
-        title: "Ignored because it's a community resource",
-        datagouv_id: "2",
-        is_community_resource: true
-      )
-
-      insert(:resource,
-        url: "https://example.com/gbfs",
-        format: "gbfs",
-        title: "Ignored because it's not GTFS or NeTEx",
-        datagouv_id: "3",
-        is_community_resource: false
-      )
-
-      insert(:resource,
-        url: "https://example.com/gtfs.zip",
-        format: "GTFS",
-        title: "Ignored because of duplicated datagouv_id",
-        datagouv_id: "4",
-        is_community_resource: false
-      )
-
-      insert(:resource,
-        url: "https://example.com/gtfs.zip",
-        format: "GTFS",
-        title: "Ignored because of duplicated datagouv_id",
-        datagouv_id: "4",
-        is_community_resource: false
-      )
-
+      assert count_resources() > 1
       assert :ok == perform_job(ResourceHistoryDispatcherJob, %{})
       assert [%{args: %{"datagouv_id" => ^datagouv_id}}] = all_enqueued(worker: ResourceHistoryJob)
       refute_enqueued(worker: ResourceHistoryDispatcherJob)
@@ -312,6 +278,75 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     end
   end
 
+  defp create_resources_for_history do
+    %{datagouv_id: datagouv_id} =
+      insert(:resource,
+        url: "https://example.com/gtfs.zip",
+        format: "GTFS",
+        title: "title",
+        datagouv_id: "1",
+        is_community_resource: false,
+        is_active: true
+      )
+
+    # Resources that should be ignored
+    insert(:resource,
+      url: "https://example.com/gtfs.zip",
+      format: "GTFS",
+      title: "Ignored because it's a community resource",
+      datagouv_id: "2",
+      is_community_resource: true,
+      is_active: true
+    )
+
+    insert(:resource,
+      url: "https://example.com/gbfs",
+      format: "gbfs",
+      title: "Ignored because it's not GTFS or NeTEx",
+      datagouv_id: "3",
+      is_community_resource: false,
+      is_active: true
+    )
+
+    insert(:resource,
+      url: "https://example.com/gtfs.zip",
+      format: "GTFS",
+      title: "Ignored because of duplicated datagouv_id",
+      datagouv_id: "4",
+      is_community_resource: false,
+      is_active: true
+    )
+
+    insert(:resource,
+      url: "https://example.com/gtfs.zip",
+      format: "GTFS",
+      title: "Ignored because of duplicated datagouv_id",
+      datagouv_id: "4",
+      is_community_resource: false,
+      is_active: true
+    )
+
+    insert(:resource,
+      url: "https://example.com/gtfs.zip",
+      format: "GTFS",
+      title: "Ignored because is not active",
+      datagouv_id: "5",
+      is_community_resource: false,
+      is_active: false
+    )
+
+    insert(:resource,
+      url: "ftp://example.com/gtfs.zip",
+      format: "GTFS",
+      title: "Ignored because is not available over HTTP",
+      datagouv_id: "6",
+      is_community_resource: false,
+      is_active: true
+    )
+
+    datagouv_id
+  end
+
   defp zip_metadata do
     [
       %{
@@ -389,6 +424,10 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
   defp count_resource_history do
     DB.Repo.one!(from(r in DB.ResourceHistory, select: count()))
+  end
+
+  defp count_resources do
+    DB.Repo.one!(from(r in DB.Resource, select: count()))
   end
 
   defp s3_mocks_create_bucket do


### PR DESCRIPTION
Ajout de filtres pour les ressources à historiser :
- uniquement les ressources actives
- celles qui sont accessible en HTTP/HTTPS (et non FTP !)