### PR TITLE
Vehicles geopoints: order by names and slugs

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -300,7 +300,7 @@ defmodule TransportWeb.API.StatsController do
       |> select([gv, dataset], %{
         geometry: fragment("ST_Centroid(geom) as geometry"),
         names: fragment("array_agg(? order by ? asc)", dataset.spatial, dataset.spatial),
-        slugs: fragment("array_agg(?)", dataset.slug)
+        slugs: fragment("array_agg(? order by ? asc)", dataset.slug, dataset.spatial)
       })
       |> where([_gv, dataset], dataset.type == "bike-scooter-sharing" and dataset.is_active)
       |> group_by(fragment("geometry"))

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -40,7 +40,11 @@ defmodule TransportWeb.API.StatsControllerTest do
           |> Geo.WKT.decode!()
       )
 
-    dataset = :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, spatial: "name"})
+    dataset1 =
+      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, spatial: "other name", slug: "a"})
+
+    dataset2 =
+      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, spatial: "name", slug: "z"})
 
     expected = [
       %{
@@ -51,8 +55,8 @@ defmodule TransportWeb.API.StatsControllerTest do
         },
         "properties" => %{
           geometry: %Geo.Point{coordinates: {55.5567, -21.3699}, properties: %{}, srid: 4326},
-          names: [dataset.spatial],
-          slugs: [dataset.slug]
+          names: [dataset2.spatial, dataset1.spatial],
+          slugs: [dataset2.slug, dataset1.slug]
         },
         "type" => "Feature"
       }


### PR DESCRIPTION
Follow up de https://github.com/etalab/transport-site/pull/1993

Il faut s'assurer que les `slugs` sont bien triés dans le même ordre également. Merci @fchabouis.