### PR TITLE
GBFS : suppression Valence pour JC Decaux

### DIFF
--- a/apps/gbfs/lib/gbfs/router.ex
+++ b/apps/gbfs/lib/gbfs/router.ex
@@ -34,8 +34,7 @@ defmodule GBFS.Router do
     "nancy" => "vélOstan'lib",
     "nantes" => "Bicloo",
     "rouen" => "cy'clic",
-    "toulouse" => "Vélô",
-    "valence" => "Libélo"
+    "toulouse" => "Vélô"
   }
 
   @reseaux_smoove [


### PR DESCRIPTION
Revoit ce qui a été fait dans https://github.com/etalab/transport-site/pull/1886. En lien avec https://github.com/etalab/transport-site/issues/1887.

En réalité le réseau `valence` de JC Decaux [se trouve en Espagne](https://transport.data.gouv.fr/tools/gbfs/analyze?url=https%3A%2F%2Ftransport.data.gouv.fr%2Fgbfs%2Fvalence%2Fgbfs.json), et non en France. Ah, les villes homonymes.

Nous avons été informés de ceci sur la liste de contact. À noter que ce flux n'est pas référencé sur le PAN, mais est visible sur https://transport.data.gouv.fr/gbfs