### PR TITLE
🪛 Réparation de la page détails des ressources

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -26,7 +26,7 @@
               </ul>
               * <%= dgettext("validations", "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)
               It corresponds to the data you can see on the map below.")%>
-              <%= unless is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
+              <%= unless is_nil(associated_geojson) or is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
                 <%= dgettext("validations", "This GeoJSON was up-to-date with the GTFS resource %{hours} ago.", hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at))%>
               <% end %>
             </li>

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -4,6 +4,7 @@ defmodule TransportWeb.ResourceControllerTest do
   alias DB.{AOM, Dataset, Resource, Validation}
   import Plug.Test
   import Mox
+  import DB.Factory
 
   setup :verify_on_exit!
 
@@ -64,7 +65,16 @@ defmodule TransportWeb.ResourceControllerTest do
     resource = Resource |> Repo.get_by(datagouv_id: "2")
     assert resource.format == "GTFS"
     refute is_nil(resource.metadata)
-    conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
+    x = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
+    IO.inspect(x)
+    File.write!("/home/francis/projects/transport/transport-site/debug.txt", x)
+    assert false
+  end
+
+  test "GTFS resource with associated NeTEx", %{conn: conn} do
+    resource = %{url: url, dataset_id: dataset_id} = Resource |> Repo.get_by(datagouv_id: "2")
+    netex_resource = insert(:resource, %{dataset_id: dataset_id, is_community_resource: true, format: "NeTEx", original_resource_url: url})
+    assert conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200) =~ "NeTEx"
   end
 
   test "GBFS resource with metadata sends back a 404", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -65,15 +65,19 @@ defmodule TransportWeb.ResourceControllerTest do
     resource = Resource |> Repo.get_by(datagouv_id: "2")
     assert resource.format == "GTFS"
     refute is_nil(resource.metadata)
-    x = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
-    IO.inspect(x)
-    File.write!("/home/francis/projects/transport/transport-site/debug.txt", x)
-    assert false
+    conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
   end
 
   test "GTFS resource with associated NeTEx", %{conn: conn} do
     resource = %{url: url, dataset_id: dataset_id} = Resource |> Repo.get_by(datagouv_id: "2")
-    netex_resource = insert(:resource, %{dataset_id: dataset_id, is_community_resource: true, format: "NeTEx", original_resource_url: url})
+
+    insert(:resource, %{
+      dataset_id: dataset_id,
+      is_community_resource: true,
+      format: "NeTEx",
+      original_resource_url: url
+    })
+
     assert conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200) =~ "NeTEx"
   end
 


### PR DESCRIPTION
Il y avait ce petit cas qui était passé entre les tests, quand il existe un NeTEx associé à une ressource, mais pas de GeoJSON, ça faisait crasher la page.