### PR TITLE
 Nettoyage des logs de test affichés pour Transport :broom: 

### DIFF
--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
@@ -33,7 +33,7 @@ msgstr "Lieux d'intérêts"
 
 #, elixir-autogen, elixir-format
 msgid "A dataset cannot be national and regional"
-msgstr "Un jeu de données ne pas pas être à la fois régional et national"
+msgstr "Un jeu de données ne peut pas être à la fois régional et national"
 
 #, elixir-autogen, elixir-format
 msgid "Unable to find INSEE code '%{insee}'"

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -3,7 +3,7 @@ defmodule Transport.GTFSRTTest do
   alias TransitRealtime.{TimeRange, TranslatedString}
   use ExUnit.Case, async: true
   import Mox
-
+  import ExUnit.CaptureLog
   setup :verify_on_exit!
 
   @sample_file "#{__DIR__}/../fixture/files/bibus-brest-gtfs-rt-alerts.pb"
@@ -27,7 +27,7 @@ defmodule Transport.GTFSRTTest do
     test "cannot decode Protobuf" do
       setup_http_response(@url, {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"foo": 42})}})
 
-      assert {:error, "Could not decode Protobuf"} == GTFSRT.decode_remote_feed(@url)
+      {{:error, "Could not decode Protobuf"}, _} = with_log(fn -> GTFSRT.decode_remote_feed(@url) end)
     end
 
     test "502 HTTP status code" do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -20,7 +20,7 @@ defmodule Transport.ImportDataTest do
   setup do
     Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
     Mox.stub_with(Transport.AvailabilityChecker.Mock, Transport.AvailabilityChecker)
-    Mox.stub_with(Hasher.Mock, Hasher)
+    Mox.stub_with(Hasher.Mock, Hasher.Dummy)
     :ok
   end
 
@@ -121,11 +121,9 @@ defmodule Transport.ImportDataTest do
 
           assert_called_exactly(HTTPoison.get!(:_, :_, :_), 1)
 
-          # for each resource, 2 head requests are potentially made
-          # one to check for availability, one to compute the resource hash.
-          assert_called_exactly(HTTPoison.head(:_, :_, :_), 2)
+          # for each resource, 1 head request is made to check for availability
+          assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
           assert_called_exactly(Datagouvfr.Client.CommunityResources.get(:_), 1)
-          assert_called_exactly(HTTPStreamV2.fetch_status_and_hash(:_), 1)
 
           # import is a success
           assert logs =~ "all datasets have been reimported (0 failures / 1)"

--- a/apps/transport/test/transport/jobs/gtfs_rt_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_rt_validation_job_test.exs
@@ -10,6 +10,7 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTValidationDispatcherJobTest do
   import Mox
   alias Transport.Jobs.{GTFSRTValidationDispatcherJob, GTFSRTValidationJob}
   alias Transport.Test.S3TestUtils
+  import ExUnit.CaptureLog
 
   @gtfs_rt_report_path "#{__DIR__}/../../fixture/files/gtfs-rt-validator-errors.json"
   @validator_filename "gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar"
@@ -360,7 +361,8 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTValidationDispatcherJobTest do
         {:error, validator_message}
       end)
 
-      assert :ok == perform_job(GTFSRTValidationJob, %{"dataset_id" => dataset.id})
+      {:ok, logs} = with_log(fn -> perform_job(GTFSRTValidationJob, %{"dataset_id" => dataset.id}) end)
+      assert logs =~ "error while calling the validator"
 
       gtfs_rt = DB.Resource |> preload([:validation, :logs_validation]) |> DB.Repo.get!(gtfs_rt.id)
 


### PR DESCRIPTION
C'est presque de l'art

![image](https://user-images.githubusercontent.com/15341118/179799568-666c5b5c-b15c-4a16-8879-f78ee78e8039.png)

J'ai eu des erreurs intermittentes pendant les tests, avec la base de donnée qui n'arrivait pas à suivre le rythme des tests. J'ai l'impression que de ne pas afficher tous ces logs dans la console fait tourner les tests un peu plus vite et que ça peut faire tirer la langue à la base. On va voir si ça se reproduit...