### PR TITLE
Gère gtfs_rt_types pour stockage des stats

### DIFF
--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -15,15 +15,17 @@ defmodule Transport.StatsHandler do
   def store_stats do
     timestamp = DateTime.truncate(DateTime.utc_now(), :second)
 
-    compute_stats()
-    |> Enum.each(fn {k, v} ->
-      %StatsHistory{
-        timestamp: timestamp,
-        metric: "#{k}",
-        value: v
-      }
-      |> Repo.insert!()
+    compute_stats() |> Enum.each(fn {k, v} -> store_stat_history(k, v, timestamp) end)
+  end
+
+  defp store_stat_history(:gtfs_rt_types = key, values, %DateTime{} = timestamp) do
+    Enum.map(values, fn item ->
+      store_stat_history("#{key}::#{Map.fetch!(item, :type)}", Map.fetch!(item, :count), timestamp)
     end)
+  end
+
+  defp store_stat_history(key, value, %DateTime{} = timestamp) when is_number(value) do
+    %StatsHistory{timestamp: timestamp, metric: to_string(key), value: value} |> Repo.insert!()
   end
 
   @doc """

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -137,7 +137,7 @@ defmodule Transport.StatsHandler do
   end
 
   defp nb_reuses do
-    Repo.aggregate(Dataset, :sum, :nb_reuses)
+    Repo.aggregate(Dataset, :sum, :nb_reuses) || 0
   end
 
   defp count_dataset_with_format(format) do

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -1,0 +1,29 @@
+defmodule Transport.StatsHandlerTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Ecto.Query
+  import Transport.StatsHandler
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "compute_stats" do
+    assert is_map(compute_stats())
+  end
+
+  test "store_stats" do
+    insert(:resource, format: "gtfs-rt", features: ["trip_updates", "vehicle_positions"])
+    stats = compute_stats()
+    store_stats()
+    assert DB.Repo.aggregate(DB.StatsHistory, :count, :id) >= Enum.count(stats)
+
+    all_metrics = DB.StatsHistory |> select([s], s.metric) |> DB.Repo.all()
+
+    stats_metrics = Map.keys(stats) |> Enum.map(&to_string/1) |> Enum.reject(&String.starts_with?(&1, "gtfs_rt_types"))
+
+    assert MapSet.subset?(MapSet.new(stats_metrics), MapSet.new(all_metrics))
+    assert Enum.member?(all_metrics, "gtfs_rt_types::vehicle_positions")
+    assert Enum.member?(all_metrics, "gtfs_rt_types::trip_updates")
+  end
+end

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -20,7 +20,8 @@ defmodule Transport.StatsHandlerTest do
 
     all_metrics = DB.StatsHistory |> select([s], s.metric) |> DB.Repo.all()
 
-    stats_metrics = Map.keys(stats) |> Enum.map(&to_string/1) |> Enum.reject(&String.starts_with?(&1, "gtfs_rt_types"))
+    stats_metrics =
+      stats |> Map.keys() |> Enum.map(&to_string/1) |> Enum.reject(&String.starts_with?(&1, "gtfs_rt_types"))
 
     assert MapSet.subset?(MapSet.new(stats_metrics), MapSet.new(all_metrics))
     assert Enum.member?(all_metrics, "gtfs_rt_types::vehicle_positions")


### PR DESCRIPTION
Bug introduit suite à https://github.com/etalab/transport-site/pull/2330

## Cause

`:gtfs_rt_types` contient une valeur du style

```elixir
[%{count: 60, type: "trip_updates"}, %{count: 44, type: "vehicle_positions"}, %{count: 13, type: "service_alerts"}]
```

et non des nombres, comme les autres clés.

Le processus d'historisation quotidien ne gérait pas cette possibilité, d'où l'apparition [d'une exception](https://sentry.io/organizations/transport-data-gouv-fr/issues/3230559511/?project=6197733&query=is%3Aunresolved).

## Non anticipation

Je n'avais pas connaissance de cette logique, donc je ne l'avais pas anticipé. Il n'y a malheureusement pas de tests sur cette classe.

## Test de ce code

Comme un vrai ingénieur, dans `iex -S mix`

```elixir
iex> recompile;Transport.StatsHandler.store_stats()
[debug] QUERY OK db=1.7ms idle=14.1ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["aom_with_errors", ~U[2022-05-02 10:08:00Z], #Decimal<0>]
[debug] QUERY OK db=1.0ms idle=14.3ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["aom_with_fatal", ~U[2022-05-02 10:08:00Z], #Decimal<15>]
[debug] QUERY OK db=0.9ms idle=13.9ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["gtfs_rt_types::trip_updates", ~U[2022-05-02 10:08:00Z], #Decimal<58>]
[debug] QUERY OK db=0.6ms idle=14.0ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["gtfs_rt_types::vehicle_positions", ~U[2022-05-02 10:08:00Z], #Decimal<43>]
[debug] QUERY OK db=0.7ms idle=13.9ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["gtfs_rt_types::service_alerts", ~U[2022-05-02 10:08:00Z], #Decimal<13>]
[debug] QUERY OK db=0.7ms idle=13.9ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_aoms", ~U[2022-05-02 10:08:00Z], #Decimal<335>]
[debug] QUERY OK db=0.6ms idle=13.9ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_aoms_with_data", ~U[2022-05-02 10:08:00Z], #Decimal<238>]
[debug] QUERY OK db=0.6ms idle=12.1ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_bikes_scooter_datasets", ~U[2022-05-02 10:08:00Z], #Decimal<45>]
[debug] QUERY OK db=0.6ms idle=10.7ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_bss_datasets", ~U[2022-05-02 10:08:00Z], #Decimal<43>]
[debug] QUERY OK db=1.5ms idle=10.4ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_dataset_types", ~U[2022-05-02 10:08:00Z], #Decimal<12>]
[debug] QUERY OK db=0.7ms idle=10.2ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_datasets", ~U[2022-05-02 10:08:00Z], #Decimal<433>]
[debug] QUERY OK db=0.6ms idle=9.8ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_gtfs", ~U[2022-05-02 10:08:00Z], #Decimal<340>]
[debug] QUERY OK db=0.9ms idle=9.3ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_gtfs_rt", ~U[2022-05-02 10:08:00Z], #Decimal<70>]
[debug] QUERY OK db=1.0ms idle=9.7ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_netex", ~U[2022-05-02 10:08:00Z], #Decimal<69>]
[debug] QUERY OK db=0.7ms idle=10.1ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_official_public_transit_realtime", ~U[2022-05-02 10:08:00Z], #Decimal<69>]
[debug] QUERY OK db=2.7ms idle=10.2ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_pt_datasets", ~U[2022-05-02 10:08:00Z], #Decimal<321>]
[debug] QUERY OK db=0.7ms idle=12.3ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_regions", ~U[2022-05-02 10:08:00Z], #Decimal<19>]
[debug] QUERY OK db=0.7ms idle=12.4ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_regions_completed", ~U[2022-05-02 10:08:00Z], #Decimal<15>]
[debug] QUERY OK db=0.8ms idle=12.5ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_reusers", ~U[2022-05-02 10:08:00Z], #Decimal<41>]
[debug] QUERY OK db=0.8ms idle=11.9ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_reuses", ~U[2022-05-02 10:08:00Z], #Decimal<260>]
[debug] QUERY OK db=0.7ms idle=12.0ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_siri", ~U[2022-05-02 10:08:00Z], #Decimal<1>]
[debug] QUERY OK db=0.7ms idle=12.1ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_siri_lite", ~U[2022-05-02 10:08:00Z], #Decimal<0>] 
[debug] QUERY OK db=0.7ms idle=12.0ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["nb_unofficial_public_transit_realtime", ~U[2022-05-02 10:08:00Z], #Decimal<18>]
[debug] QUERY OK db=0.7ms idle=11.6ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["population_couverte", ~U[2022-05-02 10:08:00Z], #Decimal<44>]
[debug] QUERY OK db=1.1ms queue=0.1ms idle=12.1ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["population_totale", ~U[2022-05-02 10:08:00Z], #Decimal<49>]
[debug] QUERY OK db=0.7ms idle=10.6ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["ratio_aom_good_quality", ~U[2022-05-02 10:08:00Z], #Decimal<0.13302752293577982>]
[debug] QUERY OK db=0.9ms idle=10.6ms
INSERT INTO "stats_history" ("metric","timestamp","value") VALUES ($1,$2,$3) RETURNING "id" ["ratio_aom_with_at_most_warnings", ~U[2022-05-02 10:08:00Z], #Decimal<0.9311926605504587>]
:ok
```


## Sur l'absence de tests

J'ai du mal à décider si je dois ajouter des tests pour éviter la survenance de tels bugs à l'avenir.

Pour l'instant j'ai dit un non (faible) car :

- la page stats est très "visuelle"
- elle est moins critique que d'autres aspects de l'app
- l'écriture de tests pour `compute_stats` suppose une mise en place de pas mal d'objets pour être pertinent

À vous de me dire si vous êtes d'accord avec moi, si je dois ajouter des tests dans cette PR, ouvrir une issue ou laisser tomber.