### PR TITLE
Historise les autres types de données

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -41,12 +41,12 @@ defmodule Transport.Jobs.ResourceHistoryDispatcherJob do
     Resource
     |> join(:inner, [r], d in DB.Dataset, on: r.dataset_id == d.id and d.is_active)
     |> where([r], not is_nil(r.url) and not is_nil(r.title) and not is_nil(r.datagouv_id))
-    |> where([r], r.format == "GTFS" or r.format == "NeTEx")
     |> where([r], r.datagouv_id not in ^duplicates)
     |> where([r], not r.is_community_resource)
     |> where([r], like(r.url, "http%"))
     |> select([r], r.datagouv_id)
     |> Repo.all()
+    |> Enum.reject(&Resource.is_real_time?/1)
   end
 end
 
@@ -57,7 +57,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   use Oban.Worker, unique: [period: 60 * 60 * 5, fields: [:args, :queue, :worker]], tags: ["history"], max_attempts: 5
   require Logger
   import Ecto.Query
-  alias DB.{Repo, Resource}
+  alias DB.{Repo, Resource, ResourceHistory}
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"datagouv_id" => datagouv_id}}) do
@@ -88,33 +88,36 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   defp process_download({:ok, resource_path, headers, body}, %Resource{datagouv_id: datagouv_id} = resource) do
     download_datetime = DateTime.utc_now()
 
-    zip_metadata =
-      try do
-        Transport.ZipMetaDataExtractor.extract!(resource_path)
-      rescue
-        _ ->
-          Logger.debug("Cannot compute ZIP metadata for #{datagouv_id}")
-          nil
-      end
+    hash = resource_hash(resource, resource_path)
 
-    case should_store_resource?(resource, zip_metadata) do
+    case should_store_resource?(resource, hash) do
       true ->
         filename = upload_filename(resource, download_datetime)
 
