### PR TITLE
Affiche message réutilisateur seulement une fois

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -18,18 +18,6 @@
           <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.", link: link_history)) %>
         </div>
       <% end %>
-
-      <div class="reuser-message pb-48">
-        <i class="fas fa-info-circle"></i>
-        <%= dgettext(
-          "page-dataset-details",
-          "You're using this dataset? %{a_start}Send an email!%{a_end}",
-          a_start: "<a href=\"#mail_form\">",
-          a_end: "</a>"
-          )
-          |> raw()
-        %>
-      </div>
     </div>
   </section>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.eex
@@ -1,0 +1,13 @@
+<section class="dataset__resources">
+  <div class="reuser-message pb-48">
+    <i class="fas fa-info-circle"></i>
+    <%= dgettext(
+      "page-dataset-details",
+      "You're using this dataset? %{a_start}Send an email!%{a_end}",
+      a_start: "<a href=\"#mail_form\">",
+      a_end: "</a>"
+      )
+      |> raw()
+    %>
+  </div>
+</section>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -70,6 +70,7 @@
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Resources"), latest_resources_history_infos: @latest_resources_history_infos %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"), latest_resources_history_infos: @latest_resources_history_infos%>
+      <%= render "_reuser_message.html" %>
       <% community_resources = community_resources(@dataset) %>
       <%= unless community_resources == [] do %>
         <section class="dataset__resources white">


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2223

Voir description ici, mais rapidement, [sur ce JDD](https://transport.data.gouv.fr/datasets/simouv-horaires-theoriques-et-temps-reel-de-transport-public-transvilles-valenciennes/) le message est affiché déjà 3 fois après chaque bloc de ressources.

J'ai vérifié que `resources_container` était utilisé uniquement ici.