### PR TITLE
Espace producteur : ajout du lien vers validateur GBFS 

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
@@ -92,7 +92,14 @@
               <%= dgettext("espace-producteurs", "You can test your data online and check its validity.") %>
             </div>
             <div class="pt-24">
-              <a href="<%= validation_path(@conn, :index) %>" class="button-outline primary"><%= dgettext("espace-producteurs", "Test a file") %></a>
+              <a href="<%= validation_path @conn, :index %>" class="button-outline primary">
+                <%= dgettext("page-producteurs", "Validate a GTFS file") %>
+              </a>
+            </div>
+            <div class="pt-24">
+              <a href="<%= gbfs_analyzer_path @conn, :index %>" class="button-outline primary">
+                <%= dgettext("page-producteurs", "Validate a GBFS feed") %>
+              </a>
             </div>
           </div>
         </div>

--- a/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.eex
@@ -54,7 +54,12 @@
           </div>
           <div class="presentation-action pt-24">
             <a href="<%= validation_path @conn, :index %>" class="button-outline primary">
-              <%= dgettext("page-producteurs", "Validate data online") %>
+              <%= dgettext("page-producteurs", "Validate a GTFS file") %>
+            </a>
+          </div>
+          <div class="presentation-action pt-24">
+            <a href="<%= gbfs_analyzer_path @conn, :index %>" class="button-outline primary">
+              <%= dgettext("page-producteurs", "Validate a GBFS feed") %>
             </a>
           </div>
         </div>

--- a/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.eex
@@ -7,21 +7,21 @@
         </h1>
       </div>
       <%= if assigns[:current_user] do %>
-        <div class="panel-producteurs signed-in">
-          <h2><%= dgettext("page-producteurs", "Welcome!") %></h2>
-          <a class="button" href="<%= page_path @conn, :espace_producteur %>"><%= dgettext("page-producteurs", "Access your producer section") %></a>
-          <div class="pt-24">
-            <%= dgettext("page-producteurs", "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data") %>
-          </div>
+      <div class="panel-producteurs signed-in">
+        <h2><%= dgettext("page-producteurs", "Welcome!") %></h2>
+        <a class="button" href="<%= page_path @conn, :espace_producteur %>"><%= dgettext("page-producteurs", "Access your producer section") %></a>
+        <div class="pt-24">
+          <%= dgettext("page-producteurs", "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data") %>
         </div>
+      </div>
       <% else %>
-        <div class="panel-producteurs">
-          <h2><%= dgettext("page-producteurs", "Access your producer section") %></h2>
-          <div>
-            <%= dgettext("page-producteurs", "To log in, you will be redirected to data.gouv.fr, the open platform for French public data") %>
-          </div>
-          <a class="button" href="<%= page_path @conn, :login, redirect_path: current_path(@conn) %>"><%= dgettext("page-dataset-details", "Log in") %></a>
+      <div class="panel-producteurs">
+        <h2><%= dgettext("page-producteurs", "Access your producer section") %></h2>
+        <div>
+          <%= dgettext("page-producteurs", "To log in, you will be redirected to data.gouv.fr, the open platform for French public data") %>
         </div>
+        <a class="button" href="<%= page_path @conn, :login, redirect_path: current_path(@conn) %>"><%= dgettext("page-dataset-details", "Log in") %></a>
+      </div>
       <% end %>
     </section>
     <section class="section producteurs-content">
@@ -49,7 +49,7 @@
               <%= dgettext("page-producteurs", "Online validation tools") %>
             </h2>
             <div>
-              <%= dgettext("page-producteurs", "Users want quality data. Validate online your GTFS files or your data following French national schemas.") %>
+              <%= dgettext("page-producteurs", "Users want quality data. Validate online GTFS files, GBFS feeds or any data following French national schemas.") %>
             </div>
           </div>
           <div class="presentation-action pt-24">

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -44,10 +44,6 @@ msgid "Publishing best practices"
 msgstr ""
 
 #, elixir-format
-msgid "Test a file"
-msgstr ""
-
-#, elixir-format
 msgid "Update a dataset"
 msgstr ""
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-producteurs.po
@@ -104,10 +104,6 @@ msgid "Users want quality data. Validate online your GTFS files or your data fol
 msgstr ""
 
 #, elixir-format
-msgid "Validate data online"
-msgstr ""
-
-#, elixir-format
 msgid "Whether you are Autorité organisatrice de mobilité, délégataire de service public, or collectivité territoriale, you may be concerned by the laws loi pour une république numérique, la Loi Orientation des Mobilités and the european reglementation."
 msgstr ""
 
@@ -125,4 +121,12 @@ msgstr ""
 
 #, elixir-format
 msgid "Why should you publish your data?"
+msgstr ""
+
+#, elixir-format
+msgid "Validate a GBFS feed"
+msgstr ""
+
+#, elixir-format
+msgid "Validate a GTFS file"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-producteurs.po
@@ -100,7 +100,7 @@ msgid "To log in, you will be redirected to data.gouv.fr, the open platform for 
 msgstr ""
 
 #, elixir-format
