### PR TITLE
Répare détection du format SIRI Lite

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -629,7 +629,7 @@ defmodule DB.Resource do
   def is_siri?(_), do: false
 
   @spec is_siri_lite?(__MODULE__.t()) :: boolean
-  def is_siri_lite?(%__MODULE__{format: "SIRI lite"}), do: true
+  def is_siri_lite?(%__MODULE__{format: "SIRI Lite"}), do: true
   def is_siri_lite?(_), do: false
 
   @spec is_documentation?(__MODULE__.t()) :: boolean


### PR DESCRIPTION
Fixes #2569

Pour une raison inconnue, la casse n'était pas bonne dans ce fichier, le L est en minuscule. Partout ailleurs c'est en majuscule.