### PR TITLE
Gestion exception dans errors_sample

### DIFF
--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -132,6 +132,8 @@ defmodule TransportWeb.ResourceView do
     Enum.take(errors, max_display_errors())
   end
 
+  def errors_sample(%DB.Resource{}), do: []
+
   def max_display_errors, do: 50
 
   def hours_ago(utcdatetime) do

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -132,7 +132,7 @@ defmodule TransportWeb.ResourceView do
     Enum.take(errors, max_display_errors())
   end
 
-  # GBFS resources to not have `errors` in the `validation` dict
+  # GBFS resources do not have `errors` in the `validation` dict
   # in the metadata because we send people to an external
   # website to see errors.
   #

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -132,7 +132,14 @@ defmodule TransportWeb.ResourceView do
     Enum.take(errors, max_display_errors())
   end
 
-  def errors_sample(%DB.Resource{}), do: []
+  # GBFS resources to not have `errors` in the `validation` dict
+  # in the metadata because we send people to an external
+  # website to see errors.
+  #
+  # It would be better to have a shared model for validations.
+  # See https://github.com/etalab/transport-site/issues/2047
+  # See DB.Resource.has_errors_details?/1
+  def errors_sample(%DB.Resource{format: "gbfs"}), do: []
 
   def max_display_errors, do: 50
 

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -30,7 +30,7 @@ defmodule TransportWeb.ResourceControllerTest do
           %Resource{
             url: "http://link.to/gbfs",
             datagouv_id: "3",
-            metadata: %{"versions" => ["2.2"]},
+            metadata: %{"versions" => ["2.2"], "validation" => %{"errors_count" => 1, "has_errors" => true}},
             format: "gbfs"
           },
           %Resource{
@@ -88,11 +88,12 @@ defmodule TransportWeb.ResourceControllerTest do
     assert conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200) =~ "NeTEx"
   end
 
-  test "GBFS resource with metadata sends back a 404", %{conn: conn} do
+  test "GBFS resource with metadata but no errors sends back a 200", %{conn: conn} do
     resource = Resource |> Repo.get_by(datagouv_id: "3")
-    refute resource.format == "GTFS"
-    refute is_nil(resource.metadata)
-    conn |> get(resource_path(conn, :details, resource.id)) |> html_response(404) |> assert =~ "404"
+    assert resource.format == "gbfs"
+    assert Resource.has_errors_details?(resource)
+    refute Map.has_key?(resource.metadata["validation"], "errors")
+    conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
   end
 
   test "resource with error details sends back a 200", %{conn: conn} do


### PR DESCRIPTION
Gère l'erreur suivante : https://sentry.io/organizations/betagouv-f7/issues/2912761831/?project=5687467

Ceci survenait pour des ressources GBFS, qui ont un rapport de validation mais pas une liste d'erreurs.

```js
{
   "ttl":0,
   "feeds":[
      "system_information",
      "vehicle_types",
      "free_bike_status",
      "system_pricing_plans",
      "geofencing_zones"
   ],
   "types":[
      "free_floating"
   ],
   "has_cors":true,
   "versions":[
      "2.2"
   ],
   "languages":[
      "fr"
   ],
   "validation":{
      "has_errors":false,
      "errors_count":0,
      "version_detected":"2.2",
      "version_validated":"2.2"
   },
   "system_details":{
      "name":"pony",
      "timezone":"Europe/Paris"
   },
   "is_cors_allowed":true
}
```