### PR TITLE
Ajout job pour répliquer backups de base de données

### DIFF
--- a/.github/workflows/backup_db.yml
+++ b/.github/workflows/backup_db.yml
@@ -42,4 +42,4 @@ jobs:
         UPLOAD_BUCKET_URI: ${{ secrets.UPLOAD_BUCKET_URI }}
 
     - name: Clean up tmp
-      run: rm -r $TARGET_DIR
+      run: rm -r $TARGET_DIR && echo "foo"

--- a/.github/workflows/backup_db.yml
+++ b/.github/workflows/backup_db.yml
@@ -41,3 +41,5 @@ jobs:
         UPLOAD_HOST: ${{ secrets.UPLOAD_HOST }}
         UPLOAD_BUCKET_URI: ${{ secrets.UPLOAD_BUCKET_URI }}
 
+    - name: Clean up tmp
+      run: rm -r $TARGET_DIR

--- a/.github/workflows/backup_db.yml
+++ b/.github/workflows/backup_db.yml
@@ -13,6 +13,9 @@ jobs:
       TARGET_DIR: /tmp/download
       TARGET_FILE: /tmp/download/files
     steps:
+    - name: Install s3cmd
+      run: sudo apt-get install s3cmd
+
     - name: Clean tmp
       run: |
         rm -rf $TARGET_DIR

--- a/.github/workflows/backup_db.yml
+++ b/.github/workflows/backup_db.yml
@@ -1,0 +1,40 @@
+name: Backup production database
+
+on:
+  push:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    env:
+      DAYS_TO_KEEP: 10
+      TARGET_DIR: /tmp/download
+      TARGET_FILE: /tmp/download/files
+    steps:
+    - name: Clean tmp
+      run: |
+        rm -rf $TARGET_DIR
+        mkdir -p $TARGET_DIR
+
+    - name: Download backups
+      run: |
+        s3cmd --access_key=$DOWNLOAD_ACCESS_KEY --secret_key=$DOWNLOAD_SECRET_KEY --host=$DOWNLOAD_HOST --host-bucket="%(bucket)s.$DOWNLOAD_HOST" ls $DOWNLOAD_BUCKET_URI | sort -n | tail -n $DAYS_TO_KEEP | awk '{n=split($4, a, "/"); print a[n]}' > $TARGET_FILE
+        s3cmd --access_key=$DOWNLOAD_ACCESS_KEY --secret_key=$DOWNLOAD_SECRET_KEY --host=$DOWNLOAD_HOST --host-bucket="%(bucket)s.$DOWNLOAD_HOST" --exclude='*' --include-from=$TARGET_FILE sync $DOWNLOAD_BUCKET_URI $TARGET_DIR
+      env:
+        DOWNLOAD_ACCESS_KEY: ${{ secrets.DOWNLOAD_ACCESS_KEY }}
+        DOWNLOAD_SECRET_KEY: ${{ secrets.DOWNLOAD_SECRET_KEY }}
+        DOWNLOAD_HOST: ${{ secrets.DOWNLOAD_HOST }}
+        DOWNLOAD_BUCKET_URI: ${{ secrets.DOWNLOAD_BUCKET_URI }}
+
+    - name: Upload backups
+      run: |
+        cd $TARGET_DIR
+        s3cmd --access_key=$UPLOAD_ACCESS_KEY --secret_key=$UPLOAD_SECRET_KEY --host=$UPLOAD_HOST --host-bucket="%(bucket)s.$UPLOAD_HOST" sync . $UPLOAD_BUCKET_URI --delete-removed
+      env:
+        UPLOAD_ACCESS_KEY: ${{ secrets.UPLOAD_ACCESS_KEY }}
+        UPLOAD_SECRET_KEY: ${{ secrets.UPLOAD_SECRET_KEY }}
+        UPLOAD_HOST: ${{ secrets.UPLOAD_HOST }}
+        UPLOAD_BUCKET_URI: ${{ secrets.UPLOAD_BUCKET_URI }}
+


### PR DESCRIPTION
Fixes #1548 

Ajout d'un job pour répliquer les sauvegardes de la base de données sur un autre Cellar.

- Source : Cellar [`Backups`](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/addons/addon_608ebc6e-4bf1-42a6-8d8e-25f185dac489), à Paris en infrastructure Clever Cloud
- Destination : Cellar [`backups-infra-ovh-roubaix`](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/addons/addon_867e765b-17b4-484a-a73c-610268663239), à Roubaix chez OVH (mais toujours sur notre compte Clever Cloud)

Garde les 10 sauvegardes les plus récentes. Le job est fait avec GitHub Actions qui utilise [s3cmd](https://s3tools.org/s3cmd)
