### PR TITLE
Fix redirection en boucle pour erreurs GTFS

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
       schedule_next_update_data()
     end
 
-    if is_final_state?(socket) and is_gtfs?(socket) do
+    if gtfs_validation_completed?(socket) do
       redirect(socket, to: socket_value(socket, :current_url))
     else
       socket
@@ -49,7 +49,15 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
     end
   end
 
-  defp is_gtfs?(socket), do: socket_value(socket, :validation).on_the_fly_validation_metadata["type"] == "gtfs"
+  defp gtfs_validation_completed?(socket) do
+    case socket_value(socket, :validation) do
+      %DB.Validation{on_the_fly_validation_metadata: metadata} ->
+        metadata["type"] == "gtfs" and metadata["state"] == "completed"
+
+      _ ->
+        false
+    end
+  end
 
   defp socket_value(%Phoenix.LiveView.Socket{assigns: assigns}, key), do: Map.fetch!(assigns, key)
 end

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -123,13 +123,25 @@ defmodule TransportWeb.ValidationControllerTest do
     end
 
     test "with an error", %{conn: conn} do
-      validation = insert(:validation, on_the_fly_validation_metadata: %{"state" => "waiting", "type" => "etalab/foo"})
-      conn = conn |> get(validation_path(conn, :show, validation.id))
+      {conn, validation} = ensure_waiting_message_is_displayed(conn, %{"state" => "waiting", "type" => "etalab/foo"})
+      {:ok, view, _html} = live(conn)
 
-      # Displays the waiting message
-      response = html_response(conn, 200)
-      assert response =~ "Validation en cours."
+      # Error message is displayed
+      error_msg = "hello world"
 
+      validation
+      |> Ecto.Changeset.change(
+        on_the_fly_validation_metadata:
+          Map.merge(validation.on_the_fly_validation_metadata, %{"state" => "error", "error_reason" => error_msg})
+      )
+      |> DB.Repo.update!()
+
+      send(view.pid, :update_data)
+      assert render(view) =~ error_msg
+    end
+
+    test "with an error for a GTFS", %{conn: conn} do
+      {conn, validation} = ensure_waiting_message_is_displayed(conn, %{"state" => "waiting", "type" => "gtfs"})
       {:ok, view, _html} = live(conn)
 
       # Error message is displayed
@@ -147,12 +159,7 @@ defmodule TransportWeb.ValidationControllerTest do
     end
 
     test "with a waiting validation", %{conn: conn} do
-      validation = insert(:validation, on_the_fly_validation_metadata: %{"state" => "waiting", "type" => "gtfs"})
-      conn = conn |> get(validation_path(conn, :show, validation.id))
-
-      # Displays the waiting message
-      response = html_response(conn, 200)
-      assert response =~ "Validation en cours."
+      {conn, validation} = ensure_waiting_message_is_displayed(conn, %{"state" => "waiting", "type" => "gtfs"})
 
       # Redirects to result's page when validation is done
       {:ok, view, _html} = live(conn)
@@ -177,13 +184,7 @@ defmodule TransportWeb.ValidationControllerTest do
         %{schema_name => %{"versions" => [], "schemas" => [%{"path" => "schema.json"}]}}
       end)
 
-      validation = insert(:validation, on_the_fly_validation_metadata: %{"state" => "waiting", "type" => schema_name})
-      conn = conn |> get(validation_path(conn, :show, validation.id))
-
-      # Displays the waiting message
-      response = html_response(conn, 200)
-      assert response =~ "Validation en cours."
-
+      {conn, validation} = ensure_waiting_message_is_displayed(conn, %{"state" => "waiting", "type" => schema_name})
       {:ok, view, _html} = live(conn)
 
       # Error messages are displayed
@@ -211,6 +212,17 @@ defmodule TransportWeb.ValidationControllerTest do
       assert render(view) =~ "2 erreurs"
       assert render(view) =~ "Value is not allowed in enum."
     end
+  end
+
+  defp ensure_waiting_message_is_displayed(conn, metadata) do
+    validation = insert(:validation, on_the_fly_validation_metadata: metadata)
+    conn = conn |> get(validation_path(conn, :show, validation.id))
+
+    # Displays the waiting message
+    response = html_response(conn, 200)
+    assert response =~ "Validation en cours."
+
+    {conn, validation}
   end
 
   defp count_validations do


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2114

Il y avait une redirection en boucle entre `OnDemandValidationLive` et `ValidationController`. Le controller ne gère que les GTFS qui sont en state `completed` et la liveview cherchait à rediriger vers cette page.

Cette PR s'assure que la redirection ne se fait que dans le cas d'un succès pour les GTFS et ajoute un test. La liveview est en mesure d'afficher une erreur de validation pour tous les types.