### PR TITLE
Section Documentation : affichage incitation à la publication

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -1,6 +1,11 @@
-<%= unless is_nil(@resources) or @resources == [] do %>
-  <section class="dataset__resources white">
+<% has_resources = not Enum.empty?(@resources || []) %>
+<% has_reuser_message = not is_nil(assigns[:reuser_message]) %>
+<%= if has_resources or has_reuser_message  do %>
+  <section class="dataset__resources white"<%= if assigns[:section_id] do %> id="<%= assigns[:section_id] %>"<% end %>>
     <h2><%= @title %></h2>
+    <%= if has_reuser_message do %>
+      <div class="reuser-message"><%= assigns[:reuser_message] %></div>
+    <% end %>
     <%= unless is_nil(assigns[:message]) do %>
       <div class="resources-message">
         <i class="fa fa-exclamation-triangle warning-red"></i>

--- a/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.eex
@@ -1,3 +1,4 @@
+<hr>
 <section class="dataset__resources">
   <div class="reuser-message pb-48">
     <i class="fas fa-info-circle"></i>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -72,11 +72,7 @@
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: real_time_official_resources(@dataset), title: dgettext("page-dataset-details", "Real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Resources"), latest_resources_history_infos: @latest_resources_history_infos %>
-      <%= if count_documentation_resources(@dataset) > 0 do %>
-        <section id="dataset-documentation" class="pt-48">
-          <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: official_documentation_resources(@dataset), title: dgettext("page-dataset-details", "Documentation"), latest_resources_history_infos: @latest_resources_history_infos %>
-        </section>
-      <% end %>
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: official_documentation_resources(@dataset), title: dgettext("page-dataset-details", "Documentation"), latest_resources_history_infos: @latest_resources_history_infos, reuser_message: dgettext("page-dataset-details", ~s(Producers can share in this section design guidelines, documentation, etc. Use the <a href="%{url}" target="_blank">documentation type</a> on data.gouv.fr.), url: "https://doc.data.gouv.fr/jeux-de-donnees/publier-un-jeu-de-donnees/#type") |> raw(), section_id: "dataset-documentation" %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: unavailable_resources(@dataset), dataset: @dataset, title: dgettext("page-dataset-details", "unavailable resources"), message: dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"), latest_resources_history_infos: @latest_resources_history_infos%>
 
       <%= render "_reuser_message.html" %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -529,3 +529,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "and "
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -529,3 +529,7 @@ msgstr "Conditions Particulières d'utilisation"
 #, elixir-autogen, elixir-format
 msgid "and "
 msgstr "et "
+
+#, elixir-autogen, elixir-format
+msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
+msgstr "Les producteurs peuvent partager dans cette section : charte graphique, documentation, etc. Utilisez <a href=\"%{url}\" target=\"_blank\">le type documentation</a> sur data.gouv.fr."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -529,3 +529,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "and "
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
+msgstr ""


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2449

Affiche tout le temps, pour tous les types de données, la section "Documentation" pour inciter les producteurs à publier des ressources de documentation : charte graphique, documents etc.

![image](https://user-images.githubusercontent.com/295709/181008271-004492e7-9e5c-4a1c-bcf8-4db9cbb9d2f8.png)

Je mets un lien vers cette doc https://doc.data.gouv.fr/jeux-de-donnees/publier-un-jeu-de-donnees/#type, à voir si @etalab/transport-bizdev 