### PR TITLE
Réduction de l'usage CircleCI en évitant la compilation "dev"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,19 +62,11 @@ jobs:
           command: mix local.rebar --force
 
       - run:
-          name: Install mix dependencies for MIX_ENV=dev
-          command: MIX_ENV=dev mix deps.get --force
-
-      - run:
-          name: Compile mix dependencies for MIX_ENV=dev
-          command: MIX_ENV=dev mix deps.compile
-
-      - run:
-          name: Install mix dependencies for MIX_ENV=test
+          name: Install mix dependencies
           command: mix deps.get
 
       - run:
-          name: Compile mix dependencies for MIX_ENV=test
+          name: Compile mix dependencies
           command: mix deps.compile
 
       # Here we attempt to create 3 different caches to optimize the build process
@@ -123,7 +115,7 @@ jobs:
 
       - run:
           name: Build PLT
-          command: MIX_ENV=dev mix dialyzer --plt
+          command: mix dialyzer --plt
           # PLT construction can stay up quite a bit without generating any output
           # We add a bit of tolerance here
           no_output_timeout: 20m

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,10 @@ defmodule Transport.MixProject do
 
   defp deps do
     [
-      {:dialyxir, "~> 1.1.0", only: :dev, runtime: false},
+      # locally, you can use :dialyxir in :dev mode, and we also add
+      # :test to ensure CI can run it with a single compilation (in test target),
+      # to reduce build time
+      {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.10", only: :test}
     ]
   end


### PR DESCRIPTION
Je fais tourner `dialyxir` en mode `test`, ainsi on peut faire disparaître la compilation qui existe en mode `dev`, et ne garder que celle en mode `test` dont on a besoin de toute façon.

Il faudra vérifier à l'usage que ça n'introduit pas d'effet de bord.