### PR TITLE
Répare `/api/places` qui était cassé

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -28,14 +28,10 @@ defmodule TransportWeb.API.PlacesController do
   end
 
   @spec places(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def places(conn, %{} = params) do
-    autocomplete(conn, %{"q" => Map.get(params, "q", "")})
-  end
-
-  @spec autocomplete(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def autocomplete(%Plug.Conn{} = conn, %{"q" => query}) do
+  def places(%Plug.Conn{} = conn, %{} = params) do
     query =
-      query
+      params
+      |> Map.get("q", "")
       # we replace '-' to ' ' because we also did this transformation for indexed_name
       |> String.replace("-", " ")
       # we replace ' ' to '%' to search for composite name to be easily searchable

--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -27,6 +27,11 @@ defmodule TransportWeb.API.PlacesController do
     |> Repo.all()
   end
 
+  @spec places(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def places(conn, %{} = params) do
+    autocomplete(conn, %{"q" => Map.get(params, "q", "")})
+  end
+
   @spec autocomplete(Plug.Conn.t(), map) :: Plug.Conn.t()
   def autocomplete(%Plug.Conn{} = conn, %{"q" => query}) do
     query =

--- a/apps/transport/lib/transport_web/api/controllers/places_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/places_controller.ex
@@ -75,12 +75,16 @@ defmodule TransportWeb.API.PlacesController do
     |> render()
   end
 
+  # TODO: amend this declaration & verify Swagger presentation. I have the feeling
+  # the metadata here is not completely correct
   @spec autocomplete_operation() :: Operation.t()
   def autocomplete_operation do
     %Operation{
       tags: ["datasets"],
+      # This seems incorrect (maybe?)
       summary: "Autocomplete search for datasets",
       description: "Given a search input, return potentialy corresponding results with the associated url",
+      # This seems incorrect (maybe?)
       operationId: "API.DatasetController.datasets_autocomplete",
       parameters: [Operation.parameter(:q, :query, :string, "query")],
       responses: %{

--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -38,7 +38,7 @@ defmodule TransportWeb.API.Router do
     scope "/places" do
       pipe_through(:public_cache)
 
-      get("/", TransportWeb.API.PlacesController, :autocomplete)
+      get("/", TransportWeb.API.PlacesController, :places)
     end
 
     scope "/datasets" do

--- a/apps/transport/test/support/database_case.ex
+++ b/apps/transport/test/support/database_case.ex
@@ -31,32 +31,36 @@ defmodule TransportWeb.DatabaseCase do
           Sandbox.mode(Repo, {:shared, self()})
         end
 
-        Repo.insert(%Region{nom: "Pays de la Loire"})
-        Repo.insert(%Region{nom: "Auvergne-Rhône-Alpes"})
-        Repo.insert(%Region{nom: "Île-de-France"})
+        Repo.insert!(%Region{id: 1000, nom: "Pays de la Loire"})
+        Repo.insert!(%Region{id: 1001, nom: "Auvergne-Rhône-Alpes"})
+        Repo.insert!(%Region{id: 1002, nom: "Île-de-France"})
 
-        Repo.insert(%AOM{
+        Repo.insert!(%AOM{
+          id: 1003,
           insee_commune_principale: "53130",
           nom: "Laval",
           region: Repo.get_by(Region, nom: "Pays de la Loire"),
           composition_res_id: 1
         })
 
-        Repo.insert(%AOM{
+        Repo.insert!(%AOM{
+          id: 1004,
           insee_commune_principale: "38185",
           nom: "Grenoble",
           region: Repo.get_by(Region, nom: "Auvergne-Rhône-Alpes"),
           composition_res_id: 2
         })
 
-        Repo.insert(%AOM{
+        Repo.insert!(%AOM{
+          id: 1005,
           insee_commune_principale: "36044",
           nom: "Châteauroux",
           region: Repo.get_by(Region, nom: "Auvergne-Rhône-Alpes"),
           composition_res_id: 3
         })
 
-        Repo.insert(%Commune{
+        Repo.insert!(%Commune{
+          id: 1006,
           insee: "38185",
           nom: "Grenoble",
           wikipedia: "fr:Grenoble",
@@ -64,7 +68,8 @@ defmodule TransportWeb.DatabaseCase do
           aom_res_id: 2
         })
 
-        Repo.insert(%Commune{
+        Repo.insert!(%Commune{
+          id: 1007,
           insee: "36044",
           nom: "Châteauroux",
           wikipedia: "fr:Châteauroux",
@@ -72,7 +77,8 @@ defmodule TransportWeb.DatabaseCase do
           aom_res_id: 3
         })
 
-        Repo.insert(%Commune{
+        Repo.insert!(%Commune{
+          id: 1008,
           insee: "63096",
           nom: "Chas",
           wikipedia: "fr:Chas",
@@ -80,14 +86,16 @@ defmodule TransportWeb.DatabaseCase do
           aom_res_id: 3
         })
 
-        Repo.insert(%AOM{
+        Repo.insert!(%AOM{
+          id: 1009,
           insee_commune_principale: "75056",
           nom: "Île-de-France Mobilités",
           region: Repo.get_by(Region, nom: "Île-de-France"),
           composition_res_id: 4
         })
 
-        Repo.insert(%Commune{
+        Repo.insert!(%Commune{
+          id: 1010,
           insee: "36063",
           nom: "Déols",
           wikipedia: "fr:Déols",

--- a/apps/transport/test/transport_web/controllers/places_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/places_controller_test.exs
@@ -18,7 +18,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
       |> Enum.map(&Map.update!(&1, "url", fn v -> cleanup(v) end))
 
   test "Search a place", %{conn: conn} do
-    path = Helpers.places_path(conn, :autocomplete, q: "chat")
+    path = Helpers.places_path(conn, :places, q: "chat")
     conn = conn |> get(path)
     r = conn |> json_response(200)
 
@@ -48,7 +48,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search a place with accent", %{conn: conn} do
     r =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "cha"))
+      |> get(Helpers.places_path(conn, :places, q: "cha"))
       |> json_response(200)
 
     assert sort_and_clean(r) ==
@@ -74,7 +74,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search a place with multiple word", %{conn: conn} do
     r =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "ile de fr"))
+      |> get(Helpers.places_path(conn, :places, q: "ile de fr"))
       |> json_response(200)
 
     assert sort_and_clean(r) ==
@@ -95,7 +95,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search a unknown place", %{conn: conn} do
     r =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "pouet"))
+      |> get(Helpers.places_path(conn, :places, q: "pouet"))
       |> json_response(200)
 
     assert sort_and_clean(r) == []


### PR DESCRIPTION
Suite à l'alerte signalée par @AntoineAugusti dans #2477, j'ai été enquêter.

Il s'avère que l'autocomplete javascript passe toujours un paramètre `q`, et que le problème ne vient pas de là. En fouillant un plus loin, puis en jouant avec Swagger, j'ai compris que l'action `autocomplete` était en fait aussi utilisée par `/api/places`.

Un appel sans paramètre `q` à `/api/places` donnait bien une erreur 500, car la méthode n'était pas implémentée.

TODO:
- décider si je reste sur autocomplete ou places
- vérifier l'impact sur swagger etc