### PR TITLE
Ajoute infos de schéma sur ResourceHistory

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -102,7 +102,9 @@ defmodule Transport.Jobs.ResourceHistoryJob do
           filename: filename,
           permanent_url: Transport.S3.permanent_url(:history, filename),
           format: resource.format,
-          dataset_id: resource.dataset_id
+          dataset_id: resource.dataset_id,
+          schema_name: resource.schema_name,
+          schema_version: resource.schema_version
         }
 
         data =

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -328,7 +328,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         datagouv_id: datagouv_id,
         dataset_id: dataset_id,
         metadata: resource_metadata,
-        title: title
+        title: title,
+        schema_name: schema_name
       } =
         resource =
         insert(:resource,
@@ -338,7 +339,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
           title: "title",
           datagouv_id: "1",
           is_community_resource: false,
-          metadata: %{"foo" => "bar"}
+          metadata: %{"foo" => "bar"},
+          schema_name: "etalab/schema-lieux-covoiturage"
         )
 
       Transport.HTTPoison.Mock
@@ -370,6 +372,18 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         assert String.starts_with?(path, "#{datagouv_id}/#{datagouv_id}.")
       end)
 
+      # Validation according to the schema
+      Transport.Shared.Schemas.Mock
+      |> expect(:transport_schemas, 1, fn -> %{schema_name => %{}} end)
+
+      Transport.Shared.Schemas.Mock
+      |> expect(:schemas_by_type, 1, fn "tableschema" -> %{schema_name => %{}} end)
+
+      validation_result = %{"fake_validation" => "fake_result"}
+
+      Shared.Validation.TableSchemaValidator.Mock
+      |> expect(:validate, fn ^schema_name, ^resource_url, nil -> validation_result end)
+
       assert 0 == count_resource_history()
       assert :ok == perform_job(ResourceHistoryJob, %{datagouv_id: datagouv_id})
       assert 1 == count_resource_history()
@@ -378,6 +392,12 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       content_hash = :sha256 |> :crypto.hash(csv_content) |> Base.encode16() |> String.downcase()
 
+      expected_metadata =
+        Map.merge(resource_metadata, %{
+          "validation" =>
+            Map.merge(%{"content_hash" => content_hash, "schema_type" => "tableschema"}, validation_result)
+        })
+
       assert %DB.ResourceHistory{
                datagouv_id: ^datagouv_id,
                payload: %{
@@ -385,12 +405,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "format" => "csv",
                  "content_hash" => ^content_hash,
                  "http_headers" => %{"content-type" => "application/octet-stream"},
-                 "resource_metadata" => ^resource_metadata,
+                 "resource_metadata" => ^expected_metadata,
                  "title" => ^title,
                  "filename" => filename,
                  "permanent_url" => permanent_url,
                  "uuid" => _uuid,
-                 "download_datetime" => _download_datetime
+                 "download_datetime" => _download_datetime,
+                 "schema_name" => ^schema_name,
+                 "schema_version" => nil
                },
                last_up_to_date_at: last_up_to_date_at
              } = DB.ResourceHistory |> DB.Repo.one!()


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2344

Ajoute `schema_name` et `schema_version` dans `ResourceHistory.payload`. Je n'ai pas fait de backfill, à voir si on en fait plus tard, ou pas ?