### PR TITLE
Recalcul des données de validation dans l'historisation

### DIFF
--- a/apps/db/lib/db/resource_history.ex
+++ b/apps/db/lib/db/resource_history.ex
@@ -8,12 +8,12 @@ defmodule DB.ResourceHistory do
 
   @derive {Jason.Encoder, only: [:datagouv_id, :payload, :last_up_to_date_at, :inserted_at, :updated_at]}
   typed_schema "resource_history" do
-    field(:datagouv_id, :string)
     field(:payload, :map)
     # the last moment we checked and the resource history was corresponding to the real online resource
     field(:last_up_to_date_at, :utc_datetime_usec)
 
     timestamps(type: :utc_datetime_usec)
+    belongs_to(:resource, DB.Resource, foreign_key: :datagouv_id, references: :datagouv_id, type: :string)
     has_many(:geo_data_import, DB.GeoDataImport)
   end
 

--- a/apps/shared/lib/schemas.ex
+++ b/apps/shared/lib/schemas.ex
@@ -5,7 +5,7 @@ defmodule Transport.Shared.Schemas.Wrapper do
   defp impl, do: Application.get_env(:transport, :schemas_impl)
 
   @callback schemas_by_type(binary()) :: map()
-  def schemas_by_type(schema_name), do: impl().schemas_by_type(schema_name)
+  def schemas_by_type(type), do: impl().schemas_by_type(type)
 
   @callback transport_schemas() :: map()
   def transport_schemas, do: impl().transport_schemas()

--- a/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
+++ b/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
@@ -1,6 +1,9 @@
 defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadata do
   @moduledoc """
   Recompute the `validation` key in `resource_metadata` for multiple `DB.ResourceHistory`.
+
+  When done, each `DB.ResourceHistory.payload` will have a key named `backfill_source`
+  set to this module name.
   """
   use Oban.Worker
   import Ecto.Query
@@ -61,7 +64,10 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadata do
     {:ok, %{"metadata" => metadata}} = Resource.validate(resource)
 
     rh
-    |> Ecto.Changeset.change(%{payload: Map.merge(payload, %{"resource_metadata" => metadata, "content_hash" => hash})})
+    |> Ecto.Changeset.change(%{
+      payload:
+        Map.merge(payload, %{"resource_metadata" => metadata, "content_hash" => hash, "backfill_source" => __MODULE__})
+    })
     |> Repo.update!()
   end
 

--- a/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
+++ b/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
@@ -1,11 +1,6 @@
 defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadata do
   @moduledoc """
-  Backfill of ResourceHistory payload to fix metadata for
-  non-GTFS resources with metadata specific to GTFS.
-
-  See also `ResourceMetadataNonGTFS`.
-
-  See https://github.com/etalab/transport-site/issues/2258
+  Recompute the `validation` key in `resource_metadata` for multiple `DB.ResourceHistory`.
   """
   use Oban.Worker
   import Ecto.Query
@@ -82,5 +77,5 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadata do
     end
   end
 
-  def http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
+  defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
 end

