### PR TITLE
Conserve uniquement ressources avec schéma pour ZFE

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -360,6 +360,7 @@ defmodule Transport.ImportData do
         "metadata" => resource["metadata"]
       }
     end)
+    |> maybe_filter_resources(type)
   end
 
   @spec get_valid_resources(map(), binary()) :: [map()]
@@ -375,6 +376,12 @@ defmodule Transport.ImportData do
   def get_valid_resources(%{"resources" => resources}, _type) do
     resources
   end
+
+  def maybe_filter_resources(resources, "low-emission-zones") do
+    resources |> Enum.filter(&(&1["schema_name"] == "etalab/schema-zfe"))
+  end
+
+  def maybe_filter_resources(resources, _), do: resources
 
   @spec get_valid_gtfs_resources([map()]) :: [map()]
   def get_valid_gtfs_resources(resources) do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -312,4 +312,13 @@ defmodule Transport.ImportDataTest do
              "siri lite" => 1
            }
   end
+
+  test "maybe_filter_resources" do
+    assert Enum.empty?(ImportData.maybe_filter_resources([%{"schema_name" => nil}], "low-emission-zones"))
+    refute Enum.empty?(ImportData.maybe_filter_resources([%{"schema_name" => nil}], "public-transit"))
+
+    assert Enum.count(
+             ImportData.maybe_filter_resources([%{"schema_name" => "etalab/schema-zfe"}], "low-emission-zones")
+           ) == 1
+  end
 end


### PR DESCRIPTION
Adapation de `ImportData` pour ne conserver que les ressources avec le schéma ZFE pour la catégorie `low-emission-zones`.

Similaire à ce qui est fait pour `public-transit` mais `get_valid_resources` est un "prefilter" alors que `maybe_filter_resources` est exécuté après avoir construit la ressource.

Le but est de nettoyer [ce JDD](https://transport.data.gouv.fr/datasets/zfe-zone-a-faibles-emissions/) par exemple.