### PR TITLE
Backoffice : ajout d'un lien permanent vers le site public

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -156,6 +156,7 @@ defmodule TransportWeb.Backoffice.PageController do
       end
 
     conn
+    |> assign(:dataset_id, dataset_id)
     |> assign(:dataset_types, Dataset.types())
     |> assign(:regions, Region |> where([r], r.nom != "National") |> Repo.all())
     |> assign(

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.eex
@@ -1,4 +1,4 @@
-<div class="pt-48 pb-48">
+<div class="pt-48">
   <%= form_for @conn, backoffice_dataset_path(@conn, :post), fn f -> %>
   <h1>
     <%= if is_nil(@dataset) do %>
@@ -7,16 +7,26 @@
       <%= dgettext("backoffice", "Edit a dataset") %>
     <% end %>
   </h1>
-  <%= text_input f, :url, [
-        placeholder: dgettext("backoffice", "Dataset's url"),
-        value: if not is_nil(@dataset) do Dataset.datagouv_url(@dataset) else "" end
-      ] %>
-  <%= text_input f, :custom_title, [
-        placeholder: dgettext("backoffice", "name"),
-        value: if not is_nil(@dataset) do @dataset.custom_title else "" end
-      ] %>
-  <%= select f, :type, @dataset_types, [
-        selected: if not is_nil(@dataset) do @dataset.type else "public-transit" end ]%>
+  <%= unless is_nil(assigns[:dataset_id]) do %>
+    <div class="pb-24">
+      <i class="fa fa-external-link-alt"></i>
+      <%= link(dgettext("backoffice", "See dataset on website"), to: dataset_path(@conn, :details, @dataset_id)) %>
+    </div>
+  <% end %>
+
+  <div class="pt-24">
+    <%= text_input f, :url, [
+            placeholder: dgettext("backoffice", "Dataset's url"),
+            value: if not is_nil(@dataset) do Dataset.datagouv_url(@dataset) else "" end
+          ] %>
+    <%= text_input f, :custom_title, [
+          placeholder: dgettext("backoffice", "name"),
+          value: if not is_nil(@dataset) do @dataset.custom_title else "" end
+        ] %>
+    <%= select f, :type, @dataset_types, [
+          selected: if not is_nil(@dataset) do @dataset.type else "public-transit" end ]%>
+  </div>
+
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -200,3 +200,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "With a resource under 90% availability"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See dataset on website"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -200,3 +200,7 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "With a resource under 90% availability"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See dataset on website"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -200,3 +200,7 @@ msgstr "Requêtes GBFS"
 #, elixir-autogen, elixir-format
 msgid "With a resource under 90% availability"
 msgstr "Ayant une ressource sous les 90% de disponibilité"
+
+#, elixir-autogen, elixir-format
+msgid "See dataset on website"
+msgstr "Voir le jeu de données sur le site"


### PR DESCRIPTION
Parce qu'on fait souvent des aller retour entre le backoffice et le site public.

![image](https://user-images.githubusercontent.com/15341118/160804469-4c17f709-2579-4b0f-aa6e-0501707635d1.png)
