### PR TITLE
Renseigne date pour validation GTFS-RT

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -15,9 +15,12 @@ defmodule TransportWeb.ValidationController do
   end
 
   def validate(%Plug.Conn{} = conn, %{"upload" => %{"url" => _, "feed_url" => _, "type" => "gtfs-rt"} = params}) do
-    metadata = build_metadata(params)
-
-    validation = %Validation{on_the_fly_validation_metadata: metadata} |> Repo.insert!()
+    validation =
+      %Validation{
+        on_the_fly_validation_metadata: build_metadata(params),
+        date: DateTime.utc_now() |> DateTime.to_string()
+      }
+      |> Repo.insert!()
 
     case dispatch_validation_job(validation) do
       :ok ->

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -179,8 +179,11 @@ defmodule TransportWeb.ValidationControllerTest do
                  "type" => "gtfs-rt",
                  "secret_url_token" => token
                },
-               id: validation_id
+               id: validation_id,
+               date: date
              } = DB.Repo.one!(DB.Validation)
+
+      refute is_nil(date)
 
       assert [
                %Oban.Job{


### PR DESCRIPTION
Le champ `DB.Validation.date` pouvait être à `null` pour les validations GTFS-RT quand il y avait une erreur. 

`OnDemandValidationJob` remplit normalement ce champ
https://github.com/etalab/transport-site/blob/350f9824f58068410e9f3818d6c7ffdbb07c15d4/apps/transport/lib/jobs/on_demand_validation_job.ex#L31

mais dans le cas d'un conflit `Oban.Job` (unique par 5 minutes), le job n'est pas exécuté.

Il vaut mieux renseigner ce champ au niveau du controller.