### PR TITLE
Ajoute menu Documentation sur dataset#details

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -22,6 +22,9 @@
         <div id="menu-item-visualisation" class="menu-item"><a href="#dataset-visualisation"><%= dgettext("page-dataset-details", "Visualization")%></a></div>
       <% end %>
       <div class="menu-item"><a href="#dataset-resources"><%= dgettext("page-dataset-details", "Resources")%> (<%= count_resources(@dataset) %>)</a></div>
+      <%= unless count_documentation_resources(@dataset) == 0 do %>
+        <div class="menu-item"><a href="#dataset-documentation"><%= dgettext("page-dataset-details", "Documentation")%></a></div>
+      <% end %>
       <%= unless is_nil(@reuses) or @reuses == [] do %>
         <div class="menu-item"><a href="#dataset-reuses"><%= dgettext("page-dataset-details", "Reuses")%></a></div>
       <% end %>
@@ -69,7 +72,9 @@
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: real_time_official_resources(@dataset), title: dgettext("page-dataset-details", "Real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Resources"), latest_resources_history_infos: @latest_resources_history_infos %>
-      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: official_documentation_resources(@dataset), title: dgettext("page-dataset-details", "Documentation"), latest_resources_history_infos: @latest_resources_history_infos %>
+      <section id="dataset-documentation" class="pt-48">
+        <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: official_documentation_resources(@dataset), title: dgettext("page-dataset-details", "Documentation"), latest_resources_history_infos: @latest_resources_history_infos %>
+      </section>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, unavailabilities: @unavailabilities, resources_updated_at: @resources_updated_at, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"), latest_resources_history_infos: @latest_resources_history_infos%>
       <%= render "_reuser_message.html" %>
       <% community_resources = community_resources(@dataset) %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -15,10 +15,18 @@ defmodule TransportWeb.DatasetView do
   alias TransportWeb.ResourceView
 
   @doc """
-  Count the number of resources (official + community)
+  Count the number of resources (official + community), excluding resources with a `documentation` type.
   """
+  @spec count_resources(Dataset.t()) :: non_neg_integer
   def count_resources(dataset) do
-    Enum.count(official_available_resources(dataset)) + Enum.count(community_resources(dataset))
+    nb_resources = Enum.count(official_available_resources(dataset))
+    nb_community_resources = Enum.count(community_resources(dataset))
+    nb_resources + nb_community_resources - count_documentation_resources(dataset)
+  end
+
+  @spec count_documentation_resources(Dataset.t()) :: non_neg_integer
+  def count_documentation_resources(dataset) do
+    dataset |> official_available_resources() |> Stream.filter(&Resource.is_documentation?/1) |> Enum.count()
   end
 
   @spec count_discussions(any) :: [45, ...] | non_neg_integer

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -2,6 +2,7 @@ defmodule TransportWeb.DatasetViewTest do
   use TransportWeb.ConnCase, async: false
   use TransportWeb.ExternalCase
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  import DB.Factory
   import TransportWeb.DatasetView
 
   doctest TransportWeb.DatasetView
@@ -104,5 +105,17 @@ defmodule TransportWeb.DatasetViewTest do
              url:
                "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/898dc67fb19fae2464c24a85a0557e8ccce18791/bnlc-.csv"
            }) == resource_path(conn, :download, id)
+  end
+
+  test "count_resources and count_documentation_resources" do
+    dataset = insert(:dataset)
+    insert(:resource, type: "documentation", url: "https://example.com/doc", dataset: dataset)
+    insert(:resource, type: "main", url: "https://example.com/file", dataset: dataset)
+    insert(:resource, type: "main", url: "https://example.com/community", dataset: dataset, is_community_resource: true)
+
+    dataset = dataset |> DB.Repo.preload(:resources)
+
+    assert count_resources(dataset) == 2
+    assert count_documentation_resources(dataset) == 1
   end
 end


### PR DESCRIPTION
Fixes #2366

Prend la suite de https://github.com/etalab/transport-site/pull/2356 et ajoute un menu "Documentation" lorsque le jeu de données contient au moins une ressource avec le type de `documentation`.

Ajuste le code existant pour exclure du nombre de ressources affiché et ajoute une section avec une ancre.

![image](https://user-images.githubusercontent.com/295709/167404879-f3ef6e44-c1b3-4c6d-89a9-4c3f2424b769.png)
