### PR TITLE
Correction calcul du hash d'une ressource non zip lors de l'historisation

### DIFF
--- a/apps/shared/lib/hasher.ex
+++ b/apps/shared/lib/hasher.ex
@@ -1,6 +1,6 @@
 defmodule Hasher do
   @moduledoc """
-  Hasher computes the hash sha256 of a file given by 
+  Hasher computes the hash sha256 of a file given by
   an URL or a local path
   """
   require Logger
@@ -60,4 +60,18 @@ defmodule Hasher do
   @spec find_etag(keyword()) :: binary()
   defp find_etag({"Etag", v}), do: v
   defp find_etag(_), do: nil
+
+  def compute_checksum(stream, algorithm) do
+    stream
+    |> Enum.reduce(:crypto.hash_init(algorithm), fn elm, acc -> :crypto.hash_update(acc, elm) end)
+    |> :crypto.hash_final()
+    |> Base.encode16()
+    |> String.downcase()
+  end
+
+  def get_file_hash(file_path) do
+    file_path
+    |> File.stream!([], 2048)
+    |> compute_checksum(:sha256)
+  end
 end

--- a/apps/shared/lib/hasher.ex
+++ b/apps/shared/lib/hasher.ex
@@ -1,6 +1,7 @@
 defmodule Hasher do
   @moduledoc """
-  Hasher computes the hash sha256 of file given by the URL
+  Hasher computes the hash sha256 of a file given by 
+  an URL or a local path
   """
   require Logger
 

--- a/apps/shared/test/hasher_test.exs
+++ b/apps/shared/test/hasher_test.exs
@@ -1,0 +1,12 @@
+defmodule HasherTest do
+  use ExUnit.Case
+
+  test "hash by streaming a local file" do
+    content = "coucou"
+    hash = :crypto.hash(:sha256, content) |> Base.encode16() |> String.downcase()
+    file_path = System.tmp_dir!() |> Path.join("coucou_file")
+    File.write!(file_path, content)
+
+    assert Hasher.get_file_hash(file_path) == hash
+  end
+end

--- a/apps/shared/test/hasher_test.exs
+++ b/apps/shared/test/hasher_test.exs
@@ -3,7 +3,7 @@ defmodule HasherTest do
 
   test "hash by streaming a local file" do
     content = "coucou"
-    hash = :crypto.hash(:sha256, content) |> Base.encode16() |> String.downcase()
+    hash = :sha256 |> :crypto.hash(content) |> Base.encode16() |> String.downcase()
     file_path = System.tmp_dir!() |> Path.join("coucou_file")
     File.write!(file_path, content)
 

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -172,7 +172,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     items |> Enum.map(&{map_get(&1, :file_name), map_get(&1, :sha256)}) |> MapSet.new()
   end
 
-  defp resource_hash(%Resource{content_hash: content_hash, datagouv_id: datagouv_id} = resource, resource_path) do
+  defp resource_hash(%Resource{datagouv_id: datagouv_id} = resource, resource_path) do
     case is_zip?(resource) do
       true ->
         try do
@@ -184,7 +184,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
         end
 
       false ->
-        content_hash
+        Hasher.get_file_hash(resource_path)
     end
   end
 

--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -35,16 +35,8 @@ defmodule Transport.ZipMetaDataExtractor do
     checksum =
       unzip
       |> Unzip.file_stream!(entry.file_name)
-      |> compute_checksum(algorithm)
+      |> Hasher.compute_checksum(algorithm)
 
     entry |> Map.put(algorithm, checksum)
-  end
-
-  def compute_checksum(stream, algorithm) do
-    stream
-    |> Enum.reduce(:crypto.hash_init(algorithm), fn elm, acc -> :crypto.hash_update(acc, elm) end)
-    |> :crypto.hash_final()
-    |> Base.encode16()
-    |> String.downcase()
   end
 end


### PR DESCRIPTION
voir https://mattermost.incubateur.net/betagouv/pl/m1acxa7u5fgjtda416jwzs8s5r

Dans le cas d'une ressource non zip, au lieu de calculer le hash de la resource qu'on vient de télécharger et qu'on s'apprete à historiser, on prend le hash qui est stocké au niveau de la %Resource{}, et qui était à jour lors du dernier import. Mais la ressource a pu changer entre temps, donc on risque de stocker un mauvais hash.