### PR TITLE
Move assert_cache_key_has_ttl

### DIFF
--- a/apps/shared/test/schemas_test.exs
+++ b/apps/shared/test/schemas_test.exs
@@ -47,10 +47,6 @@ defmodule Transport.Shared.SchemasTest do
     end
   end
 
-  def assert_cache_key_has_ttl(cache_key, expected_ttl \\ 300) do
-    assert_in_delta Cachex.ttl!(cache_name(), cache_key), :timer.seconds(expected_ttl), :timer.seconds(1)
-  end
-
   defp setup_schemas_response do
     url = "https://schema.data.gouv.fr/schemas.json"
 

--- a/apps/shared/test/support/cache_case.ex
+++ b/apps/shared/test/support/cache_case.ex
@@ -18,6 +18,10 @@ defmodule Shared.CacheCase do
         Cachex.clear(cache_name())
         on_exit(fn -> Cachex.clear(cache_name()) end)
       end
+
+      def assert_cache_key_has_ttl(cache_key, expected_ttl \\ 300) do
+        assert_in_delta Cachex.ttl!(cache_name(), cache_key), :timer.seconds(expected_ttl), :timer.seconds(1)
+      end
     end
   end
 end

--- a/apps/shared/test/validation/jsonschema_validator_test.exs
+++ b/apps/shared/test/validation/jsonschema_validator_test.exs
@@ -1,7 +1,6 @@
 defmodule Shared.Validation.JSONSchemaValidatorTest do
   use Shared.CacheCase
   import Shared.Validation.JSONSchemaValidator
-  import Transport.Shared.SchemasTest, only: [assert_cache_key_has_ttl: 1]
 
   setup do
     Mox.stub_with(Transport.Shared.Schemas.Mock, Transport.Shared.Schemas)


### PR DESCRIPTION
Suite de #2499, cette fonction était dans un module `.exs` qui n'est pas un endroit approprié. Je la déplace dans `Shared.CacheCase`