### PR TITLE
Utilisation URL pertinente pour vérifier la disponibilité

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -730,11 +730,11 @@ defmodule DB.Resource do
     end
   end
 
-  def download_url(%Plug.Conn{} = conn, %__MODULE__{} = resource) do
+  def download_url(%__MODULE__{} = resource, conn_or_endpoint \\ TransportWeb.Endpoint) do
     cond do
       needs_stable_url?(resource) -> resource.latest_url
       can_direct_download?(resource) -> resource.url
-      true -> resource_path(conn, :download, resource.id)
+      true -> resource_path(conn_or_endpoint, :download, resource.id)
     end
   end
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -10,6 +10,7 @@ defmodule DB.Resource do
   alias Transport.DataVisualization
   alias Transport.Shared.Schemas.Wrapper, as: Schemas
   import Ecto.{Changeset, Query}
+  import TransportWeb.Router.Helpers, only: [resource_path: 3]
   require Logger
 
   typed_schema "resource" do
@@ -727,5 +728,36 @@ defmodule DB.Resource do
         {:ok, updated_at, 0} = resource_history_list |> Enum.at(0) |> DateTime.from_iso8601()
         updated_at
     end
+  end
+
+  def download_url(%Plug.Conn{} = conn, %__MODULE__{} = resource) do
+    cond do
+      needs_stable_url?(resource) -> resource.latest_url
+      can_direct_download?(resource) -> resource.url
+      true -> resource_path(conn, :download, resource.id)
+    end
+  end
+
+  defp needs_stable_url?(%__MODULE__{latest_url: nil}), do: false
+
+  defp needs_stable_url?(%__MODULE__{url: url}) do
+    parsed_url = URI.parse(url)
+
+    hosted_on_static_datagouv =
+      Enum.member?(Application.fetch_env!(:transport, :datagouv_static_hosts), parsed_url.host)
+
+    hosted_on_bison_fute = parsed_url.host == Application.fetch_env!(:transport, :bison_fute_host)
+
+    cond do
+      hosted_on_bison_fute -> is_link_to_folder?(parsed_url)
+      hosted_on_static_datagouv -> true
+      true -> false
+    end
+  end
+
+  defp needs_stable_url?(%__MODULE__{}), do: false
+
+  defp is_link_to_folder?(%URI{path: path}) do
+    path |> Path.basename() |> :filename.extension() == ""
   end
 end

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -56,8 +56,8 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
     resource |> check_availability() |> update_data(resource)
   end
 
-  defp check_availability(%Resource{url: url}) do
-    Transport.AvailabilityChecker.Wrapper.available?(url)
+  defp check_availability(%Resource{} = resource) do
+    resource |> Resource.download_url() |> Transport.AvailabilityChecker.Wrapper.available?()
   end
 
   def update_data(is_available, %Resource{} = resource) do

--- a/apps/transport/lib/transport_web/templates/dataset/_community_ressource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_ressource.html.eex
@@ -9,7 +9,7 @@
     <div class="pb-24"><%= description(@resource) %></div>
   </div>
   <div class="community-resource-download">
-    <a href="<%= @resource.url %>">
+    <a href="<%= DB.Resource.download_url(@resource) %>">
       <button class="button-outline primary small"><i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %></button>
     </a>
   </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -163,7 +163,7 @@
         <a href="<%= resource_path(@conn, :details, @resource.id) %>">
           <button class="button-outline secondary small"><i class="icon icon--plus" aria-hidden="true"></i><%= dgettext("page-dataset-details", "details") %></button>
         </a>
-        <a class="download-button" href="<%= download_url(@conn, @resource) %>">
+        <a class="download-button" href="<%= DB.Resource.download_url(@conn, @resource) %>">
           <button class="button-outline primary small"><i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %></button>
         </a>
       </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -163,7 +163,7 @@
         <a href="<%= resource_path(@conn, :details, @resource.id) %>">
           <button class="button-outline secondary small"><i class="icon icon--plus" aria-hidden="true"></i><%= dgettext("page-dataset-details", "details") %></button>
         </a>
-        <a class="download-button" href="<%= DB.Resource.download_url(@conn, @resource) %>">
+        <a class="download-button" href="<%= DB.Resource.download_url(@resource, @conn) %>">
           <button class="button-outline primary small"><i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %></button>
         </a>
       </div>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