--- a/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
+++ b/apps/transport/lib/jobs/backfill/backfill_metadata_validation.ex
@@ -1,0 +1,86 @@
+defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadata do
+  @moduledoc """
+  Backfill of ResourceHistory payload to fix metadata for
+  non-GTFS resources with metadata specific to GTFS.
+
+  See also `ResourceMetadataNonGTFS`.
+
+  See https://github.com/etalab/transport-site/issues/2258
+  """
+  use Oban.Worker
+  import Ecto.Query
+  alias DB.{Repo, Resource, ResourceHistory}
+
+  @backfill_delay 1
+
+  @impl true
+  def perform(%{args: %{"resource_history_id" => resource_history_id, "backfill" => true}}) do
+    with :ok <- perform(%{args: %{"resource_history_id" => resource_history_id}}) do
+      case fetch_next(resource_history_id) do
+        next_id when is_integer(next_id) ->
+          %{resource_history_id: next_id, backfill: true} |> new(schedule_in: @backfill_delay) |> Oban.insert()
+
+        nil ->
+          :ok
+      end
+    end
+  end
+
+  def perform(%{args: %{"resource_history_id" => resource_history_id}}) do
+    update_resource_history(resource_history_id)
+    :ok
+  end
+
+  def fetch_next(resource_history_id) do
+    ResourceHistory
+    |> join(:inner, [rh], r in Resource, on: r.datagouv_id == rh.datagouv_id)
+    |> where([rh], rh.id > ^resource_history_id)
+    |> where([rh], fragment("payload->'resource_metadata' \\? 'validation'"))
+    |> order_by(asc: :id)
+    |> limit(1)
+    |> select([rh], rh.id)
+    |> Repo.one()
+  end
+
+  def update_resource_history(resource_history_id) do
+    ResourceHistory |> preload(:resource) |> Repo.get!(resource_history_id) |> do_update()
+  end
+
+  def do_update(
+        %ResourceHistory{
+          payload: %{"resource_metadata" => %{"validation" => _}} = payload,
+          resource: %Resource{schema_name: schema_name} = resource
+        } = rh
+      )
+      when not is_nil(schema_name) do
+    hash = content_hash(rh)
+
+    resource =
+      resource
+      |> struct(%{
+        url: Map.fetch!(payload, "permanent_url"),
+        metadata: Map.fetch!(payload, "resource_metadata"),
+        content_hash: hash
+      })
+
+    {:ok, %{"metadata" => metadata}} = Resource.validate(resource)
+
+    rh
+    |> Ecto.Changeset.change(%{payload: Map.merge(payload, %{"resource_metadata" => metadata, "content_hash" => hash})})
+    |> Repo.update!()
+  end
+
+  defp content_hash(%ResourceHistory{payload: %{"permanent_url" => url}}) do
+    file_path = System.tmp_dir!() |> Path.join(Ecto.UUID.generate())
+
+    try do
+      %HTTPoison.Response{status_code: 200, body: body} = http_client().get!(url)
+      File.write!(file_path, body)
+      Hasher.get_file_hash(file_path)
+    after
+      File.rm(file_path)
+    end
+  end
+
+  def http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
+end

--- a/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
+++ b/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
@@ -1,0 +1,117 @@
+defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadataTest do
+  use ExUnit.Case
+  import Transport.Jobs.Backfill.ResourceHistoryValidationMetadata
+  import DB.Factory
+  import Mox
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  @expected_hash "230d8358dc8e8890b4c58deeb62912ee2f20357ae92a5cc861b98e68fe31acb5"
+
+  setup :verify_on_exit!
+
+  describe "update_resource_history" do
+    test "with a TableSchema" do
+      permanent_url = "https://example.com/file"
+      initial_content_hash = Ecto.UUID.generate()
+      schema_name = "etalab/schema-zfe"
+      resource = insert(:resource, schema_name: schema_name, datagouv_id: Ecto.UUID.generate())
+
+      resource_history =
+        insert(:resource_history,
+          datagouv_id: resource.datagouv_id,
+          payload: %{
+            "permanent_url" => permanent_url,
+            "content_hash" => initial_content_hash,
+            "resource_metadata" => %{"validation" => %{"foo" => 42}, "bar" => "baz"}
+          }
+        )
+
+      Transport.Shared.Schemas.Mock
+      |> expect(:schemas_by_type, fn "tableschema" -> %{resource.schema_name => %{"title" => "foo"}} end)
+
+      Transport.HTTPoison.Mock
+      |> expect(:get!, fn ^permanent_url ->
+        %HTTPoison.Response{status_code: 200, body: "body"}
+      end)
+
+      validation_result = %{"errors_count" => 0, "has_errors" => false, "errors" => []}
+
+      Shared.Validation.TableSchemaValidator.Mock
+      |> expect(:validate, fn ^schema_name, ^permanent_url, nil -> validation_result end)
+
+      update_resource_history(resource_history.id)
+
+      %DB.ResourceHistory{payload: payload} = DB.Repo.reload!(resource_history)
+
+      assert %{
+               "content_hash" => @expected_hash,
+               "permanent_url" => permanent_url,
+               "resource_metadata" => %{
+                 "bar" => "baz",
+                 "validation" =>
+                   Map.merge(validation_result, %{"content_hash" => @expected_hash, "schema_type" => "tableschema"})
+               }
+             } == payload
+    end
+
+    test "with a JSON Schema" do
+      permanent_url = "https://example.com/file"
+      initial_content_hash = Ecto.UUID.generate()
+      schema_name = "etalab/schema-amenagements-cyclables"
+      resource = insert(:resource, schema_name: schema_name, datagouv_id: Ecto.UUID.generate())
+
+      resource_history =
+        insert(:resource_history,
+          datagouv_id: resource.datagouv_id,
+          payload: %{
+            "permanent_url" => permanent_url,
+            "content_hash" => initial_content_hash,
+            "resource_metadata" => %{"validation" => %{"foo" => 42}, "bar" => "baz"}
+          }
+        )
+
+      Transport.Shared.Schemas.Mock
+      |> expect(:schemas_by_type, fn "tableschema" -> %{} end)
+
+      Transport.Shared.Schemas.Mock
+      |> expect(:schemas_by_type, fn "jsonschema" -> %{resource.schema_name => %{"title" => "foo"}} end)
+
+      Transport.HTTPoison.Mock
+      |> expect(:get!, fn ^permanent_url ->
+        %HTTPoison.Response{status_code: 200, body: "body"}
+      end)
+
+      validation_result = %{"errors_count" => 0, "has_errors" => false, "errors" => []}
+
+      Shared.Validation.JSONSchemaValidator.Mock
+      |> expect(:load_jsonschema_for_schema, fn ^schema_name ->
+        %ExJsonSchema.Schema.Root{
+          schema: %{"properties" => %{"name" => %{"type" => "string"}}, "required" => ["name"], "type" => "object"},
+          version: 7
+        }
+      end)
+
+      Shared.Validation.JSONSchemaValidator.Mock
+      |> expect(:validate, fn _schema, ^permanent_url ->
+        validation_result
+      end)
+
+      update_resource_history(resource_history.id)
+
+      %DB.ResourceHistory{payload: payload} = DB.Repo.reload!(resource_history)
+
+      assert %{
+               "content_hash" => @expected_hash,
+               "permanent_url" => permanent_url,
+               "resource_metadata" => %{
+                 "bar" => "baz",
+                 "validation" =>
+                   Map.merge(validation_result, %{"content_hash" => @expected_hash, "schema_type" => "jsonschema"})
+               }
+             } == payload
+    end
+  end
+end

