### PR TITLE
Formattage des datetimes pour validation à la demande

### DIFF
--- a/apps/shared/lib/date_time_display.ex
+++ b/apps/shared/lib/date_time_display.ex
@@ -62,6 +62,12 @@ defmodule Shared.DateTimeDisplay do
   "2022-03-01 at 16:30 Europe/Paris"
   iex> format_datetime_to_paris("2022-03-01T15:30:09+00:00", "en", with_seconds: true)
   "2022-03-01 at 16:30:09 Europe/Paris"
+  # right before daylight hour change
+  iex> format_datetime_to_paris("2022-03-27T00:59+00:00", "fr")
+  "27/03/2022 à 01h59 Europe/Paris"
+  # right after daylight hour change
+  iex> format_datetime_to_paris("2022-03-27T01:00:00+00:00", "fr")
+  "27/03/2022 à 03h00 Europe/Paris"
   """
   def format_datetime_to_paris(dt, locale), do: format_datetime_to_paris(dt, locale, [])
 

--- a/apps/shared/lib/date_time_display.ex
+++ b/apps/shared/lib/date_time_display.ex
@@ -54,38 +54,52 @@ defmodule Shared.DateTimeDisplay do
   "01/03/2022 à 16h30 Europe/Paris"
   iex> format_datetime_to_paris("2022-03-01T15:30:00+01:00", "fr")
   "01/03/2022 à 15h30 Europe/Paris"
+  iex> format_datetime_to_paris("2022-03-01T15:30:00+01:00", "fr")
+  "01/03/2022 à 15h30 Europe/Paris"
+  iex> format_datetime_to_paris("2022-03-01T15:30:09+01:00", "fr", with_seconds: true)
+  "01/03/2022 à 15:30:09 Europe/Paris"
   iex> format_datetime_to_paris("2022-03-01T15:30:00+00:00", "en")
   "2022-03-01 at 16:30 Europe/Paris"
+  iex> format_datetime_to_paris("2022-03-01T15:30:09+00:00", "en", with_seconds: true)
+  "2022-03-01 at 16:30:09 Europe/Paris"
   """
-  def format_datetime_to_paris(%DateTime{} = dt, "fr") do
-    dt
-    |> convert_to_paris_time()
-    |> Calendar.strftime("%d/%m/%Y à %Hh%M Europe/Paris")
+  def format_datetime_to_paris(dt, locale), do: format_datetime_to_paris(dt, locale, [])
+
+  def format_datetime_to_paris(%DateTime{} = dt, locale, options) when locale in [nil, "fr"] do
+    format =
+      if Keyword.get(options, :with_seconds) do
+        "%d/%m/%Y à %H:%M:%S Europe/Paris"
+      else
+        "%d/%m/%Y à %Hh%M Europe/Paris"
+      end
+
+    dt |> convert_to_paris_time() |> Calendar.strftime(format)
   end
 
-  def format_datetime_to_paris(%DateTime{} = dt, nil) do
-    format_datetime_to_paris(dt, "fr")
+  def format_datetime_to_paris(%DateTime{} = dt, "en", options) do
+    format =
+      if Keyword.get(options, :with_seconds) do
+        "%Y-%m-%d at %H:%M:%S Europe/Paris"
+      else
+        "%Y-%m-%d at %H:%M Europe/Paris"
+      end
+
+    dt |> convert_to_paris_time() |> Calendar.strftime(format)
   end
 
-  def format_datetime_to_paris(%DateTime{} = dt, "en") do
-    dt
-    |> convert_to_paris_time()
-    |> Calendar.strftime("%Y-%m-%d at %H:%M Europe/Paris")
-  end
-
-  def format_datetime_to_paris(%NaiveDateTime{} = ndt, locale) do
+  def format_datetime_to_paris(%NaiveDateTime{} = ndt, locale, options) do
     ndt
     |> convert_to_paris_time()
-    |> format_datetime_to_paris(locale)
+    |> format_datetime_to_paris(locale, options)
   end
 
-  def format_datetime_to_paris(datetime, locale) when is_binary(datetime) do
+  def format_datetime_to_paris(datetime, locale, options) when is_binary(datetime) do
     datetime
     |> Timex.parse!("{ISO:Extended}")
-    |> format_datetime_to_paris(locale)
+    |> format_datetime_to_paris(locale, options)
   end
 
