### PR TITLE
Ajout lien nav "ressources communautaires"

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
@@ -1,4 +1,4 @@
-<section class="dataset__resources white">
+<section class="dataset__resources white" id="Community-resources">
   <h3><%= dgettext("page-dataset-details", "Community resources" )%></h3>
   <section class="dataset__resources">
     <div class="reuser-message">

--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.eex
@@ -1,4 +1,4 @@
-<section class="dataset__resources white" id="Community-resources">
+<section class="dataset__resources white" id="community-resources">
   <h3><%= dgettext("page-dataset-details", "Community resources" )%></h3>
   <section class="dataset__resources">
     <div class="reuser-message">

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -28,6 +28,9 @@
           <%= dgettext("page-dataset-details", "Resources") %> (<%= count_resources(@dataset) %>)
         </a>
       </div>
+      <%= unless community_resources(@dataset) == 0 do %>
+      <div class="menu-item"><a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources")%></a></div>
+      <% end %>
       <%= unless count_documentation_resources(@dataset) == 0 do %>
         <div class="menu-item">
           <a href="#dataset-documentation"><%= dgettext("page-dataset-details", "Documentation") %></a>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -28,10 +28,9 @@
           <%= dgettext("page-dataset-details", "Resources") %> (<%= count_resources(@dataset) %>)
         </a>
       </div>
-        <div class="menu-item">
-          <a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
-        </div>
-      <% end %>
+      <div class="menu-item">
+        <a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
+      </div>
       <%= unless count_documentation_resources(@dataset) == 0 do %>
         <div class="menu-item">
           <a href="#dataset-documentation"><%= dgettext("page-dataset-details", "Documentation") %></a>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -29,7 +29,7 @@
         </a>
       </div>
       <div class="menu-item">
-        <a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
+        <a href="#community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
       </div>
       <%= unless count_documentation_resources(@dataset) == 0 do %>
         <div class="menu-item">

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -28,7 +28,6 @@
           <%= dgettext("page-dataset-details", "Resources") %> (<%= count_resources(@dataset) %>)
         </a>
       </div>
-      <%= unless community_resources(@dataset) == 0 do %>
         <div class="menu-item">
           <a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
         </div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -29,7 +29,9 @@
         </a>
       </div>
       <%= unless community_resources(@dataset) == 0 do %>
-      <div class="menu-item"><a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources")%></a></div>
+        <div class="menu-item">
+          <a href="#Community-resources"><%= dgettext("page-dataset-details", "Community resources") %></a>
+        </div>
       <% end %>
       <%= unless count_documentation_resources(@dataset) == 0 do %>
         <div class="menu-item">


### PR DESCRIPTION
Création d'une sections "Ressources communautaires" dans la liste déroulante à gauche des jeux de données
https://github.com/etalab/transport-site/issues/2559
![image](https://user-images.githubusercontent.com/85080846/183040738-508e4d35-aed6-44eb-b514-a3f567fb75d5.png)
seconde pr car erreur avec mix dialyzer
première pr :  #2560