### PR TITLE
Ne plus utiliser resource.metadata, 3/X 

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -282,10 +282,6 @@
   border-top: 75px solid var(--theme-background-grey);
 }
 
-.resource--notvalid {
-  border-top: 75px solid var(--theme-error-bg);
-}
-
 .resource--unavailable {
   border-top: 75px solid var(--theme-error-bg);
 }

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -515,22 +515,6 @@ defmodule DB.Resource do
     |> validate_required([:url, :datagouv_id])
   end
 
-  @spec has_metadata?(__MODULE__.t()) :: boolean()
-  def has_metadata?(%__MODULE__{} = r), do: r.metadata != nil
-
-  @spec valid_and_available?(__MODULE__.t()) :: boolean()
-  def valid_and_available?(%__MODULE__{
-        is_available: available,
-        metadata: %{
-          "start_date" => s,
-          "end_date" => e
-        }
-      })
-      when not is_nil(s) and not is_nil(e),
-      do: available
-
-  def valid_and_available?(%__MODULE__{}), do: false
-
   @spec is_outdated?(__MODULE__.t()) :: boolean
   def is_outdated?(%__MODULE__{
         metadata: %{

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -515,6 +515,19 @@ defmodule DB.Resource do
     |> validate_required([:url, :datagouv_id])
   end
 
+  @spec valid_and_available?(__MODULE__.t()) :: boolean()
+  def valid_and_available?(%__MODULE__{
+        is_available: available,
+        metadata: %{
+          "start_date" => s,
+          "end_date" => e
+        }
+      })
+      when not is_nil(s) and not is_nil(e),
+      do: available
+
+  def valid_and_available?(%__MODULE__{}), do: false
+
   @spec is_outdated?(__MODULE__.t()) :: boolean
   def is_outdated?(%__MODULE__{
         metadata: %{

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -64,15 +64,12 @@
           <%= dgettext("page-dataset-details", "Not") %> <br>
           <%= dgettext("page-dataset-details", "available") %>
         <% else %>
-          <%= unless Resource.valid_and_available?(@resource) do %>
-            <%= dgettext("page-dataset-details", "Impossible to read") %>
-          <% else %>
-            <%= if Resource.is_outdated?(@resource) do %>
+            <%= if is_gtfs_outdated == true do %>
               <%= dgettext("page-dataset-details", "Outdated") %>
-            <% else %>
+            <% end %>
+            <%= if is_gtfs_outdated == false do %>
               <%= dgettext("page-dataset-details", "Up to date") %>
             <% end %>
-          <% end %>
         <% end %>
       </span>
     </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -64,12 +64,12 @@
           <%= dgettext("page-dataset-details", "Not") %> <br>
           <%= dgettext("page-dataset-details", "available") %>
         <% else %>
-            <%= if is_gtfs_outdated == true do %>
-              <%= dgettext("page-dataset-details", "Outdated") %>
-            <% end %>
-            <%= if is_gtfs_outdated == false do %>
-              <%= dgettext("page-dataset-details", "Up to date") %>
-            <% end %>
+          <%= if is_gtfs_outdated == true do %>
+            <%= dgettext("page-dataset-details", "Outdated") %>
+          <% end %>
+          <%= if is_gtfs_outdated == false do %>
+            <%= dgettext("page-dataset-details", "Up to date") %>
+          <% end %>
         <% end %>
       </span>
     </div>
@@ -126,7 +126,7 @@
           <% end %>
         </div>
       <% end %>
-      <%= if Resource.has_metadata?(@resource) and Resource.is_gbfs?(@resource) do %>
+      <%= if Resource.is_gbfs?(@resource) do %>
         <%= for version <- validation |> get_metadata_info("versions", []) do %>
           <a href="<%= gbfs_documentation_link(version) %>" target="_blank">
             <span class="label version"><%= dgettext("page-dataset-details", "Version %{version}", version: version) %></span>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -19,15 +19,17 @@
     </div>
   <% end %>
 
-  <% start_date = validation |> get_metadata_info("start_date") %>
-  <% end_date = validation |> get_metadata_info("end_date") %>
-  <%= if start_date && end_date do %>
-    <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
-      <i class="icon icon--calendar-alt" aria-hidden="true"></i>
-      <span><%= start_date |> DateTimeDisplay.format_date(locale) %></span>
-      <i class="icon icon--right-arrow ml-05-em" aria-hidden="true"></i>
-      <span class="<%= outdated_class(@resource) %>"><%= end_date |> DateTimeDisplay.format_date(locale) %></span>
-    </div>
+  <%= if Resource.is_gtfs?(@resource) do %>
+    <% start_date = validation |> get_metadata_info("start_date") %>
+    <% end_date = validation |> get_metadata_info("end_date") %>
+    <%= if start_date && end_date do %>
+      <div title="<%= dgettext("page-dataset-details", "Validity period") %>">
+        <i class="icon icon--calendar-alt" aria-hidden="true"></i>
+        <span><%= start_date |> DateTimeDisplay.format_date(locale) %></span>
+        <i class="icon icon--right-arrow ml-05-em" aria-hidden="true"></i>
+        <span class="<%= outdated_class(is_gtfs_outdated) %>"><%= end_date |> DateTimeDisplay.format_date(locale) %></span>
+      </div>
+    <% end %>
   <% end %>
 
   <div class="pb-24 light-gry">

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -1,12 +1,13 @@
 <% locale = get_session(@conn, :locale) %>
-<div class="panel resource <%= valid_panel_class(@resource) %>" title="<%= resource_tooltip_content(@resource) %>">
-  <% has_associated_geojson = ResourceView.has_associated_geojson(@resources_related_files, @resource.id) %>
-  <% has_associated_netex = ResourceView.has_associated_netex(@resources_related_files, @resource.id) %>
-  <% is_geojson_with_viz = ResourceView.is_geojson_with_viz(@resource, Map.get(@latest_resources_history_infos || %{}, @resource.id)) %>
-  <% unavailabilities = @resources_infos.unavailabilities %>
-  <% resources_updated_at = @resources_infos.resources_updated_at %>
-  <% [validation] = @resources_infos.validations |> Map.get(@resource.id) %>
+<% has_associated_geojson = ResourceView.has_associated_geojson(@resources_related_files, @resource.id) %>
+<% has_associated_netex = ResourceView.has_associated_netex(@resources_related_files, @resource.id) %>
+<% is_geojson_with_viz = ResourceView.is_geojson_with_viz(@resource, Map.get(@latest_resources_history_infos || %{}, @resource.id)) %>
+<% unavailabilities = @resources_infos.unavailabilities %>
+<% resources_updated_at = @resources_infos.resources_updated_at %>
+<% [validation] = @resources_infos.validations |> Map.get(@resource.id) %>
+<% is_gtfs_outdated =  Transport.Validators.GTFSTransport.is_gtfs_outdated(validation) %>
 
+<div class="panel resource <%= valid_panel_class(@resource, is_gtfs_outdated) %>" title="<%= resource_tooltip_content(@resource) %>">
   <h4>
     <%= @resource.title %>
   </h4>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.eex
@@ -58,7 +58,7 @@
   </div>
 
   <%= if Resource.is_gtfs?(@resource) or not @resource.is_available do %>
-    <div class="resource-status-corner <%= resource_class(@resource) %>">
+    <div class="resource-status-corner <%= resource_class(@resource.is_available, is_gtfs_outdated) %>">
       <span class="<%= resource_span_class(@resource) %>">
         <%= unless @resource.is_available do %>
           <%= dgettext("page-dataset-details", "Not") %> <br>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -276,12 +276,8 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
-  def outdated_class(resource) do
-    case Resource.is_outdated?(resource) do
-      true -> "resource__summary--Error"
-      false -> ""
-    end
-  end
+  def outdated_class(_is_outdated = true), do: "resource__summary--Error"
+  def outdated_class(_is_outdated = _), do: ""
 
   def valid_panel_class(%DB.Resource{is_available: false}, _), do: "invalid-resource-panel"
 

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -276,8 +276,8 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
-  def outdated_class(_is_outdated = true), do: "resource__summary--Error"
-  def outdated_class(_is_outdated = _), do: ""
+  def outdated_class(true = _is_outdated), do: "resource__summary--Error"
+  def outdated_class(_), do: ""
 
   def valid_panel_class(%DB.Resource{is_available: false}, _), do: "invalid-resource-panel"
 
@@ -442,9 +442,9 @@ defmodule TransportWeb.DatasetView do
   def resource_span_class(%DB.Resource{is_available: false}), do: "span-unavailable"
   def resource_span_class(%DB.Resource{}), do: nil
 
-  def resource_class(_is_available = false, _), do: "resource--unavailable"
-  def resource_class(_, _is_outdated = true), do: "resource--outdated"
-  def resource_class(_, _is_outdated = false), do: "resource--valid"
+  def resource_class(false = _is_available, _), do: "resource--unavailable"
+  def resource_class(_, true = _is_outdated), do: "resource--outdated"
+  def resource_class(_, false = _is_outdated), do: "resource--valid"
   def resource_class(_, _), do: ""
 
   def order_resources_by_validity(resources) do

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -283,11 +283,13 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
-  def valid_panel_class(%Resource{} = r) do
-    case {Resource.is_gtfs?(r), Resource.valid_and_available?(r), Resource.is_outdated?(r)} do
-      {true, false, _} -> "invalid-resource-panel"
-      {true, _, true} -> "invalid-resource-panel"
-      _ -> ""
+  def valid_panel_class(%DB.Resource{is_available: false}, _), do: "invalid-resource-panel"
+
+  def valid_panel_class(%DB.Resource{} = r, is_outdated) do
+    if Resource.is_gtfs?(r) && is_outdated do
+      "invalid-resource-panel"
+    else
+      ""
     end
   end
 

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -442,20 +442,10 @@ defmodule TransportWeb.DatasetView do
   def resource_span_class(%DB.Resource{is_available: false}), do: "span-unavailable"
   def resource_span_class(%DB.Resource{}), do: nil
 
-  def resource_class(%DB.Resource{is_available: false}), do: "resource--unavailable"
-
-  def resource_class(%DB.Resource{} = r) do
-    case DB.Resource.valid_and_available?(r) do
-      false ->
-        "resource--notvalid"
-
-      _ ->
-        case DB.Resource.is_outdated?(r) do
-          true -> "resource--outdated"
-          false -> "resource--valid"
-        end
-    end
-  end
+  def resource_class(_is_available = false, _), do: "resource--unavailable"
+  def resource_class(_, _is_outdated = true), do: "resource--outdated"
+  def resource_class(_, _is_outdated = false), do: "resource--valid"
+  def resource_class(_, _), do: ""
 
   def order_resources_by_validity(resources) do
     resources

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -279,10 +279,6 @@ msgid "Covered area"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Impossible to read"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "during validation"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -279,10 +279,6 @@ msgid "Covered area"
 msgstr "Couverture spatiale"
 
 #, elixir-autogen, elixir-format
-msgid "Impossible to read"
-msgstr "Illisible"
-
-#, elixir-autogen, elixir-format
 msgid "during validation"
 msgstr "lors de la validation"
 

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -279,10 +279,6 @@ msgid "Covered area"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Impossible to read"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "during validation"
 msgstr ""
 


### PR DESCRIPTION
Je continue à enlever du code qui utilise resource.metadata dans la page de détail d'un dataset.
Il en reste...