### PR TITLE
Amélioration de la carte GTFS

### DIFF
--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -80,14 +80,25 @@ function GTFSMap (mapDivId, geojsonUrl) {
                 filter: (feature) => feature.geometry.type === 'Point'
             }).addTo(markersfg)
 
-            stops.bindPopup(layer => { return layer.feature.properties.name })
+            stops.bindPopup(layer => { return formatPopupContent(layer.feature.properties) })
 
             const lines = L.geoJSON(geojson, {
                 style: GTFSLinesStyle,
-                filter: (feature) => feature.geometry.type !== 'Point'
+                filter: (feature) => feature.geometry.type !== 'Point',
+                onEachFeature: (feature, layer) => {
+                    layer.on('mouseover', () => {
+                        layer.bringToFront()
+                        stops.bringToFront()
+                        lines.setStyle({ weight: 3 })
+                        layer.setStyle({ weight: 10 })
+                    })
+                    layer.on('mouseout', () => {
+                        lines.resetStyle()
+                    })
+                }
             }).addTo(linesfg)
 
-            lines.bindPopup(layer => { return layer.feature.properties.route_long_name })
+            lines.bindPopup(layer => { return formatPopupContent(layer.feature.properties) })
 
             lines.bringToBack()
             stops.bringToFront()


### PR DESCRIPTION
La route se met par dessus les autres quand on passe dessus avec la souris
Les popups des lignes et des arrêts contiennent toutes les informations disponibles, et pas seulement les noms

https://user-images.githubusercontent.com/15341118/174118624-b3d2623e-220f-4079-b87b-a4a8f7632c1e.mp4

closes #2450 