### PR TITLE
Do not validate large files

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -93,6 +93,8 @@ defmodule DB.Resource do
     {true, "no previous validation"}
     iex> Resource.needs_validation(%Resource{format: "gtfs-rt", content_hash: "a_sha"}, true)
     {false, "cannot validate this resource"}
+    iex> Resource.needs_validation(%Resource{schema_name: "foo", filesize: 11000000}, false)
+    {false, "schema is set but file is bigger than 10 MB"}
     iex> Resource.needs_validation(%Resource{format: "GTFS", content_hash: "a_sha",
     ...> validation: %Validation{validation_latest_content_hash: "another_sha"}}, false)
     {true, "content hash has changed"}
@@ -107,6 +109,11 @@ defmodule DB.Resource do
 
   def can_validate?(%__MODULE__{format: format}) when format in ["GTFS", "gbfs"] do
     {true, "#{format} can be validated"}
+  end
+
+  def can_validate?(%__MODULE__{schema_name: schema_name, filesize: filesize})
+      when is_binary(schema_name) and is_integer(filesize) and filesize > 10_000_000 do
+    {false, "schema is set but file is bigger than 10 MB"}
   end
 
   def can_validate?(%__MODULE__{schema_name: schema_name}) when is_binary(schema_name) do


### PR DESCRIPTION
Follow up of #2029

Currently, resources with a JSON schema `schema_name` are validated on the website process and we've seen that this validation can take several seconds when validating large files (we had troubles validating a 305 MB file). Table schema resources are validated using an external web API so they are less affected.

This PR adds a quick fix to skip schema validations for files larger than 10 MB. `filesize` is not filled for all resources at the moment but it's filled for large resources. We'll need to look at validating large files (or everything) on workers.

```sql
select id, url, schema_name, filesize, content_hash
from resource
where schema_name is not null
```