### PR TITLE
URL permanente datagouv pour Bison Futé

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -461,7 +461,8 @@ defmodule TransportWeb.DatasetView do
   defp needs_stable_url?(%DB.Resource{latest_url: nil}), do: false
 
   defp needs_stable_url?(%DB.Resource{url: url, filetype: "file"}) do
-    Enum.member?(["static.data.gouv.fr", "demo-static.data.gouv.fr"], URI.parse(url).host)
+    host = URI.parse(url).host
+    Enum.member?(Application.fetch_env!(:transport, :domains_hosting_static_files), host)
   end
 
   defp needs_stable_url?(%DB.Resource{}), do: false

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -80,6 +80,13 @@ defmodule TransportWeb.DatasetViewTest do
              latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
            }) == latest_url
 
+    # Bison Futé files
+    assert download_url(conn, %DB.Resource{
+             filetype: "file",
+             url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/refDir.csv",
+             latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
+           }) == latest_url
+
     # File not hosted on data.gouv.fr
     assert download_url(conn, %DB.Resource{filetype: "file", url: url = "https://data.example.com/voies.geojson"}) ==
              url

--- a/config/config.exs
+++ b/config/config.exs
@@ -127,6 +127,9 @@ config :transport,
     }
   }
 
+config :transport,
+  domains_hosting_static_files: ["static.data.gouv.fr", "demo-static.data.gouv.fr", "tipi.bison-fute.gouv.fr"]
+
 config :datagouvfr,
   community_resources_impl: Datagouvfr.Client.CommunityResources.API,
   authentication_impl: Datagouvfr.Authentication,


### PR DESCRIPTION
Fixes #2339

Bison Futé a :
- des URLs en `http://`
- un lien qui redirige vers un directory listing en web (exemple http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/Evenementiel-DIR/grt/RRN/)

La combinaison des 2 ne plait pas à notre. En effet, quand on est dans ce cas, notre code essaie de renvoyer le contenu du fichier distant ([voir code](https://github.com/etalab/transport-site/blob/10ada526b16f1e402426eded9acf7387ab9c2de1/apps/transport/lib/transport_web/controllers/resource_controller.ex#L149-L174)).

J'adapte le code pour forcer l'utilisation d'un lien permanent data.gouv.fr, qui lui va rediriger vers le lien final.

On pourrait à terme adapter le code pour avoir une redirection 302 si `content-type: text/html` ?