### PR TITLE
Add content hash when validating resources with a schema

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -148,8 +148,23 @@ defmodule DB.Resource do
     {true, "gbfs is always validated"}
   end
 
+  def need_validate?(
+        %__MODULE__{
+          schema_name: schema_name,
+          content_hash: content_hash,
+          metadata: %{"validation" => %{"content_hash" => validation_content_hash}}
+        },
+        _force_validation
+      )
+      when is_binary(schema_name) do
+    case validation_content_hash == content_hash do
+      true -> {false, "schema is set but content hash has not changed"}
+      false -> {true, "schema is set and content hash has changed"}
+    end
+  end
+
   def need_validate?(%__MODULE__{schema_name: schema_name}, _force_validation) when is_binary(schema_name) do
-    {true, "schema is set"}
+    {true, "schema is set and no previous validation"}
   end
 
   @spec validate_and_save(__MODULE__.t() | integer(), boolean()) :: {:error, any} | {:ok, nil}
@@ -255,13 +270,14 @@ defmodule DB.Resource do
     end
   end
 
-  def validate(%__MODULE__{schema_name: schema_name, metadata: metadata} = resource) do
+  def validate(%__MODULE__{schema_name: schema_name, metadata: metadata, content_hash: content_hash} = resource) do
     schema_type = Schemas.schema_type(schema_name)
 
     metadata =
       case validate_against_schema(resource, schema_type) do
         payload when is_map(payload) ->
-          Map.merge(metadata || %{}, %{"validation" => Map.put(payload, "schema_type", schema_type)})
+          validation_details = %{"schema_type" => schema_type, "content_hash" => content_hash}
+          Map.merge(metadata || %{}, %{"validation" => Map.merge(payload, validation_details)})
 
         nil ->
           metadata


### PR DESCRIPTION
This PRs:
- adds a `content_hash` to the `validation` map when validating resources with a schema set. This is similar to what's done for GTFS resources.
- makes sure that validation is skipped if the `content_hash` of a resource with a schema is the same as the previous validation's content hash. Again, similar to what's done for GTFS resources.