### PR TITLE
Ajout headers CORS pour proxy

### DIFF
--- a/apps/unlock/lib/endpoint.ex
+++ b/apps/unlock/lib/endpoint.ex
@@ -10,6 +10,7 @@ defmodule Unlock.Endpoint do
   plug(Plug.RequestId)
   plug(Plug.Logger)
   plug(Plug.Head)
+  plug(CORSPlug, origin: "*", expose: ["*"])
 
   plug(Unlock.Router)
 end

--- a/apps/unlock/mix.exs
+++ b/apps/unlock/mix.exs
@@ -44,6 +44,7 @@ defmodule Unlock.MixProject do
       {:finch, "~> 0.8"},
       {:yaml_elixir, "~> 2.7"},
       {:cachex, "~> 3.4"},
+      {:cors_plug, "~> 2.0"},
       {:mox, "~> 1.0.0", only: :test},
       {:ymlr, "~> 2.0", only: :test}
     ]

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -90,6 +90,9 @@ defmodule Unlock.ControllerTest do
         |> Enum.reject(fn {h, _v} -> Enum.member?(our_headers, h) end)
 
       assert remaining_headers == [
+               {"access-control-allow-origin", "*"},
+               {"access-control-expose-headers", "*"},
+               {"access-control-allow-credentials", "true"},
                {"content-type", "application/json"},
                {"content-length", "7350"},
                {"date", "Thu, 10 Jun 2021 19:45:14 GMT"}
@@ -121,6 +124,9 @@ defmodule Unlock.ControllerTest do
         |> Enum.reject(fn {h, _v} -> Enum.member?(our_headers, h) end)
 
       assert remaining_headers == [
+               {"access-control-allow-origin", "*"},
+               {"access-control-expose-headers", "*"},
+               {"access-control-allow-credentials", "true"},
                {"content-type", "application/json"},
                {"content-length", "7350"},
                {"date", "Thu, 10 Jun 2021 19:45:14 GMT"}


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/1994

J'ai utilisé le même plug actuellement utilisé pour le GBFS.