### PR TITLE
Remove warnings

### DIFF
--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -6,7 +6,7 @@ defmodule Transport.ObanLogger do
 
   def handle_event(
         [:oban, :job, :exception],
-        %{duration: duration} = info,
+        %{duration: duration},
         %{args: args, error: error, id: id, worker: worker},
         nil
       ) do

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -46,7 +46,6 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
   """
   use Oban.Worker, max_attempts: 5
   require Logger
-  import Ecto.Query
   alias DB.{Repo, Resource, ResourceUnavailability}
 
   @impl Oban.Worker

--- a/apps/transport/lib/transport/history/backup.ex
+++ b/apps/transport/lib/transport/history/backup.ex
@@ -63,7 +63,7 @@ defmodule Transport.History.Backup do
   and the resource has been modified or imported since the most recent historicized resource
   """
   @spec needs_to_be_updated(DB.Resource.t()) :: boolean()
-  defp needs_to_be_updated(resource) do
+  def needs_to_be_updated(resource) do
     backuped_resources = get_already_backuped_resources(resource)
 
     if Enum.empty?(backuped_resources) do

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -6,8 +6,6 @@ defmodule TransportWeb.ValidationController do
 
   import TransportWeb.ResourceView, only: [issue_type: 1]
 
-  defp endpoint, do: Application.fetch_env!(:transport, :gtfs_validator_url) <> "/validate"
-
   def index(%Plug.Conn{} = conn, _) do
     render(conn, "index.html")
   end


### PR DESCRIPTION
Suppression de plusieurs warnings lors de la compilation.

Il en reste 2
```
warning: Supervisor.Spec.supervisor/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
Found at 2 locations:
  lib/transport/application.ex:31: Transport.Application.start/2
  lib/transport/application.ex:32: Transport.Application.start/2

warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/transport/application.ex:61: Transport.Application.add_scheduler/1
```

que je ne suis pas sûr de pouvoir corriger sans faire d'erreur donc je laisse ceci.