### PR TITLE
Formattage (sans changement) des fichiers de configuration

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,7 @@
 [
   inputs: [
     "mix.exs",
-    "config/runtime.exs",
+    "config/*.exs",
     "apps/*/{lib,test}/**/*.{ex,exs}",
     "scripts/**/*.exs",
     "ops_tests/**/*.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,8 @@ config :gbfs, jcdecaux_apikey: System.get_env("JCDECAUX_APIKEY")
 # Configures the endpoint
 config :gbfs, GBFS.Endpoint,
   render_errors: [view: GBFS.ErrorView, accepts: ~w(json)],
-  pubsub_server: GBFS.PubSub, # TODO: verify if this is truly needed? unsure.
+  # TODO: verify if this is truly needed? unsure.
+  pubsub_server: GBFS.PubSub,
   server: false
 
 # Configures the endpoint
@@ -56,14 +57,14 @@ config :phoenix, :json_library, Jason
 #
 # See https://hexdocs.pm/phoenix/1.5.8/Phoenix.Template.html#module-format-encoders
 #
-config :phoenix, :format_encoders,
-  json: Transport.Shared.ConditionalJSONEncoder
+config :phoenix, :format_encoders, json: Transport.Shared.ConditionalJSONEncoder
 
 # Configures Elixir's Logger
 config :logger,
   backends: [
     :console,
-    Sentry.LoggerBackend # error logs are also send to sentry
+    # error logs are also send to sentry
+    Sentry.LoggerBackend
   ]
 
 config :logger, :console,
@@ -75,10 +76,8 @@ config :scrivener_html,
 
 # Allow to have Markdown templates
 config :phoenix, :template_engines,
-  [
-    md: PhoenixMarkdown.Engine,
-    leex: Phoenix.LiveView.Engine
-  ]
+  md: PhoenixMarkdown.Engine,
+  leex: Phoenix.LiveView.Engine
 
 config :phoenix_markdown, :server_tags, :all
 
@@ -96,7 +95,7 @@ config :sentry,
   environment_name: sentry_env_as_atom,
   included_environments: [:prod, :staging],
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!,
+  root_source_code_path: File.cwd!(),
   filter: Transport.Shared.SentryExceptionFilter,
   # the key must be there for overriding during tests,
   # so we set it to the default based on source code for now
@@ -118,8 +117,8 @@ config :datagouvfr,
   community_resources_impl: Datagouvfr.Client.CommunityResources.API
 
 config :ex_json_schema,
-  :remote_schema_resolver,
-  fn url -> HTTPoison.get!(url).body |> Jason.decode! end
+       :remote_schema_resolver,
+       fn url -> HTTPoison.get!(url).body |> Jason.decode!() end
 
 config :ex_aws,
   access_key_id: System.get_env("CELLAR_ACCESS_KEY_ID"),
@@ -131,7 +130,7 @@ config :ex_aws,
   cellar_url: "https://~s.cellar-c2.services.clever-cloud.com",
   s3: [
     scheme: "https://",
-    host: "cellar-c2.services.clever-cloud.com",
+    host: "cellar-c2.services.clever-cloud.com"
   ],
   json_codec: Jason
 

--- a/config/database.exs
+++ b/config/database.exs
@@ -3,7 +3,7 @@ import Config
 config :db, DB.Repo,
   url: System.get_env("PG_URL") || "ecto://postgres:postgres@localhost/transport_repo",
   # NOTE: this default pool_size is overriden by "prod.exs" !
-  pool_size: (System.get_env("PG_POOL_SIZE") || "10") |> String.to_integer,
+  pool_size: (System.get_env("PG_POOL_SIZE") || "10") |> String.to_integer(),
   types: DB.PostgrexTypes
 
 config :db, ecto_repos: [DB.Repo]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,7 +14,8 @@ config :transport, TransportWeb.Endpoint,
   # A page reload is required to trigger this. More apps could
   # be added when needed here, we just added what we needed.
   reloadable_apps: [:shared, :db, :transport, :unlock]
-  # watchers are also configured via config/runtime.exs
+
+# watchers are also configured via config/runtime.exs
 
 config :transport, TransportWeb.Endpoint,
   live_reload: [
@@ -77,7 +78,10 @@ if File.exists?(extra_config_file) do
   import_config extra_config_file
 else
   require Logger
-  Logger.warn("Only the most basic features will work. Please create #{extra_config_file} based on config/dev.secret.template.exs for more advanced use.")
+
+  Logger.warn(
+    "Only the most basic features will work. Please create #{extra_config_file} based on config/dev.secret.template.exs for more advanced use."
+  )
 end
 
 if File.exists?(".envrc") do

--- a/config/gbfs_validator.exs
+++ b/config/gbfs_validator.exs
@@ -5,5 +5,6 @@ config :transport,
   gbfs_validator_impl: Shared.Validation.GBFSValidator.HTTPValidatorClient,
   # This endpoint is not really public but we can use it for now
   # See https://github.com/MobilityData/gbfs-validator/issues/53#issuecomment-957917240
-  gbfs_validator_url: System.get_env("GBFS_VALIDATOR_URL", "https://gbfs-validator.netlify.app/.netlify/functions/validator"),
+  gbfs_validator_url:
+    System.get_env("GBFS_VALIDATOR_URL", "https://gbfs-validator.netlify.app/.netlify/functions/validator"),
   gbfs_validator_website: System.get_env("GBFS_VALIDATOR_WEBSITE", "https://gbfs-validator.netlify.app")

--- a/config/gtfs_validator.exs
+++ b/config/gtfs_validator.exs
@@ -2,5 +2,5 @@ import Config
 
 # Configure GTFS Validator
 config :transport,
-   # by default, use the production validator. This can be overriden with dev.secret.exs
-   gtfs_validator_url: System.get_env("GTFS_VALIDATOR_URL", "https://transport-validator.cleverapps.io")
+  # by default, use the production validator. This can be overriden with dev.secret.exs
+  gtfs_validator_url: System.get_env("GTFS_VALIDATOR_URL", "https://transport-validator.cleverapps.io")

--- a/config/test.exs
+++ b/config/test.exs
@@ -53,8 +53,7 @@ config :datagouvfr,
 config :logger, level: :debug
 
 # ... but show only warnings and up on the console
-config :logger, :console,
-  level: :warn
+config :logger, :console, level: :warn
 
 # Configure data.gouv.fr authentication
 config :oauth2, Authentication,
@@ -65,10 +64,9 @@ config :oauth2, Authentication,
 # Validator configuration
 config :transport, gtfs_validator_url: System.get_env("GTFS_VALIDATOR_URL") || "http://127.0.0.1:7878"
 
-config :exvcr, [
+config :exvcr,
   vcr_cassette_library_dir: "test/fixture/cassettes",
   filter_request_headers: ["authorization"]
-]
 
 config :db, DB.Repo,
   url: System.get_env("PG_URL_TEST") || System.get_env("PG_URL") || "ecto://postgres:postgres@localhost/transport_test",


### PR DESCRIPTION
Je suis régulièrement embêté par ça en travaillant en local, et je m'empêchais de commiter le résultat.

Vu que la configuration est stable ("feature freeze"), on peut le faire tranquillement.

EDIT: on peut ajouter d'autres choses au formateur si ça vous paraît pertinent !