### PR TITLE
Uniformisation titres par type de Dataset

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -58,18 +58,17 @@ defmodule DB.Dataset do
   @spec type_to_str_map() :: %{binary() => binary()}
   def type_to_str_map,
     do: %{
-      "public-transit" => dgettext("dataset", "Public transit timetable"),
+      "public-transit" => dgettext("dataset", "Public transit - static schedules"),
       "carpooling-areas" => dgettext("dataset", "Carpooling areas"),
-      "stops-ref" => dgettext("dataset", "Stops referential"),
-      "charging-stations" => dgettext("dataset", "Charging stations"),
-      "air-transport" => dgettext("dataset", "Aerial"),
+      "charging-stations" => dgettext("dataset", "Charging & refuelling stations"),
+      "air-transport" => dgettext("dataset", "Air transport"),
       "bike-scooter-sharing" => dgettext("dataset", "Bike and scooter sharing"),
       "car-motorbike-sharing" => dgettext("dataset", "Car and motorbike sharing"),
       "road-network" => dgettext("dataset", "Road networks"),
       "addresses" => dgettext("dataset", "Addresses"),
       "informations" => dgettext("dataset", "Other informations"),
       "private-parking" => dgettext("dataset", "Private parking"),
-      "bike-way" => dgettext("dataset", "Bike way"),
+      "bike-way" => dgettext("dataset", "Bike networks"),
       "bike-parking" => dgettext("dataset", "Bike parking"),
       "low-emission-zones" => dgettext("dataset", "Low emission zones")
     }

--- a/apps/db/priv/gettext/dataset.pot
+++ b/apps/db/priv/gettext/dataset.pot
@@ -11,23 +11,11 @@ msgid ""
 msgstr ""
 
 #, elixir-format
-msgid "Aerial"
-msgstr ""
-
-#, elixir-format
 msgid "Bike and scooter sharing"
 msgstr ""
 
 #, elixir-format
 msgid "Carpooling areas"
-msgstr ""
-
-#, elixir-format
-msgid "Charging stations"
-msgstr ""
-
-#, elixir-format
-msgid "Stops referential"
 msgstr ""
 
 #, elixir-format
@@ -51,10 +39,6 @@ msgid "A dataset cannot be national and regional"
 msgstr ""
 
 #, elixir-format
-msgid "Public transit timetable"
-msgstr ""
-
-#, elixir-format
 msgid "Unable to find INSEE code '%{insee}'"
 msgstr ""
 
@@ -71,10 +55,6 @@ msgid "Private parking"
 msgstr ""
 
 #, elixir-format
-msgid "Bike way"
-msgstr ""
-
-#, elixir-format
 msgid "Car and motorbike sharing"
 msgstr ""
 
@@ -84,4 +64,20 @@ msgstr ""
 
 #, elixir-format
 msgid "Low emission zones"
+msgstr ""
+
+#, elixir-format
+msgid "Air transport"
+msgstr ""
+
+#, elixir-format
+msgid "Bike networks"
+msgstr ""
+
+#, elixir-format
+msgid "Charging & refuelling stations"
+msgstr ""
+
+#, elixir-format
+msgid "Public transit - static schedules"
 msgstr ""

--- a/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -12,23 +12,11 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-msgid "Aerial"
-msgstr ""
-
-#, elixir-format
 msgid "Bike and scooter sharing"
 msgstr ""
 
 #, elixir-format
 msgid "Carpooling areas"
-msgstr ""
-
-#, elixir-format
-msgid "Charging stations"
-msgstr ""
-
-#, elixir-format
-msgid "Stops referential"
 msgstr ""
 
 #, elixir-format
@@ -52,10 +40,6 @@ msgid "A dataset cannot be national and regional"
 msgstr ""
 
 #, elixir-format
-msgid "Public transit timetable"
-msgstr ""
-
-#, elixir-format
 msgid "Unable to find INSEE code '%{insee}'"
 msgstr ""
 
