### PR TITLE
Tableschema : ne lit pas nb erreurs depuis stats

### DIFF
--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -42,14 +42,13 @@ defmodule Shared.Validation.TableSchemaValidator do
     end
   end
 
-  defp build_report(%{"report" => %{"stats" => stats, "tasks" => tasks}} = report) do
-    nb_errors = Map.fetch!(stats, "errors")
-
+  defp build_report(%{"report" => %{"tasks" => tasks}} = report) do
     if Enum.count(tasks) != 1 do
       raise "tasks should have a length of 1 for report #{report}"
     end
 
     raw_errors = hd(tasks)["errors"]
+    nb_errors = Enum.count(raw_errors)
 
     {row_errors, structure_errors} =
       raw_errors |> Enum.split_with(&MapSet.disjoint?(MapSet.new(&1["tags"]), MapSet.new(@structure_tags)))

--- a/apps/shared/test/validation/tableschema_validator_test.exs
+++ b/apps/shared/test/validation/tableschema_validator_test.exs
@@ -104,6 +104,20 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
                "validator" => Shared.Validation.TableSchemaValidator
              } == validate(@schema_name, @url)
     end
+
+    test "when the custom check is not unknown and stats.errors is wrong" do
+      setup_schemas_response()
+      "validata_unknown_custom_check_error.json" |> setup_validata_response()
+
+      assert %{
+               "errors" => [
+                 "Check Error : colonne , ligne . Check is not valid: 'french_gps_coordinates': custom check inconnu."
+               ],
+               "errors_count" => 1,
+               "has_errors" => true,
+               "validator" => Shared.Validation.TableSchemaValidator
+             } == validate(@schema_name, @url)
+    end
   end
 
   defp setup_validata_response(filename), do: filename |> read_json() |> validata_response_with_body()


### PR DESCRIPTION
Nous avons fait [l'expérience](https://mattermost.incubateur.net/betagouv/pl/bh1umytqjtn3tq7yy5a5mwjn9e) que l'API de Validata pouvait retourner un nombre incohérent d'erreurs dans la section `stats` (par exemple 0) alors qu'il y a des erreurs de structure.

Le code existant prenait le parti de lire le nombre d'erreurs depuis `stats` et d'avoir la liste d'erreurs.

Cette PR fait en sorte que le nombre d'erreurs soit calculé depuis le rapport et non les stats, en attendant une correction côté Validata.