### PR TITLE
Ignore ressources communautaires pour import BNLC

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -505,13 +505,13 @@ defmodule DB.Dataset do
 
   @spec official_resources(__MODULE__.t()) :: list(Resource.t())
   def official_resources(%__MODULE__{resources: resources}),
-    do: resources |> Stream.reject(fn r -> r.is_community_resource end) |> Enum.to_list()
+    do: resources |> Stream.reject(&DB.Resource.is_community_resource?/1) |> Enum.to_list()
 
   def official_resources(%__MODULE__{}), do: []
 
   @spec community_resources(__MODULE__.t()) :: list(Resource.t())
   def community_resources(%__MODULE__{resources: resources}),
-    do: resources |> Stream.filter(fn r -> r.is_community_resource end) |> Enum.to_list()
+    do: resources |> Stream.filter(&DB.Resource.is_community_resource?/1) |> Enum.to_list()
 
   def community_resources(%__MODULE__{}), do: []
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -10,7 +10,6 @@ defmodule DB.Resource do
   alias Transport.DataVisualization
   alias Transport.Shared.Schemas.Wrapper, as: Schemas
   import Ecto.{Changeset, Query}
-  import DB.Gettext
   require Logger
 
   typed_schema "resource" do

--- a/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
@@ -14,12 +14,14 @@ defmodule Transport.Jobs.BNLCToGeoData do
   def perform(%{}) do
     transport_publisher_label = Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
 
-    # get resource id
-    %{type: "carpooling-areas", resources: [%{id: resource_id}]} =
+    # get the relevant dataset and its resource
+    dataset =
       DB.Dataset
       |> preload(:resources)
       |> where([d], d.type == "carpooling-areas" and d.organization == ^transport_publisher_label)
       |> DB.Repo.one!()
+
+    [%{id: resource_id}] = DB.Dataset.official_resources(dataset)
 
     %{id: latest_resource_history_id, payload: %{"permanent_url" => permanent_url}} =
       DB.ResourceHistory.latest_resource_history(resource_id)

--- a/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
@@ -52,7 +52,8 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
       organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
     })
 
-    # insert bnlc resource
+    # insert bnlc resources
+    insert(:resource, %{dataset_id: dataset_id, is_community_resource: true})
     %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id})
     # insert bnlc resource history
     %{id: id_0} =


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2480

Le job ne s'exécutait plus suite à l'ajout d'une ressource communautaire sur le jeu de données.

Adapte le code du job pour ne conserver que les ressources "officielles".