### PR TITLE
Comment trouver tous les GTFS-RT qui contiennent du "service alerts" uniquement avec l'API

### DIFF
--- a/scripts/api/filter_gtfs_rt_by_entity_types.exs
+++ b/scripts/api/filter_gtfs_rt_by_entity_types.exs
@@ -1,0 +1,44 @@
+Mix.install([
+  {:jason, "~> 1.3"},
+  {:req, "~> 0.2.2"}
+])
+
+url = "https://transport.data.gouv.fr/api/datasets"
+file = Regex.replace(~r/\W/, url, "-")
+
+unless File.exists?(file) do
+  %{status: 200, body: body} = Req.get!(url)
+  File.write!(file, body |> Jason.encode!())
+end
+
+IO.puts("============= first attempt =============")
+
+file
+|> File.read!()
+|> Jason.decode!()
+|> Enum.map(& &1["resources"])
+|> List.flatten()
+|> Enum.filter(&("service_alerts" in &1["features"]))
+# NOTE: we lack a `page_url` or reliable ressource id to
+# build a link back to the site here
+# https://github.com/etalab/transport-site/issues/2303
+|> IO.inspect(IEx.inspect_opts())
+
+IO.puts("============= work-around for #2303 ==============")
+
+# as a quick work-around, just report on the dataset page, which usually has only one GTFS-RT resource
+file
+|> File.read!()
+|> Jason.decode!()
+|> Enum.map(fn d ->
+  resources = d["resources"] |> Enum.filter(&("service_alerts" in &1["features"]))
+
+  if resources == [] do
+    nil
+  else
+    d["page_url"]
+  end
+end)
+|> Enum.reject(&is_nil/1)
+|> Enum.join("\n")
+|> IO.puts()


### PR DESCRIPTION
Suite à une question de @ChristinaLaumond, j'ajoute ce script. Je propose de commencer à historiser ces scripts (que ça soit du Elixir, du `jq` et du bash) dans un coin du repository, en tant que réutilisateur, car j'aimerais pouvoir capitaliser dessus dans le temps.

Au final ça m'a permis de remonter le problème suivant:

- #2303

Qui fait que répondre à la question n'est pas trivial.

### Exemple de sortie

* https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo-decembre-2021
* https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus
* https://transport.data.gouv.fr/datasets/reseau-urbain-reso
* https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole
* https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges
* https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus
* https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-vannes-kiceo-donnees-theoriques-et-temps-reel
* https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt
* https://transport.data.gouv.fr/datasets/offre-transport-st-malo
* https://transport.data.gouv.fr/datasets/simouv-horaires-theoriques-et-temps-reel-de-transport-public-transvilles-valenciennes
* https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt
* https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo