### PR TITLE
Limite nombre d'erreurs pour TableSchema et JSONSchema

### DIFF
--- a/apps/shared/lib/validation/jsonschema_validator.ex
+++ b/apps/shared/lib/validation/jsonschema_validator.ex
@@ -67,7 +67,7 @@ defmodule Shared.Validation.JSONSchemaValidator do
         {:error, errors} -> errors
       end
 
-    %{"has_errors" => not Enum.empty?(errors), "errors_count" => Enum.count(errors), "errors" => errors}
+    %{"has_errors" => not Enum.empty?(errors), "errors_count" => Enum.count(errors), "errors" => errors |> Enum.take(100)}
   end
 
   defp json_schemas_names, do: Map.keys(schemas_by_type("jsonschema"))

--- a/apps/shared/lib/validation/jsonschema_validator.ex
+++ b/apps/shared/lib/validation/jsonschema_validator.ex
@@ -67,7 +67,11 @@ defmodule Shared.Validation.JSONSchemaValidator do
         {:error, errors} -> errors
       end
 
-    %{"has_errors" => not Enum.empty?(errors), "errors_count" => Enum.count(errors), "errors" => errors |> Enum.take(100)}
+    %{
+      "has_errors" => not Enum.empty?(errors),
+      "errors_count" => Enum.count(errors),
+      "errors" => errors |> Enum.take(100)
+    }
   end
 
   defp json_schemas_names, do: Map.keys(schemas_by_type("jsonschema"))

--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -59,7 +59,9 @@ defmodule Shared.Validation.TableSchemaValidator do
         ~s(#{row["name"]} : colonne #{row["fieldName"]}, ligne #{row["rowPosition"]}. #{row["message"]})
       end)
 
-    %{"has_errors" => nb_errors > 0, "errors_count" => nb_errors, "errors" => structure_errors ++ row_errors}
+    errors = (structure_errors ++ row_errors) |> Enum.take(100)
+
+    %{"has_errors" => nb_errors > 0, "errors_count" => nb_errors, "errors" => errors}
   end
 
   defp build_report(_), do: nil


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2085

Stocke au plus 100 erreurs en base de données pour les erreurs de validation de ressources avec des schémas.

On affiche au plus 50 erreurs sur l'interface https://github.com/etalab/transport-site/blob/553aa63b3deddf8cbddaf7e2ca59a1be39318f1a/apps/transport/lib/transport_web/views/resource_view.ex#L110

Pour les ressources avec beaucoup d'erreurs, j'irai lancer une validation forcée depuis le backoffice après avoir déployé cette PR. En effet la validation n'est pas lancée si la ressource distante n'est pas changée. Il y a moins de 10 cas en production

```sql
select dataset_id, jsonb_array_length(metadata->'validation'->'errors')
from resource
where jsonb_array_length(metadata->'validation'->'errors') > 100
```