### PR TITLE
Implémentation de dev pour History.Fetcher

### DIFF
--- a/apps/transport/lib/transport/history/fetcher.ex
+++ b/apps/transport/lib/transport/history/fetcher.ex
@@ -10,3 +10,14 @@ defmodule Transport.History.Fetcher do
 
   def history_resources(%DB.Dataset{} = dataset), do: impl().history_resources(dataset)
 end
+
+defmodule Transport.History.Fetcher.Null do
+  @moduledoc """
+  A default implementation returning an empty history,
+  useful as a default implementation for dev.
+  """
+  @behaviour Transport.History.Fetcher
+
+  @impl true
+  def history_resources(%DB.Dataset{}), do: []
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,7 +43,7 @@ config :phoenix, :stacktrace_depth, 20
 # In a later version we may use dev.secret.exs file (out of git)
 # as often done.
 config :transport,
-  history_impl: Transport.History.Fetcher.Mock,
+  history_impl: Transport.History.Fetcher.Null,
   notifications_impl: Transport.Notifications.Disk
 
 # Provide a default experience that will mostly work without manual config,


### PR DESCRIPTION
La suppression de l'implémentation vide de `History.Fetcher` dans https://github.com/etalab/transport-site/pull/2060 était peut-être un peu rapide, c'est bien utile en dev, là où un mock est utile pour les tests.

Cette PR rétablit une implémentation qui ne retourne rien en dev.