### PR TITLE
Suppression backoffice rt_resource_without_siri_lite

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -109,29 +109,6 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render_index(conn, params)
   end
 
-  def index(%Plug.Conn{} = conn, %{"filter" => "rt_resource_without_siri_lite"} = params) do
-    resources_siri =
-      from(r in Resource,
-        where: r.format == "siri-lite",
-        group_by: r.dataset_id,
-        select: %{dataset_id: r.dataset_id, count: count(r.dataset_id)}
-      )
-
-    resources_gtfs_rt =
-      from(r in Resource,
-        where: r.format == "gtfs-rt",
-        group_by: r.dataset_id,
-        select: %{dataset_id: r.dataset_id, count: count(r.dataset_id)}
-      )
-
-    Dataset
-    |> join(:left, [d], rs in subquery(resources_siri), on: d.id == rs.dataset_id)
-    |> join(:left, [d], rg in subquery(resources_gtfs_rt), on: d.id == rg.dataset_id)
-    |> where([d, rs, rg], rs.count == 0 and rg.count > 0)
-    |> query_order_by_from_params(params)
-    |> render_index(conn, params)
-  end
-
   def index(%Plug.Conn{} = conn, %{"dataset_id" => dataset_id} = params) do
     conn =
       Dataset

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -75,9 +75,6 @@
       <div>
         <%= link(dgettext("backoffice", "With a resource under 90% availability"), to: backoffice_page_path(@conn, :index, %{"filter" => "resource_under_90_availability"}) <> "#list_datasets") %>
       </div>
-      <div>
-        <%= link(dgettext("backoffice", "With a gtfs-rt but without a siri-lite"), to: backoffice_page_path(@conn, :index, %{"filter" => "rt_resource_without_siri_lite"}) <> "#list_datasets") %>
-      </div>
     </div>
     <% else %>
     <%= link(dgettext("backoffice", "Show all datasets"), to: backoffice_page_path(@conn, :index) <> "#list_datasets") %>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -166,10 +166,6 @@ msgid "Rapport de complétude des imports"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "With a gtfs-rt but without a siri-lite"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "With a resource not available"
 msgstr ""
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -166,10 +166,6 @@ msgid "Rapport de complétude des imports"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "With a gtfs-rt but without a siri-lite"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "With a resource not available"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -166,10 +166,6 @@ msgid "Rapport de complétude des imports"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "With a gtfs-rt but without a siri-lite"
-msgstr "Avec un gtfs-rt et sans siri-lite"
-
-#, elixir-autogen, elixir-format
 msgid "With a resource not available"
 msgstr "Ayant une ressource non disponible"
 


### PR DESCRIPTION
Ce filtre et l'identification de telles ressources n'est plus d'actualité.

J'en profite pour indiquer que la ressource existante ne fonctionne pas, il faudrait avoir `count = 0 or cout is null`