-        data = %{
+        base = %{
           download_datetime: download_datetime,
           uuid: Ecto.UUID.generate(),
-          zip_metadata: zip_metadata,
           http_headers: headers,
           resource_metadata: resource.metadata,
           title: resource.title,
           filename: filename,
           permanent_url: Transport.S3.permanent_url(:history, filename),
-          format: resource.format,
-          filenames: zip_metadata |> Enum.map(& &1.file_name),
-          total_uncompressed_size: zip_metadata |> Enum.map(& &1.uncompressed_size) |> Enum.sum(),
-          total_compressed_size: zip_metadata |> Enum.map(& &1.compressed_size) |> Enum.sum()
+          format: resource.format
         }
+
+        data =
+          case is_zip?(resource) do
+            true ->
+              Map.merge(base, %{
+                zip_metadata: hash,
+                filenames: hash |> Enum.map(& &1.file_name),
+                total_uncompressed_size: hash |> Enum.map(& &1.uncompressed_size) |> Enum.sum(),
+                total_compressed_size: hash |> Enum.map(& &1.compressed_size) |> Enum.sum()
+              })
+
+            false ->
+              Map.merge(base, %{content_hash: hash})
+          end
 
         Transport.S3.upload_to_s3!(:history, body, filename)
         store_resource_history!(resource, data)
@@ -136,15 +139,15 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   def should_store_resource?(_, []), do: false
   def should_store_resource?(_, nil), do: false
 
-  def should_store_resource?(%Resource{datagouv_id: datagouv_id}, zip_metadata) do
+  def should_store_resource?(%Resource{datagouv_id: datagouv_id}, resource_hash) do
     history =
-      DB.ResourceHistory
+      ResourceHistory
       |> where([r], r.datagouv_id == ^datagouv_id)
       |> order_by(desc: :inserted_at)
       |> limit(1)
       |> DB.Repo.one()
 
-    case {history, is_same_resource?(history, zip_metadata)} do
+    case {history, is_same_resource?(history, resource_hash)} do
       {nil, _} -> true
       {_history, false} -> true
       {history, true} -> {false, history}
@@ -156,22 +159,44 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   the latest resource_history's row in the database by comparing sha256
   hashes for all files in the ZIP.
   """
-  def is_same_resource?(%DB.ResourceHistory{payload: payload}, zip_metadata) do
-    MapSet.equal?(set_of_sha256(payload["zip_metadata"]), set_of_sha256(zip_metadata))
+  def is_same_resource?(%ResourceHistory{payload: %{"zip_metadata" => rh_zip_metadata}}, zip_metadata) do
+    MapSet.equal?(set_of_sha256(rh_zip_metadata), set_of_sha256(zip_metadata))
+  end
+
+  def is_same_resource?(%ResourceHistory{payload: %{"content_hash" => rh_content_hash}}, content_hash) do
+    rh_content_hash == content_hash
   end
 
   def is_same_resource?(nil, _), do: false
 
   def set_of_sha256(items), do: MapSet.new(items |> Enum.map(fn m -> Map.get(m, "sha256") || Map.get(m, :sha256) end))
 
+  defp resource_hash(%Resource{content_hash: content_hash, datagouv_id: datagouv_id} = resource, resource_path) do
+    case is_zip?(resource) do
+      true ->
+        try do
+          Transport.ZipMetaDataExtractor.extract!(resource_path)
+        rescue
+          _ ->
+            Logger.debug("Cannot compute ZIP metadata for #{datagouv_id}")
+            nil
+        end
+
+      false ->
+        content_hash
+    end
+  end
+
+  defp is_zip?(%Resource{format: format}), do: format in ["NeTEx", "GTFS"]
+
   defp store_resource_history!(%Resource{datagouv_id: datagouv_id}, payload) do
     Logger.debug("Saving ResourceHistory for #{datagouv_id}")
 
-    %DB.ResourceHistory{datagouv_id: datagouv_id, payload: payload, last_up_to_date_at: DateTime.utc_now()}
+    %ResourceHistory{datagouv_id: datagouv_id, payload: payload, last_up_to_date_at: DateTime.utc_now()}
     |> DB.Repo.insert!()
   end
 
-  defp touch_resource_history!(%DB.ResourceHistory{id: id, datagouv_id: datagouv_id} = history) do
+  defp touch_resource_history!(%ResourceHistory{id: id, datagouv_id: datagouv_id} = history) do
     Logger.debug("Touching unchanged ResourceHistory #{id} for resource datagouv_id #{datagouv_id}")
 
     history |> Ecto.Changeset.change(%{last_up_to_date_at: DateTime.utc_now()}) |> DB.Repo.update!()
@@ -200,10 +225,35 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
   def remove_file(path), do: File.rm(path)
 
-  def upload_filename(%Resource{datagouv_id: datagouv_id}, %DateTime{} = dt) do
+  def upload_filename(%Resource{datagouv_id: datagouv_id} = resource, %DateTime{} = dt) do
     time = Calendar.strftime(dt, "%Y%m%d.%H%M%S.%f")
 
-    "#{datagouv_id}/#{datagouv_id}.#{time}.zip"
+    "#{datagouv_id}/#{datagouv_id}.#{time}#{file_extension(resource)}"
+  end
+
+  @doc """
+  Guess an appropriate file extension according to a format
+
+    iex> file_extension(%DB.Resource{format: "GTFS"})
+    ".zip"
+
+    iex> file_extension(%DB.Resource{format: ".csv"})
+    ".csv"
+
+    iex> file_extension(%DB.Resource{format: "HTML"})
+    ".html"
+
+    iex> file_extension(%DB.Resource{format: ".csv.zip"})
+    ".csv.zip"
+  """
+  def file_extension(%Resource{format: format} = resource) do
+    case is_zip?(resource) do
+      true ->
+        ".zip"
+
+      false ->
+        "." <> (format |> String.downcase() |> String.replace_prefix(".", ""))
+    end
   end
 
   def relevant_http_headers(%HTTPoison.Response{headers: headers}) do

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -174,7 +174,9 @@
             <tr>
               <th><%= dgettext("page-dataset-details", "File") %></th>
               <th><%= dgettext("page-dataset-details", "Publication date") %></th>
-              <th><%= dgettext("page-dataset-details", "Validity period") %></th>
+              <%= if has_validity_period?(@history_resources) do %>
+                <th><%= dgettext("page-dataset-details", "Validity period") %></th>
+              <% end %>
               <th><%= dgettext("page-dataset-details", "Format") %></th>
             </tr>
           </thead>
@@ -184,15 +186,16 @@
                 <td><%= link(resource_history.payload["title"], to: resource_history.payload["permanent_url"]) %>
                 </td>
                 <td><%= resource_history.inserted_at |> format_datetime_to_date() %></td>
-                <td>
-                  <%= unless is_nil(resource_history.payload["resource_metadata"]) or is_nil(resource_history.payload["resource_metadata"]["start_date"]) do %>
-                    <%= dgettext("page-dataset-details", "%{start} to %{end}",
-                            start: resource_history.payload["resource_metadata"]["start_date"],
-                            end: resource_history.payload["resource_metadata"]["end_date"]
-                          )
+                <%= if has_validity_period?(@history_resources) do %>
+                  <td>
+                    <%= dgettext(
+                      "page-dataset-details", "%{start} to %{end}",
+                        start: resource_history.payload["resource_metadata"]["start_date"],
+                        end: resource_history.payload["resource_metadata"]["end_date"]
+                      )
                       %>
-                  <% end %>
-                </td>
+                  </td>
+                <% end %>
                 <td><span class="label"><%= resource_history.payload["format"] %></span></td>
               </tr>
             <% end %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -454,4 +454,8 @@ defmodule TransportWeb.DatasetView do
   def download_url(%Plug.Conn{} = conn, %DB.Resource{} = resource) do
     if Resource.can_direct_download?(resource), do: resource.url, else: resource_path(conn, :download, resource.id)
   end
+
+  def has_validity_period?(history_resources) do
+    history_resources |> Enum.map(&Map.has_key?(&1.payload["resource_metadata"], "start_date")) |> Enum.any?()
+  end
 end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -9,6 +9,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   alias Transport.Jobs.{ResourceHistoryDispatcherJob, ResourceHistoryJob}
   alias Transport.Test.S3TestUtils
 
+  doctest ResourceHistoryJob, import: true
+
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
     DB.Repo.delete_all(DB.ResourceHistory)
@@ -22,18 +24,21 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
   describe "ResourceHistoryDispatcherJob" do
     test "resources_to_historise" do
-      datagouv_id = create_resources_for_history()
-      assert 7 == count_resources()
-      assert [datagouv_id] == ResourceHistoryDispatcherJob.resources_to_historise()
+      datagouv_ids = create_resources_for_history()
+      assert 8 == count_resources()
+      assert datagouv_ids == ResourceHistoryDispatcherJob.resources_to_historise()
     end
 
     test "a simple successful case" do
       S3TestUtils.s3_mocks_create_bucket()
-      datagouv_id = create_resources_for_history()
+      create_resources_for_history()
 
       assert count_resources() > 1
       assert :ok == perform_job(ResourceHistoryDispatcherJob, %{})
-      assert [%{args: %{"datagouv_id" => ^datagouv_id}}] = all_enqueued(worker: ResourceHistoryJob)
+
+      assert [%{args: %{"datagouv_id" => "7"}}, %{args: %{"datagouv_id" => "1"}}] =
+               all_enqueued(worker: ResourceHistoryJob)
+
       refute_enqueued(worker: ResourceHistoryDispatcherJob)
     end
   end
@@ -49,7 +54,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: "1"}, zip_metadata())
     end
 
-    test "with the latest ResourceHistory matching" do
+    test "with the latest ResourceHistory matching for a ZIP" do
       %{id: resource_history_id, datagouv_id: datagouv_id} =
         resource_history =
         insert(:resource_history,
@@ -61,6 +66,22 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       assert {false, %{id: ^resource_history_id}} =
                ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, zip_metadata())
+    end
+
+    test "with the latest ResourceHistory matching for a content hash" do
+      content_hash = "hash"
+
+      %{id: resource_history_id, datagouv_id: datagouv_id} =
+        resource_history =
+        insert(:resource_history,
+          payload: %{"content_hash" => content_hash}
+        )
+
+      assert 1 == count_resource_history()
+      assert ResourceHistoryJob.is_same_resource?(resource_history, content_hash)
+
+      assert {false, %{id: ^resource_history_id}} =
+               ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, content_hash)
     end
 
     test "with the latest ResourceHistory matching but for a different datagouv_id" do
@@ -95,7 +116,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, zip_metadata())
     end
 
-    test "with the latest ResourceHistory not matching" do
+    test "with the latest ResourceHistory not matching for a ZIP" do
       %{datagouv_id: datagouv_id} =
         insert(:resource_history,
           payload: %{"zip_metadata" => zip_metadata() |> Enum.take(2)}
@@ -104,6 +125,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert 1 == count_resource_history()
 
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, zip_metadata())
+    end
+
+    test "with the latest ResourceHistory not matching" do
+      %{datagouv_id: datagouv_id} = insert(:resource_history, payload: %{"content_hash" => "foo"})
+
+      assert 1 == count_resource_history()
+
+      assert ResourceHistoryJob.should_store_resource?(%DB.Resource{datagouv_id: datagouv_id}, "bar")
     end
   end
 
@@ -127,9 +156,15 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                %DB.ResourceHistory{payload: %{"zip_metadata" => zip_metadata()}},
                zip_metadata()
              )
+
+      assert ResourceHistoryJob.is_same_resource?(
+               %DB.ResourceHistory{payload: %{"content_hash" => "content_hash"}},
+               "content_hash"
+             )
     end
 
     test "failures" do
+      # For ZIPs
       refute ResourceHistoryJob.is_same_resource?(
                %DB.ResourceHistory{payload: %{"zip_metadata" => zip_metadata()}},
                zip_metadata() |> Enum.map(fn m -> Map.put(m, "sha256", "foo") end)
@@ -146,18 +181,30 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
              )
 
       refute ResourceHistoryJob.is_same_resource?(%DB.ResourceHistory{payload: %{"zip_metadata" => zip_metadata()}}, [])
+
+      # For regular files
+      refute ResourceHistoryJob.is_same_resource?(%DB.ResourceHistory{payload: %{"content_hash" => "foo"}}, "")
     end
   end
 
   describe "upload_filename" do
     test "it works" do
       assert "foo/foo.20211202.130534.393187.zip" ==
-               ResourceHistoryJob.upload_filename(%DB.Resource{datagouv_id: "foo"}, ~U[2021-12-02 13:05:34.393187Z])
+               ResourceHistoryJob.upload_filename(
+                 %DB.Resource{datagouv_id: "foo", format: "GTFS"},
+                 ~U[2021-12-02 13:05:34.393187Z]
+               )
+
+      assert "foo/foo.20211202.130534.393187.csv" ==
+               ResourceHistoryJob.upload_filename(
+                 %DB.Resource{datagouv_id: "foo", format: "csv"},
+                 ~U[2021-12-02 13:05:34.393187Z]
+               )
     end
   end
 
   describe "ResourceHistoryJob" do
-    test "a simple successful case" do
+    test "a simple successful case for a GTFS" do
       resource_url = "https://example.com/gtfs.zip"
 
       %{datagouv_id: datagouv_id, metadata: resource_metadata, title: title} =
@@ -241,6 +288,76 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       refute is_nil(last_up_to_date_at)
     end
 
+    test "a simple successful case for a CSV" do
+      resource_url = "https://example.com/file.csv"
+
+      %{datagouv_id: datagouv_id, metadata: resource_metadata, title: title, content_hash: content_hash} =
+        insert(:resource,
+          url: resource_url,
+          dataset: insert(:dataset, is_active: true),
+          format: "csv",
+          title: "title",
+          datagouv_id: "1",
+          is_community_resource: false,
+          content_hash: "hash",
+          metadata: %{"foo" => "bar"}
+        )
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn ^resource_url, _headers, options ->
+        assert options == [follow_redirect: true]
+
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: @gtfs_content,
+           headers: [{"Content-Type", "application/octet-stream"}, {"x-foo", "bar"}]
+         }}
+      end)
+
+      Transport.ExAWS.Mock
+      # Resource upload
+      |> expect(:request!, fn request ->
+        bucket_name = Transport.S3.bucket_name(:history)
+
+        assert %{
+                 service: :s3,
+                 http_method: :put,
+                 path: path,
+                 bucket: ^bucket_name,
+                 body: @gtfs_content,
+                 headers: %{"x-amz-acl" => "public-read"}
+               } = request
+
+        assert String.starts_with?(path, "#{datagouv_id}/#{datagouv_id}.")
+      end)
+
+      assert 0 == count_resource_history()
+      assert :ok == perform_job(ResourceHistoryJob, %{datagouv_id: datagouv_id})
+      assert 1 == count_resource_history()
+
+      ensure_no_tmp_files!("resource_")
+
+      assert %DB.ResourceHistory{
+               datagouv_id: ^datagouv_id,
+               payload: %{
+                 "format" => "csv",
+                 "content_hash" => ^content_hash,
+                 "http_headers" => %{"content-type" => "application/octet-stream"},
+                 "resource_metadata" => ^resource_metadata,
+                 "title" => ^title,
+                 "filename" => filename,
+                 "permanent_url" => permanent_url,
+                 "uuid" => _uuid,
+                 "download_datetime" => _download_datetime
+               },
+               last_up_to_date_at: last_up_to_date_at
+             } = DB.ResourceHistory |> DB.Repo.one!()
+
+      assert permanent_url == Transport.S3.permanent_url(:history, filename)
+      refute is_nil(last_up_to_date_at)
+    end
+
     test "does not store resource again when it did not change" do
       resource_url = "https://example.com/gtfs.zip"
 
@@ -309,7 +426,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     %{id: active_dataset_id} = insert(:dataset, is_active: true)
     %{id: inactive_dataset_id} = insert(:dataset, is_active: false)
 
-    %{datagouv_id: datagouv_id} =
+    %{datagouv_id: datagouv_id_gtfs} =
       insert(:resource,
         url: "https://example.com/gtfs.zip",
         dataset_id: active_dataset_id,
@@ -332,7 +449,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     insert(:resource,
       url: "https://example.com/gbfs",
       format: "gbfs",
-      title: "Ignored because it's not GTFS or NeTEx",
+      title: "Ignored because it's realtime",
       datagouv_id: "3",
       is_community_resource: false
     )
@@ -373,7 +490,17 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       is_community_resource: false
     )
 
-    datagouv_id
+    %{datagouv_id: datagouv_id_csv} =
+      insert(:resource,
+        url: "https://example.com/file.csv",
+        dataset_id: active_dataset_id,
+        format: "csv",
+        title: "CSV file",
+        datagouv_id: "7",
+        is_community_resource: false
+      )
+
+    [datagouv_id_gtfs, datagouv_id_csv]
   end
 
   defp count_resource_history do


### PR DESCRIPTION
Cette PR permet d'historiser toutes les ressources listées sur le PAN, sauf celles en temps réel (GTFS-RT, GBFS par exemple). Elle adapte le mécanisme permettant de déterminer si une ressource doit être historisée ou non en se basant sur le `content_hash` pour la plupart des ressources, sauf les ZIP où l'on compare les hashs des fichiers zippés.