### PR TITLE
Mise à plat des noms de domaine utilisés

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For the tests you also need to add an environment variable:
 
 ### Domain names
 
-The following domain names are currently in use:
+The following domain names are currently in use by the deployed Elixir app:
 
 * Production
   * site: https://transport.data.gouv.fr
@@ -206,6 +206,9 @@ The following domain names are currently in use:
   * jobs: https://workers.prochainement.transport.data.gouv.fr
   * proxy: https://proxy.prochainement.transport.gouv.fr
 
+These names are [configured via a CNAME on CleverCloud](https://www.clever-cloud.com/doc/administrate/domain-names/#using-personal-domain-names).
+
+The corresponding SSL certificates are auto-generated via Let's Encrypt and CleverCloud.
 
 # Blog
 The project [blog](https://blog.transport.data.gouv.fr/) code and articles are hosted in the [blog](https://github.com/etalab/transport-site/tree/blog/blog) folder of the blog branch. A specific blog branch has been created with less restrictive merge rules, to allow publishing articles directly from the CMS without needing a github code review.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,21 @@ For the tests you also need to add an environment variable:
   https://github.com/etalab/transport-ops
 
   Update it if needed (e.g. updating Elixir’s version) and then update `.circleci/config.yml`.
-  
+
+### Domain names
+
+The following domain names are currently in use:
+
+* Production
+  * site: https://transport.data.gouv.fr
+  * jobs: https://workers.transport.data.gouv.fr
+  * proxy: https://proxy.transport.data.gouv.fr
+* Staging
+  * site: https://prochainement.transport.data.gouv.fr
+  * jobs: https://workers.prochainement.transport.data.gouv.fr
+  * proxy: https://proxy.prochainement.transport.gouv.fr
+
+
 # Blog
 The project [blog](https://blog.transport.data.gouv.fr/) code and articles are hosted in the [blog](https://github.com/etalab/transport-site/tree/blog/blog) folder of the blog branch. A specific blog branch has been created with less restrictive merge rules, to allow publishing articles directly from the CMS without needing a github code review.
 


### PR DESCRIPTION
En lien avec:
- #1956
- #1688

J'ai mis à plat les domaines utilisés pour les 3 sous-parties de chaque application, et à l'équerre sur production + staging. Cela permettra d'accéder facilement à LiveDashboard notamment, mais aussi à aller voir facilement l'état d'un service donné.

### Proposition par ailleurs, votre avis ?

Je propose de supprimer les custom domains suivants (de CleverCloud), quel est votre avis ?

- `app-$REDACTED$.cleverapps.io` pour toutes les applications
- `prochainement-transport.cleverapps.io` (qui est remplacé par `prochainement.transport.data.gouv.fr`

(Si je le fais, je commencerai par le staging puis la production pour vérifier qu'on n'a pas de surprises, et je demanderai également à CleverCloud si ça peut poser un souci en terme de monitoring ou autre).

L'idée est d'avoir une façon canonique d'accéder aux parties web, ça permettra de simplifier certains bouts de code.