### PR TITLE
Nettoyage des logs de test affichés pour Shared

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -39,7 +39,7 @@ defmodule Transport.Shared.GBFSMetadata do
     }
   rescue
     e ->
-      Logger.error(inspect(e))
+      Logger.warn("Could not compute GBFS feed metadata. Reason: #{inspect(e)}")
       %{}
   end
 

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -4,6 +4,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
   import Mox
   alias Shared.Validation.GBFSValidator.Summary, as: GBFSValidationSummary
   import Transport.Shared.GBFSMetadata
+  import ExUnit.CaptureLog
   doctest Transport.Shared.GBFSMetadata
 
   @gbfs_url "https://example.com/gbfs.json"
@@ -78,14 +79,20 @@ defmodule Transport.Shared.GBFSMetadataTest do
     test "for feed with a 500 error on the root URL" do
       setup_feeds([:gbfs_with_server_error])
 
-      assert %{} == compute_feed_metadata(@gbfs_url, "http://example.com")
+      {res, logs} = with_log(fn -> compute_feed_metadata(@gbfs_url, "http://example.com") end)
+
+      assert %{} == res
+      assert logs =~ "Could not compute GBFS feed metadata"
     end
 
     test "for feed with an invalid JSON response" do
       setup_feeds([:gbfs_with_invalid_gbfs_json])
       setup_validation_result({:error, nil})
 
-      assert %{} == compute_feed_metadata(@gbfs_url, "http://example.com")
+      {res, logs} = with_log(fn -> compute_feed_metadata(@gbfs_url, "http://example.com") end)
+
+      assert %{} == res
+      assert logs =~ "Could not compute GBFS feed metadata"
     end
   end
 


### PR DESCRIPTION
On passe de 

![image](https://user-images.githubusercontent.com/15341118/179544646-50422485-dc50-4b58-8fd3-1ba1c8c3c621.png)

à 

![image](https://user-images.githubusercontent.com/15341118/179544727-e0425d6b-fbf9-4824-bb3c-d58388600de3.png)

J'ai découvert l'existence de https://hexdocs.pm/ex_unit/ExUnit.CaptureLog.html qui permet justement d'attraper les logs et de ne pas les afficher dans la console, pratique.