### PR TITLE
Modification de restoredb.sh pour permettre d'effacer les jobs oban

### DIFF
--- a/restore_db.sh
+++ b/restore_db.sh
@@ -22,3 +22,11 @@ else
 fi
 
 pg_restore -h $HOST -U $USER_NAME -d $DB_NAME --format=c --no-owner --clean --no-acl $BACKUP_PATH
+
+# https://stackoverflow.com/a/1885534
+read -p "Do you want to remove already enqueued Oban jobs? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    psql -h $HOST -U $USER_NAME -d $DB_NAME -c 'DELETE from oban_jobs'
+fi


### PR DESCRIPTION
En général quand je récupère un backup, il y a un bon paquet de jobs en attente (30k à 50k). Je trouve ça peu pratique car ça se déclenche dans certaines configurations, exemple `mix phx.server`.

J'ai fait une petite modification du script de restore en attendant mieux, qui permet de supprimer les jobs.