### PR TITLE
Expire la session si la session OAuth est expirée

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -17,6 +17,7 @@ defmodule TransportWeb.Router do
     plug(:assign_current_user)
     plug(:assign_contact_email)
     plug(:assign_token)
+    plug(:maybe_login_again)
     plug(:assign_mix_env)
     plug(Sentry.PlugContext)
   end
@@ -242,6 +243,20 @@ defmodule TransportWeb.Router do
 
   defp assign_token(conn, _) do
     assign(conn, :token, get_session(conn, :token))
+  end
+
+  defp maybe_login_again(conn, _) do
+    case conn.assigns[:token] do
+      %OAuth2.AccessToken{expires_at: expires_at} ->
+        if DateTime.compare(DateTime.from_unix!(expires_at), DateTime.utc_now()) == :lt do
+          conn |> configure_session(drop: true) |> assign(:current_user, nil) |> authentication_required(nil)
+        else
+          conn
+        end
+
+      _ ->
+        conn
+    end
   end
 
   defp authentication_required(conn, _) do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2613

Supprime la session et redirige vers la page de login quand la session OAuth2 n'est plus valide. C'est un fix qui me semble pour le moment plus simple que d'avoir du refresh de token.

J'ai testé en local en me mettant des sessions très courtes, en remplacement de cette ligne https://github.com/etalab/transport-site/blob/ac0ad38ee3e1e1b900719381b201c140a3ba76ec/apps/transport/lib/transport_web/controllers/session_controller.ex#L21

```elixir
|> put_session(:token, %{token | expires_at: (DateTime.utc_now() |> DateTime.to_unix()) + 5})
```