### PR TITLE
Pas de contrainte de filetype pour needs_stable_url?

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -460,7 +460,7 @@ defmodule TransportWeb.DatasetView do
 
   defp needs_stable_url?(%DB.Resource{latest_url: nil}), do: false
 
-  defp needs_stable_url?(%DB.Resource{url: url, filetype: "file"}) do
+  defp needs_stable_url?(%DB.Resource{url: url}) do
     host = URI.parse(url).host
     Enum.member?(Application.fetch_env!(:transport, :domains_hosting_static_files), host)
   end

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -82,7 +82,7 @@ defmodule TransportWeb.DatasetViewTest do
 
     # Bison Futé files
     assert download_url(conn, %DB.Resource{
-             filetype: "file",
+             filetype: "remote",
              url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/refDir.csv",
              latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
            }) == latest_url


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2341

En réalité les ressources pour Bison Futé ont un `filetype = remote`, ce qui est logique car c'est bien un lien distant et non un fichier déposé sur datagouv. La PR précédente n'était donc pas suffisante.

J'ai supprimé la contrainte de filetype car ça me semble acceptable de considérer qu'on utilise une URL stable datagouv dès lors que le host est un domaine static de datagouv, ou `tipi.bison-fute.gouv.fr`