### PR TITLE
Ajout d'un lien vers Validata web si trop d'erreurs

### DIFF
--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -18,6 +18,7 @@ defmodule Shared.Validation.TableSchemaValidator do
   """
   import Transport.Shared.Schemas
   @behaviour Shared.Validation.TableSchemaValidator.Wrapper
+  @validata_web_url URI.parse("https://validata.etalab.studio/table-schema")
   @validata_api_url URI.parse("https://validata-api.app.etalab.studio/validate")
   # https://git.opendatafrance.net/validata/validata-core/-/blob/75ee5258010fc43b6a164122eff2579c2adc01a7/validata_core/helpers.py#L152
   @structure_tags ["#head", "#structure"]
@@ -40,6 +41,14 @@ defmodule Shared.Validation.TableSchemaValidator do
     else
       _ -> nil
     end
+  end
+
+  def validata_web_url(schema_name) do
+    ensure_schema_is_tableschema!(schema_name)
+
+    @validata_web_url
+    |> Map.put(:query, URI.encode_query(%{schema_name: "schema-transport.#{schema_name}"}))
+    |> URI.to_string()
   end
 
   defp build_report(%{"report" => %{"tasks" => tasks}} = report) do

--- a/apps/shared/test/validation/tableschema_validator_test.exs
+++ b/apps/shared/test/validation/tableschema_validator_test.exs
@@ -120,6 +120,24 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
     end
   end
 
+  describe "validata_web_url" do
+    test "it works" do
+      setup_schemas_response()
+
+      assert "https://validata.etalab.studio/table-schema?schema_name=schema-transport.etalab%2Fschema-lieux-covoiturage" ==
+               validata_web_url(@schema_name)
+    end
+
+    test "with an unknown schema" do
+      schema_name = "foo"
+
+      assert_raise RuntimeError, "#{schema_name} is not a tableschema", fn ->
+        setup_schemas_response()
+        validata_web_url(schema_name)
+      end
+    end
+  end
+
   defp setup_validata_response(filename), do: filename |> read_json() |> validata_response_with_body()
 
   defp read_json(filename), do: File.read!("#{__DIR__}/../fixtures/#{filename}")

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -7,6 +7,7 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   use TransportWeb.InputHelpers
   import TransportWeb.Gettext
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 3]
+  import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]
   import Ecto.Query
 
   def mount(

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -138,7 +138,18 @@
               </ul>
 
               <%= if nb_errors > max_display_errors do %>
-                <p><%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors) %></p>
+                <p class="notification">
+                  <%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors) %>
+                  <%= if oban_args["type"] == "tableschema" do %>
+                    <%= raw(
+                      dgettext(
+                        "validations",
+                        ~s(See all your errors <a href="%{url}" target="_blank">using the web interface</a>.),
+                        url: validata_web_url(oban_args["schema_name"])
+                      )
+                    ) %>
+                  <% end %>
+                </p>
               <% end %>
             <% end %>
           <% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
@@ -34,7 +34,16 @@
           <% end %>
         </ul>
         <%= if nb_errors > max_display_errors() do %>
-          <p><%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors())%></p>
+          <p class="notification">
+            <%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors())%>
+            <%= if @resource.metadata["validation"]["schema_type"] == "tableschema" do %>
+              <%= raw dgettext(
+                "validations",
+                ~s(See all your errors <a href="%{url}" target="_blank">using the web interface</a>.),
+                url: validata_web_url(@resource.schema_name)
+              ) %>
+            <% end %>
+          </p>
         <% end %>
       <% end %>
     <% end %>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -8,6 +8,7 @@ defmodule TransportWeb.ResourceView do
   import DB.Resource, only: [has_errors_details?: 1]
   import DB.ResourceUnavailability, only: [round_float: 2]
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
+  import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]
   alias Shared.DateTimeDisplay
   def format_related_objects(nil), do: ""
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -260,3 +260,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "No validation error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See all your errors <a href=\"%{url}\" target=\"_blank\">using the web interface</a>."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -260,3 +260,7 @@ msgstr "La visualisation est volumineuse"
 #, elixir-autogen, elixir-format
 msgid "No validation error"
 msgstr "Aucune erreur de validation"
+
+#, elixir-autogen, elixir-format
+msgid "See all your errors <a href=\"%{url}\" target=\"_blank\">using the web interface</a>."
+msgstr "Consultez toutes les erreurs <a href=\"%{url}\" target=\"_blank\">sur ce site web</a>."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -259,3 +259,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "No validation error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See all your errors <a href=\"%{url}\" target=\"_blank\">using the web interface</a>."
+msgstr ""


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2496

Pour la validation d'un fichier par rapport à un schéma TableSchema, s'il y a plus de 50 erreurs, ajout d'un lien vers l'interface web de Validata qui permettra mieux d'appréhender le problème.

Ceci est fait pour la validation à la demande et sur la page d'une ressource.