### PR TITLE
Réparer les pages des GBFS

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
@@ -6,7 +6,6 @@
       resource_path(@conn, :details, @resource.id) <> "#validation-report"
     end %>
   <a href={link} target="_blank">
-    
     <% summary_class = if Resource.is_gbfs?(@resource), do: summary_class(@resource), else: summary_class(@validation) %>
     <span class={summary_class}>
       <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
@@ -6,7 +6,9 @@
       resource_path(@conn, :details, @resource.id) <> "#validation-report"
     end %>
   <a href={link} target="_blank">
-    <span class={summary_class(@validation)}>
+    <%# to be deleted later, when gbfs has multi_validation, https://github.com/etalab/transport-site/issues/2390 %>
+    <% summary_class = if Resource.is_gbfs?(@resource), do: summary_class(@resource), else: summary_class(@validation) %>
+    <span class={summary_class}>
       <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>
         <%= dgettext("page-dataset-details", "No error detected") %>
       <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
@@ -6,7 +6,7 @@
       resource_path(@conn, :details, @resource.id) <> "#validation-report"
     end %>
   <a href={link} target="_blank">
-    <%# to be deleted later, when gbfs has multi_validation, https://github.com/etalab/transport-site/issues/2390 %>
+    
     <% summary_class = if Resource.is_gbfs?(@resource), do: summary_class(@resource), else: summary_class(@validation) %>
     <span class={summary_class}>
       <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>


### PR DESCRIPTION
Suite à #2532, on a des erreurs 500 sur les pages dataset GBFS, remontées par Sentry.