### PR TITLE
Correction telemetry dans page_cache_test

### DIFF
--- a/apps/gbfs/test/gbfs/page_cache_test.exs
+++ b/apps/gbfs/test/gbfs/page_cache_test.exs
@@ -102,13 +102,13 @@ defmodule GBFS.PageCacheTest do
   end
 
   defp setup_telemetry_handler do
-    event_prefix = Transport.Telemetry.proxy_request_event_names() |> Enum.at(1)
-    event_prefix |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
+    events = Transport.Telemetry.gbfs_request_event_names()
+    events |> Enum.at(1) |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
     test_pid = self()
     # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
     :telemetry.attach_many(
       "test-handler-#{System.unique_integer()}",
-      Transport.Telemetry.gbfs_request_event_names(),
+      events,
       fn name, measurements, metadata, _ ->
         send(test_pid, {:telemetry_event, name, measurements, metadata})
       end,

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -183,14 +183,14 @@ defmodule Unlock.ControllerTest do
   end
 
   defp setup_telemetry_handler do
-    event_prefix = Transport.Telemetry.proxy_request_event_names() |> Enum.at(1)
-    event_prefix |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
+    events = Transport.Telemetry.proxy_request_event_names()
+    events |> Enum.at(1) |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
 
     test_pid = self()
     # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
     :telemetry.attach_many(
       "test-handler-#{System.unique_integer()}",
-      Transport.Telemetry.proxy_request_event_names(),
+      events,
       fn name, measurements, metadata, _ ->
         send(test_pid, {:telemetry_event, name, measurements, metadata})
       end,


### PR DESCRIPTION
Le nom des events n'était pas bon dans `page_cache_test`, j'avais indiqué proxy au lieu de gbfs... Donc les handlers n'avaient pas été correctement enlevés.

Cette PR corrige ce problème.