### PR TITLE
Répare bug has_validity_period?

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -459,7 +459,9 @@ defmodule TransportWeb.DatasetView do
     history_resources |> Enum.map(&has_validity_period?/1) |> Enum.any?()
   end
 
-  def has_validity_period?(%DB.ResourceHistory{payload: payload}) do
-    Map.has_key?(payload["resource_metadata"], "start_date")
+  def has_validity_period?(%DB.ResourceHistory{payload: %{"resource_metadata" => metadata}}) when is_map(metadata) do
+    Map.has_key?(metadata, "start_date")
   end
+
+  def has_validity_period?(%DB.ResourceHistory{}), do: false
 end


### PR DESCRIPTION
Répare un bug introduit dans #2123
Exception : https://sentry.io/organizations/transport-data-gouv-fr/issues/3024065273/?project=6197733&query=is%3Aunresolved

`resource_metadata` est `nil` et non `%{}`

```
BadMapError :erlang.is_map_key/2
expected a map, got: nil
```