### PR TITLE
Affichage GTFS-RT sur validation à la demande

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -19,10 +19,12 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   end
 
   defp update_data(socket) do
+    validation = DB.Repo.get!(DB.Validation, socket_value(socket, :validation_id))
     socket =
       assign(socket,
         last_updated_at: DateTime.utc_now(),
-        validation: DB.Repo.get!(DB.Validation, socket_value(socket, :validation_id))
+        validation: validation,
+        gtfs_rt_feed: maybe_gtfs_rt_feed(socket, validation)
       )
 
     unless is_final_state?(socket) do
@@ -66,4 +68,28 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   def format_datetime(dt, locale) do
     format_datetime_to_paris(dt, locale, with_seconds: true)
   end
+
+  defp maybe_gtfs_rt_feed(socket, %DB.Validation{on_the_fly_validation_metadata: %{"type" => "gtfs-rt", "state" => "completed"}} = validation) do
+    lang = socket_value(socket, :locale)
+    url = Map.fetch!(validation.on_the_fly_validation_metadata, "gtfs_rt_url")
+
+    Transport.Cache.API.fetch(
+      "gtfs_rt_feed_validation_#{validation.id}_#{lang}",
+      fn ->
+        case Transport.GTFSRT.decode_remote_feed(url) do
+          {:ok, feed} ->
+            %{
+              alerts: Transport.GTFSRT.service_alerts_for_display(feed, lang),
+              feed: feed
+            }
+
+          {:error, _} ->
+            :error
+        end
+      end,
+      :timer.minutes(1)
+    )
+  end
+
+  defp maybe_gtfs_rt_feed(_, _), do: nil
 end

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -20,6 +20,7 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
 
   defp update_data(socket) do
     validation = DB.Repo.get!(DB.Validation, socket_value(socket, :validation_id))
+
     socket =
       assign(socket,
         last_updated_at: DateTime.utc_now(),
@@ -69,7 +70,10 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
     format_datetime_to_paris(dt, locale, with_seconds: true)
   end
 
-  defp maybe_gtfs_rt_feed(socket, %DB.Validation{on_the_fly_validation_metadata: %{"type" => "gtfs-rt", "state" => "completed"}} = validation) do
+  defp maybe_gtfs_rt_feed(
+         socket,
+         %DB.Validation{on_the_fly_validation_metadata: %{"type" => "gtfs-rt", "state" => "completed"}} = validation
+       ) do
     lang = socket_value(socket, :locale)
     url = Map.fetch!(validation.on_the_fly_validation_metadata, "gtfs_rt_url")
 

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -70,6 +70,7 @@
               <h4><%= dgettext("validations", "Warnings")%></h4>
                 <%= TransportWeb.ValidationView.render "_gtfs_rt_errors_for_severity.html", errors_for_severity: errors_warning_level %>
             <% end %>
+            <%= TransportWeb.ResourceView.render("_gtfs_rt.html", gtfs_rt_feed: @gtfs_rt_feed, entities_seen_recently: nil, locale: @locale) %>
           <% end %>
 
           <%= if metadata["type"] in ["tableschema", "jsonschema"] do %>


### PR DESCRIPTION
Suite de #2242, affichage des informations contenues dans le flux GTFS-RT (entités dans le flux, service alerts si présentes et décodage du flux) sur un résultat de validation à la demande.

![image](https://user-images.githubusercontent.com/295709/159960674-eb6bd538-4597-47d7-a09f-0287e963ee64.png)
