### PR TITLE
Ajout de premiers tests "ops"

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,7 +3,8 @@
     "mix.exs",
     "config/runtime.exs",
     "apps/*/{lib,test}/**/*.{ex,exs}",
-    "scripts/**/*.exs"
+    "scripts/**/*.exs",
+    "ops_tests/**/*.exs"
   ],
   line_length: 120
 ]

--- a/ops_tests/ops_tests.exs
+++ b/ops_tests/ops_tests.exs
@@ -1,0 +1,41 @@
+# run with `elixir ops_tests/ops_tests.exs`
+# this is a starting point to implement infrastructure & DNS testing
+ExUnit.start()
+
+Mix.install([
+  {:req, "~> 0.2.1"}
+])
+
+defmodule Transport.OpsTests do
+  use ExUnit.Case
+
+  def get_header!(headers, header) do
+    {_header, value} =
+      headers
+      |> Enum.find(fn {k, _} -> k == header end)
+
+    value
+  end
+
+  def assert_redirect(from: url, to: target_url) do
+    %{status: 301, headers: headers} =
+      Req.build(:get, url)
+      |> Req.run!()
+
+    assert get_header!(headers, "location") == target_url
+  end
+
+  test "correct DOMAIN_NAME for prod-worker" do
+    assert_redirect(
+      from: "http://workers.transport.data.gouv.fr",
+      to: "https://workers.transport.data.gouv.fr/"
+    )
+  end
+
+  test "correct DOMAIN_NAME for staging-worker" do
+    assert_redirect(
+      from: "http://workers.prochainement.transport.data.gouv.fr",
+      to: "https://workers.prochainement.transport.data.gouv.fr/"
+    )
+  end
+end


### PR DESCRIPTION
Durant #2140 j'ai été amené à corriger `DOMAIN_NAME` sur les deux workers (production et staging), car "http://le-domaine" renvoyait vers des valeurs incorrectes (l'autre application etc).

Ca peut amener pas mal de confusion si d'autres problèmes se produisent en même temps, et aussi parce que je songe à ajouter un petit healthcheck HTTP si les soucis de "Monitoring/Unreachable" continuent, que je surveillerai ailleurs (updown.io) avec une fréquence resserrée pour avoir davantage d'éléments.

Ca fait une coquille de départ pour ces points là.