### PR TITLE
Valider les Resources history les plus récentes en premier

### DIFF
--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -27,6 +27,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
       on: rh.id == mv.resource_history_id and mv.validator == ^validator_name
     )
     |> where([rh, mv], fragment("payload->>'format' = ?", ^format) and is_nil(mv.id))
+    |> order_by([rh], desc: rh.inserted_at)
     |> select([rh], rh.id)
     |> DB.Repo.all()
     |> Enum.each(fn id ->


### PR DESCRIPTION
J'aimerais donner la priorité à la validation des ressources history récentes, car ce se sont celles qui nous intéressent pour le moment.