-  def format_datetime_to_paris(nil, _), do: ""
+  def format_datetime_to_paris(nil, _, _), do: ""
 
   defp convert_to_paris_time(%DateTime{} = dt), do: dt |> Timex.Timezone.convert("Europe/Paris")
   defp convert_to_paris_time(%NaiveDateTime{} = ndt), do: ndt |> Timex.Timezone.convert("Europe/Paris")

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -6,6 +6,7 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   use Phoenix.LiveView
   use TransportWeb.InputHelpers
   import TransportWeb.Gettext
+  import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 3]
 
   def mount(
         _params,
@@ -13,13 +14,14 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
         socket
       ) do
     Gettext.put_locale(locale)
-    {:ok, socket |> assign(validation_id: validation_id, current_url: current_url) |> update_data()}
+    data = %{validation_id: validation_id, current_url: current_url, locale: locale}
+    {:ok, socket |> assign(data) |> update_data()}
   end
 
   defp update_data(socket) do
     socket =
       assign(socket,
-        last_updated_at: (Time.utc_now() |> Time.truncate(:second) |> to_string()) <> " UTC",
+        last_updated_at: DateTime.utc_now(),
         validation: DB.Repo.get!(DB.Validation, socket_value(socket, :validation_id))
       )
 
@@ -60,4 +62,8 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   end
 
   defp socket_value(%Phoenix.LiveView.Socket{assigns: assigns}, key), do: Map.fetch!(assigns, key)
+
+  def format_datetime(dt, locale) do
+    format_datetime_to_paris(dt, locale, with_seconds: true)
+  end
 end

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -11,7 +11,7 @@
       </p>
       <%= if is_final_state do %>
         <p class="small">
-          <%= dgettext("validations", "Validation performed at %{date}.", date: @validation.date) %>
+          <%= dgettext("validations", "Validation performed at %{date}.", date: format_datetime(@validation.date, @locale)) %>
         </p>
       <% end %>
     </div>
@@ -39,7 +39,7 @@
             <%= TransportWeb.ValidationView.render("_errors_warnings_count.html", nb_errors: Map.fetch!(details, "errors_count"), nb_warnings: Map.fetch!(details, "warnings_count")) %>
 
             <p>
-              <%= dgettext("validations", "Validation performed at %{date}.", date: @validation.date) %>
+              <%= dgettext("validations", "Validation performed at %{date}.", date: format_datetime(@validation.date, @locale)) %>
             </p>
 
             <h4><%= dgettext("validations", "Feed details")%></h4>
@@ -57,7 +57,7 @@
                 <%= raw dgettext("validations", ~s(This validation concerns the given GTFS-RT feed and GTFS file and has been carried out using the <a href="%{validator_url}" target="_blank">CUTR GTFS-RT validator</a>. It does not validate the GTFS itself. You can validate your GTFS file <a href="%{gtfs_validator}">using our GTFS validator</a>.), gtfs_validator: TransportWeb.Router.Helpers.live_path(@socket, TransportWeb.Live.OnDemandValidationSelectLive, type: "gtfs"), validator_url: TransportWeb.ResourceView.gtfs_rt_validator_url()) %>
               </p>
               <p>
-                <%= dgettext("validations", ~s(GTFS-RT feeds change in real-time. This validation report shows the validation result performed at %{date}. You can relaunch a validation later on and get different results.), date: @validation.date) %>
+                <%= dgettext("validations", ~s(GTFS-RT feeds change in real-time. This validation report shows the validation result performed at %{date}. You can relaunch a validation later on and get different results.), date: format_datetime(@validation.date, @locale)) %>
               </p>
             </div>
 
@@ -104,7 +104,7 @@
         <% end %>
         <%= unless is_final_state do %>
           <p class="small">
-            <%= dgettext("validations", "Last updated at %{date}.", date: @last_updated_at)%>
+            <%= dgettext("validations", "Last updated at %{date}.", date: format_datetime(@last_updated_at, @locale)) %>
           </p>
         <% end %>
       </div>


### PR DESCRIPTION
Utilisation de la nouvelle fonction `format_datetime_to_paris` pour avoir quelque chose de plus agréable et modification de celle-ci pour pouvoir afficher de manière optionelle les secondes, utiles pour la validation à la demande (en particulier lors de l'attente du résultat).

![image](https://user-images.githubusercontent.com/295709/158830931-e64d93d3-7f92-4317-afd8-98b70420ebf6.png)