-msgid "Users want quality data. Validate online your GTFS files or your data following French national schemas."
+msgid "Users want quality data. Validate online GTFS files, GBFS feeds or any data following French national schemas."
 msgstr ""
 
 #, elixir-format

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -43,10 +43,6 @@ msgid "Publishing best practices"
 msgstr ""
 
 #, elixir-format
-msgid "Test a file"
-msgstr ""
-
-#, elixir-format
 msgid "Update a dataset"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -44,10 +44,6 @@ msgid "Publishing best practices"
 msgstr "Les bonnes pratiques de publication"
 
 #, elixir-format
-msgid "Test a file"
-msgstr "Analyser la qualité d'un fichier"
-
-#, elixir-format
 msgid "Update a dataset"
 msgstr "Mettre à jour un jeu de données"
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
@@ -125,7 +125,7 @@ msgstr "Pourquoi publier vos données ?"
 
 #, elixir-format
 msgid "Validate a GBFS feed"
-msgstr "Validez un flux GBFS"
+msgstr "Valider un flux GBFS"
 
 #, elixir-format
 msgid "Validate a GTFS file"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
@@ -104,10 +104,6 @@ msgid "Users want quality data. Validate online your GTFS files or your data fol
 msgstr "Les données de bonne qualité sont réutilisées. Validez vos données dans les formats GTFS ou respectant des schémas nationaux grâce à nos outils."
 
 #, elixir-format
-msgid "Validate data online"
-msgstr "Testez vos jeux de données"
-
-#, elixir-format
 msgid "Whether you are Autorité organisatrice de mobilité, délégataire de service public, or collectivité territoriale, you may be concerned by the laws loi pour une république numérique, la Loi Orientation des Mobilités and the european reglementation."
 msgstr "Que vous soyez Autorité Organisatrice des Mobilités, délégataire de service public ou collectivité territoriale, vous pouvez être concerné par la Loi pour une république Numérique, la Loi Orientation des Mobilités et le Réglement européen."
 
@@ -126,3 +122,11 @@ msgstr "Si vous avez des questions, contactez nous par email, nous serons heureu
 #, elixir-format
 msgid "Why should you publish your data?"
 msgstr "Pourquoi publier vos données ?"
+
+#, elixir-format
+msgid "Validate a GBFS feed"
+msgstr "Validez un flux GBFS"
+
+#, elixir-format
+msgid "Validate a GTFS file"
+msgstr "Valider un GTFS"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-producteurs.po
@@ -100,8 +100,8 @@ msgid "To log in, you will be redirected to data.gouv.fr, the open platform for 
 msgstr "Pour vous identifier vous allez être redirigé vers data.gouv.fr, la plateforme ouverte des données publiques françaises."
 
 #, elixir-format
-msgid "Users want quality data. Validate online your GTFS files or your data following French national schemas."
-msgstr "Les données de bonne qualité sont réutilisées. Validez vos données dans les formats GTFS ou respectant des schémas nationaux grâce à nos outils."
+msgid "Users want quality data. Validate online GTFS files, GBFS feeds or any data following French national schemas."
+msgstr "Les données de bonne qualité sont réutilisées. Validez des données GTFS, des flux GBFS ou des données respectant des schémas nationaux grâce à nos outils."
 
 #, elixir-format
 msgid "Whether you are Autorité organisatrice de mobilité, délégataire de service public, or collectivité territoriale, you may be concerned by the laws loi pour une république numérique, la Loi Orientation des Mobilités and the european reglementation."

--- a/apps/transport/priv/gettext/page-producteurs.pot
+++ b/apps/transport/priv/gettext/page-producteurs.pot
@@ -103,10 +103,6 @@ msgid "Users want quality data. Validate online your GTFS files or your data fol
 msgstr ""
 
 #, elixir-format
-msgid "Validate data online"
-msgstr ""
-
-#, elixir-format
 msgid "Whether you are Autorité organisatrice de mobilité, délégataire de service public, or collectivité territoriale, you may be concerned by the laws loi pour une république numérique, la Loi Orientation des Mobilités and the european reglementation."
 msgstr ""
 
@@ -124,4 +120,12 @@ msgstr ""
 
 #, elixir-format
 msgid "Why should you publish your data?"
+msgstr ""
+
+#, elixir-format
+msgid "Validate a GBFS feed"
+msgstr ""
+
+#, elixir-format
+msgid "Validate a GTFS file"
 msgstr ""

--- a/apps/transport/priv/gettext/page-producteurs.pot
+++ b/apps/transport/priv/gettext/page-producteurs.pot
@@ -99,7 +99,7 @@ msgid "To log in, you will be redirected to data.gouv.fr, the open platform for 
 msgstr ""
 
 #, elixir-format
-msgid "Users want quality data. Validate online your GTFS files or your data following French national schemas."
+msgid "Users want quality data. Validate online GTFS files, GBFS feeds or any data following French national schemas."
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
closes https://github.com/etalab/transport-site/issues/2000

![image](https://user-images.githubusercontent.com/15341118/150352704-aca1a407-08c5-437d-87fa-54ce8fd36ad8.png)
