### PR TITLE
Correctif pour régression sur envoi d'email

### DIFF
--- a/apps/transport/lib/mailjet/client.ex
+++ b/apps/transport/lib/mailjet/client.ex
@@ -34,7 +34,7 @@ defmodule Mailjet.Client do
   @impl Transport.EmailSender
   def send_mail(from_name, from_email, to_email, reply_to, subject, text_body, html_body) do
     mailjet_url()
-    |> httpoison_impl().post(payload!(from_name, from_email, to_email, reply_to, subject, text_body, html_body), nil,
+    |> httpoison_impl().post(payload!(from_name, from_email, to_email, reply_to, subject, text_body, html_body), [],
       hackney: [basic_auth: {mailjet_user(), mailjet_key()}]
     )
     |> case do

--- a/apps/transport/test/transport/mailjet_client_test.exs
+++ b/apps/transport/test/transport/mailjet_client_test.exs
@@ -46,6 +46,12 @@ defmodule Mailjet.ClientTest do
 
     bypass = Bypass.open()
 
+    # here we just ensure something has reached the server, to go through a real
+    # hackney path ; the payload itself is tested in the other test
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
     # reconfigure the app to tap into bypass server & stop using mocking
     config = Application.fetch_env!(:transport, Mailjet.Client)
     AppConfigHelper.change_app_config_temporarily(:transport, Mailjet.Client, Keyword.merge(config, mailjet_url: "http://localhost:#{bypass.port}"))

--- a/apps/transport/test/transport/mailjet_client_test.exs
+++ b/apps/transport/test/transport/mailjet_client_test.exs
@@ -8,7 +8,7 @@ defmodule Mailjet.ClientTest do
     Transport.HTTPoison.Mock
     |> expect(:post, fn url, body, headers, options ->
       assert url == "https://api.mailjet.com/v3.1/send"
-      assert headers == nil
+      assert headers == []
       assert options == [{:hackney, [basic_auth: {"TEST_MJ_APIKEY_PUBLIC", "TEST_MJ_APIKEY_PRIVATE"}]}]
       # see https://dev.mailjet.com/email/guides/send-api-v31/
       assert Jason.decode!(body) == %{

--- a/apps/transport/test/transport/mailjet_client_test.exs
+++ b/apps/transport/test/transport/mailjet_client_test.exs
@@ -42,7 +42,7 @@ defmodule Mailjet.ClientTest do
   end
 
   test "goes through hackney without pain (integration style)" do
-    assert Mailjet.Client.mailjet_url == "https://api.mailjet.com/v3.1/send"
+    assert Mailjet.Client.mailjet_url() == "https://api.mailjet.com/v3.1/send"
 
     bypass = Bypass.open()
 
@@ -54,12 +54,26 @@ defmodule Mailjet.ClientTest do
 
     # reconfigure the app to tap into bypass server & stop using mocking
     config = Application.fetch_env!(:transport, Mailjet.Client)
-    AppConfigHelper.change_app_config_temporarily(:transport, Mailjet.Client, Keyword.merge(config, mailjet_url: "http://localhost:#{bypass.port}"))
+
+    AppConfigHelper.change_app_config_temporarily(
+      :transport,
+      Mailjet.Client,
+      Keyword.merge(config, mailjet_url: "http://localhost:#{bypass.port}")
+    )
+
     AppConfigHelper.change_app_config_temporarily(:transport, :email_sender_impl, Mailjet.Client)
     AppConfigHelper.change_app_config_temporarily(:transport, :httpoison_impl, HTTPoison)
 
-    assert Mailjet.Client.mailjet_url == "http://localhost:#{bypass.port}"
+    assert Mailjet.Client.mailjet_url() == "http://localhost:#{bypass.port}"
 
-    Mailjet.Client.send_mail("FROM", "from@example.com", "to@example.com", "reply_to@example.com", "the subject", "plain text body", "html body")
+    Mailjet.Client.send_mail(
+      "FROM",
+      "from@example.com",
+      "to@example.com",
+      "reply_to@example.com",
+      "the subject",
+      "plain text body",
+      "html body"
+    )
   end
 end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -73,6 +73,8 @@ config :oauth2, Datagouvfr.Authentication,
   site: datagouvfr_site,
   redirect_uri: "http://localhost:5000/login/callback"
 
+config :transport, :email_sender_impl, Transport.EmailSender.Dummy
+
 extra_config_file = Path.join(__DIR__, "#{config_env()}.secret.exs")
 
 if File.exists?(extra_config_file) do
@@ -88,5 +90,3 @@ end
 if File.exists?(".envrc") do
   Mix.raise("The .envrc file is deprecated and must be removed")
 end
-
-config :transport, :email_sender_impl, Transport.EmailSender.Dummy


### PR DESCRIPTION
Le gros nettoyage de printemps ici:
- https://github.com/etalab/transport-site/pull/2290

incluait un petit souci (`nil` au lieu de `[]` pour les headers envoyés à Hackney) qui résultait en:
- https://github.com/etalab/transport-site/issues/2368

J'ai corrigé et ajouté un test d'intégration un peu plus profond (car le mocking était fait plus haut).

On va réfléchir à des contre-mesures pour détecter ça plus facilement.