### PR TITLE
Scan hebdomadaire des vulnérabilités avec Trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,14 @@ jobs:
           name: Run tests
           command: |
             mix test --warnings-as-errors
-
+  scan:
+    steps:
+      - run:
+          name: Install Trivy
+          command: apt-get update && apt-get install -y trivy
+      - run:
+          name: Run Trivy
+          command: trivy image << parameters.base_image >>
 workflows:
   version: 2
   transport:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,14 +177,7 @@ jobs:
           name: Run tests
           command: |
             mix test --warnings-as-errors
-  scan:
-    steps:
-      - run:
-          name: Install Trivy
-          command: apt-get update && apt-get install -y trivy
-      - run:
-          name: Run Trivy
-          command: trivy image << parameters.base_image >>
+
 workflows:
   version: 2
   transport:

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - vulnerabilities-container-scan
   pull_request:
 jobs:
   build:

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,0 +1,26 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          # TODO: read from Dockerfile
+          image-ref: 'ghcr.io/etalab/transport-ops:elixir-1.13.3-erlang-24.2.1-ubuntu-focal-20211006-transport-tools-1.0.3'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,7 +1,7 @@
 name: trivy_scan
 on:
   schedule:
-    - cron: 0 9 * * *
+    - cron: 0 9 * * MON
 jobs:
   build:
     name: Scan

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,13 +1,10 @@
-name: build
+name: trivy_scan
 on:
-  push:
-    branches:
-      - master
-      - vulnerabilities-container-scan
-  pull_request:
+  schedule:
+    - cron: 0 9 * * *
 jobs:
   build:
-    name: Build
+    name: Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -13,15 +13,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Extract identifier of Docker image to scan
+        id: docker_image_ref_retrieval
+        run: echo ::set-output name=TARGET_IMAGE_REF::$(cat Dockerfile | grep FROM | head -1 | cut -d' ' -f2)
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          # TODO: read from Dockerfile
-          image-ref: 'ghcr.io/etalab/transport-ops:elixir-1.13.3-erlang-24.2.1-ubuntu-focal-20211006-transport-tools-1.0.3'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: 'trivy-results.sarif'
+          image-ref: "${{ steps.docker_image_ref_retrieval.outputs.TARGET_IMAGE_REF }}"
+          format: 'table'


### PR DESCRIPTION
Cette PR est une étape de plus pour améliorer nos processus en terme de sécurité (conformité/sécurité d'ailleurs), et nous donner de la visibilité sur ces aspects dans le temps.

Dans https://github.com/etalab/transport_deploy/issues/14 j'ai été amené à lancer [Trivy](https://github.com/aquasecurity/trivy), un outil qui permet de scanner des containers Docker notamment, et à vérifier que ça nous permettrait bien de suivre un peu le vieillissement d'une image donnée.

Dans la PR présente, je franchis une étape de plus en lançant un scan hebdomadaire sous forme de GitHub Action.

L'image Docker cible utilisée est directement dynamiquement tirée du `Dockerfile`, de façon à être à jour.

Pour l'instant le résultat est simplement affiché sous forme de table (voir https://github.com/etalab/transport-site/runs/6507634995?check_suite_focus=true pour un exemple).

J'utilise l'action directement maintenue par l'équipe de Aquasecurity https://github.com/aquasecurity/trivy-action plutôt qu'un Orb CircleCI comme https://circleci.com/developer/orbs/orb/signavio/trivy, car il fallait autoriser des organisations extérieures côté CircleCI.

On pourra dans un second temps intégrer cela à GitHub code scanning, via la standardisation au format "SARIF", toutefois sur un premier test j'ai eu une erreur liée aux permissions (token etc), donc j'ai préféré écourter (https://github.com/aquasecurity/trivy-action#using-trivy-with-github-code-scanning).