### PR TITLE
Rapport de validation pour GTFS-RT

### DIFF
--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -91,3 +91,8 @@
   width: 1.25em;
   height: 1.25em;
 }
+
+.icon--validation {
+  margin-right: .5em;
+  font-size: .8em;
+}

--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -55,6 +55,14 @@ nav.validation {
   }
 }
 
+.mt-0 {
+  margin-top: 0;
+}
+
+.mb-0 {
+  margin-bottom: 0;
+}
+
 .mt-48 {
   margin-top: 48px !important;
 }

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -35,9 +35,9 @@
               <b>
               <% nb_errors = details["errors_count"] %>
               <%= if nb_errors == 0 do %>
-                ✅ <%= dgettext("validations", "No error detected") %>
+                <span class="icon--validation">✅</span><%= dgettext("validations", "No error detected") %>
               <% else %>
-                ❌ <%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
+                <span class="icon--validation">❌</span><%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
               <% end %>
               </b>
             </p>

--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_rt_errors_for_severity.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_rt_errors_for_severity.html.eex
@@ -1,0 +1,30 @@
+<%= for error <- @errors_for_severity |> Enum.sort_by(& Map.fetch!(&1, "error_id")) do %>
+  <% nb_errors = Map.fetch!(error, "errors_count") %>
+  <div class="panel">
+    <p class="mt-0 mb-0">
+      <b lang="en">
+        <%= Map.fetch!(error, "title") %>
+        <span class="small">
+          <a href="<%= gtfs_rt_validator_rule_url(error)%>" target="_blank"><%= Map.fetch!(error, "error_id")%></a>
+        </span>
+      </b>
+
+      <span class="label">
+        <%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
+      </span>
+    </p>
+
+    <p lang="en" style="margin: .5em 0">
+      <%= Map.fetch!(error, "description") %>
+    </p>
+
+    <details>
+      <summary><%= dgettext("validations", "Sample errors")%></summary>
+      <ul lang="en">
+        <%= for error_detail <- Map.fetch!(error, "errors") do %>
+          <li><%= error_detail %></li>
+        <% end %>
+      </ul>
+    </details>
+  </div>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
@@ -9,9 +9,9 @@
       <b>
       <% nb_errors = errors_count(@resource) %>
       <%= if nb_errors == 0 do %>
-        ✅ <%= dgettext("validations", "No error detected") %>
+        <span class="icon--validation">✅</span><%= dgettext("validations", "No error detected") %>
       <% else %>
-        ❌ <%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
+        <span class="icon--validation">❌</span><%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
       <% end %>
       </b>
     </p>
@@ -30,5 +30,35 @@
         <p><%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors())%></p>
       <% end %>
     <% end %>
+  <% end %>
+<% end %>
+
+<%= if DB.Resource.is_gtfs_rt?(@resource) and has_errors_details?(@resource) do %>
+  <% validation = @resource.validation %>
+  <% errors = Map.fetch!(validation.details, "errors") %>
+  <% errors_error_level = errors |> Enum.filter(& Map.fetch!(&1, "severity") == "ERROR") %>
+  <% errors_warning_level = errors |> Enum.filter(& Map.fetch!(&1, "severity") == "WARNING") %>
+  <h3><%= dgettext("validations", "Validation details")%></h3>
+  <p>
+    <b>
+    <% nb_errors = errors_count(@resource) %>
+    <%= if nb_errors == 0 do %>
+      <span class="icon--validation">✅</span><%= dgettext("validations", "No error detected") %>
+    <% else %>
+      <span class="icon--validation">❌</span><%= "#{nb_errors} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
+    <% end %>
+    </b>
+  </p>
+  <p>
+    <%= raw dgettext("validations", ~s(Validation carried out using the <a href="%{gtfs_link}">current GTFS file</a> and the <a href="%{gtfs_rt_link}">GTFS-RT</a> at %{date} using the <a href="%{validator_url}" target="_blank">CUTR GTFS-RT validator</a>.), gtfs_link: Map.fetch!(validation.details["files"], "gtfs_permanent_url"), gtfs_rt_link: Map.fetch!(validation.details["files"], "gtfs_rt_permanent_url"), date: format_datetime(validation.date), validator_url: gtfs_rt_validator_url()) %>
+  </p>
+  <%= unless Enum.empty?(errors_error_level) do %>
+    <h4><%= dgettext("validations", "Errors")%></h4>
+    <%= render "_gtfs_rt_errors_for_severity.html", errors_for_severity: errors_error_level %>
+  <% end %>
+
+  <%= unless Enum.empty?(errors_warning_level) do %>
+    <h4><%= dgettext("validations", "Warnings")%></h4>
+      <%= render "_gtfs_rt_errors_for_severity.html", errors_for_severity: errors_warning_level %>
   <% end %>
 <% end %>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -155,4 +155,10 @@ defmodule TransportWeb.ResourceView do
       _ -> Calendar.strftime(date, "%m/%d/%Y")
     end
   end
