### PR TITLE
Enregistre Telemetry events pour GBFS

### DIFF
--- a/apps/gbfs/lib/gbfs/telemetry.ex
+++ b/apps/gbfs/lib/gbfs/telemetry.ex
@@ -7,6 +7,8 @@ defmodule GBFS.Telemetry do
   # This call will result in synchronous invoke of all registered handlers for the specified events.
   # (for instance, check out `Transport.Telemetry#handle_event`, available at time of writing)
   def trace_request(network_name, request_type) when request_type in @gbfs_requests do
-    :telemetry.execute([:gbfs, :request, request_type], %{}, %{target: "gbfs:#{network_name}"})
+    :telemetry.execute([:gbfs, :request, request_type], %{}, %{target: target_for_network(network_name)})
   end
+
+  def target_for_network(network_name), do: "gbfs:#{network_name}"
 end

--- a/apps/gbfs/lib/gbfs/telemetry.ex
+++ b/apps/gbfs/lib/gbfs/telemetry.ex
@@ -1,0 +1,12 @@
+defmodule GBFS.Telemetry do
+  @gbfs_requests [:internal, :external]
+
+  @moduledoc """
+  A quick place to centralize definition of tracing events and targets
+  """
+  # This call will result in synchronous invoke of all registered handlers for the specified events.
+  # (for instance, check out `Transport.Telemetry#handle_event`, available at time of writing)
+  def trace_request(network_name, request_type) when request_type in @gbfs_requests do
+    :telemetry.execute([:gbfs, :request, request_type], %{}, %{target: "gbfs:#{network_name}"})
+  end
+end

--- a/apps/gbfs/lib/page_cache.ex
+++ b/apps/gbfs/lib/page_cache.ex
@@ -98,7 +98,7 @@ defmodule PageCache do
   end
 
   def network_name(page_cache_key) do
-    case Regex.named_captures(~r|/gbfs/(?<network>[\w]+)/|, page_cache_key) do
+    case Regex.named_captures(~r|/gbfs/(?<network>.+)/|, page_cache_key) do
       %{"network" => network} -> network
       _ -> nil
     end

--- a/apps/gbfs/test/gbfs/page_cache_test.exs
+++ b/apps/gbfs/test/gbfs/page_cache_test.exs
@@ -52,7 +52,28 @@ defmodule GBFS.PageCacheTest do
     run_query(conn, url)
   end
 
+  test "network_name" do
+    assert nil == PageCache.network_name("/foo")
+    assert nil == PageCache.network_name("/gbfs")
+    assert "rouen" == PageCache.network_name("/gbfs/rouen/gbfs.json")
+    assert "rouen" == PageCache.network_name("/gbfs/rouen/station_information.json")
+    assert "st_helene" == PageCache.network_name("/gbfs/st_helene/station_information.json")
+  end
+
   test "mirrors non-200 status code", %{conn: conn} do
+    test_pid = self()
+    # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
+    :telemetry.attach_many(
+      "test-handler-#{System.unique_integer()}",
+      Transport.Telemetry.gbfs_request_event_names(),
+      fn name, measurements, metadata, _ ->
+        send(test_pid, {:telemetry_event, name, measurements, metadata})
+      end,
+      nil
+    )
+
+    external_telemetry_event = telemetry_event("toulouse", :external)
+    internal_telemetry_event = telemetry_event("toulouse", :internal)
     enable_cache()
 
     url = "/gbfs/toulouse/station_information.json"
@@ -61,6 +82,9 @@ defmodule GBFS.PageCacheTest do
 
     # first call must result in call to third party
     r = conn |> get(url)
+    assert_received ^external_telemetry_event
+    refute_received ^internal_telemetry_event
+
     # an underlying 500 will result of a 502
     assert r.status == 502
 
@@ -74,7 +98,13 @@ defmodule GBFS.PageCacheTest do
     # This is verified by the Mox/expect definition to
     # be called only once.
     r = conn |> get(url)
+    assert_received ^internal_telemetry_event
+    refute_received ^external_telemetry_event
     assert r.status == 502
+  end
+
+  defp telemetry_event(network_name, request_type) do
+    {:telemetry_event, [:gbfs, :request, request_type], %{}, %{target: "gbfs:#{network_name}"}}
   end
 
   # To be implemented later, but for now the error handling on that (Sentry etc)

--- a/apps/gbfs/test/gbfs/page_cache_test.exs
+++ b/apps/gbfs/test/gbfs/page_cache_test.exs
@@ -58,6 +58,7 @@ defmodule GBFS.PageCacheTest do
     assert "rouen" == PageCache.network_name("/gbfs/rouen/gbfs.json")
     assert "rouen" == PageCache.network_name("/gbfs/rouen/station_information.json")
     assert "st_helene" == PageCache.network_name("/gbfs/st_helene/station_information.json")
+    assert "cergy-pontoise" == PageCache.network_name("/gbfs/cergy-pontoise/station_information.json")
   end
 
   test "mirrors non-200 status code", %{conn: conn} do
@@ -104,7 +105,7 @@ defmodule GBFS.PageCacheTest do
   end
 
   defp telemetry_event(network_name, request_type) do
-    {:telemetry_event, [:gbfs, :request, request_type], %{}, %{target: "gbfs:#{network_name}"}}
+    {:telemetry_event, [:gbfs, :request, request_type], %{}, %{target: GBFS.Telemetry.target_for_network(network_name)}}
   end
 
   # To be implemented later, but for now the error handling on that (Sentry etc)

--- a/apps/transport/test/transport/telemetry_test.exs
+++ b/apps/transport/test/transport/telemetry_test.exs
@@ -52,4 +52,13 @@ defmodule Transport.TelemetryTest do
 
     assert stored_events() |> Enum.count() == 4
   end
+
+  test "handlers have been registered" do
+    events = Transport.Telemetry.proxy_request_event_names() ++ Transport.Telemetry.gbfs_request_event_names()
+
+    events
+    |> Enum.each(fn event ->
+      refute is_nil(:telemetry.list_handlers(event))
+    end)
+  end
 end

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -31,7 +31,7 @@ defmodule Unlock.ControllerTest do
       # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
       :telemetry.attach_many(
         "test-handler-#{System.unique_integer()}",
-        [[:proxy, :request, :internal], [:proxy, :request, :external]],
+        Transport.Telemetry.proxy_request_event_names(),
         fn name, measurements, metadata, _ ->
           send(test_pid, {:telemetry_event, name, measurements, metadata})
         end,


### PR DESCRIPTION
Utilise ce qui a été ajouté dans #1925, enregistre des événements afin de connaitre l'utilisation du cache et des ressources externes pour le GBFS.

Cette PR ne contient que l'enregistrement en BDD, je ferai sûrement la partie visualisation backoffice dans la foulée.

Envoie
- `[:gbfs, :request, :internal]` avec le nom du réseau (par exemple `vcub`) dans le cas d'un _cache hit_
- `[:gbfs, :request, :external]` avec le nom du réseau (par exemple `vcub`) dans le cas d'un _cache miss_

On ne prend pas en compte les différentes URLs (gbfs.json vs station_status.json), on s'arrête au niveau du réseau GBFS.