### PR TITLE
Ajustements sur le pool de base de données (production)

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -58,7 +58,7 @@ defmodule Transport.ImportData do
         resources_id,
         fn r_id -> Resource.validate_and_save(r_id, force) end,
         max_concurrency: max_import_concurrent_jobs(),
-        timeout: 180_000
+        timeout: 240_000
       )
       |> Enum.to_list()
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,16 +18,5 @@ config :transport,
 
 config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 
-config :db, DB.Repo,
-  url:
-    System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||
-      "" |> String.replace_prefix("postgresql", "ecto"),
-  # NOTE: we must be careful with this ; front-end + worker are consuming
-  pool_size: 6,
-  # NOTE: pool_timeout is deprecated!
-  # Must be replaced by https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
-  pool_timeout: 15_000,
-  timeout: 15_000
-
 # Do not print debug messages in production
 config :logger, level: :info

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -157,3 +157,16 @@ email_host_name =
   end
 
 config :transport, :email_host_name, email_host_name
+
+if config_env() == :prod do
+  config :db, DB.Repo,
+    url:
+      System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||
+        "" |> String.replace_prefix("postgresql", "ecto"),
+    # NOTE: we must be careful with this ; front-end + worker are consuming
+    pool_size: 6,
+    # NOTE: pool_timeout is deprecated!
+    # Must be replaced by https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
+    pool_timeout: 15_000,
+    timeout: 15_000
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -159,12 +159,16 @@ email_host_name =
 config :transport, :email_host_name, email_host_name
 
 if config_env() == :prod do
+  pool_size = case app_env do
+    :production -> 15,
+    :staging -> 6
+  end
   config :db, DB.Repo,
     url:
       System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||
         "" |> String.replace_prefix("postgresql", "ecto"),
     # NOTE: we must be careful with this ; front-end + worker are consuming
-    pool_size: 6,
+    pool_size: pool_size,
     # NOTE: pool_timeout is deprecated!
     # Must be replaced by https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
     pool_timeout: 15_000,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -171,8 +171,8 @@ if config_env() == :prod do
         "" |> String.replace_prefix("postgresql", "ecto"),
     # NOTE: we must be careful with this ; front-end + worker are consuming
     pool_size: pool_size,
-    # NOTE: pool_timeout is deprecated!
-    # Must be replaced by https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
-    pool_timeout: 15_000,
+    # See https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
+    # [Ecto.Repo] :pool_timeout is no longer supported in favor of a new queue system described in DBConnection.start_link/2
+    # under "Queue config". For most users, configuring :timeout is enough, as it now includes both queue and query time
     timeout: 15_000
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -159,10 +159,12 @@ email_host_name =
 config :transport, :email_host_name, email_host_name
 
 if config_env() == :prod do
-  pool_size = case app_env do
-    :production -> 15,
-    :staging -> 6
-  end
+  pool_size =
+    case app_env do
+      :production -> 15
+      :staging -> 6
+    end
+
   config :db, DB.Repo,
     url:
       System.get_env("POSTGRESQL_ADDON_DIRECT_URI") || System.get_env("POSTGRESQL_ADDON_URI") ||


### PR DESCRIPTION
Contexte:
- https://github.com/etalab/transport-site/issues/1913
- On a des exceptions dans Sentry la nuit liées au manque de connections via le pool

Dans cette PR:
- je déplace la configuration finale de `prod.exs` (qui affecte prochainement et la production) vers `runtime.exs`
- je configure la taille du pool à 15 au lieu de 6 pour la production uniquement
- ça permet de ne pas aller au passage à contre-courant de https://github.com/etalab/transport-site/issues/1817
- je supprime `pool_timeout` qui n'avait plus d'effet de toute façon
- j'ai augmenté le timeout de validation général, car de temps en temps sur le staging ça saute

Avant d'essayer de tweaker davantage, je vais observer si rien que ça suffit à ne plus avoir de timeouts (voir https://sentry.io/organizations/transport-data-gouv-fr/issues/3016768499/events/?project=6197733), ou s'il faut ajuster plus finement.

Il faut aussi vérifier qu'on n'aura pas de rejets de Postgres (notamment au moment du déploiement où les connections sont doublées plus ou moins) par manque de connections.

Je propose de déployer sur `master` pour la nuit et de voir ce qui se passe demain matin.
