### PR TITLE
Ajustement des settings pour faciliter le travail en local

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -78,15 +78,28 @@ end
 
 base_oban_conf = [repo: DB.Repo]
 
-# Oban jobs that should be run in every environment
-oban_crontab_all_envs = [
-  {"0 */6 * * *", Transport.Jobs.ResourceHistoryDispatcherJob},
-  {"30 */6 * * *", Transport.Jobs.GtfsToGeojsonConverterJob},
-  {"0 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob},
-  {"*/10 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob, args: %{only_unavailable: true}}
-]
+# Oban jobs that should run in every deployed environment (staging, prod)
+# but not during dev or test
+# Be careful : there is "app_env :prod" in contrast  to :staging (ie production website vs prochainement)
+# and "config_env :prod" in contrast to :dev et :test
+oban_crontab_all_envs =
+  case config_env() do
+    :prod ->
+      [
+        {"0 */6 * * *", Transport.Jobs.ResourceHistoryDispatcherJob},
+        {"30 */6 * * *", Transport.Jobs.GtfsToGeojsonConverterJob},
+        {"0 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob},
+        {"*/10 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob, args: %{only_unavailable: true}}
+      ]
 
-# Oban jobs that *should not* be run in staging by the crontab
+    :dev ->
+      []
+
+    :test ->
+      []
+  end
+
+# Oban jobs that *should not* be run in staging (ie on prochainement) by the crontab
 non_staging_crontab =
   if app_env == :staging do
     []
@@ -96,7 +109,7 @@ non_staging_crontab =
   end
 
 extra_oban_conf =
-  if not worker || (iex_started? and config_env() == :prod) || config_env() == :test do
+  if not worker || iex_started? || config_env() == :test do
     [queues: false, plugins: false]
   else
     [


### PR DESCRIPTION
Ça a dû vous arriver aussi : on lance un webserver en local, il est 12h et paf, 3000 jobs `Transport.Jobs.ResourceUnavailableJob` se retrouvent dans la queue Oban à cause du Cron.

J'ai l'impression que le plus souvent, on n'a pas envie que ces jobs soient lancés automatiquement quand on lance un serveur de dev.

Idem pour la console `iex`, je suis finalement de l'avis de @thbar , on n'a pas envie qu'une session iex en local se mette à traiter des jobs.