### PR TITLE
Suppression de warnings lors de la compilation

### DIFF
--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -10,7 +10,6 @@ defmodule Transport.Application do
   use Task
   alias Transport.{CSVDocuments, ImportDataWorker, SearchCommunes}
   alias TransportWeb.Endpoint
-  import Supervisor.Spec, only: [supervisor: 2]
 
   @cache_name :transport
   # for DRY external reference
@@ -28,8 +27,8 @@ defmodule Transport.Application do
     children =
       [
         {Cachex, name: @cache_name},
-        supervisor(TransportWeb.Endpoint, []),
-        supervisor(ImportDataWorker, []),
+        TransportWeb.Endpoint,
+        ImportDataWorker,
         CSVDocuments,
         SearchCommunes,
         {Phoenix.PubSub, [name: TransportWeb.PubSub, adapter: Phoenix.PubSub.PG2]},
@@ -57,8 +56,7 @@ defmodule Transport.Application do
 
   defp add_scheduler(children) do
     if Mix.env() != :test do
-      import Supervisor.Spec, only: [worker: 2]
-      [worker(Transport.Scheduler, []) | children]
+      [Transport.Scheduler | children]
     else
       children
     end

--- a/apps/transport/lib/transport/import_data_worker.ex
+++ b/apps/transport/lib/transport/import_data_worker.ex
@@ -23,7 +23,7 @@ defmodule Transport.ImportDataWorker do
     GenServer.cast(__MODULE__, {:force_validate_all})
   end
 
-  def start_link do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 


### PR DESCRIPTION
Certaines fonctions utilisées dans application.ex sont deprecated et génèrent des warnings à la compilation.

![image](https://user-images.githubusercontent.com/15341118/150820317-860ab523-a076-417d-8f44-5d248a3522d0.png)


La seule modif que j'ai eu à faire pour faire tourner avec la nouvelle syntaxe, c'est d'ajouter un argument à la fonction `start_link` de `Transport.ImportDataWorker`.

Parce que lorsqu'on met un module dans une liste de process children qui vont se faire superviser, la fonction `child_spec` de ce module se fait appeler pour savoir comment le démarrer. Et pour un GenServer comme `Transport.ImportDataWorker`, ça donne ceci : 

```
iex(1)> Transport.ImportDataWorker.child_spec([])
%{
  id: Transport.ImportDataWorker,
  start: {Transport.ImportDataWorker, :start_link, [[]]}
}
```

Ce qui signifie que la fonction start_link va se faire appeler avec `[]` comme argument. Nous avons donc besoin d'avoir une `start_link/1` définie et non pas `start_link/0` comme précédemment.

Ressources utiles :
* https://kobrakai.de/kolumne/child-specs-in-elixir/
* https://elixir-lang.org/getting-started/mix-otp/supervisor-and-application.html