### PR TITLE
Ajustements UI autres jeux de données

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -214,12 +214,12 @@
 <% end %>
 <%= unless is_nil(@other_datasets) or @other_datasets == [] do %>
   <section class="pt-48" id="dataset-other-datasets">
-    <h2><%= dgettext("page-dataset-details", "Other datasets of ") %> <%= String.capitalize(@territory) %></h2>
+    <h2><%= dgettext("page-dataset-details", "Other datasets of %{name}", name: @territory) %></h2>
     <div class="panel">
       <ul>
         <%= for dataset <- @other_datasets do %>
           <li><%= link(
-            dataset.title,
+            dataset.spatial,
             to: dataset_path(@conn, :details, dataset.slug)
           ) %></li>
         <% end %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -159,10 +159,6 @@ msgid "Details"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Other datasets of "
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
@@ -420,4 +416,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "unknown"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Other datasets of %{name}"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -159,10 +159,6 @@ msgid "Details"
 msgstr "Détails"
 
 #, elixir-autogen, elixir-format
-msgid "Other datasets of "
-msgstr "Autres jeux de données de "
-
-#, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Site internet"
 
@@ -421,3 +417,7 @@ msgstr "date de dernière modification du contenu"
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "inconnue"
+
+#, elixir-autogen, elixir-format
+msgid "Other datasets of %{name}"
+msgstr "Autres jeux de données de %{name}"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -159,10 +159,6 @@ msgid "Details"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Other datasets of "
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
@@ -420,4 +416,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "unknown"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Other datasets of %{name}"
 msgstr ""


### PR DESCRIPTION
Fixes #2219, #2221

Retravaille "autres jeux de données" pour :
- utiliser la casse qui est enregistrée sans faire de transformations
- utiliser le nom éditorialisé des JDD plutôt que le titre sur data.gouv.fr