### PR TITLE
Ajout GitHub Action pour suivre les déploiements dans Sentry

### DIFF
--- a/.github/.workflows/sentry_release.yml
+++ b/.github/.workflows/sentry_release.yml
@@ -1,0 +1,20 @@
+name: Sentry release integration
+on:
+  push:
+    branches:
+      - master
+jobs:
+  # See https://github.com/marketplace/actions/sentry-release
+  # See https://sentry.io/settings/transport-data-gouv-fr/developer-settings/github-action-release-integration-f9f6ff/
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: 'transport-data-gouv-fr'
+          SENTRY_PROJECT: 'transport-site'
+        with:
+          environment: prod


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2174

J'ai suivi les instructions sur l'action GitHub de Sentry et [l'article de blog](https://blog.sentry.io/2020/07/30/automate-release-management-with-the-sentry-release-github-action)