@@ -72,10 +56,6 @@ msgid "Private parking"
 msgstr ""
 
 #, elixir-format
-msgid "Bike way"
-msgstr ""
-
-#, elixir-format
 msgid "Car and motorbike sharing"
 msgstr ""
 
@@ -85,4 +65,20 @@ msgstr ""
 
 #, elixir-format
 msgid "Low emission zones"
+msgstr ""
+
+#, elixir-format
+msgid "Air transport"
+msgstr ""
+
+#, elixir-format
+msgid "Bike networks"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Charging & refuelling stations"
+msgstr ""
+
+#, elixir-format, fuzzy
+msgid "Public transit - static schedules"
 msgstr ""

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -12,24 +12,12 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-msgid "Aerial"
-msgstr "Aérien"
-
-#, elixir-format
 msgid "Bike and scooter sharing"
 msgstr "Vélos et trottinettes en libre-service"
 
 #, elixir-format
 msgid "Carpooling areas"
 msgstr "Lieux de covoiturage"
-
-#, elixir-format
-msgid "Charging stations"
-msgstr "Stations de réapprovisionnement"
-
-#, elixir-format
-msgid "Stops referential"
-msgstr "Référentiel d'arrêts"
 
 #, elixir-format
 msgid "You need to fill either aom, region or use datagouv's zone"
@@ -52,10 +40,6 @@ msgid "A dataset cannot be national and regional"
 msgstr "Un jeu de données ne pas pas être à la fois régional et national"
 
 #, elixir-format
-msgid "Public transit timetable"
-msgstr "Horaires théoriques de transport public"
-
-#, elixir-format
 msgid "Unable to find INSEE code '%{insee}'"
 msgstr "Impossible de trouver le code INSEE '%{insee}'"
 
@@ -72,10 +56,6 @@ msgid "Private parking"
 msgstr "Stationnement hors voirie"
 
 #, elixir-format
-msgid "Bike way"
-msgstr "Aménagements cyclables"
-
-#, elixir-format
 msgid "Car and motorbike sharing"
 msgstr "Voitures et scooters en libre-service"
 
@@ -86,3 +66,19 @@ msgstr "Stationnement vélo"
 #, elixir-format
 msgid "Low emission zones"
 msgstr "Zones à faibles émissions"
