### PR TITLE
Ajout de la version du validateur GTFS dans la multi validation

### DIFF
--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -9,7 +9,7 @@ defmodule DB.MultiValidation do
   typed_schema "multi_validation" do
     field(:validation_timestamp, :utc_datetime_usec)
     field(:validator, :string)
-    field(:transport_tools_version, :string)
+    field(:validator_version, :string)
     field(:command, :string)
     field(:result, :map)
     field(:data_vis, :map)

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -17,7 +17,7 @@ defmodule Transport.Validators.GTFSTransport do
     with {:ok, %{"validations" => validations, "metadata" => metadata}} <-
            validator.validate_from_url(url),
          data_vis <- Transport.DataVisualization.validation_data_vis(validations) do
-      metadata = %DB.ResourceMetadata{
+      resource_metadata = %DB.ResourceMetadata{
         resource_history_id: resource_history_id,
         metadata: metadata
       }
@@ -29,7 +29,8 @@ defmodule Transport.Validators.GTFSTransport do
         data_vis: data_vis,
         command: command(url),
         resource_history_id: resource_history_id,
-        metadata: metadata
+        metadata: resource_metadata,
+        validator_version: Map.get(metadata, "validator_version")
       }
       |> DB.Repo.insert!()
 

--- a/apps/transport/priv/repo/migrations/20220601135310_change-multi-validation-field-name.exs
+++ b/apps/transport/priv/repo/migrations/20220601135310_change-multi-validation-field-name.exs
@@ -1,0 +1,7 @@
+defmodule :"Elixir.DB.Repo.Migrations.Change_multi_validation_field_name" do
+  use Ecto.Migration
+
+  def change do
+    rename table(:multi_validation), :transport_tools_version, to: :validator_version
+  end
+end

--- a/apps/transport/test/transport/validators/gtfs_transport_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_transport_validator_test.exs
@@ -15,7 +15,7 @@ defmodule Transport.Validators.GtfsTransportValidatorTest do
     %{id: resource_history_id} = insert(:resource_history)
     validation_content = %{"errors" => 2}
     data_vis_content = %{"data_vis" => "some data vis"}
-    metadata_content = %{"m" => 1}
+    metadata_content = %{"m" => 1, "validator_version" => validator_version = "0.2.0"}
 
     Transport.DataVisualization.Mock
     |> expect(:validation_data_vis, 1, fn _ ->
@@ -36,7 +36,8 @@ defmodule Transport.Validators.GtfsTransportValidatorTest do
              id: validation_id,
              result: ^validation_content,
              data_vis: ^data_vis_content,
-             resource_history_id: ^resource_history_id
+             resource_history_id: ^resource_history_id,
+             validator_version: ^validator_version
            } = DB.MultiValidation |> DB.Repo.get_by!(resource_history_id: resource_history_id)
 
     assert %{metadata: ^metadata_content, resource_history_id: ^resource_history_id} =


### PR DESCRIPTION
Grâce à https://github.com/etalab/transport-validator/pull/133, le validateur donne désormais sa version dans les métadonnées de sortie.

J'en profite pour remplir l'information dans la table `multi_validation`.

Je renomme le champ en `validator_version`, je n'avais initialement pas pensé que certains validateurs n'étaient pas appelés via transport-tools.