### PR TITLE
Messages d'erreurs supplémentaires pour validateur GTFS

### DIFF
--- a/apps/db/lib/db/resource.ex
+++ b/apps/db/lib/db/resource.ex
@@ -472,7 +472,10 @@ defmodule DB.Resource do
       "UnloadableModel" => dgettext("validations", "Not compliant with the GTFS specification"),
       "MissingMandatoryFile" => dgettext("validations", "Missing mandatory file"),
       "ExtraFile" => dgettext("validations", "Extra file"),
-      "ImpossibleToInterpolateStopTimes" => dgettext("validations", "Impossible to interpolate stop times")
+      "ImpossibleToInterpolateStopTimes" => dgettext("validations", "Impossible to interpolate stop times"),
+      "InvalidStopLocationTypeInTrip" => dgettext("validations", "Invalid stop location type in trip"),
+      "InvalidStopParent" => dgettext("validations", "Invalid stop parent"),
+      "IdNotAscii" => dgettext("validations", "ID is not ASCII-encoded")
     }
 
   @spec has_metadata?(__MODULE__.t()) :: boolean()

--- a/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/en/LC_MESSAGES/validations.po
@@ -146,3 +146,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Impossible to interpolate stop times"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "ID is not ASCII-encoded"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid stop location type in trip"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid stop parent"
+msgstr ""

--- a/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/db/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -53,7 +53,7 @@ msgstr "Coordonnées invalide"
 
 #, elixir-autogen, elixir-format
 msgid "Invalid currency"
-msgstr "Monnaie invalide"
+msgstr "Devise invalide"
 
 #, elixir-autogen, elixir-format
 msgid "Invalid language"
@@ -146,3 +146,15 @@ msgstr "Spécifications GTFS non respectées"
 #, elixir-autogen, elixir-format
 msgid "Impossible to interpolate stop times"
 msgstr "Interpolation de certains horaires impossible"
+
+#, elixir-autogen, elixir-format
+msgid "ID is not ASCII-encoded"
+msgstr "Identifiant non encodé en ASCII"
+
+#, elixir-autogen, elixir-format
+msgid "Invalid stop location type in trip"
+msgstr "Type d'arrêt invalide dans un trajet"
+
+#, elixir-autogen, elixir-format
+msgid "Invalid stop parent"
+msgstr "Arrêt parent invalide"

--- a/apps/db/priv/gettext/validations.pot
+++ b/apps/db/priv/gettext/validations.pot
@@ -145,3 +145,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Impossible to interpolate stop times"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "ID is not ASCII-encoded"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid stop location type in trip"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid stop parent"
+msgstr ""


### PR DESCRIPTION
Suite à https://github.com/etalab/transport-validator/pull/119, j'ai ajouté des messages d'erreurs pour des raisons qui n'étaient pas encore présentes.