### PR TITLE
Un peu de ménage dans le schéma de la ressource

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -14,7 +14,6 @@ defmodule DB.Resource do
   require Logger
 
   typed_schema "resource" do
-    field(:is_active, :boolean)
     # real url
     field(:url, :string)
     field(:format, :string)
@@ -399,7 +398,6 @@ defmodule DB.Resource do
     |> cast(
       params,
       [
-        :is_active,
         :url,
         :format,
         :last_import,

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -31,8 +31,6 @@ defmodule DB.Resource do
     # all the detected modes of the ressource
     field(:modes, {:array, :string}, default: [])
 
-    field(:conversion_latest_content_hash, :string)
-
     field(:is_community_resource, :boolean)
 
     # the declared official schema used by the resource

--- a/apps/db/priv/repo/migrations/20220321151717_remove_resource_conversion_content_hash.exs
+++ b/apps/db/priv/repo/migrations/20220321151717_remove_resource_conversion_content_hash.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.RemoveResourceConversionContentHash do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      remove :conversion_latest_content_hash, :string, default: ""
+    end
+  end
+end

--- a/apps/db/priv/repo/migrations/20220321151717_remove_resource_deprecated_fields.exs
+++ b/apps/db/priv/repo/migrations/20220321151717_remove_resource_deprecated_fields.exs
@@ -1,9 +1,10 @@
-defmodule DB.Repo.Migrations.RemoveResourceConversionContentHash do
+defmodule DB.Repo.Migrations.RemoveResourceDeprecatedFields do
   use Ecto.Migration
 
   def change do
     alter table(:resource) do
       remove :conversion_latest_content_hash, :string, default: ""
+      remove :is_active, :boolean
     end
   end
 end


### PR DESCRIPTION
Suppresion des champs `is_active` et `conversion_content_hash`.

`is_active` m'a demandé un peu de temps, parce que le champ du même nom pour les Datasets est très largement utilisé partout. Mais celui de resource, je n'ai vu aucune autorisation.