### PR TITLE
Historisation : prise en compte des anciennes ressources

### DIFF
--- a/apps/transport/lib/transport/history_fetcher.ex
+++ b/apps/transport/lib/transport/history_fetcher.ex
@@ -24,7 +24,9 @@ defmodule Transport.History.Fetcher.Database do
   def history_resources(%Dataset{id: id}) do
     Dataset
     |> join(:inner, [d], r in Resource, on: r.dataset_id == d.id)
-    |> join(:inner, [d, r], rh in ResourceHistory, on: rh.datagouv_id == r.datagouv_id or fragment("cast(payload->>'dataset_id' as bigint) = ?", d.id))
+    |> join(:inner, [d, r], rh in ResourceHistory,
+      on: rh.datagouv_id == r.datagouv_id or fragment("cast(payload->>'dataset_id' as bigint) = ?", d.id)
+    )
     |> where([d, _r, _rh], d.id == ^id)
     |> order_by([_d, _r, rh], desc: rh.inserted_at)
     |> select([_d, _r, rh], rh)

--- a/apps/transport/lib/transport/history_fetcher.ex
+++ b/apps/transport/lib/transport/history_fetcher.ex
@@ -24,7 +24,7 @@ defmodule Transport.History.Fetcher.Database do
   def history_resources(%Dataset{id: id}) do
     Dataset
     |> join(:inner, [d], r in Resource, on: r.dataset_id == d.id)
-    |> join(:inner, [_d, r], rh in ResourceHistory, on: rh.datagouv_id == r.datagouv_id)
+    |> join(:inner, [d, r], rh in ResourceHistory, on: rh.datagouv_id == r.datagouv_id or fragment("cast(payload->>'dataset_id' as bigint) = ?", d.id))
     |> where([d, _r, _rh], d.id == ^id)
     |> order_by([_d, _r, rh], desc: rh.inserted_at)
     |> select([_d, _r, rh], rh)

--- a/apps/transport/test/transport/history_fetcher_test.exs
+++ b/apps/transport/test/transport/history_fetcher_test.exs
@@ -19,10 +19,11 @@ defmodule Transport.History.FetcherTest do
       other_resource = insert(:resource, dataset: insert(:dataset), datagouv_id: "bar")
       insert(:resource_history, datagouv_id: resource.datagouv_id, payload: %{})
       insert(:resource_history, datagouv_id: resource.datagouv_id, payload: %{})
+      insert(:resource_history, datagouv_id: "bar", payload: %{"dataset_id" => dataset.id})
       # Should be ignored
       insert(:resource_history, datagouv_id: other_resource.datagouv_id, payload: %{})
 
-      assert Enum.count(Transport.History.Fetcher.Database.history_resources(dataset)) == 2
+      assert Enum.count(Transport.History.Fetcher.Database.history_resources(dataset)) == 3
       assert Transport.History.Fetcher.Database.history_resources(insert(:dataset)) == []
     end
   end


### PR DESCRIPTION
Utilise ce qui a été fait dans https://github.com/etalab/transport-site/pull/2192

Cette PR prend en compte les `resource_history` qui ont le même `dataset_id` et ne se limite pas que aux mêmes `resource.datagouv_id` (ayant constaté que cette information n'était pas fiable).

L'idée est de donc de "repêcher" des ressources qui étaient en lien avec ce jeu de données mais ne sont plus présentes.

J'ai fait attention à ajouter un index sur `dataset_id` dans `payload` qui est du JSONB.

## Ajout d'un index sur `payload.dataset_id`

### Avant

```
Sort  (cost=1147.91..1148.01 rows=38 width=460)
  Sort Key: r2.inserted_at DESC
  ->  Nested Loop  (cost=0.55..1146.92 rows=38 width=460)
        Join Filter: (((r2.datagouv_id)::text = (r1.datagouv_id)::text) OR (((r2.payload ->> 'dataset_id'::text))::bigint = d0.id))
        ->  Nested Loop  (cost=0.55..35.39 rows=1 width=45)
              ->  Index Only Scan using dataset_pkey on dataset d0  (cost=0.27..4.29 rows=1 width=8)
                    Index Cond: (id = 693)
              ->  Index Scan using resource_format_dataset_id_index on resource r1  (cost=0.28..31.09 rows=1 width=45)
                    Index Cond: (dataset_id = 693)
        ->  Seq Scan on resource_history r2  (cost=0.00..843.24 rows=11924 width=460)
```

**seq scan on resource_history (rows=11924)**

### Après

```
Sort  (cost=255.21..255.30 rows=38 width=460)
  Sort Key: r2.inserted_at DESC
  ->  Nested Loop  (cost=15.59..254.21 rows=38 width=460)
        ->  Nested Loop  (cost=0.55..35.39 rows=1 width=45)
              ->  Index Only Scan using dataset_pkey on dataset d0  (cost=0.27..4.29 rows=1 width=8)
                    Index Cond: (id = 693)
              ->  Index Scan using resource_format_dataset_id_index on resource r1  (cost=0.28..31.09 rows=1 width=45)
                    Index Cond: (dataset_id = 693)
        ->  Bitmap Heap Scan on resource_history r2  (cost=15.04..218.14 rows=68 width=460)
              Recheck Cond: (((datagouv_id)::text = (r1.datagouv_id)::text) OR (((payload ->> 'dataset_id'::text))::bigint = d0.id))
              ->  BitmapOr  (cost=15.04..15.04 rows=68 width=0)
                    ->  Bitmap Index Scan on resource_history_datagouv_id_index  (cost=0.00..4.34 rows=8 width=0)
                          Index Cond: ((datagouv_id)::text = (r1.datagouv_id)::text)
                    ->  Bitmap Index Scan on resource_history_payload_dataset_id  (cost=0.00..4.74 rows=60 width=0)
                          Index Cond: (((payload ->> 'dataset_id'::text))::bigint = d0.id)
```

**Bitmap Heap Scan on resource_history**