### PR TITLE
Ajout filetype pour DB.Resource

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -53,6 +53,9 @@ defmodule DB.Resource do
     field(:end_date, :date)
 
     field(:filesize, :integer)
+    # Can be `remote` or `file`. `file` are for files uploaded and hosted
+    # on data.gouv.fr
+    field(:filetype, :string)
 
     belongs_to(:dataset, Dataset)
     has_one(:validation, Validation, on_replace: :delete)
@@ -431,7 +434,8 @@ defmodule DB.Resource do
         :original_resource_url,
         :content_hash,
         :description,
-        :filesize
+        :filesize,
+        :filetype
       ]
     )
     |> validate_required([:url, :datagouv_id])

--- a/apps/db/priv/repo/migrations/20220412131157_add_resource_filetype.exs
+++ b/apps/db/priv/repo/migrations/20220412131157_add_resource_filetype.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddResourceFiletype do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      add :filetype, :string
+    end
+  end
+end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -351,6 +351,7 @@ defmodule Transport.ImportData do
         # For ODS gtfs as csv we do not have a 'latest' field
         # (the 'latest' field is the stable data.gouv.fr url)
         "latest_url" => resource["latest"] || resource["url"],
+        "filetype" => resource["filetype"],
         "id" => existing_resource[:id],
         "datagouv_id" => resource["id"],
         "is_available" => availability_checker().available?(resource),

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -24,12 +24,20 @@ defmodule Transport.ImportDataTest do
     :ok
   end
 
-  def generate_resources_payload(title \\ nil, url \\ nil, id \\ nil, schema_name \\ nil, schema_version \\ nil) do
+  def generate_resources_payload(
+        title \\ nil,
+        url \\ nil,
+        id \\ nil,
+        schema_name \\ nil,
+        schema_version \\ nil,
+        filetype \\ nil
+      ) do
     [
       %{
         "title" => title || "resource1",
         "url" => url || "http://localhost:4321/resource1",
         "id" => id || "resource1_id",
+        "filetype" => filetype || "remote",
         "schema" => %{"name" => schema_name, "version" => schema_version}
       }
     ]
@@ -166,6 +174,7 @@ defmodule Transport.ImportDataTest do
 
     [resource] = DB.Resource |> DB.Repo.all()
     assert Map.get(resource, :title) == "resource1"
+    assert Map.get(resource, :filetype) == "remote"
     resource_id = Map.get(resource, :id)
 
     # set the metadata field for this resource


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/2308

Sur les bons conseils de @fchabouis j'ajoute la colonne `filetype` pour les ressources provenant de l'API de data.gouv.fr. Ce sera bien utile dans `DatasetView` ensuite.

J'ai fait migration + changement du modèle dans la même PR. On pourrait avoir quelques exceptions lors du déploiement, je trouve que c'est acceptable.