### PR TITLE
Update piwik -> Matomo

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/app.html.eex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.eex
@@ -34,7 +34,7 @@
       document.write('<script src="https://unpkg.com/url-polyfill@1.0.14/url-polyfill.js"><\/script>');
     }
     </script>
-    <!-- Piwik -->
+    <!-- Matomo -->
     <script type="text/javascript">
       var _paq = _paq || [];
       _paq.push(["setDomains", ["*.transport.data.gouv.fr","*.transport.data.gouv.fr"]]);
@@ -42,14 +42,13 @@
       _paq.push(['enableLinkTracking']);
       (function() {
         var u="//stats.data.gouv.fr/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', '58']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
-    <noscript><p><img src="//stats.data.gouv.fr/piwik.php?idsite=58" style="border:0;" alt="" /></p></noscript>
-    <!-- End Piwik Code -->
+    <!-- End Matomo Code -->
     <% end %>
     <%= if assigns[:extra_script_tags] do %>
       <%= apply(&render/2, assigns[:extra_script_tags]) %>


### PR DESCRIPTION
changement du nom piwik en Matomo.
Suite des erreurs HTML #2429