### PR TITLE
Ajout page accessibilité

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -66,6 +66,10 @@ defmodule TransportWeb.PageController do
     single_page(conn, %{"page" => "conditions"})
   end
 
+  def accessibility(conn, _params) do
+    single_page(conn, %{"page" => "accessibility"})
+  end
+
   def infos_producteurs(conn, _params) do
     conn
     |> assign(:mailchimp_newsletter_url, Application.get_env(:transport, :mailchimp_newsletter_url))

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -42,6 +42,7 @@ defmodule TransportWeb.Router do
 
     get("/", PageController, :index)
     get("/real_time", PageController, :real_time)
+    get("/accessibilite", PageController, :accessibility)
     get("/conditions", PageController, :conditions)
     get("/infos_producteurs", PageController, :infos_producteurs)
     get("/.well-known/security.txt", PageController, :security_txt)

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -45,6 +45,11 @@
         <%= gettext "Legal Information" %>
       </a>
     </li>
+    <li>
+      <a class="footer__link footer__link--tos" href="<%= page_path(@conn, :accessibility) %>" role="link">
+        <%= gettext "Accessibility: non-compliant" %>
+      </a>
+    </li>
   </ul>
 </div>
 </footer>

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -32,21 +32,21 @@
       </li>
     <% end %>
     <li>
-      <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/" role="link">API</a>
+      <a class="footer__link" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/" role="link">API</a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
+      <a class="footer__link" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="https://github.com/etalab/transport-site/" role="link"><%= gettext("Source code")%></a>
+      <a class="footer__link" href="https://github.com/etalab/transport-site/" role="link"><%= gettext("Source code")%></a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="/legal" role="link">
+      <a class="footer__link" href="/legal" role="link">
         <%= gettext "Legal Information" %>
       </a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="<%= page_path(@conn, :accessibility) %>" role="link">
+      <a class="footer__link" href="<%= page_path(@conn, :accessibility) %>" role="link">
         <%= gettext "Accessibility: non-compliant" %>
       </a>
     </li>

--- a/apps/transport/lib/transport_web/templates/page/accessibility.html.md
+++ b/apps/transport/lib/transport_web/templates/page/accessibility.html.md
@@ -1,3 +1,5 @@
+<%= raw ~s(<div lang="fr">) %>
+
 Le Ministère de la Transition écologique s’engage à rendre ses sites web, intranet, extranet et ses progiciels accessibles (et ses applications mobiles et mobilier urbain numérique) conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
 
 À cette fin, elle met en œuvre la stratégie et les actions suivantes :
@@ -31,3 +33,4 @@ Plusieurs moyens sont à votre disposition :
 Défenseur des droits,
 Libre réponse 71120,
 75342 Paris CEDEX 07
+<%= raw ~s(</div>) %>

--- a/apps/transport/lib/transport_web/templates/page/accessibility.html.md
+++ b/apps/transport/lib/transport_web/templates/page/accessibility.html.md
@@ -1,4 +1,4 @@
-<%= raw ~s(<div lang="fr">) %>
+<%= raw ~s(<div lang=fr>) %>
 
 Le Ministère de la Transition écologique s’engage à rendre ses sites web, intranet, extranet et ses progiciels accessibles (et ses applications mobiles et mobilier urbain numérique) conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
 

--- a/apps/transport/lib/transport_web/templates/page/accessibility.html.md
+++ b/apps/transport/lib/transport_web/templates/page/accessibility.html.md
@@ -1,0 +1,33 @@
+Le Ministère de la Transition écologique s’engage à rendre ses sites web, intranet, extranet et ses progiciels accessibles (et ses applications mobiles et mobilier urbain numérique) conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
+
+À cette fin, elle met en œuvre la stratégie et les actions suivantes :
+- Fournir un site web accessible ;
+- Avoir une communication par courriels et sur les réseaux sociaux accessible ;
+- Prêter attention aux informations d'accessibilité pour les données de mobilité.
+
+Cette déclaration d’accessibilité s’applique à [transport.data.gouv.fr](https://transport.data.gouv.fr).
+
+## État de conformité
+transport.data.gouv.fr est non conforme avec le référentiel général d’amélioration de l’accessibilité (RGAA), un audit d'accessibilité n'ayant pas encore été réalisé.
+
+L'absence d'audit d'accessibilité ne remet pas en cause le caractère accessible du site web actuel.
+
+## Établissement de cette déclaration d’accessibilité
+Cette déclaration a été établie le 02/03/2022.
+
+## Retour d'information et contact
+Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter la personne responsable du site pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+
+Veuillez envoyer un courriel à [<%= @contact_email %>](mailto:<%= @contact_email %>).
+
+## Voies de recours
+Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.
+
+Plusieurs moyens sont à votre disposition :
+
+- [Écrire un message au Défenseur des droits](https://formulaire.defenseurdesdroits.fr/)
+- [Contacter le délégué du Défenseur des droits dans votre région](https://www.defenseurdesdroits.fr/saisir/delegues)
+- Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre)
+Défenseur des droits,
+Libre réponse 71120,
+75342 Paris CEDEX 07

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -92,3 +92,7 @@ msgstr ""
 #, elixir-format
 msgid "Analyze a GBFS feed"
 msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Accessibility: non-compliant"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -92,3 +92,7 @@ msgstr ""
 #, elixir-format
 msgid "Analyze a GBFS feed"
 msgstr ""
+
+#, elixir-format, ex-autogen
+msgid "Accessibility: non-compliant"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -92,3 +92,7 @@ msgstr "Outils"
 #, elixir-format
 msgid "Analyze a GBFS feed"
 msgstr "Analyser un flux GBFS"
+
+#, elixir-format, ex-autogen
+msgid "Accessibility: non-compliant"
+msgstr "Accessibilité : non conforme"

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -149,4 +149,8 @@ defmodule TransportWeb.PageControllerTest do
   test "robots.txt page", %{conn: conn} do
     conn |> get("robots.txt") |> text_response(200)
   end
+
+  test "accessibility page", %{conn: conn} do
+    conn |> get(page_path(conn, :accessibility)) |> text_response(200)
+  end
 end

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -151,6 +151,6 @@ defmodule TransportWeb.PageControllerTest do
   end
 
   test "accessibility page", %{conn: conn} do
-    conn |> get(page_path(conn, :accessibility)) |> text_response(200)
+    conn |> get(page_path(conn, :accessibility)) |> html_response(200)
   end
 end


### PR DESCRIPTION
Ajoute une page d'accessibilité et un lien "Accessibilité : non conforme" dans le footer.

J'ai suivi les recommandations sur
- https://design.numerique.gouv.fr/outils/exemple-declaration-accessibilite/
- https://design.numerique.gouv.fr/accessibilite-numerique/declaration-accessibilite/