### PR TITLE
Mise à disposition du convertisseur GTFS vers NeTEx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ default_docker: &default_docker
 defaults: &defaults
   parameters:
     base_image:
-      default: betagouv/transport:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-with-transport-tools
+      default: ghcr.io/etalab/transport-ops:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-transport-tools-1.0.1
       type: string
     # useful to invalidate the build cache manually by bumping the version
     build_cache_key:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM betagouv/transport:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-with-transport-tools
+FROM ghcr.io/etalab/transport-ops:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-transport-tools-1.0.1
 
 RUN mkdir phoenixapp
 WORKDIR /phoenixapp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM betagouv/transport:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-with-transport-tools
+FROM ghcr.io/etalab/transport-ops:elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325-transport-tools-1.0.1
 
 RUN apt-get install -y git inotify-tools postgresql-client>=11
 

--- a/apps/transport/test/build_test.exs
+++ b/apps/transport/test/build_test.exs
@@ -50,13 +50,13 @@ defmodule TransportWeb.BuildTest do
 
   test "make sure Docker image is same for production & CI" do
     content = File.read!("../../Dockerfile")
-    [[_, production_version]] = Regex.scan(~r/FROM (betagouv.*)/, content)
+    [[_, production_version]] = Regex.scan(~r/FROM (ghcr.*)/, content)
 
     content = File.read!("../../Dockerfile.dev")
-    [[_, docker_compose_version]] = Regex.scan(~r/FROM (betagouv.*)/, content)
+    [[_, docker_compose_version]] = Regex.scan(~r/FROM (ghcr.*)/, content)
 
     content = File.read!("../../.circleci/config.yml")
-    [[_, ci_version]] = Regex.scan(~r/(betagouv\/transport.*)/, content)
+    [[_, ci_version]] = Regex.scan(~r/(ghcr.*)/, content)
 
     assert ci_version == production_version
     assert ci_version == docker_compose_version


### PR DESCRIPTION
Cette PR rend disponible le binaire de conversion GTFS vers NeTEx. C'est le bout de la chaîne de ces PR:
- https://github.com/etalab/transport-tools/pull/9
- https://github.com/etalab/transport-tools/pull/11
- https://github.com/etalab/transport-tools/pull/12
- https://github.com/etalab/transport-ops/pull/34
- https://github.com/etalab/transport-ops/pull/35
- https://github.com/etalab/transport-ops/pull/36

À considérer comme beta, car:
- https://github.com/etalab/transport-tools/issues/10

### Reste à faire

- [x] ~~Un petit test de conversion pour vérifier le binaire (avec un tout petit GTFS) serait bien ([Tignes](https://transport.data.gouv.fr/resources/12606) fait 80k et est rapide à convertir ; `gtfs2netexfr --input ~/git/transport/tignes.zip --output tignes --participant test`)~~ -> à faire dans la vraie PR d'intégration plutôt
- [x] Vérification du test Dockerfile et correctif (il devrait initialement planter)
- [x] Review
- [x] Alerter @fchabouis -> précautions sur les jobs car il va falloir une queue de traitement spécifique, avec un max de 1, et on va sûrement avoir des délais de traitement très longs, et des problèmes potentiellement qui pourraient nous obliger à aller sur une autre taille de machine, ou un autre hébergeur juste pour cette partie, à voir !
- [x] Test sur prochainement ?