### PR TITLE
Set up domain_name in config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -128,10 +128,8 @@ config :ex_aws,
   ],
   json_codec: Jason
 
-domain_name = System.get_env("DOMAIN_NAME", "transport.data.gouv.fr")
-
 config :transport,
-  domain_name: domain_name,
+  domain_name: System.get_env("DOMAIN_NAME", "transport.data.gouv.fr"),
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :transport, TransportWeb.Endpoint,
   http: [port: {:system, "PORT"}, compress: true],
-  url: [scheme: "https", host: domain_name, port: 443],
+  url: [scheme: "https", host: System.get_env("DOMAIN_NAME", "transport.data.gouv.fr"), port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json",
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
   force_ssl: [rewrite_on: [:x_forwarded_proto]],


### PR DESCRIPTION
Suite de #1992. La variable `domain_name` ne peut pas leaker d'un fichier à l'autre comme ça.