### PR TITLE
Historisation : stockage de la dernière version d'un schéma

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -41,6 +41,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   use Oban.Worker, unique: [period: 60 * 60 * 5, fields: [:args, :queue, :worker]], tags: ["history"], max_attempts: 5
   require Logger
   import Ecto.Query
+  alias Transport.Shared.Schemas.Wrapper, as: Schemas
   alias DB.{Repo, Resource, ResourceHistory}
 
   @impl Oban.Worker
@@ -90,7 +91,8 @@ defmodule Transport.Jobs.ResourceHistoryJob do
           format: resource.format,
           dataset_id: resource.dataset_id,
           schema_name: resource.schema_name,
-          schema_version: resource.schema_version
+          schema_version: resource.schema_version,
+          latest_schema_version: latest_schema_version(resource)
         }
 
         data =
@@ -286,5 +288,11 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     resource = resource |> Ecto.Changeset.change(%{content_hash: to_content_hash(new_hash)}) |> Repo.update!()
     {:ok, _} = Resource.validate_and_save(resource, false)
     Repo.reload(resource)
+  end
+
+  defp latest_schema_version(%Resource{schema_name: nil}), do: nil
+
+  defp latest_schema_version(%Resource{schema_name: schema_name}) do
+    Schemas.latest_version(schema_name)
   end
 end

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -92,7 +92,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
           dataset_id: resource.dataset_id,
           schema_name: resource.schema_name,
           schema_version: resource.schema_version,
-          latest_schema_version: latest_schema_version(resource)
+          latest_schema_version_to_date: latest_schema_version_to_date(resource)
         }
 
         data =
@@ -290,9 +290,9 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     Repo.reload(resource)
   end
 
-  defp latest_schema_version(%Resource{schema_name: nil}), do: nil
+  defp latest_schema_version_to_date(%Resource{schema_name: nil}), do: nil
 
-  defp latest_schema_version(%Resource{schema_name: schema_name}) do
+  defp latest_schema_version_to_date(%Resource{schema_name: schema_name}) do
     Schemas.latest_version(schema_name)
   end
 end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -434,7 +434,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "download_datetime" => _download_datetime,
                  "schema_name" => ^schema_name,
                  "schema_version" => ^schema_version,
-                 "latest_schema_version" => ^latest_schema_version
+                 "latest_schema_version_to_date" => ^latest_schema_version
                },
                last_up_to_date_at: last_up_to_date_at
              } = DB.ResourceHistory |> DB.Repo.one!()

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -337,6 +337,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     test "a simple successful case for a CSV" do
       resource_url = "https://example.com/file.csv"
       csv_content = "col1,col2\nval1,val2"
+      latest_schema_version = "0.4.2"
 
       %{
         id: resource_id,
@@ -344,7 +345,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         dataset_id: dataset_id,
         metadata: resource_metadata,
         title: title,
-        schema_name: schema_name
+        schema_name: schema_name,
+        schema_version: schema_version
       } =
         resource =
         insert(:resource,
@@ -355,7 +357,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
           is_community_resource: false,
           datagouv_id: Ecto.UUID.generate(),
           metadata: %{"foo" => "bar"},
-          schema_name: "etalab/schema-lieux-covoiturage"
+          schema_name: "etalab/schema-lieux-covoiturage",
+          schema_version: "0.4.1"
         )
 
       Transport.HTTPoison.Mock
@@ -389,7 +392,9 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       # Validation according to the schema
       Transport.Shared.Schemas.Mock
-      |> expect(:transport_schemas, 1, fn -> %{schema_name => %{}} end)
+      |> expect(:transport_schemas, 2, fn ->
+        %{schema_name => %{"versions" => [%{"version_name" => latest_schema_version}]}}
+      end)
 
       Transport.Shared.Schemas.Mock
       |> expect(:schemas_by_type, 1, fn "tableschema" -> %{schema_name => %{}} end)
@@ -397,7 +402,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       validation_result = %{"fake_validation" => "fake_result"}
 
       Shared.Validation.TableSchemaValidator.Mock
-      |> expect(:validate, fn ^schema_name, ^resource_url, nil -> validation_result end)
+      |> expect(:validate, fn ^schema_name, ^resource_url, ^schema_version -> validation_result end)
 
       assert 0 == count_resource_history()
       assert :ok == perform_job(ResourceHistoryJob, %{resource_id: resource_id})
@@ -428,11 +433,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "uuid" => _uuid,
                  "download_datetime" => _download_datetime,
                  "schema_name" => ^schema_name,
-                 "schema_version" => nil
+                 "schema_version" => ^schema_version,
+                 "latest_schema_version" => ^latest_schema_version
                },
                last_up_to_date_at: last_up_to_date_at
              } = DB.ResourceHistory |> DB.Repo.one!()
 
+      # Prevent a potential mistake when test data or code mix up schema versions
+      assert schema_version != latest_schema_version
       assert permanent_url == Transport.S3.permanent_url(:history, filename)
       refute is_nil(last_up_to_date_at)
 

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -313,7 +313,7 @@ defmodule TransportWeb.ValidationControllerTest do
       schema_name = "etalab/foo"
 
       Transport.Shared.Schemas.Mock
-      |> expect(:transport_schemas, fn ->
+      |> expect(:transport_schemas, 3, fn ->
         %{
           schema_name => %{
             "versions" => [%{"version_name" => "0.1.0", "schema_url" => "http://example.com/schema.json"}]


### PR DESCRIPTION
Fixes #2504

Cette PR stocke la dernière version publiée d'un schéma lorsqu'une ressource est historisée et qu'elle est associée à un schéma. Ceci est fait dans un champ distinct (`latest_schema_version_to_date`) de ce qui est renseigné dans la ressource, à savoir les champs `schema_(name|version)`.

Cette PR nécessite une adapation du module en charge de la gestion des schémas pour passer des fonctions relatives aux versions des schémas dans la partie Wrapper.