### PR TITLE
Répare test format de date sur AtomController

### DIFF
--- a/apps/transport/lib/transport_web/controllers/atom_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/atom_controller.ex
@@ -5,11 +5,9 @@ defmodule TransportWeb.AtomController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    two_month_ago =
-      NaiveDateTime.utc_now()
-      |> NaiveDateTime.add(-15 * 24 * 3600)
+    two_weeks_ago = NaiveDateTime.utc_now() |> NaiveDateTime.add(-15 * 24 * 3600)
 
-    resources = get_recently_updated_resources(two_month_ago)
+    resources = get_recently_updated_resources(two_weeks_ago)
 
     conn
     |> put_layout(false)

--- a/apps/transport/test/transport_web/controllers/atom_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/atom_controller_test.exs
@@ -55,13 +55,13 @@ defmodule TransportWeb.AtomControllerTest do
 
   test "date format in atom feed", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset)
-    last_update_utc = "2022-03-28T10:00:00.000000+00:00"
-    insert(:resource, title: "today-old", last_update: last_update_utc, dataset_id: dataset_id)
+    last_update_utc = days_ago(5)
+    insert(:resource, title: "today-old", last_update: last_update_utc |> to_string(), dataset_id: dataset_id)
 
     conn = conn |> get(atom_path(conn, :index))
 
-    # the timestamp displayed gets converted from utc to paris timezone
-    last_update_paris = "2022-03-28T12:00:00.000000+02:00"
+    # The timestamp displayed gets converted from UTC to Paris timezone
+    last_update_paris = last_update_utc |> Timex.Timezone.convert("Europe/Paris") |> Formatter.format!("{ISO:Extended}")
 
     doc = conn |> response(200) |> Floki.parse_document!()
     assert {"updated", [], [last_update_paris]} == doc |> Floki.find("updated") |> Enum.at(0)


### PR DESCRIPTION
Et bien mon fix rapide de #2274 n'aura pas marché très longtemps !

En réalité `AtomController` prend les ressources modifiées lors des 15 derniers jours, on ne pouvait donc pas utiliser une valeur "hardcodée".

Cette PR répare ça.