### PR TITLE
Queue de traitement à part pour la validation des ressources history

### DIFF
--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -2,7 +2,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
   @moduledoc """
   Validate a resource history and stores result in DB
   """
-  use Oban.Worker, max_attempts: 3, tags: ["validation"]
+  use Oban.Worker, max_attempts: 3, queue: :resource_history_validation, tags: ["validation"]
 
   # wait for https://github.com/sorentwo/oban/issues/704 response
   # unique: [period: 5 * 60]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -120,7 +120,7 @@ extra_oban_conf =
     [queues: false, plugins: false]
   else
     [
-      queues: [default: 2, heavy: 1, on_demand_validation: 1],
+      queues: [default: 2, heavy: 1, on_demand_validation: 1, resource_history_validation: 1],
       plugins: [
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
         {Oban.Plugins.Cron, crontab: List.flatten(oban_crontab_all_envs, non_staging_crontab)}


### PR DESCRIPTION
A la vue des statistiques de réponse de notre validateur ces derniers temps, j'essaye de le charger un peu moins pour voir ce que ça donne. Je mets donc une queue pour la validation des ressources history à part avec une concurrence de 1.

![image](https://user-images.githubusercontent.com/15341118/168756833-48e19e6a-e6df-4d58-9b13-2a54166d0d02.png)
