### PR TITLE
Workaround pour Rambo sur Mac M1

### DIFF
--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -95,6 +95,8 @@ defmodule Transport.Mixfile do
       if apple_silicon?() do
         # branch is "aarch64-apple" but we're hardcoding the ref for security, especially since `mix.lock`
         # must not be committed in that case.
+        # NOTE: this is not enough, and a manual `mix compile.rambo` must be issued manually in order
+        # for this to work (https://github.com/jayjun/rambo/pull/13#issuecomment-1189194040).
         {:rambo, "~> 0.3.4", github: "myobie/rambo", ref: "e321db8e4f035f2a295ee2a5310dcb75034677ce"}
       else
         {:rambo, "~> 0.3.4"}

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -44,6 +44,14 @@ defmodule Transport.Mixfile do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
+  # see https://github.com/etalab/transport-site/issues/2520
+  defp apple_silicon? do
+    :system_architecture
+    |> :erlang.system_info()
+    |> List.to_string()
+    |> String.starts_with?("aarch64-apple-darwin")
+  end
+
   defp deps do
     [
       {:csv, "~> 2.1"},

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -89,7 +89,16 @@ defmodule Transport.Mixfile do
       {:phoenix_ecto, "~> 4.0"},
       {:sizeable, "~> 1.0"},
       {:mox, "~> 1.0.0", only: :test},
-      {:rambo, "~> 0.3"},
+      # temporary fix until https://github.com/jayjun/rambo/pull/13 is merged
+      # see https://github.com/etalab/transport-site/issues/2520.
+      # Not perfect since this will impact `mix.lock`
+      if apple_silicon?() do
+        # branch is "aarch64-apple" but we're hardcoding the ref for security, especially since `mix.lock`
+        # must not be committed in that case.
+        {:rambo, "~> 0.3.4", github: "myobie/rambo", ref: "e321db8e4f035f2a295ee2a5310dcb75034677ce"}
+      else
+        {:rambo, "~> 0.3.4"}
+      end,
       {:etag_plug, "~> 1.0"},
       # conservatively waiting for https://github.com/sorentwo/oban/issues/652
       # to be fixed before upgrading

--- a/apps/transport/test/build_test.exs
+++ b/apps/transport/test/build_test.exs
@@ -25,6 +25,10 @@ defmodule TransportWeb.BuildTest do
     version
   end
 
+  test "rambo rust wrapper compiles and runs" do
+    {:ok, %{out: "hello\n"}} = Rambo.run("echo", ["hello"])
+  end
+
   test "make sure Elixir version is same for asdf & CI" do
     assert System.version() == asdf_elixir_version()
   end


### PR DESCRIPTION
Voir #2520, je rétablis la possibilité de travailler avec Rambo en local sur Mac M1 (mon portable).

Avec les contraintes suivantes:
- ça s'appuie sur une PR non mergée dans le projet (mais je verrouille au commit) https://github.com/jayjun/rambo/pull/13
- il ne faut pas que je commite le fichier `mix.lock` car il sera différent
- il y a un bug qui fait que le wrapper Rust ne sera pas compilé si je ne fais pas à la main `mix compile.rambo` (avec éventuellement `MIX_ENV=test`) https://github.com/jayjun/rambo/pull/13#issuecomment-1189194040

Modulo cela, et on peut espérer que ça sera mergé à un moment, ça me permet de re-travailler en local avec des exécutions d'outils, et c'est plus que le bienvenu, vu que ça fait un moment que ça m'empêche de faire certains tests.

J'ajoute au passage un test d'intégration qui lance le wrapper pour vérifier sa bonne compilation.