### PR TITLE
Ajout TTL proxy config live

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -114,15 +114,24 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
   end
 
   defp add_cache_state(item) do
-    cache_entry =
-      item.unique_slug
-      |> Unlock.Shared.cache_key()
-      |> Unlock.Shared.cache_entry()
+    cache_key = item.unique_slug |> Unlock.Shared.cache_key()
+    cache_entry = cache_key |> Unlock.Shared.cache_entry()
+
+    cache_ttl =
+      case cache_key |> Unlock.Shared.cache_ttl() do
+        {:ok, nil} ->
+          "no ttl"
+
+        {:ok, res_in_ms} ->
+          in_seconds = res_in_ms / 1000
+          "#{in_seconds |> Float.round() |> trunc()}s"
+      end
 
     if cache_entry do
       Map.merge(item, %{
         cache_size: cache_entry.body |> byte_size() |> Sizeable.filesize(),
-        cache_status: cache_entry.status
+        cache_status: cache_entry.status,
+        cache_ttl: cache_ttl
       })
     else
       item

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.leex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.leex
@@ -11,6 +11,7 @@
                 <th title="Time To Live (durée en secondes de conservation dans le cache">TTL</th>
                 <th>Taille RAM</th>
                 <th>Statut HTTP</th>
+                <th><abbr title="Time to Live">TTL</abbr></th>
                 <th title="Requêtes reçues par le proxy sur les <%= @stats_days %> derniers jours">Req ext <%= @stats_days %>j</th>
                 <th title="Requêtes envoyées au serveur du producteur sur les <%= @stats_days %> derniers jours">Req int <%= @stats_days %>j</th>
             </tr>
@@ -26,6 +27,7 @@
                 <!-- optional stuff, only available when cache is loaded -->
                 <td><%= resource[:cache_size] %></td>
                 <td><%= resource[:cache_status] %></td>
+                <td><%= resource[:cache_ttl] %></td>
                 <!-- computed stuff -->
                 <td><%= Helpers.format_number(resource[:stats_external_requests]) %></td>
                 <td><%= Helpers.format_number(resource[:stats_internal_requests]) %></td>

--- a/apps/unlock/lib/shared.ex
+++ b/apps/unlock/lib/shared.ex
@@ -6,4 +6,5 @@ defmodule Unlock.Shared do
   def cache_key(resource_slug), do: "resource:#{resource_slug}"
   def cache_name, do: Unlock.Cachex
   def cache_entry(cache_key), do: Cachex.get!(cache_name(), cache_key)
+  def cache_ttl(cache_key), do: Cachex.ttl(cache_name(), cache_key)
 end


### PR DESCRIPTION
Affiche le TTL d'une entrée du cache sur la page de suivi du proxy