### PR TITLE
Évolution du health-check HTTP pour permettre de ne pas vérifier la base de données

### DIFF
--- a/apps/transport/lib/transport_web/plugs/health_check.ex
+++ b/apps/transport/lib/transport_web/plugs/health_check.ex
@@ -28,17 +28,17 @@ defmodule TransportWeb.Plugs.HealthCheck do
   end
 
   defp checks do
-    %{
-      "http" => fn -> true end,
-      "db" => &database_up?/0
-    }
+    [
+      %{name: "db", check: &database_up?/0},
+      %{name: "http", check: fn -> true end}
+    ]
   end
 
   @spec run_checks(map()) :: {boolean(), list()}
   defp run_checks(params) do
     checks
-    |> Enum.reject(fn {name, _} -> params[name] == "0" end)
-    |> Enum.map(fn {name, cb} -> {name, cb.()} end)
+    |> Enum.reject(fn %{name: name} -> params[name] == "0" end)
+    |> Enum.map(fn %{name: name, check: cb} -> {name, cb.()} end)
     |> Enum.reduce({true, []}, fn {check_name, check_success}, {global_success, messages} ->
       {
         global_success && check_success,

--- a/apps/transport/lib/transport_web/plugs/health_check.ex
+++ b/apps/transport/lib/transport_web/plugs/health_check.ex
@@ -13,17 +13,38 @@ defmodule TransportWeb.Plugs.HealthCheck do
     path = opts[:at]
 
     if conn.request_path == path do
-      success = database_up?()
-      message = "DATABASE: " <> if success, do: "OK", else: "KO"
-      status = if success, do: 200, else: 500
+      conn = fetch_query_params(conn)
+      {global_success, messages} = run_checks(conn.query_params)
+
+      status = if global_success, do: 200, else: 500
 
       conn
       |> put_resp_content_type("text/plain")
-      |> send_resp(status, message)
+      |> send_resp(status, messages |> Enum.join("\n"))
       |> halt()
     else
       conn
     end
+  end
+
+  defp checks do
+    %{
+      "http" => fn -> true end,
+      "db" => &database_up?/0
+    }
+  end
+
+  @spec run_checks(map()) :: {boolean(), list()}
+  defp run_checks(params) do
+    checks
+    |> Enum.reject(fn {name, _} -> params[name] == "0" end)
+    |> Enum.map(fn {name, cb} -> {name, cb.()} end)
+    |> Enum.reduce({true, []}, fn {check_name, check_success}, {global_success, messages} ->
+      {
+        global_success && check_success,
+        messages ++ ["#{check_name}: " <> if(check_success, do: "OK", else: "KO")]
+      }
+    end)
   end
 
   defp database_up? do

--- a/apps/transport/test/transport_web/routing/health_check_test.exs
+++ b/apps/transport/test/transport_web/routing/health_check_test.exs
@@ -6,14 +6,26 @@ defmodule TransportWeb.HealthCheckTest do
   test "GET /health-check", %{conn: conn} do
     conn = get(conn, "/health-check")
     body = text_response(conn, 200)
-    assert body == "DATABASE: OK"
+    assert body |> String.split("\n") == ["db: OK", "http: OK"]
   end
 
   test "GET /health-check (with db not available)", %{conn: conn} do
     with_mock Ecto.Adapters.SQL, query!: fn _, _, _ -> raise DBConnection.ConnectionError end do
       conn = get(conn, "/health-check")
       body = text_response(conn, 500)
-      assert body == "DATABASE: KO"
+      assert body |> String.split("\n") == ["db: KO", "http: OK"]
+
+      assert_called_exactly(Ecto.Adapters.SQL.query!(:_, :_, :_), 1)
+    end
+  end
+
+  test "GET /health-check?db=0 (with db not available", %{conn: conn} do
+    with_mock Ecto.Adapters.SQL, query!: fn _, _, _ -> raise DBConnection.ConnectionError end do
+      conn = get(conn, "/health-check?db=0")
+      body = text_response(conn, 200)
+      assert body |> String.split("\n") == ["http: OK"]
+
+      assert_called_exactly(Ecto.Adapters.SQL.query!(:_, :_, :_), 0)
     end
   end
 end


### PR DESCRIPTION
En rapport avec:
- #2087
- #1913

On sait à présent que le redémarrage de monitoring CleverCloud n'est pas "trop zélé".

On cherche à présent à confirmer que le souci se présentera même quand la base de données n'est pas sollicitée.

Dans cette PR, je fais évoluer le health-check pour qu'on puisse à la demande contourner la vérification base de données, à l'aide d'un paramètre.

Par défaut 2 checks sont là (`http` et `db`). On peut passer `&db=0` pour ne faire que la partie `http`, qui aura lieu de toute façon.
