### PR TITLE
Nouvelle tâche : mix check_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ Running in `--umbrella` mode will generate coverage report at the top-level `cov
 
 To extract all translations from the source, you can run `mix gettext.extract --merge` (and then edit the modified .po files).
 
+#### Check all
+To perform all the checks done on the CI with a single command, you can run `mix check_all`. It will run the different linters, credo, check the translations are up-to-date, and launch the tests.
+
 #### DB migrations
 
 To generate a new migration file:

--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -132,7 +132,7 @@ defmodule Opendatasoft.UrlExtractor do
     cond do
       String.ends_with?(filename, ".pdf") -> nil
       String.match?(filename, ~r/\bgtfs(-rt|rt| rt)\b/) -> "gtfs-rt"
-      String.contains?(filename, "trip-updates") -> "gtfs-rt"
+      String.contains?(filename, "trip-update") -> "gtfs-rt"
       String.contains?(filename, "netex") -> "netex"
       String.contains?(filename, "gtfs") -> "gtfs"
       true -> nil
@@ -290,12 +290,14 @@ defmodule Opendatasoft.UrlExtractor do
 
     iex> UrlExtractor.get_url_from_csv_line(%{"fichié_a_download" => "http://the-url"})
     nil
+    iex> UrlExtractor.get_url_from_csv_line(%{"fichier_a_telecharger" => ""})
+    nil
   """
   @spec get_url_from_csv_line(map) :: binary
   def get_url_from_csv_line(line) do
     @csv_headers
     |> Enum.map(&Map.get(line, &1))
-    |> Enum.filter(&(&1 != nil))
+    |> Enum.reject(&(is_nil(&1) or String.trim(&1) == ""))
     |> case do
       [] -> nil
       [head | _] -> head

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,9 @@ defmodule Transport.MixProject do
         plt_add_apps: [:mix],
         plt_local_path: "dialyzer-plt",
         plt_core_path: "dialyzer-plt"
+      ],
+      preferred_cli_env: [
+        check_all: :test
       ]
     ]
   end
@@ -30,7 +33,16 @@ defmodule Transport.MixProject do
   defp aliases do
     [
       test: ["ecto.create --quiet", "ecto.migrate", "test"],
-      "phx.migrate_phx.server": ["ecto.migrate", "phx.server"]
+      "phx.migrate_phx.server": ["ecto.migrate", "phx.server"],
+      check_all: [
+        "format --check-formatted",
+        "npm \"run linter:sass\"",
+        fn _ -> Mix.Task.reenable("npm") end,
+        "npm \"run linter:ecma\"",
+        "credo --strict",
+        "gettext.extract --check-up-to-date",
+        "test"
+      ]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,9 +36,13 @@ defmodule Transport.MixProject do
       "phx.migrate_phx.server": ["ecto.migrate", "phx.server"],
       check_all: [
         "format --check-formatted",
-        "npm \"run linter:sass\"",
+        ~s(npm "run linter:sass"),
+        # from https://hexdocs.pm/mix/1.12/Mix.Task.html#run/2
+        # Remember: by default, tasks will only run once, even when called repeatedly!
+        # If you need to run a task multiple times, you need to re-enable it via reenable/1 or call it using rerun/2."
+        # => here, npm task need to be run twice
         fn _ -> Mix.Task.reenable("npm") end,
-        "npm \"run linter:ecma\"",
+        ~s(npm "run linter:ecma"),
         "credo --strict",
         "gettext.extract --check-up-to-date",
         "test"


### PR DESCRIPTION
J'avais envie d'avoir une tâche unique qui permette de faire tourner tous les checks faits par le CI avant de pusher une branche et de faire des aller retours inutiles. Je n'ai pas mis dialyzer parce qu'honnêtement il ne trouve quasiment jamais rien et il prend du temps à tourner.

Usage : `mix check_all`