### PR TITLE
Remplacement de l'imge docker plus maintenu (Postgres/PostGIS/CircleCI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ defaults_with_postgres: &defaults_with_postgres
   <<: *defaults
   docker:
     - *default_docker
-    - image: circleci/postgres:12.0-alpine-postgis
+    # See https://github.com/etalab/transport_deploy/issues/50
+    - image: postgis/postgis:12-3.1-alpine
       environment:
         POSTGRES_USER: root
         POSTGRES_DB: transport_test


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-site/issues/1868
- https://github.com/etalab/transport_deploy/issues/50