### PR TITLE
Taux de disponibilité : floor plutôt que round

### DIFF
--- a/apps/transport/lib/db/resource_unavailability.ex
+++ b/apps/transport/lib/db/resource_unavailability.ex
@@ -28,23 +28,25 @@ defmodule DB.ResourceUnavailability do
 
   def availability_over_last_days(%Resource{} = resource, nb_days) when is_integer(nb_days) and nb_days > 0 do
     %{hours: hours} = unavailabilities_over_last_days(resource, nb_days)
-    round_float(100 - hours / (24.0 * nb_days) * 100)
+    floor_float(100 - hours / (24.0 * nb_days) * 100)
   end
 
   @doc """
-  Round a float up to a precision and removes unneeded zeroes.
+  Floors a float up to a precision and removes unneeded zeroes.
 
-  iex> round_float(1.23)
+  See [Float.floor/2](https://hexdocs.pm/elixir/Float.html#floor/2-known-issues) for gotchas.
+
+  iex> floor_float(1.23)
   1.2
-
-  iex> round_float(1.0)
+  iex> floor_float(1.0)
   1
-
-  iex> round_float(1.20, 2)
-  1.20
+  iex> floor_float(1.20, 2)
+  1.19
+  iex> floor_float(99.98)
+  99.9
   """
-  def round_float(float, precision \\ 1) do
-    rounded = Float.round(float, precision)
+  def floor_float(float, precision \\ 1) do
+    rounded = Float.floor(float, precision)
     trunced = trunc(float)
     if rounded == trunced, do: trunced, else: rounded
   end

--- a/apps/transport/lib/transport_web/templates/resource/_download_availability.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_download_availability.html.eex
@@ -8,7 +8,7 @@
         <span class="tooltiptext">
           <div><%= DateTimeDisplay.format_date(day_data["day"], locale) %></div>
           <div class="<%= download_availability_class_text(uptime) %>">
-            <strong><%= round_float(uptime, 1) %>%</strong>
+            <strong><%= floor_float(uptime, 1) %>%</strong>
           </div>
         </span>
       </div>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -6,7 +6,7 @@ defmodule TransportWeb.ResourceView do
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   import TransportWeb.DatasetView, only: [schema_url: 1, errors_count: 1, warnings_count: 1]
   import DB.Resource, only: [has_errors_details?: 1]
-  import DB.ResourceUnavailability, only: [round_float: 2]
+  import DB.ResourceUnavailability, only: [floor_float: 2]
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
   import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]
   alias Shared.DateTimeDisplay


### PR DESCRIPTION
Retravaille l'affichage du taux de disponibilité des ressources pour passer de `round` à `floor`.

Actuellement, en cas de très rapide indisponibilité, on affiche `100.0%`, quand il y a vraiment 0 lignes on affiche `100%` et quand c'est un peu plus important on affiche `99.9%`.

Le passage au `floor` permet de passer directement à `99.9%` dès qu'on a une indisponibilité, même rapide et d'éviter la confusion entre 100% et 100.0%.