@@ -62,7 +62,7 @@
 
     <% current_gtfs = @resource.dataset |> DB.Dataset.valid_gtfs() |> Enum.reject(&DB.Resource.is_outdated?/1) |> List.first() %>
     <%= unless is_nil(current_gtfs) do %>
-      <% validation_path = live_path(@conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "gtfs-rt", url: current_gtfs.url, feed_url: @resource.url) %>
+      <% validation_path = live_path(@conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "gtfs-rt", url: current_gtfs.url, feed_url: DB.Resource.download_url(@resource)) %>
       <a class="button" href="<%= validation_path %>" target="_blank" role="link">
         <i class="icon fa-check" aria-hidden="true"></i>
         <%= dgettext("validations", "Validate this GTFS-RT now") %>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.eex
@@ -6,7 +6,7 @@
       </h2>
       <div class="panel">
         <div>
-          <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %><a href="<%= @resource.url %>">
+          <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %><a href="<%= DB.Resource.download_url(@resource) %>">
             <strong><%= @resource.title %></strong>
           </a>
         </div>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.eex
@@ -6,7 +6,7 @@
       <h2 class="mt-48"><%= dgettext("validations", "Resource details")%></h2>
       <div class="panel">
         <p><%= dgettext("validations", "File name")%> :
-          <a href="<%= @resource.url %>">
+          <a href="<%= DB.Resource.download_url(@resource) %>">
             <strong><%= @resource.title %></strong>
           </a>
         </p>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -450,37 +450,6 @@ defmodule TransportWeb.DatasetView do
 
   def schema_label(%{schema_name: schema_name}), do: schema_name
 
-  def download_url(%Plug.Conn{} = conn, %DB.Resource{} = resource) do
-    cond do
-      needs_stable_url?(resource) -> resource.latest_url
-      Resource.can_direct_download?(resource) -> resource.url
-      true -> resource_path(conn, :download, resource.id)
-    end
-  end
-
-  defp needs_stable_url?(%DB.Resource{latest_url: nil}), do: false
-
-  defp needs_stable_url?(%DB.Resource{url: url}) do
-    parsed_url = URI.parse(url)
-
-    hosted_on_static_datagouv =
-      Enum.member?(Application.fetch_env!(:transport, :datagouv_static_hosts), parsed_url.host)
-
-    hosted_on_bison_fute = parsed_url.host == Application.fetch_env!(:transport, :bison_fute_host)
-
-    cond do
-      hosted_on_bison_fute -> is_link_to_folder?(parsed_url)
-      hosted_on_static_datagouv -> true
-      true -> false
-    end
-  end
-
-  defp needs_stable_url?(%DB.Resource{}), do: false
-
-  defp is_link_to_folder?(%URI{path: path}) do
-    path |> Path.basename() |> :filename.extension() == ""
-  end
-
   def has_validity_period?(history_resources) when is_list(history_resources) do
     history_resources |> Enum.map(&has_validity_period?/1) |> Enum.any?()
   end

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -345,27 +345,27 @@ defmodule DB.ResourceTest do
 
   test "download url", %{conn: conn} do
     # Files hosted on data.gouv.fr
