### PR TITLE
Espace production : ajout instructions pour remplacement de ressources

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.eex
@@ -13,7 +13,10 @@
             <img height=40 src="<%= static_path(@conn, "/images/producteurs/picto-maj.png") %>" alt="">
             <div>
               <h4 class="with-link"><%= dgettext("espace-producteurs", "Update a dataset") %></h4>
-              <a href="https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees"><%= dgettext("espace-producteurs", "updating a dataset guidelines") %></a>
+              <p>
+                <%= dgettext("espace-producteurs", ~s(If you need to replace a resource with a more up-to-date one, choose "Update a resource".)) %>
+              </p>
+              <a href="https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees"><%= dgettext("espace-producteurs", "Updating a dataset guidelines") %></a>
             </div>
           </div>
           <div class="resource-list">

--- a/apps/transport/lib/transport_web/templates/resource/form.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.eex
@@ -23,7 +23,7 @@
             <%= if new_resource do %>
             <h4> <%= dgettext("resource", "Option 1: Directly add the resource") %> </h4>
             <p>
-              <%= dgettext("resource", "This option allows you to add the resource on data.gouv.fr, directly from here.") %>
+              <%= raw dgettext("resource", ~s(This option allows you to add the resource on data.gouv.fr, directly from here. Do you want to publish a more up-to-date version of a resource? <a href="%{url}">Update the resource</a> instead.), url: resource_path(@conn, :resources_list, @dataset["id"])) %>
             </p>
             <% else %>
             <h4> <%= dgettext("resource", "Option 1: Directly update the resource") %> </h4>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -68,7 +68,7 @@ msgid "You can test your data online and check its validity."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "updating a dataset guidelines"
+msgid "Updating a dataset guidelines"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -93,4 +93,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "our documentation"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "If you need to replace a resource with a more up-to-date one, choose \"Update a resource\"."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -106,10 +106,6 @@ msgid "Option 1: Directly add the resource"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This option allows you to add the resource on data.gouv.fr, directly from here."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr ""
 
@@ -123,4 +119,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "This resource belongs to a dataset that has been deleted from data.gouv.fr"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This option allows you to add the resource on data.gouv.fr, directly from here. Do you want to publish a more up-to-date version of a resource? <a href=\"%{url}\">Update the resource</a> instead."
 msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -67,7 +67,7 @@ msgid "You can test your data online and check its validity."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "updating a dataset guidelines"
+msgid "Updating a dataset guidelines"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -92,4 +92,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "our documentation"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "If you need to replace a resource with a more up-to-date one, choose \"Update a resource\"."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -68,7 +68,7 @@ msgid "You can test your data online and check its validity."
 msgstr "Utilisez nos validateurs de données pour vous assurer qu'ils sont bien conformes."
 
 #, elixir-autogen, elixir-format
-msgid "updating a dataset guidelines"
+msgid "Updating a dataset guidelines"
 msgstr "Consultez le guide de mise à jour"
 
 #, elixir-autogen, elixir-format
@@ -94,3 +94,7 @@ msgstr "Notre équipe tient à jour une documentation détaillant comment publie
 #, elixir-autogen, elixir-format
 msgid "our documentation"
 msgstr "notre documentation"
+
+#, elixir-autogen, elixir-format
+msgid "If you need to replace a resource with a more up-to-date one, choose \"Update a resource\"."
+msgstr "Si vous souhaitez remplacer une ressource par une version plus à jour, choisissez \"Modifier une ressource\""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -106,10 +106,6 @@ msgid "Option 1: Directly add the resource"
 msgstr "Option 1 : ajouter la ressource simplement"
 
 #, elixir-autogen, elixir-format
-msgid "This option allows you to add the resource on data.gouv.fr, directly from here."
-msgstr "Cette option vous permet d'ajouter la ressource sur data.gouv.fr depuis ici, sans avoir à vous y rendre."
-
-#, elixir-autogen, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr "exemple : Horaires au format GTFS"
 
@@ -124,3 +120,7 @@ msgstr "La ressource n'est pas disponible sur le serveur distant"
 #, elixir-autogen, elixir-format
 msgid "This resource belongs to a dataset that has been deleted from data.gouv.fr"
 msgstr "Cette ressource appartient à un jeu de données qui a été supprimé de data.gouv.fr"
+
+#, elixir-autogen, elixir-format
+msgid "This option allows you to add the resource on data.gouv.fr, directly from here. Do you want to publish a more up-to-date version of a resource? <a href=\"%{url}\">Update the resource</a> instead."
+msgstr "Cette option vous permet d'ajouter la ressource sur data.gouv.fr depuis ici, sans avoir à vous y rendre. Vous souhaitez remplacer une ressource par une version plus à jour ? <a href=\"%{url}\">Mettez à jour la ressource</a> plutôt."

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -106,10 +106,6 @@ msgid "Option 1: Directly add the resource"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This option allows you to add the resource on data.gouv.fr, directly from here."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Example : Paris GTFS dataset"
 msgstr ""
 
@@ -123,4 +119,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "This resource belongs to a dataset that has been deleted from data.gouv.fr"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This option allows you to add the resource on data.gouv.fr, directly from here. Do you want to publish a more up-to-date version of a resource? <a href=\"%{url}\">Update the resource</a> instead."
 msgstr ""


### PR DESCRIPTION
Fixes #2501

Tentative d'orientation des producteurs qui utilisent l'espace producteur pour mettre à jour des données de les orienter vers le remplacement de ressources au lieu d'un ajout quand ils veulent remplacer un fichier.

## Captures d'écran

Sur l'accueil,

> Si vous souhaitez remplacer une ressource par une version plus à jour, choisissez "Modifier une ressource"

Si jamais la personne choisit d'ajouter une ressource

> Cette option vous permet d'ajouter la ressource sur data.gouv.fr depuis ici, sans avoir à vous y rendre. Vous souhaitez remplacer une ressource par une version plus à jour ? [Mettez à jour la ressource](#) plutôt.