### PR TITLE
Import : traitement plus explicite des ressources ODS

### DIFF
--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -28,6 +28,7 @@ defmodule Opendatasoft.UrlExtractor do
     resources
     |> filter_csv()
     |> get_resources_inside_csv()
+    |> Enum.map(fn r -> r |> Map.put("is_ods_csv", true) end)
   end
 
   @spec get_resources_inside_csv([any]) :: [any]

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -704,10 +704,21 @@ defmodule Transport.ImportData do
   def get_title(%{"url" => url}), do: Helpers.filename_from_url(url)
 
   @spec get_existing_resource(map(), binary()) :: Resource.t() | nil
+  # ODS CSV resources are identified only with their URL, as their resource datagouv id is not unique.
+  # For regular resources, we can identify them by resource datagouv id or by their url.
+  defp get_existing_resource(%{"is_ods_csv" => true, "url" => url}, dataset_datagouv_id) do
+    Resource
+    |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
+    |> where([r], r.url == ^url)
+    |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
+    |> select([r], map(r, [:id, :metadata]))
+    |> Repo.one()
+  end
+
   defp get_existing_resource(%{"url" => url, "id" => datagouv_id}, dataset_datagouv_id) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r, _d], (r.datagouv_id == ^datagouv_id and r.filetype == "file") or r.url == ^url)
+    |> where([r, _d], r.datagouv_id == ^datagouv_id or r.url == ^url)
     |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id, :metadata]))
     |> Repo.one()

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -191,10 +191,7 @@ defmodule Transport.ImportDataTest do
         generate_resources_payload(
           new_title = "new title !!! fresh !!!",
           "http://localhost:4321/resource1",
-          new_datagouv_id = "resource2_id",
-          _schema_name = nil,
-          _schema_version = nil,
-          _filetype = "file"
+          new_datagouv_id = "resource2_id"
         )
       )
 
@@ -212,9 +209,6 @@ defmodule Transport.ImportDataTest do
     # assert that the resource has been updated with a new title and a new datagouv_id
     # but its id is still the same
     assert Map.get(resource_updated, :title) == new_title
-    # Resource needs to be a file if we want to find it back
-    # with its datagouv_id afterwards
-    assert Map.get(resource_updated, :filetype) == "file"
     assert Map.get(resource_updated, :id) == resource_id
     assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
 
@@ -228,10 +222,7 @@ defmodule Transport.ImportDataTest do
         generate_resources_payload(
           new_title,
           _new_url = "https://example.com/" <> Ecto.UUID.generate(),
-          new_datagouv_id,
-          _schema_name = nil,
-          _schema_version = nil,
-          _filetype = "file"
+          new_datagouv_id
         )
       )
 
@@ -254,7 +245,6 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :display_position) == 0
 
     # and the internal resource.id did not change
-    assert Map.get(resource_updated, :filetype) == "file"
     assert Map.get(resource_updated, :id) == resource_id
   end
 


### PR DESCRIPTION
La logique d'import est légèrement différente pour les ressources ODS : on ne peut les reconnaitre que grâce à leur URL. Il n'est pas possible de se fier au datagouv_id de la ressource, car plusieurs ressources peuvent partager le même dans le cas "ODS"'.

Cette PR traite explicitement la reconnaissance d'une ressource existante lors de l'import de manière différente pour le cas normal et la cas ODS.