### PR TITLE
Compte les ressources SIRI

### DIFF
--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -79,8 +79,8 @@ defmodule Transport.StatsHandler do
       nb_bss_datasets: count_dataset_with_format("gbfs"),
       nb_bikes_scooter_datasets: nb_bikes_scooters(),
       nb_gtfs_rt: count_dataset_with_format("gtfs-rt"),
-      nb_siri: count_dataset_with_format("siri"),
-      nb_siri_lite: count_dataset_with_format("siri-lite")
+      nb_siri: count_dataset_with_format("SIRI"),
+      nb_siri_lite: count_dataset_with_format("SIRI Lite")
     }
   end
 

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -243,7 +243,9 @@ defmodule TransportWeb.API.StatsController do
         gtfs: count_aom_format(aom.id, "GTFS"),
         netex: count_aom_format(aom.id, "NeTEx"),
         gtfs_rt: count_aom_format(aom.id, "gtfs-rt"),
-        gbfs: count_aom_format(aom.id, "gbfs")
+        gbfs: count_aom_format(aom.id, "gbfs"),
+        siri: count_aom_format(aom.id, "SIRI"),
+        siri_lite: count_aom_format(aom.id, "SIRI Lite")
       },
       nom: aom.nom,
       forme_juridique: aom.forme_juridique,
@@ -283,7 +285,9 @@ defmodule TransportWeb.API.StatsController do
         gtfs: count_region_format(r.id, "GTFS"),
         netex: count_region_format(r.id, "NeTEx"),
         gtfs_rt: count_region_format(r.id, "gtfs-rt"),
-        gbfs: count_region_format(r.id, "gbfs")
+        gbfs: count_region_format(r.id, "gbfs"),
+        siri: count_region_format(r.id, "SIRI"),
+        siri_lite: count_region_format(r.id, "SIRI Lite")
       },
       dataset_types: %{
         pt: count_type_by_region(r.id, "public-transit"),


### PR DESCRIPTION
On commence à avoir des ressources en SIRI, mais quelques endroits du code n'ont pas encore été adaptés pour prendre en compte ces formats en particulier sur `/stats`.