### PR TITLE
Renommer les colonnes titres de %Dataset{}

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -17,7 +17,7 @@ defmodule DB.Dataset do
 
   typed_schema "dataset" do
     field(:datagouv_id, :string)
-    field(:spatial, :string)
+    field(:custom_title, :string)
     field(:created_at, :string)
     field(:description, :string)
     field(:frequency, :string)
@@ -254,7 +254,7 @@ defmodule DB.Dataset do
   end
 
   @spec order_datasets(Ecto.Query.t(), map()) :: Ecto.Query.t()
-  def order_datasets(datasets, %{"order_by" => "alpha"}), do: order_by(datasets, asc: :spatial)
+  def order_datasets(datasets, %{"order_by" => "alpha"}), do: order_by(datasets, asc: :custom_title)
   def order_datasets(datasets, %{"order_by" => "most_recent"}), do: order_by(datasets, desc: :created_at)
 
   def order_datasets(datasets, %{"q" => q}),
@@ -279,7 +279,7 @@ defmodule DB.Dataset do
     |> Repo.preload([:resources, :communes, :region])
     |> cast(params, [
       :datagouv_id,
-      :spatial,
+      :custom_title,
       :created_at,
       :description,
       :frequency,

--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -27,7 +27,7 @@ defmodule DB.Dataset do
     field(:full_logo, :string)
     field(:slug, :string)
     field(:tags, {:array, :string})
-    field(:title, :string)
+    field(:datagouv_title, :string)
     field(:type, :string)
     field(:organization, :string)
     field(:has_realtime, :boolean)
@@ -118,7 +118,7 @@ defmodule DB.Dataset do
     where(
       query,
       [d],
-      fragment("search_vector @@ plainto_tsquery('custom_french', ?) or unaccent(title) = unaccent(?)", ^q, ^q)
+      fragment("search_vector @@ plainto_tsquery('custom_french', ?) or unaccent(datagouv_title) = unaccent(?)", ^q, ^q)
     )
   end
 
@@ -290,7 +290,7 @@ defmodule DB.Dataset do
       :full_logo,
       :slug,
       :tags,
-      :title,
+      :datagouv_title,
       :type,
       :region_id,
       :nb_reuses,

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -14,7 +14,6 @@ defmodule DB.Resource do
   require Logger
 
   typed_schema "resource" do
-    field(:is_active, :boolean)
     # real url
     field(:url, :string)
     field(:format, :string)
@@ -399,7 +398,6 @@ defmodule DB.Resource do
     |> cast(
       params,
       [
-        :is_active,
         :url,
         :format,
         :last_import,

--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -31,8 +31,6 @@ defmodule DB.Resource do
     # all the detected modes of the ressource
     field(:modes, {:array, :string}, default: [])
 
-    field(:conversion_latest_content_hash, :string)
-
     field(:is_community_resource, :boolean)
 
     # the declared official schema used by the resource

--- a/apps/db/priv/repo/migrations/20220321151717_remove_resource_conversion_content_hash.exs
+++ b/apps/db/priv/repo/migrations/20220321151717_remove_resource_conversion_content_hash.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.RemoveResourceConversionContentHash do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      remove :conversion_latest_content_hash, :string, default: ""
+    end
+  end
+end

--- a/apps/db/priv/repo/migrations/20220321151717_remove_resource_deprecated_fields.exs
+++ b/apps/db/priv/repo/migrations/20220321151717_remove_resource_deprecated_fields.exs
@@ -1,9 +1,10 @@
-defmodule DB.Repo.Migrations.RemoveResourceConversionContentHash do
+defmodule DB.Repo.Migrations.RemoveResourceDeprecatedFields do
   use Ecto.Migration
 
   def change do
     alter table(:resource) do
       remove :conversion_latest_content_hash, :string, default: ""
+      remove :is_active, :boolean
     end
   end
 end

--- a/apps/db/priv/repo/migrations/20220322090153_rename_dataset_title_fields.exs
+++ b/apps/db/priv/repo/migrations/20220322090153_rename_dataset_title_fields.exs
@@ -3,5 +3,6 @@ defmodule DB.Repo.Migrations.RenameDatasetTitleFields do
 
   def change do
     rename table(:dataset), :title, to: :datagouv_title
+    rename table(:dataset), :spatial, to: :custom_title
   end
 end

--- a/apps/db/priv/repo/migrations/20220322090153_rename_dataset_title_fields.exs
+++ b/apps/db/priv/repo/migrations/20220322090153_rename_dataset_title_fields.exs
@@ -1,0 +1,7 @@
+defmodule DB.Repo.Migrations.RenameDatasetTitleFields do
+  use Ecto.Migration
+
+  def change do
+    rename table(:dataset), :title, to: :datagouv_title
+  end
+end

--- a/apps/db/priv/repo/migrations/20220322135059_update_search_conf_field_name.exs
+++ b/apps/db/priv/repo/migrations/20220322135059_update_search_conf_field_name.exs
@@ -1,0 +1,125 @@
+defmodule DB.Repo.Migrations.UpdateSearchConfFieldName do
+    use Ecto.Migration
+
+    def up do
+      # same function as before, but spatial columns becomes custom_title
+      execute("""
+      CREATE OR REPLACE FUNCTION dataset_search_update() RETURNS trigger as $$
+      DECLARE
+      nom text;
+      region_nom region.nom%TYPE;
+      population dataset.population%TYPE;
+      BEGIN
+
+      NEW.search_vector = setweight(to_tsvector('custom_french', coalesce(NEW.custom_title, '')), 'B') ||
+      setweight(to_tsvector('custom_french', array_to_string(NEW.tags, ',')), 'C') ||
+      setweight(to_tsvector('custom_french', coalesce(NEW.description, '')), 'D');
+
+      IF NEW.aom_id IS NOT NULL THEN
+      SELECT aom.nom, region.nom, aom.population_totale_2014 INTO nom, region_nom, population
+      FROM aom
+      JOIN region ON region.id = aom.region_id
+      WHERE aom.id = NEW.aom_id;
+
+      NEW.search_vector = NEW.search_vector ||
+      setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A') ||
+      setweight(to_tsvector('custom_french', coalesce(region_nom, '')), 'B');
+      NEW.population = population;
+
+      SELECT string_agg(commune.nom, ' ') INTO nom
+      FROM commune
+      JOIN aom ON aom.composition_res_id = commune.aom_res_id
+      WHERE aom.id = NEW.aom_id;
+
+      NEW.search_vector = NEW.search_vector ||
+      setweight(to_tsvector('custom_french', coalesce(nom, '')), 'B');
+
+      ELSIF NEW.region_id IS NOT NULL THEN
+      SELECT region.nom, SUM(aom.population_totale_2014) INTO nom, population
+      FROM region
+      JOIN aom ON aom.region_id = region.id
+      WHERE region.id = NEW.region_id
+      GROUP BY region.nom;
+
+      NEW.search_vector = NEW.search_vector ||
+      setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A');
+      NEW.population = population;
+      END IF;
+
+      IF EXISTS (SELECT 1 FROM aom WHERE parent_dataset_id = NEW.id) THEN
+      SELECT string_agg(aom.nom, ' ') INTO nom FROM aom WHERE parent_dataset_id = NEW.id;
+
+      NEW.search_vector = NEW.search_vector ||
+      setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A');
+      END IF;
+
+      RETURN NEW;
+      END
+      $$ LANGUAGE plpgsql;
+      """)
+
+      # Force update
+      execute("UPDATE dataset SET id = id", "")
+    end
+
+    def down do
+    # previous function definition, using "spatial" column
+   execute("""
+    CREATE OR REPLACE FUNCTION dataset_search_update() RETURNS trigger as $$
+    DECLARE
+    nom text;
+    region_nom region.nom%TYPE;
+    population dataset.population%TYPE;
+    BEGIN
+
+    NEW.search_vector = setweight(to_tsvector('custom_french', coalesce(NEW.spatial, '')), 'B') ||
+    setweight(to_tsvector('custom_french', array_to_string(NEW.tags, ',')), 'C') ||
+    setweight(to_tsvector('custom_french', coalesce(NEW.description, '')), 'D');
+
+    IF NEW.aom_id IS NOT NULL THEN
+    SELECT aom.nom, region.nom, aom.population_totale_2014 INTO nom, region_nom, population
+    FROM aom
+    JOIN region ON region.id = aom.region_id
+    WHERE aom.id = NEW.aom_id;
+
+    NEW.search_vector = NEW.search_vector ||
+    setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A') ||
+    setweight(to_tsvector('custom_french', coalesce(region_nom, '')), 'B');
+    NEW.population = population;
+
+    SELECT string_agg(commune.nom, ' ') INTO nom
+    FROM commune
+    JOIN aom ON aom.composition_res_id = commune.aom_res_id
+    WHERE aom.id = NEW.aom_id;
+
+    NEW.search_vector = NEW.search_vector ||
+    setweight(to_tsvector('custom_french', coalesce(nom, '')), 'B');
+
+    ELSIF NEW.region_id IS NOT NULL THEN
+    SELECT region.nom, SUM(aom.population_totale_2014) INTO nom, population
+    FROM region
+    JOIN aom ON aom.region_id = region.id
+    WHERE region.id = NEW.region_id
+    GROUP BY region.nom;
+
+    NEW.search_vector = NEW.search_vector ||
+    setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A');
+    NEW.population = population;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM aom WHERE parent_dataset_id = NEW.id) THEN
+    SELECT string_agg(aom.nom, ' ') INTO nom FROM aom WHERE parent_dataset_id = NEW.id;
+
+    NEW.search_vector = NEW.search_vector ||
+    setweight(to_tsvector('custom_french', coalesce(nom, '')), 'A');
+    END IF;
+
+    RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql;
+    """)
+
+      # Force update
+      execute("UPDATE dataset SET id = id", "")
+    end
+end

--- a/apps/db/test/db_dataset_test.exs
+++ b/apps/db/test/db_dataset_test.exs
@@ -136,7 +136,7 @@ defmodule DB.DatasetDBTest do
 
   describe "resources last content update time" do
     test "for a dataset, get resources last update times" do
-      %{id: dataset_id} = insert(:dataset, %{datagouv_id: "xxx", title: "coucou"})
+      %{id: dataset_id} = insert(:dataset, %{datagouv_id: "xxx", datagouv_title: "coucou"})
 
       %{id: resource_id_1} = insert(:resource, %{datagouv_id: datagouv_id_1 = "datagouv_id_1", dataset_id: dataset_id})
       %{id: resource_id_2} = insert(:resource, %{datagouv_id: datagouv_id_2 = "datagouv_id_2", dataset_id: dataset_id})

--- a/apps/db/test/support/factory.ex
+++ b/apps/db/test/support/factory.ex
@@ -26,7 +26,7 @@ defmodule DB.Factory do
 
   def dataset_factory do
     %DB.Dataset{
-      title: "Hello",
+      datagouv_title: "Hello",
       slug: sequence("dataset_slug", fn i -> "dataset-#{i}" end),
       # NOTE: need to figure out how to pass aom/region together with changeset checks here
       datagouv_id: "123",

--- a/apps/transport/lib/transport/comments_checker.ex
+++ b/apps/transport/lib/transport/comments_checker.ex
@@ -105,7 +105,7 @@ defmodule Transport.CommentsChecker do
   defp get_dataset_title(datagouv_id) do
     Dataset
     |> where([d], d.datagouv_id == ^datagouv_id)
-    |> select([d], d.spatial)
+    |> select([d], d.custom_title)
     |> Repo.one()
   end
 

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -159,7 +159,7 @@ defmodule Transport.DataChecker do
 
   def link_and_name(dataset) do
     link = link(dataset)
-    name = dataset.title
+    name = dataset.datagouv_title
 
     " * #{name} - #{link}"
   end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -161,7 +161,8 @@ defmodule Transport.ImportData do
   def prepare_dataset_from_data_gouv_response(%{} = data_gouv_resp, type) do
     dataset =
       data_gouv_resp
-      |> Map.take(["title", "description", "id", "slug", "frequency", "tags"])
+      |> Map.take(["description", "id", "slug", "frequency", "tags"])
+      |> Map.put("datagouv_title", data_gouv_resp["title"])
       |> Map.put("datagouv_id", data_gouv_resp["id"])
       |> Map.put("logo", get_logo_thumbnail(data_gouv_resp))
       |> Map.put("full_logo", get_logo(data_gouv_resp))

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -146,7 +146,7 @@ defmodule TransportWeb.API.DatasetController do
       # to help discoverability, we explicitly add the datagouv_id as the id
       # (since it's used in /dataset/:id)
       "id" => dataset.datagouv_id,
-      "title" => dataset.spatial,
+      "title" => dataset.custom_title,
       "created_at" => dataset.created_at,
       "page_url" => TransportWeb.Router.Helpers.dataset_url(conn, :details, dataset.slug),
       "slug" => dataset.slug,

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -303,8 +303,8 @@ defmodule TransportWeb.API.StatsController do
       |> join(:left, [gv], dataset in Dataset, on: dataset.id == gv.dataset_id)
       |> select([gv, dataset], %{
         geometry: fragment("ST_Centroid(geom) as geometry"),
-        names: fragment("array_agg(? order by ? asc)", dataset.spatial, dataset.spatial),
-        slugs: fragment("array_agg(? order by ? asc)", dataset.slug, dataset.spatial)
+        names: fragment("array_agg(? order by ? asc)", dataset.custom_title, dataset.custom_title),
+        slugs: fragment("array_agg(? order by ? asc)", dataset.slug, dataset.custom_title)
       })
       |> where([_gv, dataset], dataset.type == "bike-scooter-sharing" and dataset.is_active)
       |> group_by(fragment("geometry"))

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -259,7 +259,7 @@ defmodule TransportWeb.API.StatsController do
           )
       },
       parent_dataset_slug: parent_dataset.slug,
-      parent_dataset_name: parent_dataset.title
+      parent_dataset_name: parent_dataset.datagouv_title
     })
   end
 

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -237,7 +237,7 @@ defmodule TransportWeb.Backoffice.PageController do
     order_by =
       case params do
         %{"order_by" => "end_date"} -> :end_date
-        %{"order_by" => "spatial"} -> :spatial
+        %{"order_by" => "custom_title"} -> :custom_title
         _ -> nil
       end
 
@@ -250,7 +250,7 @@ defmodule TransportWeb.Backoffice.PageController do
 
     case field do
       :end_date -> order_by(query, [d, r], {^dir, field(r, :end_date)})
-      :spatial -> order_by(query, [d, r], {^dir, field(d, :spatial)})
+      :custom_title -> order_by(query, [d, r], {^dir, field(d, :custom_title)})
       _ -> query
     end
   end

--- a/apps/transport/lib/transport_web/templates/atom/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/atom/index.html.eex
@@ -10,11 +10,11 @@
 
   <%= for resource <- @resources do %>
   <entry>
-    <title><%= resource.dataset.spatial %> — <%= resource.title %></title>
+    <title><%= resource.dataset.custom_title %> — <%= resource.title %></title>
     <link href="<%= resource.latest_url %>" />
     <id><%= resource_url(@conn, :details, resource.id) %></id>
     <updated><%= DateTimeDisplay.format_naive_datetime_to_paris_tz(resource.last_update) %></updated>
-    <summary>Cette resource fait partie du jeux de données <%= resource.dataset.spatial %></summary>
+    <summary>Cette resource fait partie du jeux de données <%= resource.dataset.custom_title %></summary>
     <content type="html">
       <![CDATA[
       <%= TransportWeb.MarkdownHandler.markdown_to_safe_html!(resource.dataset.description) %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.eex
@@ -1,7 +1,7 @@
 <tr>
   <td>
     <strong>
-      <%= @dataset.spatial %>
+      <%= @dataset.custom_title %>
     </strong>
   </td>
   <td class="is-centered">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -11,9 +11,9 @@
         placeholder: dgettext("backoffice", "Dataset's url"),
         value: if not is_nil(@dataset) do Dataset.datagouv_url(@dataset) else "" end
       ] %>
-  <%= text_input f, :spatial, [
+  <%= text_input f, :custom_title, [
         placeholder: dgettext("backoffice", "name"),
-        value: if not is_nil(@dataset) do @dataset.spatial else "" end
+        value: if not is_nil(@dataset) do @dataset.custom_title else "" end
       ] %>
   <%= select f, :type, @dataset_types, [
         selected: if not is_nil(@dataset) do @dataset.type else "public-transit" end ]%>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.eex
@@ -86,7 +86,7 @@
   </div>
   <table class="backoffice-datasets">
     <tr>
-      <th class="sortable"><%= backoffice_sort_link(@conn, "Dataset", :spatial, @order_by) %>
+      <th class="sortable"><%= backoffice_sort_link(@conn, "Dataset", :custom_title, @order_by) %>
       </th>
       <th>transport</th>
       <th>data.gouv.fr</th>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -7,7 +7,7 @@
 <div class="dataset-title-div" id="dataset-top">
   <%= dgettext("page-dataset-details", "dataset")%>
   <h1>
-    <%= @dataset.spatial %>
+    <%= @dataset.custom_title %>
   </h1>
   <%= if admin?(assigns[:current_user]) do %>
     <i class="fa fa-external-link-alt"></i>
@@ -220,7 +220,7 @@
       <ul>
         <%= for dataset <- @other_datasets do %>
           <li><%= link(
-            dataset.spatial,
+            dataset.custom_title,
             to: dataset_path(@conn, :details, dataset.slug)
           ) %></li>
         <% end %>
@@ -232,7 +232,7 @@
 <div class="dataset-metas">
   <div class="panel">
     <div class="dataset__logo">
-      <%= img_tag(@dataset.full_logo, alt: @dataset.spatial) %>
+      <%= img_tag(@dataset.full_logo, alt: @dataset.custom_title) %>
     </div>
     <div>
       <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(@dataset) %>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -232,7 +232,7 @@
 <div class="dataset-metas">
   <div class="panel">
     <div class="dataset__logo">
-      <%= img_tag(@dataset.full_logo, alt: @dataset.title) %>
+      <%= img_tag(@dataset.full_logo, alt: @dataset.spatial) %>
     </div>
     <div>
       <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(@dataset) %>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -1,24 +1,24 @@
 <div class="container dataset-page-top">
   <div class="form__group">
     <%= form_for @conn, dataset_path(@conn, :index), [method: "get", class: "shortlist-form"], fn f -> %>
-      <div class="searchBar">
-        <%= search_input f, :q, [id: "autoComplete", autocomplete: "off", value: assigns[:q] || "", placeholder: dgettext("page-index", "Find dataset"), "aria-label": dgettext("page-index", "Find dataset")] %>
-        <div class="autoCompleteResultsField">
-          <div id="autoCompleteResults">
-          </div>
+    <div class="searchBar">
+      <%= search_input f, :q, [id: "autoComplete", autocomplete: "off", value: assigns[:q] || "", placeholder: dgettext("page-index", "Find dataset"), "aria-label": dgettext("page-index", "Find dataset")] %>
+      <div class="autoCompleteResultsField">
+        <div id="autoCompleteResults">
         </div>
-    <% end %>
+      </div>
+      <% end %>
     </div>
     <div class="dataset-page-title">
       <%= if @conn.assigns[:page_title] do %>
-        <%= @page_title.type %>
-        <h1> <%= @page_title.name %> </h1>
+      <%= @page_title.type %>
+      <h1> <%= @page_title.name %> </h1>
       <% else  %>
-        <%= if @conn.assigns[:q] do %>
-          <h1><%= @datasets.total_entries %> <%= dngettext("page-shortlist", "result", "results", @datasets.total_entries) %> pour "<%= @q %>" </h1>
-        <% else %>
-        <h1><%= dgettext("page-index", "Datasets") %></h1>
-        <% end %>
+      <%= if @conn.assigns[:q] do %>
+      <h1><%= @datasets.total_entries %> <%= dngettext("page-shortlist", "result", "results", @datasets.total_entries) %> pour "<%= @q %>" </h1>
+      <% else %>
+      <h1><%= dgettext("page-index", "Datasets") %></h1>
+      <% end %>
       <% end %>
     </div>
   </div>
@@ -26,140 +26,140 @@
 
 
 <%= if @conn.assigns[:category_custom_message] do %>
-  <%= render TransportWeb.DatasetView, "_custom_message.html", conn: @conn, msg: @category_custom_message %>
+<%= render TransportWeb.DatasetView, "_custom_message.html", conn: @conn, msg: @category_custom_message %>
 <% end %>
 
 <%= if is_nil(@conn.assigns[:q]) or @datasets.total_entries > 0  do %>
-  <section id="datasets-results" class="section-grey">
-    <div class="container">
-      <div class="shortlist">
-        <nav class="side-pane" role="navigation">
-          <div class="pt-48">
-            <ul class="side-pane__menu">
+<section id="datasets-results" class="section-grey">
+  <div class="container">
+    <div class="shortlist">
+      <nav class="side-pane" role="navigation">
+        <div class="pt-48">
+          <ul class="side-pane__menu">
 
-              <li class="side-pane__title">
-                <h3><%= dgettext("page-shortlist", "Data type") %></h3>
-                <li class="side-pane__dropdown unfolded">
-                  <ul class="side-pane__submenu">
-                    <li><%= type_link(@conn, %{msg: dgettext("page-shortlist", "All"), type: nil, count: @types |> Enum.map(&(&1.count)) |> Enum.sum}) %></li>
-                    <%= for type <- @types do %>
-                      <li><%= type_link(@conn, type) %></li>
-                    <% end %>
-                  </ul>
-                </li>
-              </li>
+            <li class="side-pane__title">
+              <h3><%= dgettext("page-shortlist", "Data type") %></h3>
+            <li class="side-pane__dropdown unfolded">
+              <ul class="side-pane__submenu">
+                <li><%= type_link(@conn, %{msg: dgettext("page-shortlist", "All"), type: nil, count: @types |> Enum.map(&(&1.count)) |> Enum.sum}) %></li>
+                <%= for type <- @types do %>
+                <li><%= type_link(@conn, type) %></li>
+                <% end %>
+              </ul>
+            </li>
+            </li>
 
-              <li class="side-pane__title">
-                <h3><%= dgettext("page-shortlist", "Real Time") %></h3>
-                <li class="side-pane__dropdown unfolded">
-                  <ul class="side-pane__submenu">
-                    <li><%= real_time_link(@conn, %{only_realtime: false, msg: dgettext("page-shortlist", "Any"), count: @number_realtime_datasets.all}) %></li>
-                    <li><%= real_time_link(@conn, %{only_realtime: true, msg: dgettext("page-shortlist", "with real time"), count: @number_realtime_datasets.true}) %></li>
-                  </ul>
-                </li>
-              </li>
+            <li class="side-pane__title">
+              <h3><%= dgettext("page-shortlist", "Real Time") %></h3>
+            <li class="side-pane__dropdown unfolded">
+              <ul class="side-pane__submenu">
+                <li><%= real_time_link(@conn, %{only_realtime: false, msg: dgettext("page-shortlist", "Any"), count: @number_realtime_datasets.all}) %></li>
+                <li><%= real_time_link(@conn, %{only_realtime: true, msg: dgettext("page-shortlist", "with real time"), count: @number_realtime_datasets.true}) %></li>
+              </ul>
+            </li>
+            </li>
 
-              <%= if assigns[:regions] do %>
-                <li class="side-pane__title">
-                  <h3><%= dgettext("page-shortlist", "Regions") %></h3>
-                  <li class="side-pane__dropdown unfolded">
-                    <ul class="side-pane__submenu">
-                      <li><%= region_link(@conn, %{nom: dgettext("page-shortlist", "All"), count: @regions |> Enum.map(&(&1.count)) |> Enum.sum, id: nil}) %></li>
-                      <%= for region <- @regions do %>
-                        <%= unless region.count == 0 do %>
-                          <li><%= region_link(@conn, region) %></li>
-                        <% end %>
-                      <% end %>
-                    </ul>
-                  </li>
-                </li>
-              <% end %>
+            <%= if assigns[:regions] do %>
+            <li class="side-pane__title">
+              <h3><%= dgettext("page-shortlist", "Regions") %></h3>
+            <li class="side-pane__dropdown unfolded">
+              <ul class="side-pane__submenu">
+                <li><%= region_link(@conn, %{nom: dgettext("page-shortlist", "All"), count: @regions |> Enum.map(&(&1.count)) |> Enum.sum, id: nil}) %></li>
+                <%= for region <- @regions do %>
+                <%= unless region.count == 0 do %>
+                <li><%= region_link(@conn, region) %></li>
+                <% end %>
+                <% end %>
+              </ul>
+            </li>
+            </li>
+            <% end %>
 
-            </ul>
+          </ul>
+        </div>
+      </nav>
+      <div class="main-pane transparent">
+        <%= if @conn.assigns[:empty_message] do %>
+        <div class="container pt-48">
+          <div class="notification">
+            <%= @empty_message %>
           </div>
-        </nav>
-          <div class="main-pane transparent">
-            <%= if @conn.assigns[:empty_message] do %>
-              <div class="container pt-48">
-                <div class="notification">
-                  <%= @empty_message %>
-                </div>
-              </div>
-            <% else %>
-              <div class="order-by">
-                <span class="order-by__title"><%= dgettext("page-shortlist", "Order by") %></span>
-                <span class="order-by-option"><%= order_link(@conn, "alpha") %></span>
-                <span class="order-by-option"><%= order_link(@conn, "most_recent") %> </span>
-              </div>
+        </div>
+        <% else %>
+        <div class="order-by">
+          <span class="order-by__title"><%= dgettext("page-shortlist", "Order by") %></span>
+          <span class="order-by-option"><%= order_link(@conn, "alpha") %></span>
+          <span class="order-by-option"><%= order_link(@conn, "most_recent") %> </span>
+        </div>
 
-              <%= for dataset <- @datasets do %>
-                <div class="panel dataset__panel">
-                  <div class="panel__content">
-                    <div class="dataset__description" >
-                      <div class="dataset__image" data-provider="<%= dataset.title%>">
-                        <%= img_tag(dataset.logo, alt: dataset.title) %>
-                      </div>
-                      <div class="dataset__infos">
-                        <h3 class="dataset__title">
-                          <a href="/datasets/<%= dataset.slug %>/">
-                            <%= dataset.spatial %>
-                          </a>
-                          <%= if admin?(assigns[:current_user]) do %>
-                            <span class="dataset-backoffice-link">
-                              <i class="fa fa-external-link-alt"></i>
-                              <%= link("backoffice", to: backoffice_page_path(@conn, :edit, dataset.id)) %>
-                            </span>
-                          <% end %>
-                        </h3>
-                        <div class="dataset-localization">
-                          <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(dataset) %></<i>
-                        </div>
-                      </div>
-                    </div>
-                    <%= unless is_nil(icon_type_path(dataset)) do %>
-                      <div class="dataset__type">
-                        <%= img_tag(icon_type_path(dataset), alt: dataset.type) %>
-                      </div>
-                    <% end %>
-                  </div>
-                  <div class="panel__extra">
-                    <div class="dataset__info">
-                      <div class="shortlist__notices">
-                        <div class="dataset-udpate-date ml-1em">
-                          <%= dgettext("page-shortlist", "added on") %> <%= DateTimeDisplay.format_date(dataset.created_at, get_session(@conn, :locale)) %>
-                        </div>
-                        <dl class="dataset-format shortlist__notice">
-                          <%= unless Dataset.formats(dataset) == [] do %>
-                            <dt class="shortlist__label"><%= dgettext("page-shortlist", "Format") %></dt>
-                            <%= for format <- Dataset.formats(dataset) do %>
-                              <dd class="label"><%= format %></dd>
-                            <% end %>
-                          <% end %>
-                        </dl>
-                        <div class="dataset-type-text">
-                          <%= Dataset.type_to_str(dataset.type) %>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+        <%= for dataset <- @datasets do %>
+        <div class="panel dataset__panel">
+          <div class="panel__content">
+            <div class="dataset__description">
+              <div class="dataset__image" data-provider="<%= dataset.spatial%>">
+                <%= img_tag(dataset.logo, alt: dataset.spatial) %>
+              </div>
+              <div class="dataset__infos">
+                <h3 class="dataset__title">
+                  <a href="/datasets/<%= dataset.slug %>/">
+                    <%= dataset.spatial %>
+                  </a>
+                  <%= if admin?(assigns[:current_user]) do %>
+                  <span class="dataset-backoffice-link">
+                    <i class="fa fa-external-link-alt"></i>
+                    <%= link("backoffice", to: backoffice_page_path(@conn, :edit, dataset.id)) %>
+                  </span>
+                  <% end %>
+                </h3>
+                <div class="dataset-localization">
+                  <i class="fa fa-map-marker-alt"></i> <%= Dataset.get_territory_or_nil(dataset) %></<i>
                 </div>
-              <% end %>
+              </div>
+            </div>
+            <%= unless is_nil(icon_type_path(dataset)) do %>
+            <div class="dataset__type">
+              <%= img_tag(icon_type_path(dataset), alt: dataset.type) %>
+            </div>
             <% end %>
           </div>
+          <div class="panel__extra">
+            <div class="dataset__info">
+              <div class="shortlist__notices">
+                <div class="dataset-udpate-date ml-1em">
+                  <%= dgettext("page-shortlist", "added on") %> <%= DateTimeDisplay.format_date(dataset.created_at, get_session(@conn, :locale)) %>
+                </div>
+                <dl class="dataset-format shortlist__notice">
+                  <%= unless Dataset.formats(dataset) == [] do %>
+                  <dt class="shortlist__label"><%= dgettext("page-shortlist", "Format") %></dt>
+                  <%= for format <- Dataset.formats(dataset) do %>
+                  <dd class="label"><%= format %></dd>
+                  <% end %>
+                  <% end %>
+                </dl>
+                <div class="dataset-type-text">
+                  <%= Dataset.type_to_str(dataset.type) %>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="shortlist__pagination">
-          <%= pagination_links @conn, @datasets %>
-        </div>
-        <div class="api-link">
-          <i class="fas fa-cogs"></i>
-          <%= link(
+        <% end %>
+        <% end %>
+      </div>
+    </div>
+    <div class="shortlist__pagination">
+      <%= pagination_links @conn, @datasets %>
+    </div>
+    <div class="api-link">
+      <i class="fas fa-cogs"></i>
+      <%= link(
           dgettext("page-shortlist", "Get dataset list via an API"),
           to: "#{swagger_ui_path(@conn, [path: "/api/openapi"])}#/datasets/API.DatasetController.datasets"
         )
         %>
-          -
-        </div>
-      </div>
-    </section>
-  <% end %>
-  <script src="<%= static_path(@conn, "/js/autocomplete.js") %>"></script>
+      -
+    </div>
+  </div>
+</section>
+<% end %>
+<script src="<%= static_path(@conn, "/js/autocomplete.js") %>"></script>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.eex
@@ -96,13 +96,13 @@
         <div class="panel dataset__panel">
           <div class="panel__content">
             <div class="dataset__description">
-              <div class="dataset__image" data-provider="<%= dataset.spatial%>">
-                <%= img_tag(dataset.logo, alt: dataset.spatial) %>
+              <div class="dataset__image" data-provider="<%= dataset.custom_title%>">
+                <%= img_tag(dataset.logo, alt: dataset.custom_title) %>
               </div>
               <div class="dataset__infos">
                 <h3 class="dataset__title">
                   <a href="/datasets/<%= dataset.slug %>/">
-                    <%= dataset.spatial %>
+                    <%= dataset.custom_title %>
                   </a>
                   <%= if admin?(assigns[:current_user]) do %>
                   <span class="dataset-backoffice-link">

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
@@ -18,16 +18,16 @@
           </div>
           <div class="resource-list">
             <%= if @datasets == [] do %>
-              <%= dgettext("espace-producteurs", "You have no resource to update for the moment") %>
+            <%= dgettext("espace-producteurs", "You have no resource to update for the moment") %>
             <% end %>
             <%= for dataset <- @datasets do %>
-              <div class="pt-24 panel dataset-item">
-                <strong><%= dataset.title %></strong>
-                <div class="pt-12">
-                  <%= link(dgettext("espace-producteurs", "Update a resource"),to: resource_path(@conn, :resources_list, dataset.datagouv_id), class: "button-outline primary small") %>
-                  <%= link(dgettext("espace-producteurs", "Add a resource"),to: resource_path(@conn, :form, dataset.datagouv_id), class: "button-outline secondary small") %>
-                </div>
+            <div class="pt-24 panel dataset-item">
+              <strong><%= dataset.datagouv_title %></strong>
+              <div class="pt-12">
+                <%= link(dgettext("espace-producteurs", "Update a resource"),to: resource_path(@conn, :resources_list, dataset.datagouv_id), class: "button-outline primary small") %>
+                <%= link(dgettext("espace-producteurs", "Add a resource"),to: resource_path(@conn, :form, dataset.datagouv_id), class: "button-outline secondary small") %>
               </div>
+            </div>
             <% end %>
           </div>
         </div>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -11,7 +11,7 @@
           </a>
         </p>
         <p>
-          <%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.title, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.
+          <%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.spatial, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.
         </p>
         <%= render "_validation_report.html", resource: @resource, conn: @conn %>
       </div>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -11,7 +11,7 @@
           </a>
         </p>
         <p>
-          <%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.spatial, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.
+          <%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.custom_title, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.
         </p>
         <%= render "_validation_report.html", resource: @resource, conn: @conn %>
       </div>

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -4,16 +4,16 @@
   <section class="pt-48 pb-24">
     <div class="container">
       <%= if new_resource do %>
-        <%= breadcrumbs [@conn, :new_resource] %>
+      <%= breadcrumbs [@conn, :new_resource] %>
       <% else %>
-        <%= breadcrumbs [@conn, :update_resource, @dataset["id"]] %>
+      <%= breadcrumbs [@conn, :update_resource, @dataset["id"]] %>
       <% end %>
     </div>
   </section>
   <section class="choose-file">
 
     <div class="container pt-24">
-      <strong><%= @dataset["title"] %></strong>
+      <strong><%= @dataset["datagouv_title"] %></strong>
       <div class="pt-24">
         <h2><%= title(@conn) %></h2>
       </div>
@@ -21,15 +21,15 @@
         <div class="panel">
           <div>
             <%= if new_resource do %>
-              <h4> <%= dgettext("resource", "Option 1: Directly add the resource") %> </h4>
-              <p>
-                <%= dgettext("resource", "This option allows you to add the resource on data.gouv.fr, directly from here.") %>
-              </p>
+            <h4> <%= dgettext("resource", "Option 1: Directly add the resource") %> </h4>
+            <p>
+              <%= dgettext("resource", "This option allows you to add the resource on data.gouv.fr, directly from here.") %>
+            </p>
             <% else %>
-              <h4> <%= dgettext("resource", "Option 1: Directly update the resource") %> </h4>
-              <p>
-                <%= dgettext("resource", "This option allows you to update the resource on data.gouv.fr, directly from here.") %>
-              </p>
+            <h4> <%= dgettext("resource", "Option 1: Directly update the resource") %> </h4>
+            <p>
+              <%= dgettext("resource", "This option allows you to update the resource on data.gouv.fr, directly from here.") %>
+            </p>
             <% end %>
           </div>
           <div>
@@ -50,33 +50,33 @@ value: resource["format"]
 %>
             <div class="pt-48">
               <%= if new_resource do %>
-                <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
-                <div class="choose-or">
-                  - <%= dgettext("resource", "or") %> -
-                </div>
-                <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
-                <div class="choose-submit pt-24">
-                  <%= submit dgettext("resource", "Add the resource"), class: "button primary" %>
-                </div>
+              <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
+              <div class="choose-or">
+                - <%= dgettext("resource", "or") %> -
+              </div>
+              <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+              <div class="choose-submit pt-24">
+                <%= submit dgettext("resource", "Add the resource"), class: "button primary" %>
+              </div>
               <% else %>
-                <%= if remote?(resource) do %>
-                  <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
-                <% else %>
-                  <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
-                <% end %>
-                <div class="choose-submit pt-24">
-                  <%= submit dgettext("resource", "Update the resource"), class: "button primary" %>
-                </div>
+              <%= if remote?(resource) do %>
+              <%= render "_specify_url.html", resource: resource, f: f, conn: @conn %>
+              <% else %>
+              <%= render "_upload_file.html", resource: resource, f: f, conn: @conn %>
+              <% end %>
+              <div class="choose-submit pt-24">
+                <%= submit dgettext("resource", "Update the resource"), class: "button primary" %>
+              </div>
               <% end %>
             </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="option-2 mt-48">
-      <div class="panel">
-        <div>
-          <%= if new_resource do %>
+      <div class="option-2 mt-48">
+        <div class="panel">
+          <div>
+            <%= if new_resource do %>
             <h4><%= dgettext("resource", "Option 2: for more options, create the resource on data.gouv.fr") %></h4>
             <div>
               <a class="button primary" href="<%= link_to_datagouv_resource_creation(@dataset["id"]) %>" role="link" target="_blank">
@@ -84,7 +84,7 @@ value: resource["format"]
                 <%=dgettext("resource", "Create it directly on data.gouv.fr")%>
               </a>
             </div>
-          <% else %>
+            <% else %>
             <h4><%= dgettext("resource", "Option 2: for more options, edit the resource on data.gouv.fr") %></h4>
             <div>
               <a class="button primary" href="<%= link_to_datagouv_resource_edit(@dataset["id"], @conn.params["resource_id"]) %>" role="link" target="_blank">
@@ -92,20 +92,20 @@ value: resource["format"]
                 <%= dgettext("resource", "Edit directly on data.gouv.fr") %>
               </a>
             </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="pt-48">
-      <p>
-        <%= link(
+      <div class="pt-48">
+        <p>
+          <%= link(
 dgettext("resource", "I'm not sure. Learn more."),
 to: "https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees"
 )%>
-      </p>
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 </div>
 <script>
   function fill(id) {

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
@@ -10,47 +10,47 @@
             <strong><%= @resource.title %></strong>
           </a>
         </p>
-        <p><%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.title, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.</p>
+        <p><%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.spatial, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.</p>
         <%= render "_resources_details.html", conn: @conn, metadata: @resource.metadata %>
         <%= if !is_nil(associated_geojson) or !is_nil(associated_netex) do %>
-          <div id="other-formats">
-            <%= dgettext("validations", "This resource is also available in the following formats:")%>
-            <ul>
-              <%= unless is_nil(associated_geojson) do %>
-                <li><a href="<%= associated_geojson.url %>">GeoJSON</a>*
-                  <br>
-                <% end %>
-                <%= unless is_nil(associated_netex) do %>
-                  <li><a href="<%= associated_netex.url %>">NeTEx</a></li>
-                <% end %>
-              </ul>
-              * <%= dgettext("validations", "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)
-              It corresponds to the data you can see on the map below.")%>
-              <%= unless is_nil(associated_geojson) or is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
-                <%= dgettext("validations", "This GeoJSON was up-to-date with the GTFS resource %{hours} ago.", hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at))%>
+        <div id="other-formats">
+          <%= dgettext("validations", "This resource is also available in the following formats:")%>
+          <ul>
+            <%= unless is_nil(associated_geojson) do %>
+            <li><a href="<%= associated_geojson.url %>">GeoJSON</a>*
+              <br>
               <% end %>
-            </li>
-          </div>
+              <%= unless is_nil(associated_netex) do %>
+            <li><a href="<%= associated_netex.url %>">NeTEx</a></li>
+            <% end %>
+          </ul>
+          * <%= dgettext("validations", "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)
+              It corresponds to the data you can see on the map below.")%>
+          <%= unless is_nil(associated_geojson) or is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
+          <%= dgettext("validations", "This GeoJSON was up-to-date with the GTFS resource %{hours} ago.", hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at))%>
+          <% end %>
+          </li>
+        </div>
         <% end %>
         <div class="pt-12">
           <%= if length(@resource.features) > 0 do %>
-            <%= dgettext("page-dataset-details", "Features available in the resource:") %>
-            <div>
-              <%= for tag <- @resource.features do %>
-                <span class="label"><%= tag %></span>
-              <% end %>
-            </div>
+          <%= dgettext("page-dataset-details", "Features available in the resource:") %>
+          <div>
+            <%= for tag <- @resource.features do %>
+            <span class="label"><%= tag %></span>
+            <% end %>
+          </div>
           <% end %>
 
           <%= if length(@resource.modes) > 0 do %>
-            <%= dgettext("page-dataset-details", "Modes available in the resource:") %>
-            <div class="resource-features">
-                <div>
-                  <%= for mode <- @resource.modes do %>
-                    <span class="label mode"><%= mode %></span>
-                  <% end %>
-                </div>
+          <%= dgettext("page-dataset-details", "Modes available in the resource:") %>
+          <div class="resource-features">
+            <div>
+              <%= for mode <- @resource.modes do %>
+              <span class="label mode"><%= mode %></span>
+              <% end %>
             </div>
+          </div>
           <% end %>
         </div>
       </div>
@@ -59,12 +59,12 @@
       <%= render "_download_availability.html", uptime_per_day: @uptime_per_day, conn: @conn %>
 
       <%= unless is_nil(associated_geojson) do %>
-        <h2 class="mt-48" id="visualization"><%= dgettext("validations", "Stops and routes visualization of the GTFS file")%></h2>
-        <div class="panel no-padding">
-          <div id="resource-geojson-info" class="p-24"></div>
-          <div id="resource-geojson"></div>
-          <script src="<%= static_path(@conn, "/js/mapgeojson.js") %>"></script>
-          <script>
+      <h2 class="mt-48" id="visualization"><%= dgettext("validations", "Stops and routes visualization of the GTFS file")%></h2>
+      <div class="panel no-padding">
+        <div id="resource-geojson-info" class="p-24"></div>
+        <div id="resource-geojson"></div>
+        <script src="<%= static_path(@conn, "/js/mapgeojson.js") %>"></script>
+        <script>
             document.addEventListener("DOMContentLoaded", function() {
               GTFSGeojsonMap(
                 'resource-geojson',
@@ -76,48 +76,48 @@
                 )
               })
               </script>
-              </div>
-              <%= unless is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
-              <div class="is-centered no-margin">
-                <%= dgettext("validations", "Visualization up-to-date %{hours} ago.", hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at))%>
-              </div>
-              <% end %>
+      </div>
+      <%= unless is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
+      <div class="is-centered no-margin">
+        <%= dgettext("validations", "Visualization up-to-date %{hours} ago.", hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at))%>
+      </div>
+      <% end %>
       <% end %>
       <h2 class="mt-48"><%= dgettext("validations", "Validation report")%></h2>
       <div class="panel" id="issues">
         <nav class="issues-list validation" role="navigation">
           <%= unless @resource.validation do %>
-            <%= dgettext("validations", "No validation available") %>
+          <%= dgettext("validations", "No validation available") %>
           <% else %>
-            <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, issues: @issues, conn: @conn, data_vis: @data_vis, token: nil %>
+          <%= render "_validation_summary.html", validation_summary: @validation_summary, severities_count: @severities_count, issues: @issues, conn: @conn, data_vis: @data_vis, token: nil %>
           <% end %>
         </nav>
         <div class="main-pane">
           <%= unless @resource.validation do %>
-            <%= dgettext("validations", "No validation available") %>
+          <%= dgettext("validations", "No validation available") %>
           <% else %>
-            <%= pagination_links @conn, @issues, [@resource.id], issue_type: issue_type(@issues.entries),
+          <%= pagination_links @conn, @issues, [@resource.id], issue_type: issue_type(@issues.entries),
               path: &resource_path/4, action: :details %>
           <% end %>
           <%=  render template(@issues), issues: @issues || [] , conn: @conn %>
         </div>
       </div>
       <%= if length(@other_resources) > 0 do %>
-        <div class="mt-48 validation-section">
-          <h1><%= TransportWeb.Gettext.dgettext("validations", "Other resources") %></h1>
-          <ul>
-            <%= for resource <- @other_resources do %>
-              <li>
-                <%= link(resource.title,
+      <div class="mt-48 validation-section">
+        <h1><%= TransportWeb.Gettext.dgettext("validations", "Other resources") %></h1>
+        <ul>
+          <%= for resource <- @other_resources do %>
+          <li>
+            <%= link(resource.title,
                       to: resource_path(@conn, :details, resource.id)
                     )%>
-              </li>
-            <% end %>
-          </ul>
-        </div>
+          </li>
+          <% end %>
+        </ul>
+      </div>
       <% end %>
     </div>
-  </section>
+</section>
 </div>
 <script src="<%= static_path(@conn, "/js/utils.js") %>"></script>
 <script>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
@@ -10,7 +10,7 @@
             <strong><%= @resource.title %></strong>
           </a>
         </p>
-        <p><%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.spatial, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.</p>
+        <p><%= dgettext("validations", "This resource file is part of the dataset")%> <%= link(@resource.dataset.custom_title, to: dataset_path(@conn, :details, @resource.dataset.slug) )%>.</p>
         <%= render "_resources_details.html", conn: @conn, metadata: @resource.metadata %>
         <%= if !is_nil(associated_geojson) or !is_nil(associated_netex) do %>
         <div id="other-formats">

--- a/apps/transport/lib/transport_web/templates/resource/list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/list.html.eex
@@ -1,15 +1,15 @@
 <section class="section section-grey">
-    <div class="container">
-        <div class="existing">
-            <h1><%= dgettext("resource", "Select a dataset to update it.") %></h1>
-            <%= for dataset <- @datasets ++ @org_datasets do %>
-            <div class="panel">
-                <h2><%= dataset.title %></h2>
-                <%= link(
+  <div class="container">
+    <div class="existing">
+      <h1><%= dgettext("resource", "Select a dataset to update it.") %></h1>
+      <%= for dataset <- @datasets ++ @org_datasets do %>
+      <div class="panel">
+        <h2><%= dataset.datagouv_title %></h2>
+        <%= link(
                     dgettext("resource", "Select this dataset"),
                     to: resource_path(@conn, :resources_list, dataset.datagouv_id)) %>
-            </div>
-            <% end %>
-        </div>
+      </div>
+      <% end %>
     </div>
+  </div>
 </section>

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.eex
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="pt-24">
       <strong>
-        <%= @dataset["title"] %>
+        <%= @dataset["datagouv_title"] %>
       </strong>
       <div>
         <%= link(dgettext("resource", "Visit the dataset page"), to: "/datasets/#{@dataset["id"]}") %>
@@ -18,12 +18,12 @@
     </div>
     <div class="resources-update-list pt-24">
       <%= for resource <- @dataset["resources"] do %>
-        <a href="<%= resource_path(@conn, :form, @conn.params["dataset_id"], resource["id"]) %>">
-          <div class="panel">
-            <img height=20 src="<%= static_path(@conn, "/images/producteurs/picto-maj.png") %>" alt="">
-            <strong><%= resource["title"] %></strong>
-          </div>
-        </a>
+      <a href="<%= resource_path(@conn, :form, @conn.params["dataset_id"], resource["id"]) %>">
+        <div class="panel">
+          <img height=20 src="<%= static_path(@conn, "/images/producteurs/picto-maj.png") %>" alt="">
+          <strong><%= resource["title"] %></strong>
+        </div>
+      </a>
       <% end %>
     </div>
   </div>

--- a/apps/transport/lib/transport_web/views/seo_metadata.ex
+++ b/apps/transport/lib/transport_web/views/seo_metadata.ex
@@ -20,8 +20,8 @@ defmodule TransportWeb.SeoMetadata do
 
     %{
       title:
-        dgettext("seo", "%{spatial} - Open %{formats} datasets - %{territory}",
-          spatial: dataset.spatial,
+        dgettext("seo", "%{custom_title} - Open %{formats} datasets - %{territory}",
+        custom_title: dataset.custom_title,
           territory: DB.Dataset.get_territory_or_nil(dataset),
           formats: formats
         )
@@ -49,8 +49,8 @@ defmodule TransportWeb.SeoMetadata do
   def metadata(TransportWeb.ResourceView, %{resource: %{format: format, title: title, dataset: dataset}}),
     do: %{
       title:
-        dgettext("seo", "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}",
-          spatial: dataset.spatial,
+        dgettext("seo", "%{format} Transport open dataset - %{title} for %{custom_title} - %{territory}",
+          custom_title: dataset.custom_title,
           territory: DB.Dataset.get_territory_or_nil(dataset),
           format: format,
           title: title

--- a/apps/transport/lib/transport_web/views/seo_metadata.ex
+++ b/apps/transport/lib/transport_web/views/seo_metadata.ex
@@ -21,7 +21,7 @@ defmodule TransportWeb.SeoMetadata do
     %{
       title:
         dgettext("seo", "%{custom_title} - Open %{formats} datasets - %{territory}",
-        custom_title: dataset.custom_title,
+          custom_title: dataset.custom_title,
           territory: DB.Dataset.get_territory_or_nil(dataset),
           formats: formats
         )

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-autogen, elixir-format
-msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
+msgid "%{format} Transport open dataset - %{title} for %{custom_title} - %{territory}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -32,7 +32,7 @@ msgid "%{q}: Available transport open datasets"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "%{spatial} - Open %{formats} datasets - %{territory}"
+msgid "%{custom_title} - Open %{formats} datasets - %{territory}"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-autogen, elixir-format
-msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
-msgstr "Jeu de données ouvert %{format} - %{title} pour %{spatial} - %{territory}"
+msgid "%{format} Transport open dataset - %{title} for %{custom_title} - %{territory}"
+msgstr "Jeu de données ouvert %{format} - %{title} pour %{custom_title} - %{territory}"
 
 #, elixir-autogen, elixir-format
 msgid "Publish, improve and reuse French public transport data"
@@ -32,8 +32,8 @@ msgid "%{q}: Available transport open datasets"
 msgstr "%{q} : Jeux de données ouverts disponibles"
 
 #, elixir-autogen, elixir-format
-msgid "%{spatial} - Open %{formats} datasets - %{territory}"
-msgstr "%{spatial} - Données %{formats} ouvertes - %{territory}"
+msgid "%{custom_title} - Open %{formats} datasets - %{territory}"
+msgstr "%{custom_title} - Données %{formats} ouvertes - %{territory}"
 
 #, elixir-autogen, elixir-format
 msgid "National Access Point for transport open data"

--- a/apps/transport/priv/gettext/seo.pot
+++ b/apps/transport/priv/gettext/seo.pot
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "%{format} Transport open dataset - %{title} for %{spatial} - %{territory}"
+msgid "%{format} Transport open dataset - %{title} for %{custom_title} - %{territory}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -31,7 +31,7 @@ msgid "%{q}: Available transport open datasets"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "%{spatial} - Open %{formats} datasets - %{territory}"
+msgid "%{custom_title} - Open %{formats} datasets - %{territory}"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/test/transport/comments_checker_test.exs
+++ b/apps/transport/test/transport/comments_checker_test.exs
@@ -23,7 +23,7 @@ defmodule Transport.CommentsCheckerTest do
   end
 
   test "check for new comments on data.gouv.fr" do
-    %{id: dataset_id} = insert(:dataset, title: "dataset 1")
+    %{id: dataset_id} = insert(:dataset, datagouv_title: "dataset 1")
 
     # when the dataset is created, no comment timestamp is stored
     assert_dataset_ts(dataset_id, nil)

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -28,7 +28,7 @@ defmodule Transport.DataCheckerTest do
         ]
       end)
 
-      dataset = %DB.Dataset{slug: dataset_slug, title: "title"}
+      dataset = %DB.Dataset{slug: dataset_slug, datagouv_title: "title"}
 
       fun = fn ->
         Transport.DataChecker.send_outdated_data_notifications({7, [dataset]}, true)
@@ -59,7 +59,7 @@ defmodule Transport.DataCheckerTest do
         ]
       end)
 
-      dataset = %DB.Dataset{slug: dataset_slug, title: "title"}
+      dataset = %DB.Dataset{slug: dataset_slug, datagouv_title: "title"}
 
       fun = fn ->
         Transport.DataChecker.send_outdated_data_notifications({custom_delay, [dataset]}, true)
@@ -84,7 +84,7 @@ defmodule Transport.DataCheckerTest do
         ]
       end)
 
-      dataset = %DB.Dataset{slug: dataset_slug, title: "title"}
+      dataset = %DB.Dataset{slug: dataset_slug, datagouv_title: "title"}
 
       fun = fn ->
         Transport.DataChecker.send_outdated_data_notifications({42, [dataset]}, true)

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -20,7 +20,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   @dataset_url "https://demo.data.gouv.fr/fr/datasets/horaires-theoriques-du-reseau-de-transport-tag-1/"
   @dataset %{
     "url" => @dataset_url,
-    "spatial" => "Grenoble",
+    "custom_title" => "Grenoble",
     "region_id" => 1,
     "insee" => "38185",
     "type" => "public-transit",
@@ -30,7 +30,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   @dataset_with_zones_url "https://demo.data.gouv.fr/fr/datasets/test-jeu-de-donnees-associes-a-plusieurs-villes-2/"
   @dataset_with_zones %{
     "url" => @dataset_with_zones_url,
-    "spatial" => "Grenoble",
+    "custom_title" => "Grenoble",
     "type" => "public-transit",
     "action" => "new"
   }

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -48,7 +48,7 @@ defmodule TransportWeb.DatasetControllerTest do
   test "GET /api/datasets/:id", %{conn: conn} do
     dataset =
       %DB.Dataset{
-        spatial: "title",
+        custom_title: "title",
         type: "public-transit",
         datagouv_id: "datagouv",
         slug: "slug-1",

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -12,7 +12,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
         description: "Un jeu de données",
         licence: "odc-odbl",
         datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
-        spatial: "Horaires Angers",
+        custom_title: "Horaires Angers",
         type: "public-transit",
         slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
         datagouv_id: "5b4cd3a0b59508054dd496cd",

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -11,7 +11,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
       %Dataset{
         description: "Un jeu de données",
         licence: "odc-odbl",
-        title: "Horaires et arrêts du réseau IRIGO - format GTFS",
+        datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
         spatial: "Horaires Angers",
         type: "public-transit",
         slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
@@ -36,7 +36,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
       %Dataset{
         description: "Un autre jeu de données",
         licence: "odc-odbl",
-        title: "offre de transport du réseau de LAVAL Agglomération (GTFS)",
+        datagouv_title: "offre de transport du réseau de LAVAL Agglomération (GTFS)",
         slug: "offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
         type: "public-transit",
         datagouv_id: "5bc493d08b4c416c84a69500",

--- a/apps/transport/test/transport_web/controllers/nav_test.exs
+++ b/apps/transport/test/transport_web/controllers/nav_test.exs
@@ -12,7 +12,7 @@ defmodule TransportWeb.NavTest do
 
     insert(:dataset,
       description: "Un jeu de données",
-      spatial: "Horaires Angers",
+      custom_title: "Horaires Angers",
       resources: [
         build(:resource, url: "https://link.to/angers.zip")
       ],

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -70,8 +70,8 @@ defmodule TransportWeb.PageControllerTest do
     end
 
     test "renders successfully when data gouv returns no error", %{conn: conn} do
-      ud = Repo.insert!(%Dataset{title: "User Dataset", datagouv_id: "123"})
-      uod = Repo.insert!(%Dataset{title: "Org Dataset", datagouv_id: "456"})
+      ud = Repo.insert!(%Dataset{datagouv_title: "User Dataset", datagouv_id: "123"})
+      uod = Repo.insert!(%Dataset{datagouv_title: "Org Dataset", datagouv_id: "456"})
 
       # It would be ultimately better to have a mock implementation of `Datagouvfr.Client.OAuth` for the
       # whole test suite, like Hex.pm does:

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -16,7 +16,7 @@ defmodule TransportWeb.SeoMetadataTest do
         description: "Un jeu de données",
         licence: "odc-odbl",
         datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
-        spatial: "Horaires Angers",
+        custom_title: "Horaires Angers",
         type: "public-transit",
         slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
         datagouv_id: "5b4cd3a0b59508054dd496cd",

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -15,7 +15,7 @@ defmodule TransportWeb.SeoMetadataTest do
       %Dataset{
         description: "Un jeu de données",
         licence: "odc-odbl",
-        title: "Horaires et arrêts du réseau IRIGO - format GTFS",
+        datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
         spatial: "Horaires Angers",
         type: "public-transit",
         slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -41,10 +41,10 @@ defmodule TransportWeb.API.StatsControllerTest do
       )
 
     dataset1 =
-      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, spatial: "other name", slug: "a"})
+      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, custom_title: "other name", slug: "a"})
 
     dataset2 =
-      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, spatial: "name", slug: "z"})
+      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, custom_title: "name", slug: "z"})
 
     expected = [
       %{
@@ -55,7 +55,7 @@ defmodule TransportWeb.API.StatsControllerTest do
         },
         "properties" => %{
           geometry: %Geo.Point{coordinates: {55.5567, -21.3699}, properties: %{}, srid: 4326},
-          names: [dataset2.spatial, dataset1.spatial],
+          names: [dataset2.custom_title, dataset1.custom_title],
           slugs: [dataset2.slug, dataset1.slug]
         },
         "type" => "Feature"
@@ -75,13 +75,13 @@ defmodule TransportWeb.API.StatsControllerTest do
       )
 
     %{id: dataset_active_id} =
-      :dataset |> insert(%{type: "public-transit", is_active: true, aom: aom, spatial: "Ajaccio", slug: "a"})
+      :dataset |> insert(%{type: "public-transit", is_active: true, aom: aom, custom_title: "Ajaccio", slug: "a"})
 
     # the active dataset has an outdated resource
     :resource |> insert(%{dataset_id: dataset_active_id, end_date: Date.new!(2000, 1, 1)})
 
     %{id: dataset_inactive_id} =
-      :dataset |> insert(%{type: "public-transit", is_active: false, aom: aom, spatial: "Ajacciold", slug: "z"})
+      :dataset |> insert(%{type: "public-transit", is_active: false, aom: aom, custom_title: "Ajacciold", slug: "z"})
 
     # but the inactive dataset has an up-to-date resource
     :resource |> insert(%{dataset_id: dataset_inactive_id, end_date: Date.new!(2100, 1, 1)})

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -41,7 +41,8 @@ defmodule TransportWeb.API.StatsControllerTest do
       )
 
     dataset1 =
-      :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, custom_title: "other name", slug: "a"})
+      :dataset
+      |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, custom_title: "other name", slug: "a"})
 
     dataset2 =
       :dataset |> insert(%{type: "bike-scooter-sharing", is_active: true, aom: aom, custom_title: "name", slug: "z"})


### PR DESCRIPTION
`title` devient `datagouv_title`
`spatial` devient `custom_title`

Il n'y a plus de champ `title`, comme ça on est obligés de savoir de quel "title" on parle pour les datasets. Et puis il y a deja trop de choses qui s'appelent title, je préfère les noms qu'on peut rechercher facilement sans confusion possible.

J'en ai profité pour remplacer quelques datagouv_title par des custom_title, quand c'était visiblement une erreur.

J'ai eu du mal à trouver qu'une des migrations avait créé une fonction utilisée dans notre moteur de recherche et qui utilisait la colonne spatiale...j'étais passé vite sur les occurences de "spatial" dans les fichiers de migrations...

Remarque : ça ne modifie pas notre API, qui expose le champ "title" (et qui contient le titre PAN, aka `custom_title`)