### PR TITLE
Affichage flux GTFS-RT décodé

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -33,7 +33,7 @@ defmodule TransportWeb.ResourceController do
     lang = get_session(conn, :locale)
 
     Transport.Cache.API.fetch(
-      "service_alerts_#{resource.id}_#{lang}",
+      "gtfs_rt_feed_#{resource.id}_#{lang}",
       fn ->
         if Resource.is_gtfs_rt?(resource) do
           case Transport.GTFSRT.decode_remote_feed(resource.url) do
@@ -43,8 +43,8 @@ defmodule TransportWeb.ResourceController do
                 feed: feed
               }
 
-            _ ->
-              nil
+            {:error, _} ->
+              :error
           end
         else
           nil

--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.eex
@@ -1,6 +1,16 @@
-<%= unless is_nil(@gtfs_rt_feed) or Enum.empty?(@gtfs_rt_feed.alerts)  do %>
-  <h2><%= dgettext("page-dataset-details", "GTFS-RT feed content") %></h2>
-  <div class="panel">
+<h2><%= dgettext("page-dataset-details", "GTFS-RT feed content") %></h2>
+
+<div class="panel">
+  <%= if @gtfs_rt_feed == :error do %>
+    <div class="notification error full-width mt-0">
+      <p><%= dgettext("page-dataset-details", "Could not decode the GTFS-RT feed.") %></p>
+    </div>
+    <p>
+      <%= dgettext("page-dataset-details", "The GTFS-RT feed should be accessible over HTTP, without authentication and use the Protobuf format.") %>
+    </p>
+  <% end %>
+
+  <%= unless @gtfs_rt_feed == :error or Enum.empty?(@gtfs_rt_feed.alerts) do %>
     <h3 id="service-alerts"><%= raw dgettext("page-dataset-details", "Service alerts") %></h3>
     <p>
       <%= dgettext("page-dataset-details", "Here is a display of service alerts contained in this feed at %{date}.", date: format_datetime_to_paris(Transport.GTFSRT.timestamp(@gtfs_rt_feed.feed), @locale)) %>
@@ -41,20 +51,24 @@
         <% end %>
       </div>
     <% end %>
+  <% end %>
+
+  <%= unless @gtfs_rt_feed == :error do %>
+    <h3 id="gtfs-rt-decoded-feed"><%= dgettext("page-dataset-details", "Decoded GTFS-RT feed") %></h3>
 
     <details>
       <summary><%= dgettext("page-dataset-details", "See full payload") %></summary>
         <p>
-          <%= raw dgettext("page-dataset-details", "Here is the decoded GTFS-RT feed Protobuf. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>.", link: "https://developers.google.com/transit/gtfs-realtime/reference") %>
+          <%= raw dgettext("page-dataset-details", "Here is the decoded GTFS-RT feed Protobuf at %{date}. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>.", link: "https://developers.google.com/transit/gtfs-realtime/reference", date: format_datetime_to_paris(Transport.GTFSRT.timestamp(@gtfs_rt_feed.feed), @locale)) %>
         </p>
-        <button class="button" data-clipboard-target="#alerts_payload">
+        <button class="button" data-clipboard-target="#feed_payload">
           <i class="fa fa-copy"></i>
           <%= dgettext("page-dataset-details", "Copy to clipboard") %>
         </button>
-        <code id="alerts_payload">
+        <code id="feed_payload">
           <%= inspect(@gtfs_rt_feed.feed, pretty: true, width: 120) %>
         </code>
     </details>
-  </div>
+  <% end %>
+</div>
 <script defer type="text/javascript" src="/js/clipboard.js"></script>
-<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -40,7 +40,9 @@
       </div>
       <% end %>
 
-      <%= render "_service_alerts.html", gtfs_rt_feed: @gtfs_rt_feed, locale: get_session(@conn, :locale)%>
+      <%= if DB.Resource.is_gtfs_rt?(@resource) do %>
+        <%= render "_gtfs_rt.html", gtfs_rt_feed: @gtfs_rt_feed, locale: get_session(@conn, :locale) %>
+      <% end %>
     </div>
   </div>
 </section>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -479,10 +479,6 @@ msgid "Here is a display of service alerts contained in this feed at %{date}."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Here is the decoded GTFS-RT feed Protobuf. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "See full payload"
 msgstr ""
 
@@ -492,4 +488,20 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Real time resources"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Could not decode the GTFS-RT feed."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Decoded GTFS-RT feed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The GTFS-RT feed should be accessible over HTTP, without authentication and use the Protobuf format."
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Here is the decoded GTFS-RT feed Protobuf at %{date}. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -479,10 +479,6 @@ msgid "Here is a display of service alerts contained in this feed at %{date}."
 msgstr "Voici un aperçu des informations de trafic présentes dans ce flux le %{date}."
 
 #, elixir-autogen, elixir-format
-msgid "Here is the decoded GTFS-RT feed Protobuf. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
-msgstr "Voici le flux GTFS-RT décodé au format Protobuf. Vous pouvez consulter <a href=\"%{link}\" target=\"_blank\">la documentation GTFS-RT</a>."
-
-#, elixir-autogen, elixir-format
 msgid "See full payload"
 msgstr "Voir le contenu du flux"
 
@@ -493,3 +489,19 @@ msgstr "Autres jeux de données de %{name}"
 #, elixir-autogen, elixir-format
 msgid "Real time resources"
 msgstr "Ressources temps réel"
+
+#, elixir-autogen, elixir-format
+msgid "Could not decode the GTFS-RT feed."
+msgstr "Impossible de décoder le flux GTFS-RT"
+
+#, elixir-autogen, elixir-format
+msgid "Decoded GTFS-RT feed"
+msgstr "Flux GTFS-RT décodé"
+
+#, elixir-autogen, elixir-format
+msgid "The GTFS-RT feed should be accessible over HTTP, without authentication and use the Protobuf format."
+msgstr "Le flux GTFS-RT doit être accessible en HTTP, sans authentification et utiliser le format Protobuf."
+
+#, elixir-autogen, elixir-format
+msgid "Here is the decoded GTFS-RT feed Protobuf at %{date}. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
+msgstr "Voici le flux GTFS-RT décodé au format Protobuf le %{date}. Vous pouvez consulter <a href=\"%{link}\" target=\"_blank\">la documentation GTFS-RT</a>."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -479,10 +479,6 @@ msgid "Here is a display of service alerts contained in this feed at %{date}."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Here is the decoded GTFS-RT feed Protobuf. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "See full payload"
 msgstr ""
 
@@ -492,4 +488,20 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Real time resources"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Could not decode the GTFS-RT feed."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Decoded GTFS-RT feed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The GTFS-RT feed should be accessible over HTTP, without authentication and use the Protobuf format."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Here is the decoded GTFS-RT feed Protobuf at %{date}. You can look at <a href=\"%{link}\" target=\"_blank\">the GTFS-RT documentation</a>."
 msgstr ""


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2235

- Résumé tout en haut, de façon systématique (même avec 0 entités) du nombre d'entités par type d'entité
- Copy-paste du flux décodé quel que soit le type de flux GTFS-RT
- Si une erreur se produise au moment de la lecture (HTTP, décodage), on prévient que le flux n'a pas pu être décodé, avec un message explicite