### PR TITLE
Ajout Jason.Encoder pour ResourceHistory

### DIFF
--- a/apps/db/lib/db/resource_history.ex
+++ b/apps/db/lib/db/resource_history.ex
@@ -5,6 +5,7 @@ defmodule DB.ResourceHistory do
   use Ecto.Schema
   use TypedEctoSchema
 
+  @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   typed_schema "resource_history" do
     field(:datagouv_id, :string)
     field(:payload, :map)

--- a/apps/db/lib/db/resource_history.ex
+++ b/apps/db/lib/db/resource_history.ex
@@ -5,7 +5,7 @@ defmodule DB.ResourceHistory do
   use Ecto.Schema
   use TypedEctoSchema
 
-  @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
+  @derive {Jason.Encoder, only: [:datagouv_id, :payload, :last_up_to_date_at, :inserted_at, :updated_at]}
   typed_schema "resource_history" do
     field(:datagouv_id, :string)
     field(:payload, :map)


### PR DESCRIPTION
Suite à des 500 sur `GET api/datasets/:dataset_id`, l'application ne savait pas comment sérialiser des `DB.ResourceHistory`.

https://github.com/etalab/transport-site/blob/90b54ea44522bf5bc70f74f4953167128c8200cb/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex#L174