### PR TITLE
Gestion erreur timeout pour validateur GTFS

### DIFF
--- a/apps/shared/lib/validation/gtfs_validator.ex
+++ b/apps/shared/lib/validation/gtfs_validator.ex
@@ -29,7 +29,7 @@ defmodule Shared.Validation.GtfsValidator do
   Return {:ok, validation_report} if validation succeed with or without errors.
   Return {:error} if validation cannot be done.
   """
-  @spec validate(binary()) :: {:ok, map()}
+  @spec validate(binary()) :: {:ok, map()} | {:error, binary()}
   def validate(gtfs),
     do:
       build_validate_url()
@@ -37,6 +37,7 @@ defmodule Shared.Validation.GtfsValidator do
       |> handle_validation_response()
 
   @impl Validator
+  @spec validate_from_url(binary()) :: {:ok, map()} | {:error, binary()}
   def validate_from_url(gtfs_url),
     do:
       gtfs_url
@@ -71,6 +72,10 @@ defmodule Shared.Validation.GtfsValidator do
 
   defp handle_validation_response({_, %{body: body}}) do
     Logger.error(body)
+    {:error, "Error while requesting GTFS validator"}
+  end
+
+  defp handle_validation_response({:error, _}) do
     {:error, "Error while requesting GTFS validator"}
   end
 

--- a/apps/shared/test/validation/gtfs_validator_test.exs
+++ b/apps/shared/test/validation/gtfs_validator_test.exs
@@ -37,7 +37,7 @@ defmodule GtfsValidatorTest do
       {:error, %HTTPoison.Error{reason: :timeout}}
     end)
 
-    assert {:error, "Error while requesting GTFS validator"} == GtfsValidator.validate_from_url(gtfs_url)-
+    assert {:error, "Error while requesting GTFS validator"} == GtfsValidator.validate_from_url(gtfs_url)
   end
 
   defp assert_validation_report_is({:ok, obtained_validation_report}, expected_validation_report),

--- a/apps/shared/test/validation/gtfs_validator_test.exs
+++ b/apps/shared/test/validation/gtfs_validator_test.exs
@@ -28,6 +28,18 @@ defmodule GtfsValidatorTest do
     |> assert_validation_report_is(expected_validation_report)
   end
 
+  test "with a timeout" do
+    gtfs_url = "http://example.com/gtfs.zip"
+    expected_url = "https://validation.transport.data.gouv.fr/validate?url=#{URI.encode_www_form(gtfs_url)}"
+
+    Transport.HTTPoison.Mock
+    |> expect(:get, fn ^expected_url, [], [recv_timeout: 180_000] ->
+      {:error, %HTTPoison.Error{reason: :timeout}}
+    end)
+
+    assert {:error, "Error while requesting GTFS validator"} == GtfsValidator.validate_from_url(gtfs_url)-
+  end
+
   defp assert_validation_report_is({:ok, obtained_validation_report}, expected_validation_report),
     do: assert(obtained_validation_report == expected_validation_report)
 


### PR DESCRIPTION
Lié à https://github.com/etalab/transport-site/issues/2376

En regardant les erreurs de la validation/validation à la demande, je tombe sur un cas qui ne semble pas être traité par le code existant, le cas de timeout lors de l'appel HTTP au validateur GTFS.

La stacktrace enregistrée est

```
%FunctionClauseError{args: nil, arity: 1, clauses: nil, function: :handle_validation_response, kind: nil, module: Shared.Validation.GtfsValidator}
```

ce qui est assez cryptique. J'ai déjà vu ça dans le backoffice aussi.

La façon de gérer les timeouts avec HTTPoison est assez bancale https://github.com/edgurgel/httpoison/issues/215 mais ma compréhension est que ça devrait être `%HTTPoison.Error{reason: :timeout}`.