### PR TITLE
Gestion des validations en performed => false

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -93,12 +93,7 @@ defmodule TransportWeb.ResourceController do
           nil
       end
 
-    validation = DB.MultiValidation.resource_latest_validation(resource_id, validator)
-
-    case validation do
-      %{result: %{"validation_performed" => false}} -> nil
-      validation -> validation
-    end
+    DB.MultiValidation.resource_latest_validation(resource_id, validator)
   end
 
   defp latest_validation(_), do: nil

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -93,7 +93,12 @@ defmodule TransportWeb.ResourceController do
           nil
       end
 
-    DB.MultiValidation.resource_latest_validation(resource_id, validator)
+    validation = DB.MultiValidation.resource_latest_validation(resource_id, validator)
+
+    case validation do
+      %{result: %{"validation_performed" => false}} -> nil
+      validation -> validation
+    end
   end
 
   defp latest_validation(_), do: nil

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -103,7 +103,7 @@
   <%= unless Resource.is_gtfs?(@resource) do %>
     <% [validation] = Map.get(validations, @resource.id) %>
     <%= if multi_validation_plugged?(@resource) do %>
-      <%= if not is_nil(validation) do %>
+      <%= if multi_validation_performed?(validation) do %>
         <% nb_warnings = warnings_count(validation) %>
         <% nb_errors = errors_count(validation) %>
         <%= render TransportWeb.DatasetView, "_resource_validation_summary.html",  conn: @conn, resource: @resource, validation: validation, nb_warnings: nb_warnings, nb_errors: nb_errors %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
@@ -1,23 +1,25 @@
-<div class="pb-24">
-  <% link =
-    if Resource.is_gbfs?(@resource) do
-      gbfs_validation_link(@resource)
-    else
-      resource_path(@conn, :details, @resource.id) <> "#validation-report"
-    end %>
-  <a href={link} target="_blank">
-    <% summary_class = if Resource.is_gbfs?(@resource), do: summary_class(@resource), else: summary_class(@validation) %>
-    <span class={summary_class}>
-      <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>
-        <%= dgettext("page-dataset-details", "No error detected") %>
-      <% end %>
-      <%= if @nb_errors == 0 and is_integer(@nb_warnings) and @nb_warnings > 0 do %>
-        <%= "#{format_number(@nb_warnings)} #{dpngettext("validations", "warnings", "warning", "warnings", @nb_warnings)}" %>
-      <% end %>
-      <%= if @nb_errors > 0 do %>
-        <%= "#{format_number(@nb_errors)} #{dpngettext("validations", "errors", "error", "errors", @nb_errors)}" %>
-      <% end %>
-    </span>
-  </a>
-  <span><%= dgettext("page-dataset-details", "during validation") %></span>
-</div>
+<%= unless is_nil(@nb_errors) and is_nil(@nb_warnings) do %>
+  <div class="pb-24">
+    <% link =
+      if Resource.is_gbfs?(@resource) do
+        gbfs_validation_link(@resource)
+      else
+        resource_path(@conn, :details, @resource.id) <> "#validation-report"
+      end %>
+    <a href={link} target="_blank">
+      <% summary_class = if Resource.is_gbfs?(@resource), do: summary_class(@resource), else: summary_class(@validation) %>
+      <span class={summary_class}>
+        <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>
+          <%= dgettext("page-dataset-details", "No error detected") %>
+        <% end %>
+        <%= if @nb_errors == 0 and is_integer(@nb_warnings) and @nb_warnings > 0 do %>
+          <%= "#{format_number(@nb_warnings)} #{dpngettext("validations", "warnings", "warning", "warnings", @nb_warnings)}" %>
+        <% end %>
+        <%= if @nb_errors > 0 do %>
+          <%= "#{format_number(@nb_errors)} #{dpngettext("validations", "errors", "error", "errors", @nb_errors)}" %>
+        <% end %>
+      </span>
+    </a>
+    <span><%= dgettext("page-dataset-details", "during validation") %></span>
+  </div>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
@@ -1,18 +1,18 @@
-<% show_schema_validation = not is_nil(@resource.schema_name) and not is_nil(@multi_validation) %>
-<% show_gtfs_rt_validation = DB.Resource.is_gtfs_rt?(@resource) and not is_nil(@multi_validation) %>
+<% show_schema_validation = not is_nil(@resource.schema_name) and multi_validation_performed?(@multi_validation) %>
+<% show_gtfs_rt_validation = DB.Resource.is_gtfs_rt?(@resource) and multi_validation_performed?(@multi_validation) %>
 
 <h2 id="validation-report"><%= dgettext("validations", "Validation details")%></h2>
 
 <%= if show_schema_validation do %>
-  <%= render "_validation_report_schema.html" , resource: @resource, conn: @conn, multi_validation: @multi_validation %>
+  <%= render "_validation_report_schema.html", resource: @resource, conn: @conn, multi_validation: @multi_validation %>
 <% end %>
 
 <%= if show_gtfs_rt_validation do %>
-  <%= render "_validation_report_gtfs_rt.html" , resource: @resource, conn: @conn, multi_validation: @multi_validation %>
+  <%= render "_validation_report_gtfs_rt.html", resource: @resource, conn: @conn, multi_validation: @multi_validation %>
 <% end %>
 
 <%= if not show_schema_validation and not show_gtfs_rt_validation do %>