--- a/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
+++ b/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
@@ -48,6 +48,7 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadataTest do
 
       assert %{
                "content_hash" => @expected_hash,
+               "backfill_source" => "Elixir.Transport.Jobs.Backfill.ResourceHistoryValidationMetadata",
                "permanent_url" => permanent_url,
                "resource_metadata" => %{
                  "bar" => "baz",
@@ -105,6 +106,7 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadataTest do
 
       assert %{
                "content_hash" => @expected_hash,
+               "backfill_source" => "Elixir.Transport.Jobs.Backfill.ResourceHistoryValidationMetadata",
                "permanent_url" => permanent_url,
                "resource_metadata" => %{
                  "bar" => "baz",


### PR DESCRIPTION
Cette PR est une PR de backfill, qui recalcule les informations de validation de ressources qui ont été historisées avec des informations de validation périmées. C'est dû au fait qu'il n'y avait pas encore https://github.com/etalab/transport-site/pull/2326 et qu'ainsi on historisait un nouveau fichier avec des informations de validation de la version d'avant.

## Périmètre

En prod il y a actuellement 155 `ResourceHistory` qui sont concernées

```sql
select rh.payload->'format', r.schema_name, rh.payload->'content_hash', rh.payload->'resource_metadata'->'validation'->'content_hash', rh.payload
from resource_history rh
join resource r on r.datagouv_id = rh.datagouv_id
where rh.payload->'resource_metadata' ? 'validation'
```

C'est un nombre assez faible car actuellement l'historisation comporte des informations de validation uniquement pour les ressources avec un schéma JSON Schema / Table Schema. Le grand absent est GTFS, qu'on pourra calculer à un moment dans le futur sur l'historique si on souhaite. GBFS est hors périmètre car données temps réel.

## Exécution

L'exécution se fait comme les autres jobs de backfill, en dispatchant le premier job en production avec le 1er ID.

```elixir
Transport.Jobs.Backfill.ResourceHistoryValidationMetadata.perform(%{args: %{"resource_history_id" => 17135, "backfill" => true}})
```

On peut suivre l'exécution avec les jobs Oban ensuite.

J'ai fait tourner ceci en local avec un dump de prod sans rencontrer d'erreurs.