### PR TITLE
Gère null pour has_validity_period?

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -462,7 +462,7 @@ defmodule TransportWeb.DatasetView do
   end
 
   def has_validity_period?(%DB.ResourceHistory{payload: %{"resource_metadata" => metadata}}) when is_map(metadata) do
-    Map.has_key?(metadata, "start_date")
+    not is_nil(Map.get(metadata, "start_date"))
   end
 
   def has_validity_period?(%DB.ResourceHistory{}), do: false

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -136,4 +136,16 @@ defmodule TransportWeb.DatasetControllerTest do
     doc = Floki.parse_document!(html)
     assert [] == Floki.find(doc, "#custom-message")
   end
+
+  test "has_validity_period?" do
+    assert TransportWeb.DatasetView.has_validity_period?(%DB.ResourceHistory{
+             payload: %{"resource_metadata" => %{"start_date" => "2022-02-17"}}
+           })
+
+    refute TransportWeb.DatasetView.has_validity_period?(%DB.ResourceHistory{
+             payload: %{"resource_metadata" => %{"start_date" => nil}}
+           })
+
+    refute TransportWeb.DatasetView.has_validity_period?(%DB.ResourceHistory{payload: %{}})
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2228

J'ai été surpris de voir que pour les NeTEx il y avait bien des `start_date` mais à `null`.

Exemple

```json
{
   "end_date":null,
   "has_fares":false,
   "has_shapes":false,
   "issues_count":{
      "ExtraFile":26,
      "MissingMandatoryFile":5,
      "UnloadableModel":1
   },
   "lines_count":0,
   "modes":[
      
   ],
   "networks":[
      
   ],
   "some_stops_need_phone_agency":false,
   "some_stops_need_phone_driver":false,
   "start_date":null,
   "stop_areas_count":0,
   "stop_points_count":0
}
```