### PR TITLE
Correction texte bouton abonnement aux commentaires

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -121,9 +121,9 @@
               <%= form_for @conn, follower_path(@conn, :toggle, @dataset.datagouv_id), [class: "form"], fn _f -> %>
               <button class="button">
                 <%= if @is_subscribed do %>
-                  <%= dgettext("page-dataset-details", "Subscribe to comments") %>
-                <% else %>
                   <%= dgettext("page-dataset-details", "Unsubscribe to comments") %>
+                <% else %>
+                  <%= dgettext("page-dataset-details", "Subscribe to comments") %>
                 <% end %>
               </button>
             <% end %>


### PR DESCRIPTION
Un bug étonnant présent visiblement depuis au moins 2 ans : le texte du bouton d'abonnement/désabonnement aux commentaires est inversé.

Démo :
- aller sur https://transport.data.gouv.fr/datasets/trottinettes-montlucon/
- voir le bouton "Se désabonner des discussions ce jeu de données" alors que vous n'êtes pas abonné