### PR TITLE
Nettoyage des logs de test affichés pour GBFS

### DIFF
--- a/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/jcdecaux_test.exs
@@ -3,6 +3,7 @@ defmodule GBFS.JCDecauxControllerTest do
   alias GBFS.Router.Helpers, as: Routes
   import Mox
   import GBFS.Checker
+  import ExUnit.CaptureLog
 
   setup :verify_on_exit!
 
@@ -36,8 +37,9 @@ defmodule GBFS.JCDecauxControllerTest do
     test "on invalid jcdecaux response", %{conn: conn} do
       Transport.HTTPoison.Mock |> expect(:get, fn _url -> {:ok, %HTTPoison.Response{status_code: 500}} end)
 
-      conn = conn |> get(Routes.toulouse_path(conn, :station_status))
+      {conn, logs} = with_log(fn -> conn |> get(Routes.toulouse_path(conn, :station_status)) end)
       assert %{"error" => "jcdecaux service unavailable"} == json_response(conn, 502)
+      assert logs =~ "impossible to query jcdecaux"
     end
   end
 

--- a/apps/gbfs/test/gbfs/controllers/smoove_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/smoove_controller_test.exs
@@ -3,6 +3,7 @@ defmodule GBFS.SmooveControllerTest do
   alias GBFS.Router.Helpers, as: Routes
   import Mox
   import GBFS.Checker
+  import ExUnit.CaptureLog
 
   setup :verify_on_exit!
 
@@ -38,8 +39,9 @@ defmodule GBFS.SmooveControllerTest do
     test "on invalid response", %{conn: conn} do
       Transport.HTTPoison.Mock |> expect(:get, fn _url -> {:ok, %HTTPoison.Response{status_code: 500}} end)
 
-      conn = conn |> get(Routes.strasbourg_path(conn, :station_status))
+      {conn, logs} = with_log(fn -> conn |> get(Routes.strasbourg_path(conn, :station_status)) end)
       assert %{"error" => "smoove service unavailable"} == json_response(conn, 502)
+      assert logs =~ "impossible to query smoove"
     end
 
     defp setup_stations_response do

--- a/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/vcub_controller_test.exs
@@ -3,6 +3,7 @@ defmodule GBFS.VCubControllerTest do
   alias GBFS.Router.Helpers, as: Routes
   import Mox
   import GBFS.Checker
+  import ExUnit.CaptureLog
 
   setup :verify_on_exit!
 
@@ -73,8 +74,9 @@ defmodule GBFS.VCubControllerTest do
     test "on invalid VCub response", %{conn: conn} do
       Transport.HTTPoison.Mock |> expect(:get, fn _url -> {:ok, %HTTPoison.Response{status_code: 500}} end)
 
-      conn = conn |> get(Routes.v_cub_path(conn, :station_status))
+      {conn, logs} = with_log(fn -> conn |> get(Routes.v_cub_path(conn, :station_status)) end)
       assert %{"error" => "VCub service unavailable"} == json_response(conn, 502)
+      assert logs =~ "impossible to query VCub"
     end
   end
 

--- a/apps/gbfs/test/gbfs/page_cache_test.exs
+++ b/apps/gbfs/test/gbfs/page_cache_test.exs
@@ -5,6 +5,7 @@ defmodule GBFS.PageCacheTest do
   use GBFS.ExternalCase
   import Mox
   import AppConfigHelper
+  import ExUnit.CaptureLog
 
   setup :verify_on_exit!
 
@@ -75,9 +76,11 @@ defmodule GBFS.PageCacheTest do
     Transport.HTTPoison.Mock |> expect(:get, 1, fn _url -> {:ok, %HTTPoison.Response{status_code: 500}} end)
 
     # first call must result in call to third party
-    r = conn |> get(url)
+    {r, logs} = with_log(fn -> conn |> get(url) end)
+
     assert_received ^internal_telemetry_event
     assert_received ^external_telemetry_event
+    assert logs =~ "impossible to query jcdecaux"
 
     # an underlying 500 will result of a 502
     assert r.status == 502


### PR DESCRIPTION
avant :

![image](https://user-images.githubusercontent.com/15341118/179560289-cf85b1de-7373-4eb2-8a90-9f9fcf8660a1.png)

après :

![image](https://user-images.githubusercontent.com/15341118/179560111-16954125-ccdf-40cd-87c3-ebc9226f907b.png)
