### PR TITLE
Mise à jour contenu rappel données expirées

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -8,7 +8,7 @@ defmodule Transport.DataChecker do
   import Ecto.Query
   require Logger
 
-  @update_data_doc_link "https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees"
+  @update_data_doc_link "https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau"
   @default_outdated_data_delays [0, 7, 14]
 
   @doc """
@@ -107,7 +107,9 @@ defmodule Transport.DataChecker do
 
           #{link_and_name(dataset)}
 
-          Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour. Veuillez anticiper vos prochaines mises à jour. N'hésitez pas à consulter la documentation pour mettre à jour vos données #{@update_data_doc_link}.
+          Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour. Pour cela, veuillez remplacer la ressource périmée par la nouvelle ressource : #{@update_data_doc_link}.
+
+          Veuillez également anticiper vos prochaines mises à jour, au moins 7 jours avant l'expiration de votre fichier.
 
           L’équipe transport.data.gouv.fr
 


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-notifications/issues/17, en lien avec #2501.

Une adaptation du texte envoyé en tant qu'e-mail de rappel.