### PR TITLE
Ajout test validateur JSONSchema et dependentRequired

### DIFF
--- a/apps/shared/test/validation/jsonschema_validator_test.exs
+++ b/apps/shared/test/validation/jsonschema_validator_test.exs
@@ -96,6 +96,50 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
 
       assert nil == validate(name_jsonschema(), url)
     end
+
+    test "can validate dependencies" do
+      schema = %ExJsonSchema.Schema.Root{
+        schema: %{
+          "properties" => %{"name" => %{"type" => "string"}, "age" => %{"type" => "integer"}},
+          "type" => "object",
+          "dependencies" => %{"name" => ["age"], "age" => ["name"]}
+        },
+        version: 7
+      }
+
+      assert %{
+               "errors" => ["#: Property name depends on property age to be present but it was not."],
+               "errors_count" => 1,
+               "has_errors" => true,
+               "validator" => Shared.Validation.JSONSchemaValidator
+             } == validate(schema, %{"name" => "Bob"})
+
+      assert %{
+               "errors" => ["#: Property age depends on property name to be present but it was not."],
+               "errors_count" => 1,
+               "has_errors" => true,
+               "validator" => Shared.Validation.JSONSchemaValidator
+             } == validate(schema, %{"age" => 42})
+
+      # Our Elixir validator does not recognise `dependentRequired` yet,
+      # even if it exists in the JSONSchema spec
+      # https://json-schema.org/understanding-json-schema/reference/conditionals.html#id4
+      #
+      # See https://github.com/etalab/transport-site/issues/2347
+      dependent_required_schema = %ExJsonSchema.Schema.Root{
+        schema:
+          Enum.into(schema.schema, %{}, fn
+            {"dependencies", value} -> {"dependentRequired", value}
+            pair -> pair
+          end),
+        version: 7
+      }
+
+      assert Map.has_key?(dependent_required_schema.schema, "dependentRequired")
+
+      assert %{"has_errors" => false} = validate(dependent_required_schema, %{"name" => "Bob"})
+      assert %{"has_errors" => false} = validate(dependent_required_schema, %{"age" => 42})
+    end
   end
 
   defp name_jsonschema do

--- a/apps/shared/test/validation/jsonschema_validator_test.exs
+++ b/apps/shared/test/validation/jsonschema_validator_test.exs
@@ -140,12 +140,10 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
       # https://json-schema.org/understanding-json-schema/reference/conditionals.html#id4
       #
       # See https://github.com/etalab/transport-site/issues/2347
+      {value, base_schema} = Map.pop!(schema.schema, "dependencies")
+
       dependent_required_schema = %ExJsonSchema.Schema.Root{
-        schema:
-          Enum.into(schema.schema, %{}, fn
-            {"dependencies", value} -> {"dependentRequired", value}
-            pair -> pair
-          end),
+        schema: Map.put(base_schema, "dependentRequired", value),
         version: 7
       }
 

--- a/apps/shared/test/validation/jsonschema_validator_test.exs
+++ b/apps/shared/test/validation/jsonschema_validator_test.exs
@@ -97,6 +97,20 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
       assert nil == validate(name_jsonschema(), url)
     end
 
+    test "supports version up to 7" do
+      base_schema = %{"type" => "object", "properties" => %{"foo" => %{"type" => "string"}}}
+      v7_schema = Map.put(base_schema, "$schema", "http://json-schema.org/draft-07/schema")
+
+      assert ExJsonSchema.Schema.resolve(v7_schema)
+
+      # 2019-09 was previously known as version 8
+      assert_raise ExJsonSchema.Schema.UnsupportedSchemaVersionError, fn ->
+        base_schema
+        |> Map.put("$schema", "https://json-schema.org/draft/2019-09/schema")
+        |> ExJsonSchema.Schema.resolve()
+      end
+    end
+
     test "can validate dependencies" do
       schema = %ExJsonSchema.Schema.Root{
         schema: %{


### PR DESCRIPTION
Lié à https://github.com/etalab/transport-site/issues/2347

Ajoute un test pour vérifier le comportement de notre validateur JSON Schema vis-à-vis de `dependencies` et `dependentRequired`, lié au fait que notre validateur ne supporte pas les versions 2019 et 2020 pour le moment. https://github.com/jonasschmidt/ex_json_schema/issues/75