### PR TITLE
Correctif pour le backoffice du proxy

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -81,15 +81,29 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
     |> Map.values()
     |> Enum.sort_by(& &1.identifier)
     |> Enum.map(fn resource ->
-      %{
-        unique_slug: resource.identifier,
-        proxy_url: get_proxy_resource_url(proxy_base_url, resource.identifier),
-        original_url: resource.target_url,
-        ttl: resource.ttl
-      }
+      proxy_base_url
+      |> extract_config(resource)
       |> add_cache_state()
       |> add_stats(stats)
     end)
+  end
+
+  defp extract_config(proxy_base_url, %Unlock.Config.Item.GTFS.RT{} = resource) do
+    %{
+      unique_slug: resource.identifier,
+      proxy_url: get_proxy_resource_url(proxy_base_url, resource.identifier),
+      original_url: resource.target_url,
+      ttl: resource.ttl
+    }
+  end
+
+  defp extract_config(proxy_base_url, %Unlock.Config.Item.SIRI{} = resource) do
+    %{
+      unique_slug: resource.identifier,
+      proxy_url: get_proxy_resource_url(proxy_base_url, resource.identifier),
+      original_url: resource.target_url,
+      ttl: nil
+    }
   end
 
   defp event_names do

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.leex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.leex
@@ -2,6 +2,7 @@
     <h1>Configuration du Proxy</h1>
     <a class="button" phx-click="refresh_proxy_config">Recharger la configuration</a>
     <p>Attention: il faut attendre 5 minutes après le dernier commit sur la <a href="https://github.com/etalab/transport-proxy-config/blob/master/proxy-config.yml">configuration GitHub</a> pour recharger, car GitHub met en cache ses propre fichiers.</p>
+    <p>Les items SIRI sont affichés mais sans métriques et avec des informations manquantes (ex: requestor_ref) pour l'instant</p>
     <table class="table mt-48">
         <thead>
             <tr>

--- a/apps/transport/test/support/live_case.ex
+++ b/apps/transport/test/support/live_case.ex
@@ -17,7 +17,8 @@ defmodule TransportWeb.LiveCase do
         |> Floki.find("table tbody tr")
         |> Enum.map(fn row ->
           cells =
-            Floki.find(row, "td")
+            row
+            |> Floki.find("td")
             |> Enum.map(&Floki.text/1)
 
           headers

--- a/apps/transport/test/support/live_case.ex
+++ b/apps/transport/test/support/live_case.ex
@@ -12,8 +12,18 @@ defmodule TransportWeb.LiveCase do
       def extract_data_from_html(html) do
         doc = Floki.parse_document!(html)
         headers = doc |> Floki.find("table thead tr th") |> Enum.map(&Floki.text/1)
-        row = doc |> Floki.find("table tbody tr td") |> Enum.map(&Floki.text/1)
-        headers |> Enum.zip(row) |> Enum.into(%{})
+
+        doc
+        |> Floki.find("table tbody tr")
+        |> Enum.map(fn row ->
+          cells =
+            Floki.find(row, "td")
+            |> Enum.map(&Floki.text/1)
+
+          headers
+          |> Enum.zip(cells)
+          |> Enum.into(%{})
+        end)
       end
 
       def setup_admin_in_session(conn) do

--- a/apps/transport/test/transport_web/live_views/gbfs_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/gbfs_live_test.exs
@@ -39,11 +39,13 @@ defmodule TransportWeb.Backoffice.GBFSLiveTest do
     response = html_response(conn, 200)
     assert response =~ "Statistiques des requêtes GBFS"
 
-    assert %{
-             "Réseau" => ^network_name,
-             "Req int 7j" => "1",
-             "Req ext 7j" => "2"
-           } = extract_data_from_html(response)
+    assert [
+             %{
+               "Réseau" => ^network_name,
+               "Req int 7j" => "1",
+               "Req ext 7j" => "2"
+             }
+           ] = extract_data_from_html(response)
 
     {:ok, view, _html} = live(conn)
 
@@ -51,10 +53,12 @@ defmodule TransportWeb.Backoffice.GBFSLiveTest do
 
     send(view.pid, :update_data)
 
-    assert %{
-             "Réseau" => ^network_name,
-             "Req int 7j" => "2",
-             "Req ext 7j" => "4"
-           } = extract_data_from_html(render(view))
+    assert [
+             %{
+               "Réseau" => ^network_name,
+               "Req int 7j" => "2",
+               "Req ext 7j" => "4"
+             }
+           ] = extract_data_from_html(render(view))
   end
 end

--- a/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
@@ -63,19 +63,18 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
     response = html_response(conn, 200)
     assert response =~ "Configuration du Proxy"
 
-    assert [first_item, second_item] = extract_data_from_html(response)
-
-    assert %{
-             "Identifiant" => "siri-slug",
-             "Req ext 7j" => "0",
-             "Req int 7j" => "0"
-           } = second_item
-
-    assert %{
-             "Identifiant" => "gtfs-rt-slug",
-             "Req ext 7j" => "2",
-             "Req int 7j" => "1"
-           } = first_item
+    assert [
+             %{
+               "Identifiant" => "gtfs-rt-slug",
+               "Req ext 7j" => "2",
+               "Req int 7j" => "1"
+             },
+             %{
+               "Identifiant" => "siri-slug",
+               "Req ext 7j" => "0",
+               "Req int 7j" => "0"
+             }
+           ] = extract_data_from_html(response)
 
     {:ok, view, _html} = live(conn)
 
@@ -83,12 +82,13 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
 
     send(view.pid, :update_data)
 
-    [first_item, _second_item] = extract_data_from_html(render(view))
-
-    assert %{
-             "Identifiant" => "gtfs-rt-slug",
-             "Req ext 7j" => "4",
-             "Req int 7j" => "2"
-           } = first_item
+    assert [
+             %{
+               "Identifiant" => "gtfs-rt-slug",
+               "Req ext 7j" => "4",
+               "Req int 7j" => "2"
+             },
+             _second_item
+           ] = extract_data_from_html(render(view))
   end
 end


### PR DESCRIPTION
Le déploiement de #2459 a créé une petite régression dans le backoffice du proxy, car les éléments de configuration SIRI n'étaient pas intégrés.

Je répare ici et j'ajoute des tests.