### PR TITLE
Availability checker : autorise les réponses 2XX

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -25,7 +25,7 @@ defmodule Transport.AvailabilityChecker do
 
   def available?(url, false) when is_binary(url) do
     case HTTPoison.head(url, [], follow_redirect: true) do
-      {:ok, %Response{status_code: 200}} -> true
+      {:ok, %Response{status_code: code}} when code >= 200 and code < 300 -> true
       {:ok, %Response{status_code: code}} when code in [401, 403, 405] -> available?(url, _use_http_streaming = true)
       _ -> false
     end


### PR DESCRIPTION
closes #2234 

2XX : This class of status codes indicates the action requested by the client was received, understood, and accepted.

Du coup, on peut considérer que toute réponse 2XX signifie que le serveur est opérationnel et que la ressource est bien disponible.