### PR TITLE
Handle another error for datagouv#reuses

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
@@ -13,7 +13,7 @@ defmodule Datagouvfr.Client.Reuses do
       {:ok, %{"data" => data}} ->
         {:ok, Enum.map(data, &add_name/1)}
 
-      {:error, body} ->
+      {:error, body} when is_map(body) ->
         {:error, "Unable to get reuses of dataset #{dataset_id} because of #{body}"}
 
       {:error, %Jason.DecodeError{}} ->

--- a/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
@@ -13,11 +13,8 @@ defmodule Datagouvfr.Client.Reuses do
       {:ok, %{"data" => data}} ->
         {:ok, Enum.map(data, &add_name/1)}
 
-      {:error, %{body: body}} ->
+      {:error, body} ->
         {:error, "Unable to get reuses of dataset #{dataset_id} because of #{body}"}
-
-      {:error, %{reason: reason}} ->
-        {:error, "Unable to get reuses of dataset #{dataset_id} because of #{reason}"}
 
       {:error, %Jason.DecodeError{}} ->
         {:error, "Unable to get reuses of dataset #{dataset_id} could not decode JSON"}

--- a/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/reuses.ex
@@ -14,7 +14,7 @@ defmodule Datagouvfr.Client.Reuses do
         {:ok, Enum.map(data, &add_name/1)}
 
       {:error, body} when is_map(body) ->
-        {:error, "Unable to get reuses of dataset #{dataset_id} because of #{body}"}
+        {:error, "Unable to get reuses of dataset #{dataset_id} because of #{inspect(body)}"}
 
       {:error, %Jason.DecodeError{}} ->
         {:error, "Unable to get reuses of dataset #{dataset_id} could not decode JSON"}

--- a/apps/datagouvfr/test/datagouvfr/client/reuses_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/reuses_test.exs
@@ -1,0 +1,34 @@
+defmodule Datagouvfr.Client.ReusesTest do
+  use ExUnit.Case, async: true
+  alias Datagouvfr.Client.API
+  alias Datagouvfr.Client.Reuses
+  import Datagouvfr.ApiFixtures, only: [mock_httpoison_request: 3]
+  import Mox
+
+  setup :verify_on_exit!
+
+  describe "get" do
+    test "with a 200" do
+      mock_httpoison_request(
+        "reuses" |> API.process_url(),
+        {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"data":[], "owner": null})}},
+        follow_redirect: true,
+        params: %{dataset: "id"}
+      )
+
+      assert {:ok, []} == Reuses.get(%{datagouv_id: "id"})
+    end
+
+    test "with a server error" do
+      mock_httpoison_request(
+        "reuses" |> API.process_url(),
+        {:ok, %HTTPoison.Response{status_code: 500, body: ~s({"message": "Internal Server Error"})}},
+        follow_redirect: true,
+        params: %{dataset: "id"}
+      )
+
+      assert {:error, ~s(Unable to get reuses of dataset id because of %{"message" => "Internal Server Error"})} ==
+               Reuses.get(%{datagouv_id: "id"})
+    end
+  end
+end

--- a/apps/datagouvfr/test/datagouvfr/client/reuses_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/reuses_test.exs
@@ -30,5 +30,17 @@ defmodule Datagouvfr.Client.ReusesTest do
       assert {:error, ~s(Unable to get reuses of dataset id because of %{"message" => "Internal Server Error"})} ==
                Reuses.get(%{datagouv_id: "id"})
     end
+
+    test "with a decode error" do
+      mock_httpoison_request(
+        "reuses" |> API.process_url(),
+        {:ok, %HTTPoison.Response{status_code: 200, body: "foo"}},
+        follow_redirect: true,
+        params: %{dataset: "id"}
+      )
+
+      {:error, message} = Reuses.get(%{datagouv_id: "id"})
+      assert String.starts_with?(message, "Unable to get reuses of dataset id because of %Jason.DecodeError")
+    end
   end
 end

--- a/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
+++ b/apps/datagouvfr/test/support/data_gouv_api_fixtures.ex
@@ -57,13 +57,18 @@ defmodule Datagouvfr.ApiFixtures do
     nil
   end
 
-  def mock_httpoison_request(expected_url, expected_response) do
+  def mock_httpoison_request(expected_url, expected_response, expected_options \\ nil) do
     Transport.HTTPoison.Mock
     |> expect(
       :request,
       1,
-      fn _method, requested_url, _body, _headers, _options ->
+      fn _method, requested_url, _body, _headers, options ->
         assert expected_url == requested_url
+
+        unless is_nil(expected_options) do
+          assert expected_options == options
+        end
+
         expected_response
       end
     )


### PR DESCRIPTION
Voir exception https://sentry.io/organizations/betagouv-f7/issues/2590167890/?project=5687467

Il est possible d'avoir une erreur 500 avec le contenu

```
{
  "message": "Internal Server Error"
}
```

Cette PR refactor le code existant pour gérer ce cas et rendre plus générique la gestion des erreurs. En lisant `api.ex` et `client.ex` je ne suis même pas sûr qu'il soit possible d'avoir `body` et `reason` avec des atoms en réalité.