### PR TITLE
Réparation syntaxe eex dataset/details

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -165,7 +165,7 @@
   </section>
 <% end %>
 <%= unless @history_resources == [] do %>
-  <%= has_validity_period_col = has_validity_period?(@history_resources) %>
+  <% has_validity_period_col = has_validity_period?(@history_resources) %>
   <section class="white pt-48" id="backed-up-resources">
     <h3><%= dgettext("page-dataset-details", "Backed up resources")%></h3>
     <div class="">
@@ -199,7 +199,7 @@
                         )
                         %>
                     </td>
-                  <%= else %>
+                  <% else %>
                     <td></td>
                   <% end %>
                 <% end %>


### PR DESCRIPTION
Le `=` en plus a pour effet de faire un `echo` et donc d'afficher `true` :facepalm:

![image](https://user-images.githubusercontent.com/295709/155094917-cb30570b-08a2-4038-9648-fd5ca2bb59fd.png)
