### PR TITLE
Fix discussions sur dataset suite conversion HEEX

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -208,12 +208,14 @@
             <% end %>
           </div>
           <%= unless @discussions == nil do %>
-            <%= render_many(@discussions, TransportWeb.DatasetView, "_discussion.html",
-              as: :discussion,
-              current_user: @current_user,
-              conn: @conn,
-              dataset: @dataset
-            ) %>
+            <%= for discussion <- @discussions do %>
+              <%= render("_discussion.html",
+                discussion: discussion,
+                current_user: @current_user,
+                conn: @conn,
+                dataset: @dataset
+              ) %>
+            <% end %>
           <% else %>
             <%= dgettext("page-dataset-details", "Unable to retrieve discussions from data.gouv.fr") %>
           <% end %>


### PR DESCRIPTION
Répare un bug introduit dans https://github.com/etalab/transport-site/pull/2616, les templates HEEX ne passent pas dans `render_many`.

J'imagine qu'on a pas de tests qui renvoient des discussions (seulement des listes vides ?).