### PR TITLE
Ajuste URL derrière le bouton Télécharger

### DIFF
--- a/apps/db/lib/db/dataset.ex
+++ b/apps/db/lib/db/dataset.ex
@@ -100,7 +100,8 @@ defmodule DB.Dataset do
         features: r.features,
         modes: r.modes,
         schema_name: r.schema_name,
-        schema_version: r.schema_version
+        schema_version: r.schema_version,
+        filetype: r.filetype
       }
     )
   end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -458,6 +458,8 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
+  defp needs_stable_url?(%DB.Resource{latest_url: nil}), do: false
+
   defp needs_stable_url?(%DB.Resource{url: url, filetype: "file"}) do
     Enum.member?(["static.data.gouv.fr", "demo-static.data.gouv.fr"], URI.parse(url).host)
   end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -451,8 +451,18 @@ defmodule TransportWeb.DatasetView do
   def schema_label(%{schema_name: schema_name}), do: schema_name
 
   def download_url(%Plug.Conn{} = conn, %DB.Resource{} = resource) do
-    if Resource.can_direct_download?(resource), do: resource.url, else: resource_path(conn, :download, resource.id)
+    cond do
+      needs_stable_url?(resource) -> resource.latest_url
+      Resource.can_direct_download?(resource) -> resource.url
+      true -> resource_path(conn, :download, resource.id)
+    end
   end
+
+  defp needs_stable_url?(%DB.Resource{url: url, filetype: "file"}) do
+    Enum.member?(["static.data.gouv.fr", "demo-static.data.gouv.fr"], URI.parse(url).host)
+  end
+
+  defp needs_stable_url?(%DB.Resource{}), do: false
 
   def has_validity_period?(history_resources) when is_list(history_resources) do
     history_resources |> Enum.map(&has_validity_period?/1) |> Enum.any?()


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2308 utilise ce qui a été fait dans #2319 

Utilise une URL stable pour le bouton "Télécharger" si les fichiers sont hébergés sur data.gouv.fr.