### PR TITLE
Dataset#details lien vers temps réel transport public

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_type.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_type.html.eex
@@ -1,0 +1,10 @@
+<div class="dataset-type-info">
+  <%= unless is_nil(@icon) do %>
+    <span class="dataset-icon-type">
+      <%= img_tag(@icon, alt: @text) %>
+    </span>
+  <% end %>
+  <a href="<%= @link %>">
+    <b><%= @text %></b>
+  </a>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -253,14 +253,10 @@
     </div>
     <div class="pt-12">
       <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "Data type")%></span>
-      <div class="dataset-type-info">
-        <%= unless is_nil(icon_type_path(@dataset)) do %>
-          <span class="dataset-icon-type">
-            <%= img_tag(icon_type_path(@dataset), alt: @dataset.type) %>
-          </span>
-        <% end %>
-        <b><%= Dataset.type_to_str(@dataset.type) %></b>
-      </div>
+      <%= render "_dataset_type.html", conn: @conn, link: dataset_path(@conn, :index, type: @dataset.type), text: Dataset.type_to_str(@dataset.type), icon: icon_type_path(@dataset) %>
+      <%= if is_real_time_public_transit?(@dataset) do %>
+        <%= render "_dataset_type.html", conn: @conn, link: dataset_path(@conn, :index, type: "public-transit", filter: "has_realtime"), text: dgettext("page-index", "Public transport - realtime traffic"), icon: icon_type_path("real-time-public-transit") %>
+      <%= end %>
     </div>
     <div class="pt-12">
       <%= render "_licence.html", conn: @conn, dataset: @dataset %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -329,6 +329,12 @@ defmodule TransportWeb.DatasetView do
     |> Enum.filter(&Resource.is_documentation?/1)
   end
 
+  def is_real_time_public_transit?(%Dataset{type: "public-transit"} = dataset) do
+    not Enum.empty?(real_time_official_resources(dataset))
+  end
+
+  def is_real_time_public_transit?(%Dataset{}), do: false
+
   def community_resources(dataset), do: Dataset.community_resources(dataset)
 
   def licence_url("fr-lo"),


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2093

- Ajout d'un lien vers la catégorie associée au jeu de données
- Ajout d'une seconde catégorie, "Transport public collectif - horaires temps réel", uniquement pour les JDD dans `public-transit` ayant des ressources avec du temps réel.

![image](https://user-images.githubusercontent.com/295709/169557525-6d839fd9-21ec-4690-966b-a74e3733d5d1.png)