+
+#, elixir-format
+msgid "Air transport"
+msgstr "Transport aérien"
+
+#, elixir-format
+msgid "Bike networks"
+msgstr "Réseaux cyclables"
+
+#, elixir-format, fuzzy
+msgid "Charging & refuelling stations"
+msgstr "Stations de réapprovisionnement de véhicules"
+
+#, elixir-format, fuzzy
+msgid "Public transit - static schedules"
+msgstr "Transport public collectif - horaires théoriques"

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -168,12 +168,7 @@ defmodule TransportWeb.PageController do
     counts = home_index_stats()
 
     [
-      %Tile{
-        link: dataset_path(conn, :index, type: "public-transit"),
-        icon: icon_type_path("public-transit"),
-        title: dgettext("page-index", "Public transport - static schedules"),
-        count: Keyword.fetch!(counts, :count_by_type)["public-transit"]
-      },
+      type_tile(conn, "public-transit"),
       %Tile{
         link: dataset_path(conn, :index, type: "public-transit", filter: "has_realtime"),
         icon: icon_type_path("real-time-public-transit"),
@@ -199,72 +194,26 @@ defmodule TransportWeb.PageController do
         title: dgettext("page-index", "Sea and river transport"),
         count: Keyword.fetch!(counts, :count_boat)
       },
-      %Tile{
-        link: dataset_path(conn, :index, type: "air-transport"),
-        icon: icon_type_path("air-transport"),
-        title: dgettext("page-index", "Air transport"),
-        count: Keyword.fetch!(counts, :count_by_type)["air-transport"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "bike-scooter-sharing"),
-        icon: icon_type_path("bike-scooter-sharing"),
-        title: dgettext("page-index", "Bike and scooter sharing"),
-        count: Keyword.fetch!(counts, :count_by_type)["bike-scooter-sharing"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "bike-way"),
-        icon: icon_type_path("bike-way"),
-        title: dgettext("page-index", "Bike networks"),
-        count: Keyword.fetch!(counts, :count_by_type)["bike-way"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "bike-parking"),
-        icon: icon_type_path("bike-parking"),
-        title: dgettext("page-index", "Bike parking"),
-        count: Keyword.fetch!(counts, :count_by_type)["bike-parking"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "road-network"),
-        icon: icon_type_path("road-network"),
-        title: dgettext("page-index", "Road networks"),
-        count: Keyword.fetch!(counts, :count_by_type)["road-network"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "low-emission-zones"),
-        icon: icon_type_path("low-emission-zones"),
-        title: dgettext("page-index", "Low emission zones"),
-        count: Keyword.fetch!(counts, :count_by_type)["low-emission-zones"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "carpooling-areas"),
-        icon: icon_type_path("carpooling-areas"),
-        title: dgettext("page-index", "Carpooling areas"),
-        count: Keyword.fetch!(counts, :count_by_type)["carpooling-areas"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "charging-stations"),
-        icon: icon_type_path("charging-stations"),
-        title: dgettext("page-index", "Charging & refuelling stations"),
-        count: Keyword.fetch!(counts, :count_by_type)["charging-stations"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "private-parking"),
-        icon: icon_type_path("private-parking"),
-        title: dgettext("page-index", "Private parking"),
-        count: Keyword.fetch!(counts, :count_by_type)["private-parking"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "addresses"),
-        icon: icon_type_path("addresses"),
-        title: dgettext("page-index", "Addresses"),
-        count: Keyword.fetch!(counts, :count_by_type)["addresses"]
-      },
-      %Tile{
-        link: dataset_path(conn, :index, type: "informations"),
-        icon: icon_type_path("informations"),
-        title: dgettext("page-index", "Other informations"),
-        count: Keyword.fetch!(counts, :count_by_type)["informations"]
-      }
+      type_tile(conn, "air-transport"),
+      type_tile(conn, "bike-scooter-sharing"),
+      type_tile(conn, "bike-way"),
+      type_tile(conn, "bike-parking"),
+      type_tile(conn, "road-network"),
+      type_tile(conn, "low-emission-zones"),
+      type_tile(conn, "carpooling-areas"),
+      type_tile(conn, "charging-stations"),
+      type_tile(conn, "private-parking"),
+      type_tile(conn, "addresses"),
+      type_tile(conn, "informations")
     ]
