### PR TITLE
Stratégie de retry pour SingleGtfsToNetexConverterJob

### DIFF
--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -15,12 +15,19 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJob do
   @moduledoc """
   Conversion Job of a GTFS to a NeTEx, saving the resulting file in S3
   """
-  use Oban.Worker, max_attempts: 3, queue: :heavy
+  use Oban.Worker, max_attempts: 3, queue: :heavy, unique: [period: :infinity]
   alias Transport.Jobs.GTFSGenericConverter
 
   @impl true
   def perform(%{args: %{"resource_history_id" => resource_history_id}}) do
     GTFSGenericConverter.perform_single_conversion_job(resource_history_id, "NeTEx", Transport.GtfsToNeTExConverter)
+  end
+
+  @impl true
+  def backoff(%Oban.Job{attempt: attempt}) do
+    # Retry in 1 day, in 2 days, in 3 days etc.
+    one_day = 60 * 60 * 24
+    attempt * one_day
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2360

Adapte la stratégie de [`backoff`](https://hexdocs.pm/oban/Oban.Worker.html#module-customizing-backoff) pour le job de conversion GTFS vers NeTEx et ajoute un attribut `unique` empêchant d'ajouter des jobs qui sont déjà en attente d'exécution.

La combinaison de l'étalement des nouveaux essais et du caractère unique devrait diminuer la charge.

À noter qu'il est possible de ne pas _retry_ certains jobs du tout https://github.com/etalab/transport-site/issues/2360#issuecomment-1121104830. À voir si on modifie le job ou si on part sur un enregistrement des échecs permanents de jobs dans une base, comme discuté hier à l'oral en point dev.