### PR TITLE
Redirect Montpellier GBFS to Klervi

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/redirect_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/redirect_controller.ex
@@ -1,0 +1,13 @@
+defmodule GBFS.RedirectController do
+  use GBFS, :controller
+
+  def index(%Plug.Conn{assigns: %{redirect_params: %{redirects: redirects}}} = conn, %{"path" => path}) do
+    if Map.has_key?(redirects, path) do
+      base = Map.fetch!(redirects, path)
+      destination = base |> URI.merge(path) |> to_string()
+      conn |> put_status(301) |> redirect(external: destination)
+    else
+      conn |> put_status(:not_found) |> text("404 not found")
+    end
+  end
+end

--- a/apps/gbfs/test/gbfs/controllers/redirect_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/redirect_controller_test.exs
@@ -1,0 +1,25 @@
+defmodule GBFS.RedirectControllerTest do
+  use GBFS.ConnCase, async: true
+
+  describe "Montpellier" do
+    test "it redirects", %{conn: conn} do
+      klervi_base = "https://montpellier-fr-smoove.klervi.net/gbfs/"
+
+      expected = %{
+        "gbfs.json" => klervi_base <> "gbfs.json",
+        "system_information.json" => klervi_base <> "en/system_information.json",
+        "station_information.json" => klervi_base <> "en/station_information.json",
+        "station_status.json" => klervi_base <> "en/station_status.json"
+      }
+
+      for {path, target} <- expected do
+        conn = conn |> get("/gbfs/montpellier/#{path}")
+        assert redirected_to(conn, 301) == target
+      end
+    end
+
+    test "unknown path", %{conn: conn} do
+      assert conn |> get("/gbfs/montpellier/foo") |> text_response(404) == "404 not found"
+    end
+  end
+end

--- a/apps/gbfs/test/gbfs/controllers/smoove_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/smoove_controller_test.exs
@@ -8,13 +8,13 @@ defmodule GBFS.SmooveControllerTest do
 
   describe "Smoove GBFS conversion" do
     test "on gbfs.json", %{conn: conn} do
-      conn = conn |> get(Routes.montpellier_path(conn, :index))
+      conn = conn |> get(Routes.strasbourg_path(conn, :index))
       body = json_response(conn, 200)
       check_entrypoint(body)
     end
 
     test "on system_information.json", %{conn: conn} do
-      conn = conn |> get(Routes.montpellier_path(conn, :system_information))
+      conn = conn |> get(Routes.strasbourg_path(conn, :system_information))
       body = json_response(conn, 200)
       check_system_information(body)
     end
@@ -22,7 +22,7 @@ defmodule GBFS.SmooveControllerTest do
     test "on station_information.json", %{conn: conn} do
       setup_stations_response()
 
-      conn = conn |> get(Routes.montpellier_path(conn, :station_information))
+      conn = conn |> get(Routes.strasbourg_path(conn, :station_information))
       body = json_response(conn, 200)
       check_station_information(body)
     end
@@ -30,7 +30,7 @@ defmodule GBFS.SmooveControllerTest do
     test "on station_status.json", %{conn: conn} do
       setup_stations_response()
 
-      conn = conn |> get(Routes.montpellier_path(conn, :station_status))
+      conn = conn |> get(Routes.strasbourg_path(conn, :station_status))
       body = json_response(conn, 200)
       check_station_status(body)
     end
@@ -38,14 +38,14 @@ defmodule GBFS.SmooveControllerTest do
     test "on invalid response", %{conn: conn} do
       Transport.HTTPoison.Mock |> expect(:get, fn _url -> {:ok, %HTTPoison.Response{status_code: 500}} end)
 
-      conn = conn |> get(Routes.montpellier_path(conn, :station_status))
+      conn = conn |> get(Routes.strasbourg_path(conn, :station_status))
       assert %{"error" => "smoove service unavailable"} == json_response(conn, 502)
     end
 
     defp setup_stations_response do
       Transport.HTTPoison.Mock
       |> expect(:get, fn url ->
-        assert url == "https://data.montpellier3m.fr/sites/default/files/ressources/TAM_MMM_VELOMAG.xml"
+        assert url == "http://velhop.strasbourg.eu/tvcstations.xml"
 
         {:ok,
          %HTTPoison.Response{

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -13,7 +13,7 @@ config :transport, TransportWeb.Endpoint,
   # NOTE: this is required to ensure code reloading will work.
   # A page reload is required to trigger this. More apps could
   # be added when needed here, we just added what we needed.
-  reloadable_apps: [:shared, :db, :transport, :unlock]
+  reloadable_apps: [:shared, :db, :transport, :unlock, :gbfs]
 
 # watchers are also configured via config/runtime.exs
 


### PR DESCRIPTION
Fixes #2292

Le GBFS de Montpellier était diffusé par le PAN précédemment, mais il semble que Smoove/Klervi diffuse des données. Cette PR adapte le code existant pour faire des redirections vers la véritable source des données, avec des `HTTP 301`. Les métriques sont toujours enregistrées pour Montpellier. On _devrait_ pouvoir observer une baisse du trafic vers le PAN au fur et à mesure que les réutilisateurs utilisent directement le flux de Klervi.