### PR TITLE
Incohérence de validation GTFS

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -80,7 +80,7 @@ defmodule TransportWeb.ResourceController do
            Transport.Validators.GTFSTransport.get_issues(validation_result, params)}
 
         nil ->
-          {nil, nil, nil, nil}
+          {nil, nil, nil, []}
       end
 
     issue_type =

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -76,9 +76,8 @@ defmodule TransportWeb.ResourceController do
       case validation do
         %{result: validation_result, metadata: %{metadata: metadata}} ->
           {Transport.Validators.GTFSTransport.summary(validation_result),
-           Transport.Validators.GTFSTransport.count_by_severity(validation_result),
-          metadata,
-          Transport.Validators.GTFSTransport.get_issues(validation_result, params)}
+           Transport.Validators.GTFSTransport.count_by_severity(validation_result), metadata,
+           Transport.Validators.GTFSTransport.get_issues(validation_result, params)}
 
         nil ->
           {nil, nil, nil, nil}

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -67,20 +67,21 @@ defmodule TransportWeb.ResourceController do
 
   defp render_gtfs_details(conn, params, resource) do
     config = make_pagination_config(params)
-    issues = resource.validation |> Validation.get_issues(params)
 
     validation =
       resource.id
       |> DB.MultiValidation.resource_latest_validation(Transport.Validators.GTFSTransport)
 
-    {validation_summary, severities_count, metadata} =
+    {validation_summary, severities_count, metadata, issues} =
       case validation do
-        %{result: validation, metadata: %{metadata: metadata}} ->
-          {Transport.Validators.GTFSTransport.summary(validation),
-           Transport.Validators.GTFSTransport.count_by_severity(validation), metadata}
+        %{result: validation_result, metadata: %{metadata: metadata}} ->
+          {Transport.Validators.GTFSTransport.summary(validation_result),
+           Transport.Validators.GTFSTransport.count_by_severity(validation_result),
+          metadata,
+          Transport.Validators.GTFSTransport.get_issues(validation_result, params)}
 
         nil ->
-          {nil, nil, nil}
+          {nil, nil, nil, nil}
       end
 
     issue_type =


### PR DESCRIPTION
closes #2417, merci @AntoineAugusti d'avoir remarqué le problème grâce à ton suivi quotidien de la page de Dijon !

J'avais laissé un endroit où l'on allait lire les résultats de la validation V1 pour les GTFS alors que je pensais avoir tout débranché.

Ça s'est vu suite à la mise à jour du validateur GTFS