### PR TITLE
Correctif pour urls contenus dans les emails

### DIFF
--- a/apps/transport/lib/mailjet/email_host.ex
+++ b/apps/transport/lib/mailjet/email_host.ex
@@ -1,5 +1,15 @@
 defmodule Transport.RuntimeConfig.EmailHost do
-  # See https://github.com/etalab/transport-site/issues/2154
+  @moduledoc """
+  Emails can be sent from various machines (site vs workers), and each machine
+  has its own host name. When sending emails with links to the site, though, by
+  default the url construction (based on the endpoint settings) will be incorrect
+  for our use.
+
+  This module helps ensure one can get a base URI with the correct email host name,
+  to be used with `Router.Helpers`.
+
+  See https://github.com/etalab/transport-site/issues/2154 for some historical context.
+  """
 
   def email_host(
         endpoint \\ TransportWeb.Endpoint,

--- a/apps/transport/lib/mailjet/email_host.ex
+++ b/apps/transport/lib/mailjet/email_host.ex
@@ -1,7 +1,10 @@
 defmodule Transport.RuntimeConfig.EmailHost do
   # See https://github.com/etalab/transport-site/issues/2154
 
-  def email_host(endpoint \\ TransportWeb.Endpoint, email_host_name \\ Application.fetch_env!(:transport, :email_host_name)) do
+  def email_host(
+        endpoint \\ TransportWeb.Endpoint,
+        email_host_name \\ Application.fetch_env!(:transport, :email_host_name)
+      ) do
     endpoint.url()
     |> URI.parse()
     |> Map.put(:host, email_host_name)

--- a/apps/transport/lib/mailjet/email_host.ex
+++ b/apps/transport/lib/mailjet/email_host.ex
@@ -4,6 +4,8 @@ defmodule Transport.RuntimeConfig.EmailHost do
   def email_host(endpoint \\ TransportWeb.Endpoint, email_host_name \\ Application.fetch_env!(:transport, :email_host_name)) do
     endpoint.url()
     |> URI.parse()
-    |> URI.merge(%URI{host: email_host_name})
+    |> Map.put(:host, email_host_name)
+    # see https://hexdocs.pm/elixir/1.12/URI.html#to_string/1, just in case
+    |> Map.put(:authority, nil)
   end
 end

--- a/apps/transport/lib/mailjet/email_host.ex
+++ b/apps/transport/lib/mailjet/email_host.ex
@@ -1,0 +1,31 @@
+defmodule Transport.RuntimeConfig.EmailHost do
+  # See https://github.com/etalab/transport-site/issues/2154
+
+  def email_host(endpoint \\ TransportWeb.Endpoint) do
+    case Mix.env() do
+      :dev ->
+        # this will bring the correct scheme, host, and port
+        endpoint.url()
+
+      :test ->
+        endpoint.url()
+        |> URI.parse()
+        # to help automate catching emails that are not properly configured, we're overriding
+        |> URI.merge(%URI{host: "email.localhost"})
+
+      :prod ->
+        host =
+          case Application.fetch_env!(:transport, :app_env) do
+            # NOTE: in the future, we'll avoid hardcoding here, and use a mandatory
+            # EMAIL_DOMAIN_NAME of sorts
+            # https://github.com/etalab/transport-site/issues/1688
+            :staging -> "prochainement.transport.data.gouv.fr"
+            :prod -> "transport.data.gouv.fr"
+          end
+
+        endpoint.url()
+        |> URI.parse()
+        |> URI.merge(%URI{host: host})
+    end
+  end
+end

--- a/apps/transport/lib/mailjet/email_host.ex
+++ b/apps/transport/lib/mailjet/email_host.ex
@@ -1,31 +1,9 @@
 defmodule Transport.RuntimeConfig.EmailHost do
   # See https://github.com/etalab/transport-site/issues/2154
 
-  def email_host(endpoint \\ TransportWeb.Endpoint) do
-    case Mix.env() do
-      :dev ->
-        # this will bring the correct scheme, host, and port
-        endpoint.url()
-
-      :test ->
-        endpoint.url()
-        |> URI.parse()
-        # to help automate catching emails that are not properly configured, we're overriding
-        |> URI.merge(%URI{host: "email.localhost"})
-
-      :prod ->
-        host =
-          case Application.fetch_env!(:transport, :app_env) do
-            # NOTE: in the future, we'll avoid hardcoding here, and use a mandatory
-            # EMAIL_DOMAIN_NAME of sorts
-            # https://github.com/etalab/transport-site/issues/1688
-            :staging -> "prochainement.transport.data.gouv.fr"
-            :prod -> "transport.data.gouv.fr"
-          end
-
-        endpoint.url()
-        |> URI.parse()
-        |> URI.merge(%URI{host: host})
-    end
+  def email_host(endpoint \\ TransportWeb.Endpoint, email_host_name \\ Application.fetch_env!(:transport, :email_host_name)) do
+    endpoint.url()
+    |> URI.parse()
+    |> URI.merge(%URI{host: email_host_name})
   end
 end

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -152,8 +152,12 @@ defmodule Transport.DataChecker do
   defp delay_str(0), do: "demain"
   defp delay_str(d), do: "dans #{d} jours"
 
-  defp link_and_name(dataset) do
-    link = dataset_url(TransportWeb.Endpoint, :details, dataset.slug)
+  def link(dataset) do
+    dataset_url(TransportWeb.Endpoint, :details, dataset.slug)
+  end
+
+  def link_and_name(dataset) do
+    link = link(dataset)
     name = dataset.title
 
     " * #{name} - #{link}"

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -153,7 +153,8 @@ defmodule Transport.DataChecker do
   defp delay_str(d), do: "dans #{d} jours"
 
   def link(dataset) do
-    dataset_url(TransportWeb.Endpoint, :details, dataset.slug)
+    base = Transport.RuntimeConfig.EmailHost.email_host()
+    dataset_url(base, :details, dataset.slug)
   end
 
   def link_and_name(dataset) do

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -3,12 +3,11 @@ defmodule Transport.DataCheckerTest do
   import ExUnit.CaptureLog
   import Mox
   import DB.Factory
-  use DB.DatabaseCase, cleanup: [:datasets]
 
   setup :verify_on_exit!
 
   test "link_and_name relies on proper email host name" do
-    dataset = insert(:dataset)
+    dataset = build(:dataset)
     link = Transport.DataChecker.link(dataset)
     assert URI.parse(link).host == "email.localhost"
   end

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -2,8 +2,16 @@ defmodule Transport.DataCheckerTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
   import Mox
+  import DB.Factory
+  use DB.DatabaseCase, cleanup: [:datasets]
 
   setup :verify_on_exit!
+
+  test "link_and_name relies on proper email host name" do
+    dataset = insert(:dataset)
+    link = Transport.DataChecker.link(dataset)
+    assert URI.parse(link).host == "email.localhost"
+  end
 
   describe "send_outdated_data_notifications" do
     test "with a default delay" do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,3 +136,12 @@ if config_env() == :dev do
     #  We also make sure to start the assets watcher only if the webserver is up, to avoid cluttering the logs.
     watchers: if(webserver, do: [npm: ["run", "--prefix", "apps/transport/client", "watch"]], else: [])
 end
+
+email_host_name =
+  cond do
+    config_env() == :dev -> "localhost"
+    config_env() == :test -> "email.localhost"
+    true -> System.fetch_env!("EMAIL_HOST_NAME")
+  end
+
+config :transport, :email_host_name, email_host_name

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -143,6 +143,8 @@ email_host_name =
       "localhost"
 
     :test ->
+      # used to make sure we are replacing the app host name by the email host name
+      # when it is different, in some email testing
       "email.localhost"
 
     :prod ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -138,10 +138,20 @@ if config_env() == :dev do
 end
 
 email_host_name =
-  cond do
-    config_env() == :dev -> "localhost"
-    config_env() == :test -> "email.localhost"
-    true -> System.fetch_env!("EMAIL_HOST_NAME")
+  case config_env() do
+    :dev ->
+      "localhost"
+
+    :test ->
+      "email.localhost"
+
+    :prod ->
+      # NOTE: it would be best to configure this via EMAIL_HOST_NAME var instead,
+      # but that will do for today.
+      case app_env do
+        :staging -> "prochainement.transport.data.gouv.fr"
+        :production -> "transport.data.gouv.fr"
+      end
   end
 
 config :transport, :email_host_name, email_host_name


### PR DESCRIPTION
Correctif pour #2154.

J'introduis une notion de "email host name", qu'il faudra utiliser pour chaque utilisation des "routes helpers" pour créer des liens dans les emails.
