### PR TITLE
Ajoute resource_id dans ResourceHistory

### DIFF
--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -6,8 +6,9 @@ defmodule DB.ResourceHistory do
   use TypedEctoSchema
   import Ecto.Query
 
-  @derive {Jason.Encoder, only: [:datagouv_id, :payload, :last_up_to_date_at, :inserted_at, :updated_at]}
+  @derive {Jason.Encoder, only: [:resource_id, :payload, :last_up_to_date_at, :inserted_at, :updated_at]}
   typed_schema "resource_history" do
+    field(:datagouv_id, :string)
     field(:payload, :map)
     # the last moment we checked and the resource history was corresponding to the real online resource
     field(:last_up_to_date_at, :utc_datetime_usec)

--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -15,7 +15,6 @@ defmodule DB.ResourceHistory do
 
     timestamps(type: :utc_datetime_usec)
     belongs_to(:resource, DB.Resource)
-    # belongs_to(:resource, DB.Resource, foreign_key: :datagouv_id, references: :datagouv_id, type: :string)
     has_many(:geo_data_import, DB.GeoDataImport)
     has_many(:validations, DB.MultiValidation)
   end

--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -13,7 +13,8 @@ defmodule DB.ResourceHistory do
     field(:last_up_to_date_at, :utc_datetime_usec)
 
     timestamps(type: :utc_datetime_usec)
-    belongs_to(:resource, DB.Resource, foreign_key: :datagouv_id, references: :datagouv_id, type: :string)
+    belongs_to(:resource, DB.Resource)
+    # belongs_to(:resource, DB.Resource, foreign_key: :datagouv_id, references: :datagouv_id, type: :string)
     has_many(:geo_data_import, DB.GeoDataImport)
     has_many(:validations, DB.MultiValidation)
   end

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -209,10 +209,15 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
   defp is_zip?(%Resource{format: format}), do: format in ["NeTEx", "GTFS"]
 
-  defp store_resource_history!(%Resource{datagouv_id: datagouv_id}, payload) do
+  defp store_resource_history!(%Resource{datagouv_id: datagouv_id, id: resource_id}, payload) do
     Logger.debug("Saving ResourceHistory for #{datagouv_id}")
 
-    %ResourceHistory{datagouv_id: datagouv_id, payload: payload, last_up_to_date_at: DateTime.utc_now()}
+    %ResourceHistory{
+      datagouv_id: datagouv_id,
+      id: resource_id,
+      payload: payload,
+      last_up_to_date_at: DateTime.utc_now()
+    }
     |> DB.Repo.insert!()
   end
 

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -214,7 +214,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
     %ResourceHistory{
       datagouv_id: datagouv_id,
-      id: resource_id,
+      resource_id: resource_id,
       payload: payload,
       last_up_to_date_at: DateTime.utc_now()
     }

--- a/apps/transport/priv/repo/migrations/20220523132328_add_resource_history_resource_id.exs
+++ b/apps/transport/priv/repo/migrations/20220523132328_add_resource_history_resource_id.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddResourceHistoryResourceId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_history) do
+      add :resource_id, references(:resource)
+    end
+  end
+end

--- a/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
+++ b/apps/transport/test/transport/jobs/backfill/backill_metadata_validation_test.exs
@@ -17,11 +17,11 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadataTest do
       permanent_url = "https://example.com/file"
       initial_content_hash = Ecto.UUID.generate()
       schema_name = "etalab/schema-zfe"
-      resource = insert(:resource, schema_name: schema_name, datagouv_id: Ecto.UUID.generate())
+      resource = insert(:resource, schema_name: schema_name)
 
       resource_history =
         insert(:resource_history,
-          datagouv_id: resource.datagouv_id,
+          resource: resource,
           payload: %{
             "permanent_url" => permanent_url,
             "content_hash" => initial_content_hash,
@@ -62,11 +62,11 @@ defmodule Transport.Jobs.Backfill.ResourceHistoryValidationMetadataTest do
       permanent_url = "https://example.com/file"
       initial_content_hash = Ecto.UUID.generate()
       schema_name = "etalab/schema-amenagements-cyclables"
-      resource = insert(:resource, schema_name: schema_name, datagouv_id: Ecto.UUID.generate())
+      resource = insert(:resource, schema_name: schema_name)
 
       resource_history =
         insert(:resource_history,
-          datagouv_id: resource.datagouv_id,
+          resource: resource,
           payload: %{
             "permanent_url" => permanent_url,
             "content_hash" => initial_content_hash,

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -216,7 +216,13 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     test "a simple successful case for a GTFS" do
       resource_url = "https://example.com/gtfs.zip"
 
-      %{datagouv_id: datagouv_id, dataset_id: dataset_id, title: title, content_hash: first_content_hash} =
+      %{
+        datagouv_id: datagouv_id,
+        dataset_id: dataset_id,
+        title: title,
+        content_hash: first_content_hash,
+        id: resource_id
+      } =
         resource =
         insert(:resource,
           url: resource_url,
@@ -281,6 +287,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       assert %DB.ResourceHistory{
                id: resource_history_id,
+               resource_id: ^resource_id,
                datagouv_id: ^datagouv_id,
                payload: %{
                  "filenames" => [
@@ -325,6 +332,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       csv_content = "col1,col2\nval1,val2"
 
       %{
+        id: resource_id,
         datagouv_id: datagouv_id,
         dataset_id: dataset_id,
         metadata: resource_metadata,
@@ -399,6 +407,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         })
 
       assert %DB.ResourceHistory{
+               resource_id: ^resource_id,
                datagouv_id: ^datagouv_id,
                payload: %{
                  "dataset_id" => ^dataset_id,


### PR DESCRIPTION
Lié à https://github.com/etalab/transport-site/issues/2410

Cette PR ajoute une colonne `resource_id` dans la table `resource_history`, dans le but moyen terme de supprimer `datagouv_id`.

Je fais une première PR pour éviter l'effet big bang et commencer dès maintenant à remplir cette nouvelle colonne.