### PR TITLE
Import de données : utilise datagouv_id

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -704,11 +704,11 @@ defmodule Transport.ImportData do
   def get_title(%{"url" => url}), do: Helpers.filename_from_url(url)
 
   @spec get_existing_resource(map(), binary()) :: Resource.t() | nil
-  defp get_existing_resource(%{"url" => url}, dataset_id) do
+  defp get_existing_resource(%{"url" => url, "id" => datagouv_id}, dataset_datagouv_id) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r, _d], r.url == ^url)
-    |> where([_r, d], d.datagouv_id == ^dataset_id)
+    |> where([r, _d], r.datagouv_id == ^datagouv_id or r.url == ^url)
+    |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id, :metadata]))
     |> Repo.one()
   end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -221,7 +221,7 @@ defmodule Transport.ImportDataTest do
         datagouv_id,
         generate_resources_payload(
           new_title,
-          _new_url = "http://localhost:4321/resource1_new",
+          _new_url = "https://example.com/" <> Ecto.UUID.generate(),
           new_datagouv_id
         )
       )
@@ -244,8 +244,8 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
     assert Map.get(resource_updated, :display_position) == 0
 
-    # but its a new one : its DB id has been incremented
-    refute Map.get(resource_updated, :id) == resource_id
+    # and the internal resource.id did not change
+    assert Map.get(resource_updated, :id) == resource_id
   end
 
   test "import dataset with a community resource" do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2442

Utilise `resource.datagouv_id` lors de l'import de données pour assurer une meilleure stabilité des identifiants de ressources côté PAN.