### PR TITLE
Affiche lien vers ressources historisées dans plus de cas

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_history_message.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_history_message.html.eex
@@ -1,0 +1,8 @@
+<%= if @count_history_resources > 0 do %>
+  <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
+  <section class="dataset__resources">
+    <p>
+      <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.", link: link_history)) %>
+    </p>
+  </section>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.eex
@@ -11,13 +11,6 @@
       <div class="ressources-list">
         <%= render_many @resources |> order_resources_by_validity() |> order_resources_by_format(), TransportWeb.DatasetView, "_resource.html", as: :resource, conn: @conn, resources_related_files: assigns[:resources_related_files], dataset: assigns[:dataset], resources_infos: assigns[:resources_infos], latest_resources_history_infos: assigns[:latest_resources_history_infos] %>
       </div>
-
-      <%= if assigns[:show_history_section_link] do %>
-        <% link_history =  safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
-        <div class="pb-24" style="font-weight: bold">
-          <%= raw(dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.", link: link_history)) %>
-        </div>
-      <% end %>
     </div>
   </section>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.eex
@@ -64,14 +64,12 @@
       </section>
     <% end %>
     <section id="dataset-resources" class="pt-48">
-
       <% gtfs_official_resources= gtfs_official_resources(@dataset) %>
-      <% show_history_section_link= @history_resources !== [] and gtfs_official_resources !== [] %>
-
-      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: gtfs_official_resources, resources_related_files: @resources_related_files, dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources"), show_history_section_link: show_history_section_link %>
+      <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: gtfs_official_resources, resources_related_files: @resources_related_files, dataset: @dataset, title: dgettext("page-dataset-details", "GTFS resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: real_time_official_resources(@dataset), title: dgettext("page-dataset-details", "Real time resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: netex_official_resources(@dataset), title: dgettext("page-dataset-details", "NeTEx resources") %>
       <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: other_official_resources(@dataset), title: dgettext("page-dataset-details", "Resources"), latest_resources_history_infos: @latest_resources_history_infos %>
+      <%= render "_history_message.html", count_history_resources: Enum.count(@history_resources) %>
       <%= if count_documentation_resources(@dataset) > 0 do %>
         <section id="dataset-documentation" class="pt-48">
           <%= render TransportWeb.DatasetView, "_resources_container.html", conn: @conn, resources_infos: @resources_infos, resources: official_documentation_resources(@dataset), title: dgettext("page-dataset-details", "Documentation"), latest_resources_history_infos: @latest_resources_history_infos %>


### PR DESCRIPTION
Fixes #2355

Affiche la mention

> Les versions précédentes des ressources de ce jeu de données sont disponibles dans la section Ressources historisées.

sur toutes les pages d'un jeu de données dès lors que des ressources ont été historisées.

Dans le passé c'était limité aux GTFS et affiché en bas du bloc GTFS. Désormais ce sera après la dernière section présentant des ressources (et avant la section Documentation).

![image](https://user-images.githubusercontent.com/295709/181213110-b92b5ada-9f59-4a62-ade4-a27d755585e1.png)
![image](https://user-images.githubusercontent.com/295709/181213136-06c156d0-a604-4f59-9210-8974cd082781.png)
