### PR TITLE
Ajuste détection du format GeoJSON

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -622,6 +622,9 @@ defmodule Transport.ImportData do
       iex> ImportData.formated_format(%{"title" => "Export au format GeoJSON", "format" => "json"}, "low-emission-zones", false)
       "geojson"
 
+      iex> ImportData.formated_format(%{"url" => "https://data.strasbourg.eu/api/datasets/1.0/zfe_voie_exception/alternative_exports/zfe_voie_speciale_eurometropole_strasbourg_geojson", "format" => "a"}, "low-emission-zones", false)
+      "geojson"
+
       iex> ImportData.formated_format(%{"format" => "GeoJSON"}, "low-emission-zones", false)
       "geojson"
   """
@@ -647,6 +650,7 @@ defmodule Transport.ImportData do
   # Classify GeoJSONs from ODS as geojson instead of json
   # See https://github.com/opendatateam/udata-ods/issues/211
   defp is_geojson?(%{"title" => "Export au format GeoJSON"}, _), do: true
+  defp is_geojson?(%{"url" => url}, format), do: is_format?(format, ["geojson"]) or String.ends_with?(url, "geojson")
   defp is_geojson?(_, format), do: is_format?(format, ["geojson"])
 
   defp is_gbfs?(%{"url" => url}) do


### PR DESCRIPTION
Ajuste le code de détection du format GeoJSON dans ImportData, pour traiter un cas spécial dans les ZFE où le fichier "Export au format GeoJSON" ne fonctionne pas car ODS supprime les colonnes qui contient des valeurs à `null`, ce qui rend le fichier invalide.

Le producteur [a publié un fichier alternatif](https://transport.data.gouv.fr/datasets/zfe-m-voies-exceptionnelles), mais le format détecté (ou renseigné) est `a` et non `geojson`.

Sombre histoire, n'est-ce pas ?

Les nombreux tests existants devraient permettre d'assurer un fonctionnement correct.