### PR TITLE
Ajout incitation publication pour Ressources communautaires

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
@@ -1,0 +1,32 @@
+<section class="dataset__resources white">
+  <h3><%= dgettext("page-dataset-details", "Community resources" )%></h3>
+  <section class="dataset__resources">
+    <div class="reuser-message">
+      <%
+      odbl_text =
+      if @dataset.licence == "odc-odbl" do
+        dgettext(
+          "page-dataset-details",
+          ", in accordance with the share-alike clause (article 4.4) of <a href=\"%{doc_link}\" target=\"_blank\">the ODbL License</a>",
+          doc_link: "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/conditions-dutilisation-des-donnees/licence-odbl#conditions-particulieres-dutilisation"
+          )
+      else
+        ""
+      end
+      %>
+      <%= dgettext(
+        "page-dataset-details",
+        "Reusers can share in this section edits made on resources%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publish your own ressource</a> on data.gouv.fr or <a href=\"%{doc_link}\" target=\"_blank\">browse our documentation.</a>",
+        datagouv_link: publish_community_resource_url(@dataset),
+        doc_link: "https://doc.transport.data.gouv.fr/reutilisateurs/utilisation-par-les-reutilisateurs-de-donnees/repartager-les-modifications-apportees-a-une-ressource",
+        odbl_text: odbl_text
+        )
+      |> raw()
+      %>
+    </div>
+  </section>
+
+  <div class="ressources-list">
+    <%= render_many community_resources(@dataset), TransportWeb.DatasetView, "_community_ressource.html", as: :resource %>
+  </div>
+</section>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -80,15 +80,7 @@
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"), latest_resources_history_infos: @latest_resources_history_infos%>
 
       <%= render "_reuser_message.html" %>
-      <% community_resources = community_resources(@dataset) %>
-      <%= unless community_resources == [] do %>
-        <section class="dataset__resources white">
-          <h3><%= dgettext("page-dataset-details", "Community ressources" )%></h3>
-          <div class="ressources-list">
-            <%= render_many community_resources, TransportWeb.DatasetView, "_community_ressource.html", as: :resource %>
-          </div>
-        </section>
-      <% end %>
+      <%= render "_community_resources.html", dataset: @dataset %>
     </section>
     <%= unless is_nil(@reuses) or @reuses == [] do %>
       <section class="white pt-48" id="dataset-reuses">

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -503,4 +503,10 @@ defmodule TransportWeb.DatasetView do
       end
     end
   end
+
+  def publish_community_resource_url(%DB.Dataset{datagouv_id: datagouv_id}) do
+    :transport
+    |> Application.fetch_env!(:datagouvfr_site)
+    |> Path.join("/admin/community-resource/new/?dataset_id=#{datagouv_id}")
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -171,7 +171,7 @@ msgid "Outdated"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Community ressources"
+msgid "Community resources"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -520,4 +520,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Documentation"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reusers can share in this section edits made on resources%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publish your own ressource</a> on data.gouv.fr or <a href=\"%{doc_link}\" target=\"_blank\">browse our documentation.</a>"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid ", in accordance with the share-alike clause (article 4.4) of <a href=\"%{doc_link}\" target=\"_blank\">the ODbL License</a>"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -171,7 +171,7 @@ msgid "Outdated"
 msgstr "Périmé"
 
 #, elixir-autogen, elixir-format
-msgid "Community ressources"
+msgid "Community resources"
 msgstr "Ressources communautaires"
 
 #, elixir-autogen, elixir-format
@@ -521,3 +521,11 @@ msgstr "Entités présentes dans ce flux lors des %{nb} derniers jours."
 #, elixir-autogen, elixir-format
 msgid "Documentation"
 msgstr "Documentation"
+
+#, elixir-autogen, elixir-format
+msgid "Reusers can share in this section edits made on resources%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publish your own ressource</a> on data.gouv.fr or <a href=\"%{doc_link}\" target=\"_blank\">browse our documentation.</a>"
+msgstr "Les réutilisateurs peuvent partager dans cette section les modifications apportées à une ressource%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publiez votre ressource</a> sur data.gouv.fr ou <a href=\"%{doc_link}\" target=\"_blank\">consultez la documentation.</a>"
+
+#, elixir-autogen, elixir-format
+msgid ", in accordance with the share-alike clause (article 4.4) of <a href=\"%{doc_link}\" target=\"_blank\">the ODbL License</a>"
+msgstr ", conformément à la clause de partage à l’identique (article 4.4) de la <a href=\"%{doc_link}\" target=\"_blank\">licence ODbL</a>"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -171,7 +171,7 @@ msgid "Outdated"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Community ressources"
+msgid "Community resources"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -520,4 +520,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Documentation"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reusers can share in this section edits made on resources%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publish your own ressource</a> on data.gouv.fr or <a href=\"%{doc_link}\" target=\"_blank\">browse our documentation.</a>"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid ", in accordance with the share-alike clause (article 4.4) of <a href=\"%{doc_link}\" target=\"_blank\">the ODbL License</a>"
 msgstr ""


### PR DESCRIPTION
- Affiche toujours la section "Ressources communautaires" y compris en l'absence de ressources communautaires
- Ajout de messages pour la section "Ressources communautaires" pour inciter au partage de données en incluant des liens vers data.gouv.fr et la doc.

Le message est différent si la licence est ODbL ou pas.

### Si licence != ODbL

![image](https://user-images.githubusercontent.com/295709/177320700-5d662b2a-ec12-40dc-ab88-5a205b105ac6.png)

### Si licence ODbL
![image](https://user-images.githubusercontent.com/295709/177320724-9acd1bf8-5ad3-4e05-8caf-125a6af6a54e.png)

[Voir sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/h93js71dsprg3xrtco8ewr9p5e)