### PR TITLE
Correction lien brisé adresse contact

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/real_time.html.md
+++ b/apps/transport/lib/transport_web/templates/page/real_time.html.md
@@ -34,7 +34,7 @@ Cependant, certains réseaux de transport disposent de données temps-réel non 
 <% end %>
 </table>
 
-Vous pouvez signaler à l'équipe du PAN un jeu de données à ajouter ci-dessus en écrivant à <%= @contact_email %></a>.
+Vous pouvez signaler à l'équipe du PAN un jeu de données à ajouter ci-dessus en écrivant à [<%= @contact_email %>](mailto:<%= @contact_email %>).
 
 # Autre données temps-réel
 


### PR DESCRIPTION
Il y avait une balise cassée sur [cette page](https://transport.data.gouv.fr/real_time) (uniquement la balise de fermeture). Cette PR rétablit un lien vers l'adresse de contact.