-    assert Resource.download_url(conn, %Resource{
+    assert Resource.download_url(%Resource{
              filetype: "file",
              url: "https://demo-static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
              latest_url: latest_url = "https://demo.data.gouv.fr/fake_stable_url"
            }) == latest_url
 
-    assert Resource.download_url(conn, %Resource{
+    assert Resource.download_url(%Resource{
              filetype: "file",
              url: "https://static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
              latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
            }) == latest_url
 
     # Bison Futé folder
-    assert Resource.download_url(conn, %Resource{
+    assert Resource.download_url(%Resource{
              filetype: "remote",
              url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/",
              latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
            }) == latest_url
 
     # Bison Futé files
-    assert Resource.download_url(conn, %Resource{
+    assert Resource.download_url(%Resource{
              filetype: "remote",
              id: id = 1,
              url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/refDir.csv",
@@ -373,17 +373,17 @@ defmodule DB.ResourceTest do
            }) == resource_path(conn, :download, id)
 
     # File not hosted on data.gouv.fr
-    assert Resource.download_url(conn, %Resource{filetype: "file", url: url = "https://data.example.com/voies.geojson"}) ==
+    assert Resource.download_url(%Resource{filetype: "file", url: url = "https://data.example.com/voies.geojson"}) ==
              url
 
     # Remote filetype / can direct download
-    assert Resource.download_url(conn, %Resource{filetype: "remote", url: url = "https://data.example.com/data"}) == url
+    assert Resource.download_url(%Resource{filetype: "remote", url: url = "https://data.example.com/data"}) == url
     # http URL
-    assert Resource.download_url(conn, %Resource{id: id = 1, filetype: "remote", url: "http://data.example.com/data"}) ==
+    assert Resource.download_url(%Resource{id: id = 1, filetype: "remote", url: "http://data.example.com/data"}) ==
              resource_path(conn, :download, id)
 
     # file hosted on GitHub
-    assert Resource.download_url(conn, %Resource{
+    assert Resource.download_url(%Resource{
              id: id = 1,
              filetype: "remote",
              url:

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -1,5 +1,5 @@
 defmodule DB.ResourceTest do
-  use ExUnit.Case, async: true
+  use TransportWeb.ConnCase, async: true
   alias Shared.Validation.Validator.Mock, as: ValidatorMock
   alias DB.{LogsValidation, Repo, Resource, Validation}
   import Mox
@@ -211,12 +211,12 @@ defmodule DB.ResourceTest do
     insert_data_conversion(uuid4, "url4", 10)
 
     assert %{url: "url2", filesize: "12", resource_history_last_up_to_date_at: _} =
-             DB.Resource.get_related_geojson_info(resource_id_1)
+             Resource.get_related_geojson_info(resource_id_1)
 
-    assert nil == DB.Resource.get_related_geojson_info(resource_id_1 - 10)
+    assert nil == Resource.get_related_geojson_info(resource_id_1 - 10)
 
     assert %{geojson: %{url: "url2", filesize: "12", resource_history_last_up_to_date_at: _}} =
-             DB.Resource.get_related_files(%DB.Resource{id: resource_id_1})
+             Resource.get_related_files(%Resource{id: resource_id_1})
   end
 
   defp insert_resource_history(resource_id, uuid, datetime, time_delta_seconds \\ 0) do
@@ -341,5 +341,53 @@ defmodule DB.ResourceTest do
 
       assert expected_last_update_time == resource_id |> Resource.content_updated_at()
     end
+  end
+
+  test "download url", %{conn: conn} do
+    # Files hosted on data.gouv.fr
+    assert Resource.download_url(conn, %Resource{
+             filetype: "file",
+             url: "https://demo-static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
+             latest_url: latest_url = "https://demo.data.gouv.fr/fake_stable_url"
+           }) == latest_url
+
+    assert Resource.download_url(conn, %Resource{
+             filetype: "file",
+             url: "https://static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
+             latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
+           }) == latest_url
+
+    # Bison Futé folder
+    assert Resource.download_url(conn, %Resource{
+             filetype: "remote",
+             url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/",
+             latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
+           }) == latest_url
+
+    # Bison Futé files
+    assert Resource.download_url(conn, %Resource{
+             filetype: "remote",
+             id: id = 1,
+             url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/refDir.csv",
+             latest_url: "https://data.gouv.fr/fake_stable_url"
+           }) == resource_path(conn, :download, id)
+
+    # File not hosted on data.gouv.fr
+    assert Resource.download_url(conn, %Resource{filetype: "file", url: url = "https://data.example.com/voies.geojson"}) ==
+             url
+
+    # Remote filetype / can direct download
+    assert Resource.download_url(conn, %Resource{filetype: "remote", url: url = "https://data.example.com/data"}) == url
+    # http URL
+    assert Resource.download_url(conn, %Resource{id: id = 1, filetype: "remote", url: "http://data.example.com/data"}) ==
+             resource_path(conn, :download, id)
+
+    # file hosted on GitHub
+    assert Resource.download_url(conn, %Resource{
+             id: id = 1,
+             filetype: "remote",
+             url:
+               "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/898dc67fb19fae2464c24a85a0557e8ccce18791/bnlc-.csv"
+           }) == resource_path(conn, :download, id)
   end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -71,54 +71,6 @@ defmodule TransportWeb.DatasetViewTest do
     assert "tipi.bison-fute.gouv.fr" == Application.fetch_env!(:transport, :bison_fute_host)
   end
 
-  test "download url", %{conn: conn} do
-    # Files hosted on data.gouv.fr
-    assert download_url(conn, %DB.Resource{
-             filetype: "file",
-             url: "https://demo-static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
-             latest_url: latest_url = "https://demo.data.gouv.fr/fake_stable_url"
-           }) == latest_url
-
-    assert download_url(conn, %DB.Resource{
-             filetype: "file",
-             url: "https://static.data.gouv.fr/resources/base-nationale-zfe/20220412-121638/voies.geojson",
-             latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
-           }) == latest_url
-
-    # Bison Futé folder
-    assert download_url(conn, %DB.Resource{
-             filetype: "remote",
-             url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/",
-             latest_url: latest_url = "https://data.gouv.fr/fake_stable_url"
-           }) == latest_url
-
-    # Bison Futé files
-    assert download_url(conn, %DB.Resource{
-             filetype: "remote",
-             id: id = 1,
-             url: "http://tipi.bison-fute.gouv.fr/bison-fute-ouvert/publicationsDIR/QTV-DIR/refDir.csv",
-             latest_url: "https://data.gouv.fr/fake_stable_url"
-           }) == resource_path(conn, :download, id)
-
-    # File not hosted on data.gouv.fr
-    assert download_url(conn, %DB.Resource{filetype: "file", url: url = "https://data.example.com/voies.geojson"}) ==
-             url
-
-    # Remote filetype / can direct download
-    assert download_url(conn, %DB.Resource{filetype: "remote", url: url = "https://data.example.com/data"}) == url
-    # http URL
-    assert download_url(conn, %DB.Resource{id: id = 1, filetype: "remote", url: "http://data.example.com/data"}) ==
-             resource_path(conn, :download, id)
-
-    # file hosted on GitHub
-    assert download_url(conn, %DB.Resource{
-             id: id = 1,
-             filetype: "remote",
-             url:
-               "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/898dc67fb19fae2464c24a85a0557e8ccce18791/bnlc-.csv"
-           }) == resource_path(conn, :download, id)
-  end
-
   test "other_official_resources is sorted by display position" do
     dataset = %DB.Dataset{
       type: "low-emission-zones",

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -263,7 +263,7 @@ defmodule TransportWeb.ResourceControllerTest do
 
   test "flash message when parent dataset is inactive", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset, %{is_active: false})
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id})
+    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, url: "https://example.com/file"})
 
     conn = conn |> get(resource_path(conn, :details, resource_id))
     assert conn |> html_response(200) =~ "supprimé de data.gouv.fr"
@@ -271,7 +271,7 @@ defmodule TransportWeb.ResourceControllerTest do
 
   test "no flash message when parent dataset is active", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset, %{is_active: true})
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id})
+    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, url: "https://example.com/file"})
 
     conn = conn |> get(resource_path(conn, :details, resource_id))
     refute conn |> html_response(200) =~ "supprimé de data.gouv.fr"
@@ -281,7 +281,12 @@ defmodule TransportWeb.ResourceControllerTest do
     %{id: dataset_id} = insert(:dataset)
 
     %{id: resource_id} =
-      insert(:resource, %{dataset_id: dataset_id, format: "GTFS", datagouv_id: datagouv_id = "datagouv_id"})
+      insert(:resource, %{
+        dataset_id: dataset_id,
+        format: "GTFS",
+        datagouv_id: datagouv_id = "datagouv_id",
+        url: "https://example.com/file"
+      })
 
     conn1 = conn |> get(resource_path(conn, :details, resource_id))
     assert conn1 |> html_response(200) =~ "Pas de validation disponible"


### PR DESCRIPTION
Fixes #2485 

- Déplace `download_url` de `DatasetView` vers `Resource` (et les tests associés)
- Utilise `download_url` au lieu de `url` dans le job en charge de vérifier la disponibilité des ressources
- Remplace `resource.url` par `download_url(@resource)` dans les templates lorsque pertinent