### PR TITLE
Ajout explicite de la dépendance ymlr

### DIFF
--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -117,6 +117,7 @@ defmodule Transport.Mixfile do
       {:ecto_interval, "~> 0.2.5"},
       {:scrivener_ecto, "~> 2.7.0"},
       {:typed_ecto_schema, ">= 0.1.1"},
+      {:ymlr, "~> 2.0"},
       {:ex_machina, "~> 2.4", only: :test}
     ]
   end


### PR DESCRIPTION
Suite à #2587 , il faut ajouter explicitement la dépendance à ymlr (voir https://github.com/open-api-spex/open_api_spex/commit/338434a888c3e8ac037f6c36520a13b4d32e6c87)