### PR TITLE
Stats : compte types de flux GTFS-RT

### DIFF
--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -79,9 +79,19 @@ defmodule Transport.StatsHandler do
       nb_bss_datasets: count_dataset_with_format("gbfs"),
       nb_bikes_scooter_datasets: nb_bikes_scooters(),
       nb_gtfs_rt: count_dataset_with_format("gtfs-rt"),
+      gtfs_rt_types: count_feed_types_gtfs_rt(),
       nb_siri: count_dataset_with_format("SIRI"),
       nb_siri_lite: count_dataset_with_format("SIRI Lite")
     }
+  end
+
+  defp count_feed_types_gtfs_rt do
+    Resource
+    |> select([r], %{type: fragment("unnest(?) as type", r.features), count: count(r.id)})
+    |> where([r], r.format == "gtfs-rt")
+    |> group_by([r], fragment("type"))
+    |> order_by([r], desc: count(r.id))
+    |> Repo.all()
   end
 
   defp get_population(datasets) do

--- a/apps/transport/lib/transport_web/templates/stats/index.html.eex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.eex
@@ -219,15 +219,24 @@
           <div class="panel">
              <div class=tile>
                <h3><%= @nb_gtfs_rt %></h3>
-               <div>jeux de données en <strong>GTFS-RT</strong></div>
+               <div>jeux de données<br>en <strong>GTFS-RT</strong></div>
+               <div>
+                 <ul class="small">
+                  <%= for el <- @gtfs_rt_types do %>
+                    <li>
+                      <span title="<%= el.type %>"><%= friendly_gtfs_type(el.type) %></span> : <%= format_number(el.count) %>
+                    </li>
+                  <% end %>
+                 </ul>
+               </div>
              </div>
              <div class=tile>
                <h3><%= @nb_siri %></h3>
-               <div>jeux de données en <strong>SIRI</strong></div>
+               <div>jeux de données<br>en <strong>SIRI</strong></div>
              </div>
              <div class=tile>
                <h3><%= @nb_siri_lite %></h3>
-               <div>jeux de données en <strong>SIRI Lite</strong></div>
+               <div>jeux de données<br>en <strong>SIRI Lite</strong></div>
              </div>
           </div>
       </div>

--- a/apps/transport/lib/transport_web/views/stats_view.ex
+++ b/apps/transport/lib/transport_web/views/stats_view.ex
@@ -1,3 +1,14 @@
 defmodule TransportWeb.StatsView do
   use TransportWeb, :view
+
+  def friendly_gtfs_type(type) when is_binary(type) do
+    Map.fetch!(
+      %{
+        "trip_updates" => dgettext("stats", "Trip updates"),
+        "vehicle_positions" => dgettext("stats", "Vehicle positions"),
+        "service_alerts" => dgettext("stats", "Service alerts")
+      },
+      type
+    )
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/stats.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/stats.po
@@ -1,0 +1,24 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-autogen, elixir-format
+msgid "Service alerts"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip updates"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Vehicle positions"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/stats.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/stats.po
@@ -1,0 +1,24 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-autogen, elixir-format
+msgid "Service alerts"
+msgstr "Info trafic"
+
+#, elixir-autogen, elixir-format
+msgid "Trip updates"
+msgstr "Prochains passages"
+
+#, elixir-autogen, elixir-format
+msgid "Vehicle positions"
+msgstr "Positions des véhicules"

--- a/apps/transport/priv/gettext/stats.pot
+++ b/apps/transport/priv/gettext/stats.pot
@@ -1,0 +1,23 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Service alerts"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip updates"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Vehicle positions"
+msgstr ""


### PR DESCRIPTION
Fixes #2316

Une prise en compte partielle de ce qui a été décrit dans l'issue, mais qui est déjà une amélioration. Utilise ce qui a été fait dans https://github.com/etalab/transport-site/pull/2248 pour afficher le nombre de flux GTFS-RT diffusant chaque type d'information.

![image](https://user-images.githubusercontent.com/295709/164648478-356862d2-ed04-4de2-92ef-c3532f1155ff.png)

J'ai tenté de faire un truc pas trop moche sans faire de CSS custom ou en changeant totalement l'aspect de cette page.
