### PR TITLE
Nettoyage des logs de test affichés pour Datagouvfr

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -146,7 +146,7 @@ defmodule Datagouvfr.Client.API do
     {:ok, fetch_all_pages!(path, method)}
   rescue
     error ->
-      Logger.error(error)
+      Logger.warn(error)
       {:error, error}
   end
 end

--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -135,7 +135,7 @@ defmodule Datagouvfr.Client.API do
           raise reason
 
         {:error, error} ->
-          raise error
+          raise inspect(error)
       end
     end)
     |> Enum.to_list()

--- a/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
@@ -4,6 +4,7 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
 
   import Datagouvfr.ApiFixtures
   import Mox
+  import ExUnit.CaptureLog
 
   alias Datagouvfr.Client.CommunityResources.API, as: CommunityResourcesAPI
 
@@ -47,9 +48,12 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
       |> given_request_return_response_with_next_page(@data_containing_1_element)
       |> given_request_return_an_error("community resource error")
 
-      a_dataset_id
+      {res, logs} = with_log(fn -> a_dataset_id
       |> CommunityResourcesAPI.get()
-      |> assert_is_an_error_response
+    end)
+
+    res |> assert_is_an_error_response
+    assert logs =~ "community resource error"
     end
   end
 

--- a/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/community_resources_test.exs
@@ -48,12 +48,14 @@ defmodule Datagouvfr.Client.CommunityResources.APITest do
       |> given_request_return_response_with_next_page(@data_containing_1_element)
       |> given_request_return_an_error("community resource error")
 
-      {res, logs} = with_log(fn -> a_dataset_id
-      |> CommunityResourcesAPI.get()
-    end)
+      {res, logs} =
+        with_log(fn ->
+          a_dataset_id
+          |> CommunityResourcesAPI.get()
+        end)
 
-    res |> assert_is_an_error_response
-    assert logs =~ "community resource error"
+      res |> assert_is_an_error_response
+      assert logs =~ "community resource error"
     end
   end
 


### PR DESCRIPTION
Avant :

![image](https://user-images.githubusercontent.com/15341118/179553323-4d6136f5-0a5b-4387-bc89-5495126923d2.png)

Après :

![image](https://user-images.githubusercontent.com/15341118/179553383-218de61e-ccc4-47e7-bab1-e8db63237dcc.png)

J'en profite pour corriger un bug : le message d'erreur disait qu'on appelait mal la fonction raise, et c'est ça qui faisait un raise :upside_down_face: 