### PR TITLE
Ne plus utiliser resource.metadata, 1/X

### DIFF
--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -136,4 +136,20 @@ defmodule DB.MultiValidation do
       end
     end)
   end
+
+  @doc """
+  Get a metadata field, given a preloaded multi_validation struct. Returns nil if it fails.
+
+  iex> get_metadata_info(%DB.MultiValidation{metadata: %DB.ResourceMetadata{metadata: %{age: 11}}}, :age)
+  11
+  iex> get_metadata_info(%DB.MultiValidation{metadata: %DB.ResourceMetadata{metadata: %{age: 11}}}, :foo)
+  nil
+  iex> get_metadata_info(nil, :foo)
+  nil
+  """
+  def get_metadata_info(%__MODULE__{metadata: %{metadata: metadata}}, metadata_key) do
+    Map.get(metadata, metadata_key)
+  end
+
+  def get_metadata_info(_, _), do: nil
 end

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -5,7 +5,7 @@
   <% is_geojson_with_viz = ResourceView.is_geojson_with_viz(@resource, Map.get(@latest_resources_history_infos || %{}, @resource.id)) %>
   <% unavailabilities = @resources_infos.unavailabilities %>
   <% resources_updated_at = @resources_infos.resources_updated_at %>
-  <% validations = @resources_infos.validations %>
+  <% [validation] = @resources_infos.validations |> Map.get(@resource.id) %>
 
   <h4>
     <%= @resource.title %>
@@ -21,9 +21,9 @@
   <%= if Resource.valid_and_available?(@resource) do %>
     <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
       <i class="icon icon--calendar-alt" aria-hidden="true"></i>
-      <span><%= DateTimeDisplay.format_date(@resource.metadata["start_date"], locale) %></span>
+      <span><%= validation |> get_metadata_info("start_date") |> DateTimeDisplay.format_date(locale) %></span>
       <i class="icon icon--right-arrow ml-05-em" aria-hidden="true"></i>
-      <span class="<%= outdated_class(@resource) %>"><%= DateTimeDisplay.format_date(@resource.metadata["end_date"], locale) %></span>
+      <span class="<%= outdated_class(@resource) %>"><%= validation |> get_metadata_info("end_date") |> DateTimeDisplay.format_date(locale) %></span>
     </div>
   <% end %>
   <div class="pb-24 light-gry">
@@ -74,7 +74,6 @@
   <% end %>
 
   <%= if Resource.is_gtfs?(@resource) do %>
-    <% [validation] = Map.get(validations, @resource.id) %>
     <%= if GTFSTransport.is_mine?(validation) do %>
       <div class="pb-24">
         <a href="<%= resource_path(@conn, :details, @resource.id)<>"#validation-report" %>">
@@ -101,7 +100,6 @@
 
 
   <%= unless Resource.is_gtfs?(@resource) do %>
-    <% [validation] = Map.get(validations, @resource.id) %>
     <%= if multi_validation_plugged?(@resource) do %>
       <%= if multi_validation_performed?(validation) do %>
         <% nb_warnings = warnings_count(validation) %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -18,16 +18,18 @@
     </div>
   <% end %>
 
-  <%= if Resource.valid_and_available?(@resource) do %>
+  <% start_date = validation |> get_metadata_info("start_date") %>
+  <% end_date = validation |> get_metadata_info("end_date") %>
+  <%= if start_date && end_date do %>
     <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
       <i class="icon icon--calendar-alt" aria-hidden="true"></i>
-      <span><%= validation |> get_metadata_info("start_date") |> DateTimeDisplay.format_date(locale) %></span>
+      <span><%= start_date |> DateTimeDisplay.format_date(locale) %></span>
       <i class="icon icon--right-arrow ml-05-em" aria-hidden="true"></i>
-      <span class="<%= outdated_class(@resource) %>"><%= validation |> get_metadata_info("end_date") |> DateTimeDisplay.format_date(locale) %></span>
+      <span class="<%= outdated_class(@resource) %>"><%= end_date |> DateTimeDisplay.format_date(locale) %></span>
     </div>
   <% end %>
-  <div class="pb-24 light-gry">
 
+  <div class="pb-24 light-gry">
     <span title="<%= dgettext("page-dataset-details", "last content modification") %>">
       <i class="icon icon--sync-alt" aria-hidden="true"></i>
         <%= show_resource_last_update(resources_updated_at, @resource, locale) %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -8,7 +8,6 @@ defmodule TransportWeb.DatasetView do
   # ~H expects a variable named `assigns`, so wrapping the calls to `~H` inside
   # a helper function would be cleaner and more future-proof to avoid conflicts at some point.
   import Phoenix.LiveView.Helpers, only: [sigil_H: 2]
-  import Transport.GBFSUtils, only: [gbfs_validation_link: 1]
   import DB.MultiValidation, only: [get_metadata_info: 2]
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -9,6 +9,7 @@ defmodule TransportWeb.DatasetView do
   # a helper function would be cleaner and more future-proof to avoid conflicts at some point.
   import Phoenix.LiveView.Helpers, only: [sigil_H: 2]
   import Transport.GbfsUtils, only: [gbfs_validation_link: 1]
+  import DB.MultiValidation, only: [get_metadata_info: 2]
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport
 

--- a/apps/transport/test/db/multi_validation_test.exs
+++ b/apps/transport/test/db/multi_validation_test.exs
@@ -1,6 +1,6 @@
 defmodule DB.MultiValidationTest do
   use ExUnit.Case, async: true
-  doctest DB.MultiValidation
+  doctest DB.MultiValidation, import: true
   import DB.Factory
   import Ecto.Query
 


### PR DESCRIPTION
Ces dates là
![image](https://user-images.githubusercontent.com/15341118/186876109-78ea50ab-5fef-438e-b3cb-34f3bd1b2242.png)
étaient prises dans resource.metadata, mais on veut qu'elles viennent des metadatas associées à la dernière multi_validation.