### PR TITLE
Lien cassé vers la FAQ

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -165,7 +165,7 @@ defmodule TransportWeb.Router do
     end
 
     # old static pages that have been moved to doc.transport
-    get("/faq", Redirect, external: "https://doc.transport.data.gouv.fr/foire-aux-questions")
+    get("/faq", Redirect, external: "https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites")
 
     get("/guide", Redirect,
       external:

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.eex
@@ -35,7 +35,7 @@
       <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/" role="link">API</a>
     </li>
     <li>
-      <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions" role="link">FAQ</a>
+      <a class="footer__link footer__link--tos" href="https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites" role="link">FAQ</a>
     </li>
     <li>
       <a class="footer__link footer__link--tos" href="https://github.com/etalab/transport-site/" role="link"><%= gettext("Source code")%></a>


### PR DESCRIPTION
En allant trainer du côté du footer (merci @AntoineAugusti), je me suis rendu compte que le lien vers notre FAQ était cassé.