### PR TITLE
Refactoring de la configuration proxy pour supporter SIRI

### DIFF
--- a/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
@@ -18,7 +18,7 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
 
   def setup_proxy_config(slug) do
     config = %{
-      slug => %Unlock.Config.Item{
+      slug => %Unlock.Config.Item.GTFS.RT{
         identifier: slug,
         target_url: "http://localhost/some-remote-resource",
         ttl: 10

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -90,7 +90,7 @@ defmodule Unlock.Controller do
   # RAM consumption
   @max_allowed_cached_byte_size 20 * 1024 * 1024
 
-  defp process_resource(conn, item) do
+  defp process_resource(conn, %Unlock.Config.Item.GTFS.RT{} = item) do
     Telemetry.trace_request(item.identifier, :external)
     response = fetch_remote(item)
 

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -103,6 +103,11 @@ defmodule Unlock.Controller do
     |> send_resp(response.status, response.body)
   end
 
+  defp process_resource(conn, %Unlock.Config.Item.SIRI{}) do
+    conn
+    |> send_resp(501, "Not Implemented")
+  end
+
   defp fetch_remote(item) do
     comp_fn = fn _key ->
       Logger.info("Processing proxy request for identifier #{item.identifier}")

--- a/apps/unlock/lib/siri.ex
+++ b/apps/unlock/lib/siri.ex
@@ -1,0 +1,10 @@
+defmodule Unlock.SIRI do
+  @doc """
+  iex> Unlock.SIRI.parse_incoming("<elem attr='value'>text</elem>")
+  {"elem", [{"attr", "value"}], ["text"]}
+  """
+  def parse_incoming(body) do
+    {:ok, parsed_request} = Saxy.SimpleForm.parse_string(body, cdata_as_characters: false)
+    parsed_request
+  end
+end

--- a/apps/unlock/lib/siri.ex
+++ b/apps/unlock/lib/siri.ex
@@ -1,4 +1,8 @@
 defmodule Unlock.SIRI do
+  @moduledoc """
+  All the SIRI XML management functions are grouped here at this point.
+  """
+
   @doc """
   iex> Unlock.SIRI.parse_incoming("<elem attr='value'>text</elem>")
   {"elem", [{"attr", "value"}], ["text"]}

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -13,7 +13,7 @@ defmodule Unlock.ConfigFetcherTest do
     """
 
     assert parse_config(yaml_config) == [
-             %Unlock.Config.Item{
+             %Unlock.Config.Item.GTFS.RT{
                identifier: "httpbin-get",
                target_url: "https://httpbin.org/get",
                ttl: 10

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -3,50 +3,73 @@ defmodule Unlock.ConfigFetcherTest do
 
   def parse_config(yaml), do: Unlock.Config.Fetcher.convert_yaml_to_config_items(yaml)
 
-  test "parses and converts basic configuration" do
-    yaml_config = """
-    ---
-    feeds:
-      - identifier: "httpbin-get"
-        target_url: "https://httpbin.org/get"
-        ttl: 10
-    """
+  describe "for GTFS-RT items" do
+    test "parses and converts configuration" do
+      yaml_config = """
+      ---
+      feeds:
+        - identifier: "httpbin-get"
+          target_url: "https://httpbin.org/get"
+          ttl: 10
+      """
 
-    assert parse_config(yaml_config) == [
-             %Unlock.Config.Item.GTFS.RT{
-               identifier: "httpbin-get",
-               target_url: "https://httpbin.org/get",
-               ttl: 10
-             }
-           ]
+      assert parse_config(yaml_config) == [
+               %Unlock.Config.Item.GTFS.RT{
+                 identifier: "httpbin-get",
+                 target_url: "https://httpbin.org/get",
+                 ttl: 10
+               }
+             ]
+    end
+
+    test "defaults to TTL 0 if TTL is unspecified" do
+      yaml_config = """
+      ---
+      feeds:
+        - identifier: "httpbin-get"
+          target_url: "https://httpbin.org/get"
+      """
+
+      [item] = parse_config(yaml_config)
+
+      assert item.ttl == 0
+    end
+
+    # This was the cleanest/most robust way I could find to express this in YAML
+    test "supports requests headers as array of 2-element arrays, mapped into tuples" do
+      yaml_config = """
+      ---
+      feeds:
+        - identifier: "httpbin-header-auth-ok"
+          target_url: "https://httpbin.org/bearer"
+          request_headers:
+            - ["Authorization", "Bearer some-value"]
+      """
+
+      [item] = parse_config(yaml_config)
+
+      assert item.request_headers == [{"Authorization", "Bearer some-value"}]
+    end
   end
 
-  test "defaults to TTL 0 if TTL is unspecified" do
-    yaml_config = """
-    ---
-    feeds:
-      - identifier: "httpbin-get"
-        target_url: "https://httpbin.org/get"
-    """
+  describe "for SIRI items" do
+    test "it parses basic information" do
+      yaml_config = """
+      ---
+      feeds:
+        - identifier: "httpbin-get"
+          type: "siri"
+          target_url: "https://httpbin.org/get"
+          requestor_ref: the-ref
+      """
 
-    [item] = parse_config(yaml_config)
-
-    assert item.ttl == 0
-  end
-
-  # This was the cleanest/most robust way I could find to express this in YAML
-  test "supports requests headers as array of 2-element arrays, mapped into tuples" do
-    yaml_config = """
-    ---
-    feeds:
-      - identifier: "httpbin-header-auth-ok"
-        target_url: "https://httpbin.org/bearer"
-        request_headers:
-          - ["Authorization", "Bearer some-value"]
-    """
-
-    [item] = parse_config(yaml_config)
-
-    assert item.request_headers == [{"Authorization", "Bearer some-value"}]
+      assert parse_config(yaml_config) == [
+               %Unlock.Config.Item.SIRI{
+                 identifier: "httpbin-get",
+                 target_url: "https://httpbin.org/get",
+                 requestor_ref: "the-ref"
+               }
+             ]
+    end
   end
 end

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -32,7 +32,28 @@ defmodule Unlock.ControllerTest do
     |> stub(:fetch_config!, fn -> config end)
   end
 
-  describe "GET /resource/:slug" do
+  describe "GET /resource/:slug (on a SIRI item)" do
+    test "responds with 501 for now" do
+      slug = "an-existing-identifier"
+
+      setup_proxy_config(%{
+        slug => %Unlock.Config.Item.SIRI{
+          identifier: slug,
+          target_url: "http://localhost/some-remote-resource",
+          requestor_ref: "the-ref"
+        }
+      })
+
+      resp =
+        build_conn()
+        |> get("/resource/an-existing-identifier")
+
+      assert resp.resp_body == "Not Implemented"
+      assert resp.status == 501
+    end
+  end
+
+  describe "GET /resource/:slug (on a GTFS-RT item)" do
     test "handles a regular read" do
       slug = "an-existing-identifier"
 

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -39,7 +39,7 @@ defmodule Unlock.ControllerTest do
       ttl_in_seconds = 30
 
       setup_proxy_config(%{
-        slug => %Unlock.Config.Item{
+        slug => %Unlock.Config.Item.GTFS.RT{
           identifier: slug,
           target_url: target_url = "http://localhost/some-remote-resource",
           ttl: ttl_in_seconds
@@ -152,7 +152,7 @@ defmodule Unlock.ControllerTest do
 
     test "handles optional hardcoded request headers" do
       setup_proxy_config(%{
-        "some-identifier" => %Unlock.Config.Item{
+        "some-identifier" => %Unlock.Config.Item.GTFS.RT{
           identifier: "some-identifier",
           target_url: "http://localhost/some-remote-resource",
           ttl: 10,
@@ -186,7 +186,7 @@ defmodule Unlock.ControllerTest do
       identifier = "foo"
 
       setup_proxy_config(%{
-        identifier => %Unlock.Config.Item{
+        identifier => %Unlock.Config.Item.GTFS.RT{
           identifier: identifier,
           target_url: url,
           ttl: 10

--- a/apps/unlock/test/enforce_ttl_test.exs
+++ b/apps/unlock/test/enforce_ttl_test.exs
@@ -16,12 +16,12 @@ defmodule Unlock.EnforceTTLTest do
     ttl_config_value = 10
 
     setup_proxy_config(%{
-      "no_ttl" => %Unlock.Config.Item{
+      "no_ttl" => %Unlock.Config.Item.GTFS.RT{
         identifier: "no_ttl",
         target_url: "https://example.com",
         ttl: ttl_config_value
       },
-      "with_ttl" => %Unlock.Config.Item{
+      "with_ttl" => %Unlock.Config.Item.GTFS.RT{
         identifier: "with_ttl",
         target_url: "https://example.com",
         ttl: ttl_config_value

--- a/apps/unlock/test/github_config_test.exs
+++ b/apps/unlock/test/github_config_test.exs
@@ -52,7 +52,7 @@ defmodule UnlockGitHubConfigTest do
     assert Cachex.ttl(cache_name(), @config_cache_key) == {:ok, nil}
 
     assert data == %{
-             "test-slug" => %Unlock.Config.Item{
+             "test-slug" => %Unlock.Config.Item.GTFS.RT{
                identifier: "test-slug",
                ttl: 0,
                target_url: "http://localhost/real-time"

--- a/apps/unlock/test/siri_test.exs
+++ b/apps/unlock/test/siri_test.exs
@@ -1,0 +1,5 @@
+defmodule Unlock.SIRITests do
+  use ExUnit.Case
+
+  doctest Unlock.SIRI
+end


### PR DESCRIPTION
Je me suis débrouillé pour faire une PR intermédiaire qui ne doit pas avoir d'impact sur la production, qui est légère de façon à faciliter la revue de code et le merge.

Je vais continuer à travailler sur une sous-branche qui suppose que celle-ci est mergée.

Dans cette PR,  je modifie la configuration par YAML du proxy, pour supporter autant des éléments SIRI que GTFS-RT.

Cela passe par:
- l'ajout d'une clé optionnelle "type" égale à "gtfs-rt" par défaut
- la création d'une structure `Unlock.Config.Item.SIRI` avec quelques éléments (qui pourront évoluer plus tard si besoin, ils ne sont pas gelés), qui coexiste avec l'ancienne `Unlock.Config.Item` que je renomme en `Unlock.Config.Item.GTFS.RT`
- si un élément de type SIRI est dans la configuration, une requête dessus retournera un HTTP 501 `Not Implemented` pour le moment

J'ai aussi commencé à ajouter un module SIRI qui va grouper les fonctions de traitement XML, avec un peu de doctest, qui va remplacer le module déjà présent `SIRI.Saxy.Handler` dans la prochaine PR.