### PR TITLE
Enregistre erreurs datagouv Sentry

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client.ex
@@ -31,8 +31,8 @@ defmodule Datagouvfr.Client do
           {:ok, %{status_code: status_code, body: body}} when status_code in [200, 201, 202, 204] ->
             {:ok, body}
 
-          {:ok, %{status_code: status_code, body: body}} ->
-            maybe_report_error(response)
+          {:ok, %{status_code: status_code, body: body} = resp} ->
+            maybe_report_error(resp)
             {:error, body}
 
           {:error, error} ->

--- a/apps/datagouvfr/lib/datagouvfr/client.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client.ex
@@ -43,14 +43,14 @@ defmodule Datagouvfr.Client do
       # private
       defp maybe_report_error(%HTTPoison.Response{status_code: status_code, body: body, request_url: url} = response)
            when status_code >= 400 and status_code < 500 and status_code != 404 do
-        Sentry.capture_exception("datagouv error: #{status_code} on #{url}",
+        Sentry.capture_message("datagouv error: #{status_code} on #{url}",
           extra: %{request: response.request, body: body, headers: response.headers}
         )
       end
 
       defp maybe_report_error(%OAuth2.Response{status_code: status_code, body: body, headers: headers})
            when status_code >= 400 and status_code < 500 and status_code != 404 do
-        Sentry.capture_exception("datagouv OAuth2 error: #{status_code}",
+        Sentry.capture_message("datagouv OAuth2 error: #{status_code}",
           extra: %{body: body, headers: headers}
         )
       end

--- a/apps/datagouvfr/lib/datagouvfr/client.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client.ex
@@ -28,13 +28,34 @@ defmodule Datagouvfr.Client do
         Logger.debug(fn -> "response: #{inspect(response)}" end)
 
         case response do
-          {:ok, %{status_code: status_code, body: body}} when status_code in [200, 201, 202, 204] -> {:ok, body}
-          {:ok, %{status_code: _, body: body}} -> {:error, body}
-          {:error, error} -> {:error, error}
+          {:ok, %{status_code: status_code, body: body}} when status_code in [200, 201, 202, 204] ->
+            {:ok, body}
+
+          {:ok, %{status_code: status_code, body: body}} ->
+            maybe_report_error(response)
+            {:error, body}
+
+          {:error, error} ->
+            {:error, error}
         end
       end
 
       # private
+      defp maybe_report_error(%HTTPoison.Response{status_code: status_code, body: body, request_url: url} = response)
+           when status_code >= 400 and status_code < 500 and status_code != 404 do
+        Sentry.capture_exception("datagouv error: #{status_code} on #{url}",
+          extra: %{request: response.request, body: body, headers: response.headers}
+        )
+      end
+
+      defp maybe_report_error(%OAuth2.Response{status_code: status_code, body: body, headers: headers})
+           when status_code >= 400 and status_code < 500 and status_code != 404 do
+        Sentry.capture_exception("datagouv OAuth2 error: #{status_code}",
+          extra: %{body: body, headers: headers}
+        )
+      end
+
+      defp maybe_report_error(_response), do: :ok
 
       @spec add_trailing_slash(map() | path) :: binary()
       defp add_trailing_slash(uri) when is_map(uri) do

--- a/apps/datagouvfr/mix.exs
+++ b/apps/datagouvfr/mix.exs
@@ -44,7 +44,8 @@ defmodule Datagouvfr.MixProject do
       # Using master until https://github.com/CargoSense/vex/issues/68 is fixed
       {:vex, github: "CargoSense/vex", ref: "328a39f7"},
       {:exvcr, "~> 0.10", only: :test},
-      {:mox, "~> 1.0.0", only: :test}
+      {:mox, "~> 1.0.0", only: :test},
+      {:sentry, "~> 8.0"}
     ]
   end
 end


### PR DESCRIPTION
Enregistre certaines erreurs provenant de datagouv dans Sentry, en particulier quand on a des erreurs OAuth2.

Je n'ai pas pu ajouté un test il n'y a pas de behaviour sur `Datagouvfr.Client.OAuth` ou la lib OAuth.

C'est le même problème que là https://github.com/etalab/transport-site/blob/c71348d127f40ef0abbfe6d44b98cd985dd46e99/apps/transport/test/transport_web/controllers/page_controller_test.exs#L76-L78