### PR TITLE
ImportData: use datagouv_id only for files

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -707,7 +707,7 @@ defmodule Transport.ImportData do
   defp get_existing_resource(%{"url" => url, "id" => datagouv_id}, dataset_datagouv_id) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r, _d], r.datagouv_id == ^datagouv_id or r.url == ^url)
+    |> where([r, _d], (r.datagouv_id == ^datagouv_id and r.filetype == "file") or r.url == ^url)
     |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id, :metadata]))
     |> Repo.one()

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -191,7 +191,10 @@ defmodule Transport.ImportDataTest do
         generate_resources_payload(
           new_title = "new title !!! fresh !!!",
           "http://localhost:4321/resource1",
-          new_datagouv_id = "resource2_id"
+          new_datagouv_id = "resource2_id",
+          _schema_name = nil,
+          _schema_version = nil,
+          _filetype = "file"
         )
       )
 
@@ -209,6 +212,9 @@ defmodule Transport.ImportDataTest do
     # assert that the resource has been updated with a new title and a new datagouv_id
     # but its id is still the same
     assert Map.get(resource_updated, :title) == new_title
+    # Resource needs to be a file if we want to find it back
+    # with its datagouv_id afterwards
+    assert Map.get(resource_updated, :filetype) == "file"
     assert Map.get(resource_updated, :id) == resource_id
     assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
 
@@ -222,7 +228,10 @@ defmodule Transport.ImportDataTest do
         generate_resources_payload(
           new_title,
           _new_url = "https://example.com/" <> Ecto.UUID.generate(),
-          new_datagouv_id
+          new_datagouv_id,
+          _schema_name = nil,
+          _schema_version = nil,
+          _filetype = "file"
         )
       )
 
@@ -245,6 +254,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :display_position) == 0
 
     # and the internal resource.id did not change
+    assert Map.get(resource_updated, :filetype) == "file"
     assert Map.get(resource_updated, :id) == resource_id
   end
 


### PR DESCRIPTION
Follow up de #2497

Si on ne scope pas sur `filetype = 'file'` on a des problèmes pour les ressources qui sont hébergées sur ODS avec le même datagouv_id.

Bug visible lorsqu'on essaie d'importer [ce jeu de données](https://transport.data.gouv.fr/backoffice/datasets/286/edit) par exemple.

```sql
select datagouv_id, count(1)
from resource
where filetype = 'file'
group by 1
having count(1) > 1
```
retourne bien 0 lignes.