### PR TITLE
Ajout d'une catégorie pour les ressources avec un schema

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -645,6 +645,10 @@ defmodule DB.Resource do
     is_gtfs_rt?(resource) or is_gbfs?(resource) or is_siri_lite?(resource) or is_siri?(resource)
   end
 
+  @spec has_schema?(__MODULE__.t()) :: boolean
+  def has_schema?(%__MODULE__{schema_name: schema_name}) when not is_nil(schema_name), do: true
+  def has_schema?(_), do: false
+
   @spec ttl(__MODULE__.t()) :: integer() | nil
   def ttl(%__MODULE__{format: "gbfs", metadata: %{"ttl" => ttl}})
       when is_integer(ttl) and ttl >= 0,

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -112,6 +112,12 @@
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,
         resources_infos: @resources_infos,
+        resources: schemas_resources(@dataset),
+        title: dgettext("page-dataset-details", "Resources with a schema")
+      ) %>
+      <%= render(TransportWeb.DatasetView, "_resources_container.html",
+        conn: @conn,
+        resources_infos: @resources_infos,
         resources: other_official_resources(@dataset),
         title: dgettext("page-dataset-details", "Resources"),
         latest_resources_history_infos: @latest_resources_history_infos

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -335,6 +335,12 @@ defmodule TransportWeb.DatasetView do
       |> official_available_resources()
       |> Enum.filter(&Resource.is_netex?/1)
 
+  def schemas_resources(dataset) do
+    dataset
+    |> official_available_resources()
+    |> Enum.filter(&Resource.has_schema?/1)
+  end
+
   def other_official_resources(dataset) do
     dataset
     |> official_available_resources()
@@ -342,6 +348,7 @@ defmodule TransportWeb.DatasetView do
     |> Stream.reject(&Resource.is_netex?/1)
     |> Stream.reject(&Resource.is_real_time?/1)
     |> Stream.reject(&Resource.is_documentation?/1)
+    |> Stream.reject(&Resource.has_schema?/1)
     |> Enum.to_list()
     |> Enum.sort_by(& &1.display_position)
   end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -533,3 +533,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resources with a schema"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -533,3 +533,7 @@ msgstr "et "
 #, elixir-autogen, elixir-format
 msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
 msgstr "Les producteurs peuvent partager dans cette section : charte graphique, documentation, etc. Utilisez <a href=\"%{url}\" target=\"_blank\">le type documentation</a> sur data.gouv.fr."
+
+#, elixir-autogen, elixir-format
+msgid "Resources with a schema"
+msgstr "Ressources avec schéma"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -533,3 +533,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Producers can share in this section design guidelines, documentation, etc. Use the <a href=\"%{url}\" target=\"_blank\">documentation type</a> on data.gouv.fr."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resources with a schema"
+msgstr ""


### PR DESCRIPTION
J'ai l'impression que c'est une bonne manière de répondre aux demandes de @ChristinaLaumond et @Miryad3108 de https://github.com/etalab/transport-site/issues/2562

![image](https://user-images.githubusercontent.com/15341118/186700372-b88bf2f4-91ea-46fc-b4f9-6450834e0f87.png)

Il est difficile de deviner quelle est la ressource "principale" d'un dataset, mais le fait de mettre à part et en avant les ressources qui suivent un schéma permet de les faire sortir du lot je trouve.