+
+  def gtfs_rt_validator_url, do: "https://github.com/CUTR-at-USF/gtfs-realtime-validator"
+
+  def gtfs_rt_validator_rule_url(%{"error_id" => error_id}) do
+    "https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md##{error_id}"
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -169,3 +169,19 @@ msgstr ""
 #, elixir-format, ex-autogen
 msgid "Once you have fixed your errors, you can verify that your file is valid <a href=\"%{link}\" target=\"_blank\">using our validators</a>."
 msgstr ""
+
+#, elixir-format, ex-autogen, fuzzy
+msgid "Errors"
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Sample errors"
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS file</a> and the <a href=\"%{gtfs_rt_link}\">GTFS-RT</a> at %{date} using the <a href=\"%{validator_url}\" target=\"_blank\">CUTR GTFS-RT validator</a>."
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Warnings"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -169,3 +169,19 @@ msgstr "Rapport de validation"
 #, elixir-format, ex-autogen
 msgid "Once you have fixed your errors, you can verify that your file is valid <a href=\"%{link}\" target=\"_blank\">using our validators</a>."
 msgstr "Une fois vos erreurs réparées, vous pouvez vérifier que votre fichier est valide <a href=\"%{link}\" target=\"_blank\">en utilisant nos validateurs</a>."
+
+#, elixir-format, ex-autogen
+msgid "Errors"
+msgstr "Erreurs"
+
+#, elixir-format, ex-autogen
+msgid "Sample errors"
+msgstr "Exemples d'erreurs"
+
+#, elixir-format, ex-autogen
+msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS file</a> and the <a href=\"%{gtfs_rt_link}\">GTFS-RT</a> at %{date} using the <a href=\"%{validator_url}\" target=\"_blank\">CUTR GTFS-RT validator</a>."
+msgstr "Validation effectée en utilisant <a href=\"%{gtfs_link}\">le fichier GTFS en vigueur</a> et le <a href=\"%{gtfs_rt_link}\">GTFS-RT</a> à la date du %{date} avec <a href=\"%{validator_url}\" target=\"_blank\">le validateur CUTR GTFS-RT</a>."
+
+#, elixir-format, ex-autogen
+msgid "Warnings"
+msgstr "Avertissements"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -168,3 +168,19 @@ msgstr ""
 #, elixir-format, ex-autogen
 msgid "Once you have fixed your errors, you can verify that your file is valid <a href=\"%{link}\" target=\"_blank\">using our validators</a>."
 msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Errors"
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Sample errors"
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS file</a> and the <a href=\"%{gtfs_rt_link}\">GTFS-RT</a> at %{date} using the <a href=\"%{validator_url}\" target=\"_blank\">CUTR GTFS-RT validator</a>."
+msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Warnings"
+msgstr ""


### PR DESCRIPTION
Suite de #2139

Cette PR ajoute l'affichage d'un rapport de validation pour les ressources GTFS-RT qui ont été validées.

![image](https://user-images.githubusercontent.com/295709/155528852-aad0d98a-b4ce-4991-b581-a7042cdc72c4.png)

