### PR TITLE
Mettre les calques des GBFS dans le bon ordre

### DIFF
--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -223,10 +223,13 @@ function featureScore (f) {
 }
 
 function fillGeofencingZones (geojson, geoFencingZones) {
-    // sort geojson features, so that forbidden areas layers appear above others
-    geojson.features.sort((f1, f2) => {
-        return featureScore(f1) - featureScore(f2)
-    })
+    // According to GBFS specification, in case of conflicting rules
+    // the first rule in the GeoJSON takes precedence
+    // see https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#geofencing_zonesjson-added-in-v21
+    // In leaflet, the last features in the GeoJSON are displayed above the first, so to reflect the spirit of the rule
+    // we need to revert the array.
+    geojson.features = geojson.features.reverse()
+
     L.geoJSON(geojson, {
         onEachFeature: (feature, layer) => setGBFSGeofencingStyle(feature, layer)
     }).addTo(geoFencingZones)

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -208,20 +208,6 @@ function fillFreeFloating (geojson, freeFloating) {
     }).addTo(freeFloating)
 }
 
-function featureScore (f) {
-    const rules = f.properties.rules
-    const rule = rules.length > 0 ? rules[0] : undefined
-    if (rule === undefined) {
-        return 0
-    } else if (rule.ride_through_allowed === false) {
-        return 3
-    } else if (rule.ride_allowed === false) {
-        return 2
-    } else {
-        return 1
-    }
-}
-
 function fillGeofencingZones (geojson, geoFencingZones) {
     // According to GBFS specification, in case of conflicting rules
     // the first rule in the GeoJSON takes precedence


### PR DESCRIPTION
Je m'étais posé la question de pourquoi on avait des villes interdites de circulation partout, cf issue #1990 .
Il s'avère que même si la doc GBFS n'est actuellement [pas très bien rédigée](https://github.com/NABSA/gbfs/issues/361), la règle est quand même claire :  quand des zones de geofencing sont en conflit, la première règle définie a la priorité.

Pour des raisons de clarté, j'avais choisi de toujours faire apparaitre les interdictions au dessus des autorisations, mais ce n'est pas comme ça que sont interprétées les règles, donc j'affiche les règles sur la carte de telle sorte que celle qui s'applique soit celle du dessus (sur laquelle on peut cliquer).

Au passage, j'ai la réponse à ma question initiale, les zones définies par Bird ne semblent pas correctes. Par exemple pour Castres, ils commencent par définir toute la ville en `ride_allowed : false` et cette règle aura la priorité sur toutes les autres. Fini la trotinette :)
Pour Marseille, la zone autorisée de toute la ville est définie en premier, donc la règle écrase toutes les suivantes, et la trotinette est autorisée partout.

Avant :
![image](https://user-images.githubusercontent.com/15341118/148409952-cc6d8e0b-cd70-4f17-b145-afa7cd6df150.png)

Après :
![image](https://user-images.githubusercontent.com/15341118/148409926-656aa757-6051-4b60-83ec-9f78206623ad.png)
