### PR TITLE
Unlock: gère exception dans comp_fn

### DIFF
--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -122,7 +122,8 @@ defmodule Unlock.Controller do
         e ->
           # NOTE: if an error occurs around the HTTP query, then
           # we want to track it down and return Bad Gateway
-          {:error, {:computation_error, e, __STACKTRACE__}}
+          Logger.error(Exception.format(:error, e, __STACKTRACE__))
+          {:ignore, bad_gateway_response()}
       end
     end
 
@@ -152,8 +153,12 @@ defmodule Unlock.Controller do
       :error ->
         # NOTE: we'll want to have some monitoring here, but not using Sentry
         # because in case of troubles, we will blow up our quota.
-        %Unlock.HTTP.Response{status: 502, body: "Bad Gateway", headers: [{"content-type", "text/plain"}]}
+        bad_gateway_response()
     end
+  end
+
+  defp bad_gateway_response do
+    %Unlock.HTTP.Response{status: 502, body: "Bad Gateway", headers: [{"content-type", "text/plain"}]}
   end
 
   # Inspiration (MIT) here https://github.com/tallarium/reverse_proxy_plug


### PR DESCRIPTION
Fixes #2006

Ma compréhension du problème avec le code actuel est que si une exception survenait, elle était dans le cache de manière permanente.

Doc: https://hexdocs.pm/cachex/Cachex.html#fetch/4

> A fallback function should return a Tuple consisting of a :commit or :ignore tag and a value. If the Tuple is tagged :commit the value will be placed into the cache and then returned. If tagged :ignore the value will be returned without being written to the cache. **If you return a value which does not fit this structure, it will be assumed that you are committing the value.**

Comme la valeur retournée est `:error`, elle est commit dans le cache.

https://github.com/etalab/transport-site/blob/c069513510b9db7d65e6ea6d9fb1b9f4be6266c5/apps/unlock/lib/controller.ex#L125-L156

Comme l'operation n'était pas un vrai `:commit`, le `Cachex.expire` n'était pas exécuté. `:error` est une possible valeur de retour de `Cachex.fetch`, quand il y a un problème pour accéder au cache et ne semble pas approprié pour gérer une erreur.

La PR fait en sorte de renvoyer une 502 mais de ne pas stocker ceci dans le cache.