### PR TITLE
Méthode commune de validation pour Dataset

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -521,10 +521,8 @@ defmodule DB.Dataset do
   def formats(_), do: []
 
   @spec validate(binary | integer | __MODULE__.t()) :: {:error, String.t()} | {:ok, nil}
-  def validate(%__MODULE__{id: id, type: type}) when type in ["public-transit", "bike-scooter-sharing"],
-    do: validate(id)
+  def validate(%__MODULE__{id: id}), do: validate(id)
 
-  def validate(%__MODULE__{}), do: {:ok, nil}
   def validate(id) when is_binary(id), do: id |> String.to_integer() |> validate()
 
   def validate(id) when is_integer(id) do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2110

Il n'y a pas lieu d'avoir un raccourci désormais étant donné que des ressources peuvent avoir un schéma ou autre chose. On conserve ainsi une seule méthode qu'importe l'input, qui délègue à chaque ressource ensuite.