### PR TITLE
Ajout job pour supprimer data_conversion orphelines

### DIFF
--- a/apps/transport/lib/jobs/clean_orphan_conversions_job.ex
+++ b/apps/transport/lib/jobs/clean_orphan_conversions_job.ex
@@ -1,0 +1,48 @@
+defmodule Transport.Jobs.CleanOrphanConversionsJob do
+  @moduledoc """
+  Job in charge of clean `DB.DataConversion` rows
+  where the underlying `DB.ResourceHistory` does not exist.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+  alias DB.{DataConversion, Repo}
+
+  @max_objects 500
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    objects =
+      DataConversion
+      |> where([_d], fragment("resource_history_uuid not in (select (payload->>'uuid')::uuid from resource_history)"))
+      |> limit(@max_objects)
+      |> Repo.all()
+
+    ids = objects |> Enum.map(& &1.id)
+    paths = objects |> Enum.map(&Map.fetch!(&1.payload, "filename"))
+
+    mark_for_deletion(ids)
+    remove_s3_objects(paths)
+    remove_rows(ids)
+
+    if Enum.count(objects) == @max_objects do
+      %{} |> __MODULE__.new() |> Oban.insert!()
+    end
+
+    :ok
+  end
+
+  defp mark_for_deletion(ids) do
+    DataConversion
+    |> where([r], r.id in ^ids)
+    |> update(set: [payload: fragment("jsonb_set(payload, '{mark_for_deletion}', 'true')")])
+    |> Repo.update_all([])
+  end
+
+  defp remove_rows(ids) do
+    DataConversion |> where([r], r.id in ^ids) |> Repo.delete_all()
+  end
+
+  defp remove_s3_objects(paths) do
+    paths |> Enum.each(&Transport.S3.delete_object!(:history, &1))
+  end
+end

--- a/apps/transport/test/transport/jobs/clean_orphan_conversions_job_test.exs
+++ b/apps/transport/test/transport/jobs/clean_orphan_conversions_job_test.exs
@@ -1,0 +1,54 @@
+defmodule Transport.Test.Transport.Jobs.CleanOrphanConversionsJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  alias DB.Repo
+  alias Transport.Jobs.CleanOrphanConversionsJob
+  alias Transport.Test.S3TestUtils
+
+  setup :verify_on_exit!
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "CleanOrphanConversionsJob" do
+    test "it deletes orphan rows" do
+      uuid = Ecto.UUID.generate()
+      filename = "folder/file.zip"
+
+      data_conversion =
+        insert(:data_conversion,
+          resource_history_uuid: uuid,
+          payload: %{"filename" => filename},
+          convert_from: "GTFS",
+          convert_to: "NeTEx"
+        )
+
+      S3TestUtils.s3_mocks_delete_object(Transport.S3.bucket_name(:history), filename)
+
+      assert :ok == perform_job(CleanOrphanConversionsJob, %{})
+
+      assert is_nil(Repo.reload(data_conversion))
+    end
+
+    test "it ignores rows with a matching ResourceHistory" do
+      uuid = Ecto.UUID.generate()
+
+      insert(:resource_history, payload: %{"uuid" => uuid})
+
+      data_conversion =
+        insert(:data_conversion,
+          resource_history_uuid: uuid,
+          payload: %{},
+          convert_from: "GTFS",
+          convert_to: "NeTEx"
+        )
+
+      assert :ok == perform_job(CleanOrphanConversionsJob, %{})
+
+      refute is_nil(Repo.reload(data_conversion))
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -91,6 +91,7 @@ oban_crontab_all_envs =
         {"30 */6 * * *", Transport.Jobs.GtfsToGeojsonConverterJob},
         # every 6 hours but not at the same time as other jobs
         {"0 3,9,15,21 * * *", Transport.Jobs.GtfsToNetexConverterJob},
+        {"20 8 * * *", Transport.Jobs.CleanOrphanConversionsJob},
         {"0 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob},
         {"*/10 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob, args: %{only_unavailable: true}}
       ]


### PR DESCRIPTION
Fixes #2127

Création d'un job pour supprimer les lignes et objets de `data_conversion` où la `ResourceHistory` correspondante a été supprimée suite à un processus de déduplication.