### PR TITLE
Correction d'une erreure 500 sur la validation de certains GBFS

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -23,31 +23,24 @@ defmodule Transport.Shared.GBFSMetadata do
   """
   @impl Transport.Shared.GBFSMetadata.Wrapper
   def compute_feed_metadata(url, cors_base_url) do
-    with {:ok, %{status_code: 200, body: body} = response} <-
-           http_client().get(url, [{"origin", cors_base_url}]),
-         {:ok, json} <- Jason.decode(body) do
-      try do
-        %{
-          validation: validation(url),
-          has_cors: has_cors?(response),
-          is_cors_allowed: cors_headers_allows_self?(cors_base_url, response),
-          feeds: feeds(json),
-          versions: versions(json),
-          languages: languages(json),
-          system_details: system_details(json),
-          types: types(json),
-          ttl: ttl(json)
-        }
-      rescue
-        e in FunctionClauseError ->
-          Logger.error(inspect(e))
-          %{}
-      end
-    else
-      e ->
-        Logger.error(inspect(e))
-        %{}
-    end
+    {:ok, %{status_code: 200, body: body} = response} = http_client().get(url, [{"origin", cors_base_url}])
+    {:ok, json} = Jason.decode(body)
+
+    %{
+      validation: validation(url),
+      has_cors: has_cors?(response),
+      is_cors_allowed: cors_headers_allows_self?(cors_base_url, response),
+      feeds: feeds(json),
+      versions: versions(json),
+      languages: languages(json),
+      system_details: system_details(json),
+      types: types(json),
+      ttl: ttl(json)
+    }
+  rescue
+    e ->
+      Logger.error(inspect(e))
+      %{}
   end
 
   @spec validation(binary()) :: GBFSValidationSummary.t() | nil


### PR DESCRIPTION
closes #2151 

On avait une exception dans le try do, mais qui n'était pas du bon type, du coup ça faisait une 500. Maintenant on attrape tout.