### PR TITLE
Correction casse traduction FR 'Subscribe'

### DIFF
--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -22,7 +22,7 @@ msgstr "Adresse email"
 msgid "Subscribe to our email newsletter to receive update"
 msgstr "Pour être informé·e des nouveautés, inscrivez-vous à notre newsletter :"
 
-msgid "subscribe"
+msgid "Subscribe"
 msgstr "Inscription"
 
 msgid "Join us on"


### PR DESCRIPTION
J'avais changé la casse de ce mot dans https://github.com/etalab/transport-site/pull/2165 et fait la mise à jour "à la main" mais j'ai mal fait ceci dans la partie `fr`. Ceci a pour effet d'avoir une chaîne de caractères non traduite en prod.