### PR TITLE
ResourceHistoryJob : gère erreurs ZIP

### DIFF
--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -37,9 +37,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   end
 
   describe "should_store_resource?" do
+    test "with an empty or a nil ZIP metadata" do
+      refute ResourceHistoryJob.should_store_resource?(%DB.Resource{}, nil)
+      refute ResourceHistoryJob.should_store_resource?(%DB.Resource{}, [])
+    end
+
     test "with no ResourceHistory records" do
       assert 0 == count_resource_history()
-      assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: "1"}, [])
+      assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: "1"}, zip_metadata())
     end
 
     test "with the latest ResourceHistory matching" do


### PR DESCRIPTION
Gère de potentielles erreurs lorsqu'on essaie de calculer des métadonnées sur un fichier ZIP.

Stacktrace dans Oban
```
** (MatchError) no match of right hand side value: {:error, \"Invalid zip file, missing EOCD record\"}
(transport 0.0.1) lib/zip.ex:10: Transport.ZipMetaDataExtractor.extract!/1
(transport 0.0.1) lib/jobs/resource_history_job.ex:88: Transport.Jobs.ResourceHistoryJob.process_download/2
(transport 0.0.1) lib/jobs/resource_history_job.ex:68: Transport.Jobs.ResourceHistoryJob.perform/1
(oban 2.10.1) lib/oban/queue/executor.ex:218: Oban.Queue.Executor.perform_inline/2
(oban 2.10.1) lib/oban/queue/executor.ex:206: Oban.Queue.Executor.perform_inline/2
(elixir 1.12.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
(elixir 1.12.2) lib/task/supervised.ex:35: Task.Supervised.reply/5
(stdlib 3.15.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/
```

Arrive par exemple pour des ressources "GTFS" qui pointent vers des pages HTML ou des KML.