### PR TITLE
Tri des ressources dans un JDD sur dataset#details

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -101,7 +101,8 @@ defmodule DB.Dataset do
         modes: r.modes,
         schema_name: r.schema_name,
         schema_version: r.schema_version,
-        type: r.type
+        type: r.type,
+        display_position: r.display_position
       }
     )
   end

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -60,6 +60,7 @@ defmodule DB.Resource do
     # https://github.com/opendatateam/udata/blob/fab505fd9159c6a9f63e3cb55f0d6479b7ca91e2/udata/core/dataset/models.py#L89-L96
     # Example: `main`, `documentation`, `api`, `code` etc.
     field(:type, :string)
+    field(:display_position, :integer)
 
     belongs_to(:dataset, Dataset)
     has_one(:validation, Validation, on_replace: :delete)
@@ -440,7 +441,8 @@ defmodule DB.Resource do
         :description,
         :filesize,
         :filetype,
-        :type
+        :type,
+        :display_position
       ]
     )
     |> validate_required([:url, :datagouv_id])

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -314,15 +314,7 @@ defmodule TransportWeb.DatasetView do
     |> Stream.reject(&Resource.is_real_time?/1)
     |> Stream.reject(&Resource.is_documentation?/1)
     |> Enum.to_list()
-    |> Enum.sort(fn r1, r2 ->
-      nd1 = NaiveDateTime.from_iso8601(Map.get(r1, :last_update, ""))
-      nd2 = NaiveDateTime.from_iso8601(Map.get(r2, :last_update, ""))
-
-      case {nd1, nd2} do
-        {{:ok, nd1}, {:ok, nd2}} -> NaiveDateTime.compare(nd1, nd2) == :gt
-        _ -> true
-      end
-    end)
+    |> Enum.sort_by(& &1.display_position)
   end
 
   def official_documentation_resources(dataset) do

--- a/apps/transport/priv/repo/migrations/20220505115659_add_resource_display_position.exs
+++ b/apps/transport/priv/repo/migrations/20220505115659_add_resource_display_position.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddResourceDisplayPosition do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource) do
+      add :display_position, :integer
+    end
+  end
+end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -177,6 +177,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource, :title) == "resource1"
     assert Map.get(resource, :filetype) == "remote"
     assert Map.get(resource, :type) == "main"
+    assert Map.get(resource, :display_position) == 0
     resource_id = Map.get(resource, :id)
 
     # set the metadata field for this resource
@@ -241,6 +242,7 @@ defmodule Transport.ImportDataTest do
     # the resource is up-to-date with data.gouv
     assert Map.get(resource_updated, :title) == new_title
     assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
+    assert Map.get(resource_updated, :display_position) == 0
 
     # but its a new one : its DB id has been incremented
     refute Map.get(resource_updated, :id) == resource_id
@@ -272,6 +274,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource, :title) == community_resource_title
     assert Map.get(resource, :schema_name) == schema_name
     assert Map.get(resource, :schema_version) == schema_version
+    assert Map.get(resource, :display_position) == 0
   end
 
   # test "error while connecting to datagouv server"

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -105,4 +105,28 @@ defmodule TransportWeb.DatasetViewTest do
                "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/898dc67fb19fae2464c24a85a0557e8ccce18791/bnlc-.csv"
            }) == resource_path(conn, :download, id)
   end
+
+  test "other_official_resources is sorted by display position" do
+    dataset = %DB.Dataset{
+      type: "low-emission-zones",
+      resources: [
+        %DB.Resource{
+          id: 1,
+          url: "https://example.com/zfe.geojson",
+          format: "geojson",
+          schema_name: "etalab/schema-zfe",
+          display_position: 1
+        },
+        %DB.Resource{
+          id: 2,
+          url: "https://example.com/voies.geojson",
+          format: "geojson",
+          schema_name: "etalab/schema-zfe",
+          display_position: 0
+        }
+      ]
+    }
+
+    assert [{0, 2}, {1, 1}] == dataset |> other_official_resources() |> Enum.map(&{&1.display_position, &1.id})
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2340

Ajoute une colonne `display_position` qui reprend l'ordre d'affichage des ressources tel que présent sur data.gouv.fr.

Le tri est effectué pour les ressources "génériques", pas les GTFS qui sont triés par date de validité.

L'API de data.gouv.fr ne donne pas cette information clairement, mais c'est dans l'ordre. On peut donc avoir un index croissant pour chaque dataset, tant qu'on le génère.

À noter que notre code d'import exclut certaines ressources (des PDF ou des choses qui ne respectent pas un schéma pour certaines catégories). On peut donc avoir une suite de `resource.display_position` avec "des trous". Pas grave, ce qui compte c'est la possibilité de trier.