### PR TITLE
Meilleurs output de Transport.Jobs.ResourceHistoryValidationJob

### DIFF
--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -32,7 +32,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
     |> Enum.each(fn id ->
       %{resource_history_id: id, validator: validator}
       |> Transport.Jobs.ResourceHistoryValidationJob.new()
-      |> Oban.insert()
+      |> Oban.insert!()
     end)
 
     :ok
@@ -71,7 +71,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
     Transport.ValidatorsSelection.formats_and_validators()
     |> Enum.flat_map(fn {format, validators} -> Enum.zip(Stream.cycle([format]), validators) end)
     |> Enum.each(fn {format, validator} ->
-      %{format: format, validator: validator} |> Transport.Jobs.ResourceHistoryValidationJob.new() |> Oban.insert()
+      %{format: format, validator: validator} |> Transport.Jobs.ResourceHistoryValidationJob.new() |> Oban.insert!()
     end)
 
     :ok

--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -40,16 +40,16 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
 
   # validate one resource history with one validator
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"resource_history_id" => resource_history_id, "validator" => validator}})
+  def perform(%Oban.Job{args: %{"resource_history_id" => resource_history_id, "validator" => validator_string}})
       when is_integer(resource_history_id) do
-    validator = String.to_existing_atom(validator)
+    validator = String.to_existing_atom(validator_string)
     resource_history = DB.ResourceHistory |> DB.Repo.get!(resource_history_id)
 
-    unless resource_history |> DB.MultiValidation.already_validated?(validator) do
-      validator.validate(resource_history)
+    if resource_history |> DB.MultiValidation.already_validated?(validator) do
+      {:discard, "resource history #{resource_history_id} is already validated by #{validator_string}"}
+    else
+      :ok = validator.validate(resource_history)
     end
-
-    :ok
   end
 
   # validate one resource history with all validators


### PR DESCRIPTION
Le job `Transport.Jobs.ResourceHistoryValidationJob` avait la facheuse tendance à toujours renvoyer `:ok`, ce qui n'est pas très pratique pour comprendre ce qu'il se passe.