### PR TITLE
Unlock: plug for CORS in the right place

### DIFF
--- a/apps/unlock/lib/endpoint.ex
+++ b/apps/unlock/lib/endpoint.ex
@@ -10,7 +10,6 @@ defmodule Unlock.Endpoint do
   plug(Plug.RequestId)
   plug(Plug.Logger)
   plug(Plug.Head)
-  plug(CORSPlug, origin: "*", expose: ["*"])
 
   plug(Unlock.Router)
 end

--- a/apps/unlock/lib/router.ex
+++ b/apps/unlock/lib/router.ex
@@ -1,6 +1,14 @@
 defmodule Unlock.Router do
   use Phoenix.Router
 
-  get("/", Unlock.Controller, :index)
-  get("/resource/:id", Unlock.Controller, :fetch, as: :resource)
+  pipeline :api do
+    plug(CORSPlug, origin: "*", expose: ["*"])
+  end
+
+  scope "/" do
+    pipe_through(:api)
+
+    get("/", Unlock.Controller, :index)
+    get("/resource/:id", Unlock.Controller, :fetch, as: :resource)
+  end
 end


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/1995

En réalité le plug était ignoré en production mais pas dans les tests https://github.com/etalab/transport-site/blob/6e4f4103df7c9727fc16edb4a3f861456cf97fd7/apps/transport/lib/transport_web/plugs/router.ex#L9-L13. Je l'ai donc bougé directement dans le router et j'ai confirmé ça en localhost.