### PR TITLE
Manque @conn pour resources_details.html

### DIFF
--- a/apps/transport/lib/transport_web/templates/validation/show.html.eex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.eex
@@ -17,7 +17,7 @@
 
       <%= unless is_nil(@metadata) do %>
         <div class="panel validation-metadata">
-          <%= render "_resources_details.html", metadata: @metadata %>
+          <%= render "_resources_details.html", metadata: @metadata, conn: @conn %>
         </div>
       <% end %>
 


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2185

Il manque `@conn` ici, [voir l'exception](https://sentry.io/organizations/transport-data-gouv-fr/issues/3102861833/?project=6197733&statsPeriod=14d)