### PR TITLE
Correction du cache PLT Dialyzer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ defaults: &defaults
       default: build-v2
       type: string
     plt_cache_key:
-      default: plt-v2
+      default: plt-v3
       type: string
   working_directory: ~/transport
   docker:


### PR DESCRIPTION
Dans #2270 j'ai réduit le temps de compilation, et passé Dialyzer du mode dev au mode test.

Du coup, le "build PLT" prend 6 minutes et tourne à chaque tour, car il "trouve un cache" mais qui ne contient que l'info pour la build de dev (si j'ai compris), et après il ne sauve pas le cache pour autant.

Voir https://app.circleci.com/pipelines/github/etalab/transport-site/3935/workflows/08c11f42-6506-4bcf-a4b5-25ec457ff9af/jobs/37013

