### PR TITLE
ImportData : ne pas filtrer ressources pour les ZFE

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -369,7 +369,6 @@ defmodule Transport.ImportData do
        }, display_position + 1}
     end)
     |> elem(0)
-    |> maybe_filter_resources(type)
   end
 
   @spec get_valid_resources(map(), binary()) :: [map()]
@@ -385,12 +384,6 @@ defmodule Transport.ImportData do
   def get_valid_resources(%{"resources" => resources}, _type) do
     resources
   end
-
-  def maybe_filter_resources(resources, "low-emission-zones") do
-    resources |> Enum.filter(&(&1["schema_name"] == "etalab/schema-zfe"))
-  end
-
-  def maybe_filter_resources(resources, _), do: resources
 
   @spec get_valid_gtfs_resources([map()]) :: [map()]
   def get_valid_gtfs_resources(resources) do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -331,13 +331,4 @@ defmodule Transport.ImportDataTest do
              "siri lite" => 1
            }
   end
-
-  test "maybe_filter_resources" do
-    assert Enum.empty?(ImportData.maybe_filter_resources([%{"schema_name" => nil}], "low-emission-zones"))
-    refute Enum.empty?(ImportData.maybe_filter_resources([%{"schema_name" => nil}], "public-transit"))
-
-    assert Enum.count(
-             ImportData.maybe_filter_resources([%{"schema_name" => "etalab/schema-zfe"}], "low-emission-zones")
-           ) == 1
-  end
 end


### PR DESCRIPTION
Suite aux changements apportés dans https://github.com/etalab/transport-site/pull/2595, supprime ce qui avait été fait dans #2260.

Pour la catégorie des ZFE, si des ressources n'ont pas de schéma, elles seront moins en évidence.