-<div class="panel">
-  <%= dgettext("validations", "No validation available") %>
-</div>
+  <div class="panel">
+    <%= dgettext("validations", "No validation available") %>
+  </div>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.eex
@@ -12,5 +12,7 @@
 <% end %>
 
 <%= if not show_schema_validation and not show_gtfs_rt_validation do %>
+<div class="panel">
   <%= dgettext("validations", "No validation available") %>
+</div>
 <% end %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -269,8 +269,6 @@ defmodule TransportWeb.DatasetView do
       when is_integer(errors_count) and errors_count >= 0,
       do: errors_count
 
-  def errors_count(%DB.MultiValidation{}), do: nil
-
   # will be deprecated
   # https://github.com/etalab/transport-site/issues/2390
   def errors_count(%Resource{metadata: %{"validation" => %{"errors_count" => errors_count}}})
@@ -531,4 +529,8 @@ defmodule TransportWeb.DatasetView do
   end
 
   def multi_validation_plugged?(%Resource{}), do: false
+
+  def multi_validation_performed?(%DB.MultiValidation{result: %{"validation_performed" => false}}), do: false
+  def multi_validation_performed?(%DB.MultiValidation{}), do: true
+  def multi_validation_performed?(nil), do: false
 end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -12,6 +12,8 @@ defmodule TransportWeb.DatasetView do
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport
 
+  @gtfsrtValidatorName Transport.Validators.GTFSRT.validator_name()
+
   @doc """
   Count the number of resources (official + community), excluding resources with a `documentation` type.
   """
@@ -250,7 +252,9 @@ defmodule TransportWeb.DatasetView do
       when is_integer(warnings_count) and warnings_count >= 0,
       do: warnings_count
 
-  def warnings_count(%DB.MultiValidation{}), do: 0
+  def warnings_count(%DB.MultiValidation{validator: @gtfsrtValidatorName}), do: 0
+
+  def warnings_count(%DB.MultiValidation{}), do: nil
 
   # will be deprecated
   # https://github.com/etalab/transport-site/issues/2390
@@ -264,6 +268,8 @@ defmodule TransportWeb.DatasetView do
   def errors_count(%DB.MultiValidation{result: %{"errors_count" => errors_count}})
       when is_integer(errors_count) and errors_count >= 0,
       do: errors_count
+
+  def errors_count(%DB.MultiValidation{}), do: nil
 
   # will be deprecated
   # https://github.com/etalab/transport-site/issues/2390

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -12,7 +12,7 @@ defmodule TransportWeb.DatasetView do
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport
 
-  @gtfsrtValidatorName Transport.Validators.GTFSRT.validator_name()
+  @gtfs_rt_validator_name Transport.Validators.GTFSRT.validator_name()
 
   @doc """
   Count the number of resources (official + community), excluding resources with a `documentation` type.
@@ -252,7 +252,7 @@ defmodule TransportWeb.DatasetView do
       when is_integer(warnings_count) and warnings_count >= 0,
       do: warnings_count
 
-  def warnings_count(%DB.MultiValidation{validator: @gtfsrtValidatorName}), do: 0
+  def warnings_count(%DB.MultiValidation{validator: @gtfs_rt_validator_name}), do: 0
 
   def warnings_count(%DB.MultiValidation{}), do: nil
 

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -4,7 +4,10 @@ defmodule TransportWeb.ResourceView do
   import DB.Validation
   import Phoenix.Controller, only: [current_url: 2]
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
-  import TransportWeb.DatasetView, only: [schema_url: 1, errors_count: 1, warnings_count: 1]
+
+  import TransportWeb.DatasetView,
+    only: [schema_url: 1, errors_count: 1, warnings_count: 1, multi_validation_performed?: 1]
+
   import DB.ResourceUnavailability, only: [floor_float: 2]
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
   import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -210,6 +210,36 @@ defmodule TransportWeb.DatasetControllerTest do
     assert conn |> html_response(200) =~ "Ressources temps réel"
   end
 
+  test "does not crash when validation_performed is false", %{conn: conn} do
+    %{id: dataset_id} = insert(:dataset, %{slug: slug = "dataset-slug"})
+
+    %{id: resource_id} =
+      insert(:resource, %{
+        dataset_id: dataset_id,
+        format: "geojson",
+        schema_name: schema_name = "etalab/zfe",
+        url: "https://example.com/file"
+      })
+
+    Transport.Shared.Schemas.Mock
+    |> expect(:schemas_by_type, 2, fn type ->
+      case type do
+        "tableschema" -> %{}
+        "jsonschema" -> %{schema_name => %{}}
+      end
+    end)
+
+    insert(:multi_validation, %{
+      resource_history: insert(:resource_history, %{resource_id: resource_id}),
+      validator: Transport.Validators.EXJSONSchema.validator_name(),
+      result: %{"validation_performed" => false}
+    })
+
+    set_empty_mocks()
+
+    conn |> get(dataset_path(conn, :details, slug)) |> html_response(200)
+  end
+
   defp set_empty_mocks do
     Datagouvfr.Client.Reuses.Mock |> expect(:get, fn _ -> {:ok, []} end)
     Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _ -> %{} end)


### PR DESCRIPTION
Certaines validations se passent mal, et se retrouvent en base avec %{"validation_performed" => false}.
Ce cas n'était pas bien géré pour la page dataset et la page ressource.
Je fais un quick fix, il y aura peut-être moyen de faire mieux par la suite.

Bug introduit par #2532 

[Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3452697255/?environment=prod&project=6197733)