### PR TITLE
Ajout attributs pour ressources dans l'API

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -189,7 +189,12 @@ defmodule TransportWeb.API.DatasetController do
         "content_hash" => resource.content_hash,
         "community_resource_publisher" => resource.community_resource_publisher,
         "metadata" => resource.metadata,
-        "original_resource_url" => resource.original_resource_url
+        "original_resource_url" => resource.original_resource_url,
+        "filesize" => resource.filesize,
+        "modes" => resource.modes,
+        "features" => resource.features,
+        "schema_name" => resource.schema_name,
+        "schema_version" => resource.schema_version
       }
       |> Enum.filter(fn {_, v} -> !is_nil(v) end)
       |> Enum.into(%{})

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -45,6 +45,82 @@ defmodule TransportWeb.DatasetControllerTest do
     conn |> recycle() |> put_req_header("if-none-match", etag) |> get(path) |> response(304)
   end
 
+  test "GET /api/datasets/:id", %{conn: conn} do
+    dataset =
+      %DB.Dataset{
+        spatial: "title",
+        type: "public-transit",
+        datagouv_id: "datagouv",
+        slug: "slug-1",
+        resources: [
+          %DB.Resource{
+            url: "https://link.to/file.zip",
+            latest_url: "https://static.data.gouv.fr/foo",
+            content_hash: "hash",
+            datagouv_id: "1",
+            format: "GTFS",
+            filesize: 42
+          },
+          %DB.Resource{
+            url: "http://link.to/file.zip?foo=bar",
+            datagouv_id: "2",
+            metadata: %{"has_errors" => false},
+            format: "geojson",
+            schema_name: "etalab/schema-zfe"
+          }
+        ],
+        aom: %DB.AOM{id: 4242, nom: "Angers Métropole", siren: "siren"}
+      }
+      |> DB.Repo.insert!()
+
+    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _ -> [] end)
+
+    path = TransportWeb.API.Router.Helpers.dataset_path(conn, :by_id, dataset.datagouv_id)
+
+    assert %{
+             "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
+             "community_resources" => [],
+             "covered_area" => %{
+               "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
+               "name" => "Angers Métropole",
+               "type" => "aom"
+             },
+             "created_at" => nil,
+             "datagouv_id" => "datagouv",
+             "history" => [],
+             "id" => "datagouv",
+             "page_url" => "http://127.0.0.1:5100/datasets/slug-1",
+             "publisher" => %{"name" => nil, "type" => "organization"},
+             "resources" => [
+               %{
+                 "content_hash" => "hash",
+                 "datagouv_id" => "1",
+                 "features" => [],
+                 "filesize" => 42,
+                 "format" => "GTFS",
+                 "modes" => [],
+                 "original_url" => "https://link.to/file.zip",
+                 "updated" => "",
+                 "url" => "https://static.data.gouv.fr/foo"
+               },
+               %{
+                 "datagouv_id" => "2",
+                 "features" => [],
+                 "format" => "geojson",
+                 "metadata" => %{"has_errors" => false},
+                 "modes" => [],
+                 "original_url" => "http://link.to/file.zip?foo=bar",
+                 "schema_name" => "etalab/schema-zfe",
+                 "updated" => ""
+               }
+             ],
+             "slug" => "slug-1",
+             "title" => "title",
+             "type" => "public-transit",
+             "updated" => ""
+           } == conn |> get(path) |> json_response(200)
+  end
+
   test "the search custom message gets displayed", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index, type: "public-transit"))
     html = html_response(conn, 200)


### PR DESCRIPTION
Fixes #1850 (ouvert depuis longtemps !)

Ajout des champs suivants pour chaque ressource dans l'API :
- filesize
- modes
- features
- schema_name
- schema_version

qui étaient manquants jusqu'à présent. Certains me paraissent très importants pour des intégrations tierces, comme les schémas.

J'ai écrit un premier test (:grimacing:) pour `dataset#by_id` au passage.