+  end
+
+  defp type_tile(conn, type) do
+    %Tile{
+      link: dataset_path(conn, :index, type: type),
+      icon: icon_type_path(type),
+      title: DB.Dataset.type_to_str(type),
+      count: Keyword.fetch!(home_index_stats(), :count_by_type)[type]
+    }
   end
 end

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -172,7 +172,7 @@ defmodule TransportWeb.PageController do
       %Tile{
         link: dataset_path(conn, :index, type: "public-transit", filter: "has_realtime"),
         icon: icon_type_path("real-time-public-transit"),
-        title: dgettext("page-index", "Public transport - realtime trafic"),
+        title: dgettext("page-index", "Public transport - realtime traffic"),
         count: Keyword.fetch!(counts, :count_public_transport_has_realtime)
       },
       %Tile{

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -50,23 +50,7 @@ msgid "subtitle"
 msgstr "Gather all french mobility data"
 
 #, elixir-format
-msgid "Bike and scooter sharing"
-msgstr ""
-
-#, elixir-format
-msgid "Carpooling areas"
-msgstr ""
-
-#, elixir-format
-msgid "Charging & refuelling stations"
-msgstr ""
-
-#, elixir-format
 msgid "Long distance coach"
-msgstr ""
-
-#, elixir-format
-msgid "Public transport - static schedules"
 msgstr ""
 
 #, elixir-format
@@ -84,14 +68,6 @@ msgid "See newly added datasets"
 msgstr ""
 
 #, elixir-format
-msgid "Air transport"
-msgstr ""
-
-#, elixir-format
-msgid "Bike parking"
-msgstr ""
-
-#, elixir-format
 msgid "Coming soon"
 msgstr ""
 
@@ -100,15 +76,7 @@ msgid "Car and motorbike sharing"
 msgstr ""
 
 #, elixir-format
-msgid "Private parking"
-msgstr ""
-
-#, elixir-format
 msgid "Rail transport"
-msgstr ""
-
-#, elixir-format
-msgid "Road networks"
 msgstr ""
 
 #, elixir-format
@@ -188,14 +156,6 @@ msgid "Search data for a region, a city, a network…"
 msgstr ""
 
 #, elixir-format
-msgid "Addresses"
-msgstr ""
-
-#, elixir-format
-msgid "Other informations"
-msgstr ""
-
-#, elixir-format
 msgid "Datasets"
 msgstr ""
 
@@ -213,14 +173,6 @@ msgstr ""
 
 #, elixir-format
 msgid "You can also"
-msgstr ""
-
-#, elixir-format
-msgid "Bike networks"
-msgstr ""
-
-#, elixir-format
-msgid "Low emission zones"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -54,7 +54,7 @@ msgid "Long distance coach"
 msgstr "Autocars longue distance"
 
 #, elixir-format
-msgid "Public transport - realtime trafic"
+msgid "Public transport - realtime traffic"
 msgstr "Transport public collectif - horaires temps réel"
 
 #, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -50,24 +50,8 @@ msgid "subtitle"
 msgstr "Rassembler les données de toute l’offre de mobilité à travers la France"
 
 #, elixir-format
-msgid "Bike and scooter sharing"
-msgstr "Vélos et trottinettes en libre-service"
-
-#, elixir-format
-msgid "Carpooling areas"
-msgstr "Lieux de covoiturage"
-
-#, elixir-format
-msgid "Charging & refuelling stations"
-msgstr "Stations de réapprovisionnement de véhicules"
-
-#, elixir-format
 msgid "Long distance coach"
 msgstr "Autocars longue distance"
-
-#, elixir-format
-msgid "Public transport - static schedules"
-msgstr "Transport public collectif - horaires théoriques"
 
 #, elixir-format
 msgid "Public transport - realtime trafic"
@@ -84,14 +68,6 @@ msgid "See newly added datasets"
 msgstr "Voir les jeux de données récents"
 
 #, elixir-format
-msgid "Air transport"
-msgstr "Transport aérien"
-
-#, elixir-format
-msgid "Bike parking"
-msgstr "Stationnement cyclable"
-
-#, elixir-format
 msgid "Coming soon"
 msgstr "À venir dans les prochains mois"
 
@@ -100,16 +76,8 @@ msgid "Car and motorbike sharing"
 msgstr "Voitures et scooters en libre-service"
 
 #, elixir-format
-msgid "Private parking"
-msgstr "Stationnement hors voirie"
-
-#, elixir-format
 msgid "Rail transport"
 msgstr "Transport ferroviaire"
-
-#, elixir-format
-msgid "Road networks"
-msgstr "Réseaux routiers"
 
 #, elixir-format
 msgid "Sea and river transport"
@@ -188,14 +156,6 @@ msgid "Search data for a region, a city, a network…"
 msgstr "Cherchez les données d’une région, d’une ville, d’un réseau…"
 
 #, elixir-format
-msgid "Addresses"
-msgstr "Adresses"
-
-#, elixir-format
-msgid "Other informations"
-msgstr "Autres informations"
-
-#, elixir-format
 msgid "Datasets"
 msgstr "Jeux de données"
 
@@ -214,14 +174,6 @@ msgstr "Rechercher sur la carte"
 #, elixir-format
 msgid "You can also"
 msgstr "Vous pouvez également"
-
-#, elixir-format
-msgid "Bike networks"
-msgstr "Réseaux cyclables"
-
-#, elixir-format
-msgid "Low emission zones"
-msgstr "Zones à faibles émissions"
 
 #, elixir-format
 msgid "A freely accessible service"

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -50,23 +50,7 @@ msgid "subtitle"
 msgstr ""
 
 #, elixir-format
-msgid "Bike and scooter sharing"
-msgstr ""
-
-#, elixir-format
-msgid "Carpooling areas"
-msgstr ""
-
-#, elixir-format
-msgid "Charging & refuelling stations"
-msgstr ""
-
-#, elixir-format
 msgid "Long distance coach"
-msgstr ""
-
-#, elixir-format
-msgid "Public transport - static schedules"
 msgstr ""
 
 #, elixir-format
@@ -84,14 +68,6 @@ msgid "See newly added datasets"
 msgstr ""
 
 #, elixir-format
-msgid "Air transport"
-msgstr ""
-
-#, elixir-format
-msgid "Bike parking"
-msgstr ""
-
-#, elixir-format
 msgid "Coming soon"
 msgstr ""
 
@@ -100,15 +76,7 @@ msgid "Car and motorbike sharing"
 msgstr ""
 
 #, elixir-format
-msgid "Private parking"
-msgstr ""
-
-#, elixir-format
 msgid "Rail transport"
-msgstr ""
-
-#, elixir-format
-msgid "Road networks"
 msgstr ""
 
 #, elixir-format
@@ -188,14 +156,6 @@ msgid "Search data for a region, a city, a network…"
 msgstr ""
 
 #, elixir-format
-msgid "Addresses"
-msgstr ""
-
-#, elixir-format
-msgid "Other informations"
-msgstr ""
-
-#, elixir-format
 msgid "Datasets"
 msgstr ""
 
@@ -213,14 +173,6 @@ msgstr ""
 
 #, elixir-format
 msgid "You can also"
-msgstr ""
-
-#, elixir-format
-msgid "Bike networks"
-msgstr ""
-
-#, elixir-format
-msgid "Low emission zones"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -54,7 +54,7 @@ msgid "Long distance coach"
 msgstr ""
 
 #, elixir-format
-msgid "Public transport - realtime trafic"
+msgid "Public transport - realtime traffic"
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -64,17 +64,17 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   test "GET /datasets filter", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index))
     # info dans les filtres à gauche des datasets
-    assert html_response(conn, 200) =~ "Horaires théoriques de transport public (2)"
+    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (2)"
   end
 
   test "GET /datasets?modes[]=ferry", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index), %{modes: ["ferry"]})
-    assert html_response(conn, 200) =~ "Horaires théoriques de transport public (1)"
+    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (1)"
   end
 
   test "GET /datasets?features[]=tarifs", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index), %{features: ["tarifs"]})
-    assert html_response(conn, 200) =~ "Horaires théoriques de transport public (1)"
+    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (1)"
   end
 
   test "GET /datasets?type=public-transit", %{conn: conn} do


### PR DESCRIPTION
Une PR de refactor de https://github.com/etalab/transport-site/pull/2030. Lié aussi à #1862 

Suite à cette PR, on avait des incohérences entre le titre d'une tuile sur l'accueil et sur la liste des jeux de données.

Exemple :
- "Transport public collectif - horaires théoriques" sur l'accueil
- "Horaires théoriques de transport public" sur https://transport.data.gouv.fr/datasets?type=public-transit

Cette PR uniformise la source de traduction vers `DB.Dataset.type_to_str`, ce qui simplifie la création des tuiles aussi.