### PR TITLE
Validation GTFS : ajout token dans pagination

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -55,6 +55,7 @@ defmodule TransportWeb.ValidationController do
         |> assign(:severities_count, Validation.count_by_severity(validation))
         |> assign(:metadata, validation.on_the_fly_validation_metadata)
         |> assign(:data_vis, data_vis(validation, issue_type))
+        |> assign(:token, token)
         |> render("show.html")
 
       # Handles waiting for validation to complete, errors and

--- a/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.eex
@@ -11,7 +11,7 @@
                 <%= if issue.count > 0 do %>
                 <%= link(
                     "#{issue.title} (#{issue.count})",
-                    to: "#{current_url(@conn, %{"issue_type" => "#{key}"})}#issues",
+                    to: "#{current_url(@conn, %{"issue_type" => key, "token" => @token} |> Map.reject(fn {_, v} -> is_nil(v) end))}#issues",
                     class: (if key == issue_type(@issues.entries), do: "active")
                 ) %>
                 <% end %>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
@@ -89,7 +89,7 @@
           <%= unless @resource.validation do %>
             <%= dgettext("validations", "No validation available") %>
           <% else %>
-            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, issues: @issues, conn: @conn, data_vis: @data_vis %>
+            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, issues: @issues, conn: @conn, data_vis: @data_vis, token: nil %>
           <% end %>
         </nav>
         <div class="main-pane">

--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -22,17 +22,17 @@
       <% end %>
 
       <%= if has_errors?(@validation_summary) do %>
-        <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues, data_vis: @data_vis %>
+        <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, conn: @conn, issues: @issues, data_vis: @data_vis, token: @token %>
       <% end %>
 
       <div class="validation-content-details">
         <div class="panel" style="overflow-x:auto;">
           <%= if has_errors?(@validation_summary) do %>
-            <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
+            <%= pagination_links @conn, @issues, [@validation_id], issue_type: issue_type(@issues.entries), token: @token,
                 path: &validation_path/4, action: :show %>
             <%= render template(@issues), issues: @issues || [] , conn: @conn %>
             <div class="pt-24">
-              <%= pagination_links @conn, @issues,  [@validation_id], issue_type: issue_type(@issues.entries),
+              <%= pagination_links @conn, @issues, [@validation_id], issue_type: issue_type(@issues.entries), token: @token,
                 path: &validation_path/4, action: :show %>
             </div>
           <% else %>


### PR DESCRIPTION
Suite à https://github.com/etalab/transport-site/pull/2163, un token a été ajouté aux validations à la demande pour rendre le rapport non public.

Ce query param `token` a été oublié dans les URLs de la validation GTFS pour quand on souhaite filtrer par type de problème ou quand on pagine les erreurs. Cette PR ajoute ce paramètre à ces URLs.