### PR TITLE
Ajout de tags "couleurs des routes" et "description des correspondances"

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -385,6 +385,7 @@ defmodule DB.Resource do
     |> Enum.concat(has_shapes_tag(metadata))
     |> Enum.concat(has_odt_tag(metadata))
     |> Enum.concat(has_route_colors_tag(metadata))
+    |> Enum.concat(has_pathways_tag(metadata))
     |> Enum.uniq()
   end
 
@@ -422,6 +423,10 @@ defmodule DB.Resource do
     do: ["couleurs des lignes"]
 
   def has_route_colors_tag(_), do: []
+
+  @spec has_pathways_tag(map()) :: [binary()]
+  def has_pathways_tag(%{"has_pathways" => true}), do: ["description des correspondances"]
+  def has_pathways_tag(_), do: []
 
   @spec base_tag(__MODULE__.t()) :: [binary()]
   def base_tag(%__MODULE__{format: "GTFS"}),

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -384,6 +384,7 @@ defmodule DB.Resource do
     |> Enum.concat(has_fares_tag(metadata))
     |> Enum.concat(has_shapes_tag(metadata))
     |> Enum.concat(has_odt_tag(metadata))
+    |> Enum.concat(has_route_colors_tag(metadata))
     |> Enum.uniq()
   end
 
@@ -405,6 +406,22 @@ defmodule DB.Resource do
   def has_odt_tag(%{"some_stops_need_phone_agency" => true}), do: ["transport à la demande"]
   def has_odt_tag(%{"some_stops_need_phone_driver" => true}), do: ["transport à la demande"]
   def has_odt_tag(_), do: []
+
+  @doc """
+  Outputs a tag if all GTFS routes have a custom color
+
+  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 10, "lines_count" => 10})
+  ["couleurs des lignes"]
+  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 8, "lines_count" => 10})
+  []
+  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 0, "lines_count" => 0})
+  []
+  """
+  @spec has_route_colors_tag(map()) :: [binary()]
+  def has_route_colors_tag(%{"lines_with_custom_color_count" => n, "lines_count" => n}) when n > 0,
+    do: ["couleurs des lignes"]
+
+  def has_route_colors_tag(_), do: []
 
   @spec base_tag(__MODULE__.t()) :: [binary()]
   def base_tag(%__MODULE__{format: "GTFS"}),

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -6,7 +6,7 @@ defmodule DB.ResourceTest do
   import DB.Factory
   import Ecto.Query
 
-  doctest Resource
+  doctest Resource, import: true
 
   setup do
     Mox.stub_with(Transport.DataVisualization.Mock, Transport.DataVisualization.Impl)


### PR DESCRIPTION
suite à https://github.com/etalab/transport-validator/pull/126 et https://github.com/etalab/transport-validator/pull/129

ça permet d'ajouter des petits tags dans la page détails de la ressource
![image](https://user-images.githubusercontent.com/15341118/171014297-27a59a33-f0af-4794-9f2f-3b30a06f9132.png)

et aussi de faire des recherches avec ce tag (feature secrète !)
![image](https://user-images.githubusercontent.com/15341118/171014405-98aa4dca-1f5a-4da1-b6a8-f942a49f29fd.png)

J'ai mis description des correspondances pour la présence d'un fichier pathways.txt, je suis ouvert à la discussion ;)