### PR TITLE
Correctif tests qui ne plantent qu'en local

### DIFF
--- a/apps/db/lib/db/resource_unavailability.ex
+++ b/apps/db/lib/db/resource_unavailability.ex
@@ -59,7 +59,7 @@ defmodule DB.ResourceUnavailability do
       |> where(
         [r],
         fragment(
-          ~s["end" IS NULL OR "end" between now() - '1 day'::interval * ? and now()],
+          ~s["end" IS NULL OR "end" between (now() at time zone 'UTC') - '1 day'::interval * ? and (now() at time zone 'UTC')],
           ^nb_days
         )
       )


### PR DESCRIPTION
Après enquête un peu pénible je dois dire 😺 je crois avoir compris l'origine de:

- #2281.

Sur un ordinateur de dév, qui sera en heure française, la fonction `now()` SQL retourne l'heure locale:

```sql
select now(), now() at time zone 'utc'
```

| now                           | timezone                   |
|-------------------------------|----------------------------|
| 2022-04-12 15:43:01.659895+02 | 2022-04-12 13:43:01.659895 |

Or, en production et sur CircleCI, on va être en UTC (donc le problème n'apparaîtra pas).

J'ai l'impression que ça veut peut-être dire que ce test n'est jamais passé en local ?

J'adapte la requête.

En regardant rapidement, je ne vois pas d'autre instance de `now()` en SQL, mais il faudra vérifier.