### PR TITLE
Filtre les datasets par licence par le biais de l'URL

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -254,6 +254,10 @@ defmodule DB.Dataset do
   defp filter_by_active(query, %{"list_inactive" => true}), do: query
   defp filter_by_active(query, _), do: where(query, [d], d.is_active)
 
+  @spec filter_by_licence(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  defp filter_by_licence(query, %{"licence" => licence}), do: where(query, [d], d.licence == ^licence)
+  defp filter_by_licence(query, _), do: query
+
   @spec list_datasets(map()) :: Ecto.Query.t()
   def list_datasets(%{} = params) do
     preload_without_validations()
@@ -265,6 +269,7 @@ defmodule DB.Dataset do
     |> filter_by_type(params)
     |> filter_by_aom(params)
     |> filter_by_commune(params)
+    |> filter_by_licence(params)
     |> filter_by_fulltext(params)
     |> order_datasets(params)
   end

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -255,6 +255,9 @@ defmodule DB.Dataset do
   defp filter_by_active(query, _), do: where(query, [d], d.is_active)
 
   @spec filter_by_licence(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  defp filter_by_licence(query, %{"licence" => "licence-ouverte"}),
+    do: where(query, [d], d.licence in ["fr-lo", "lov2"])
+
   defp filter_by_licence(query, %{"licence" => licence}), do: where(query, [d], d.licence == ^licence)
   defp filter_by_licence(query, _), do: query
 

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -35,8 +35,9 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     {:ok, _} =
       %Dataset{
         description: "Un autre jeu de données",
-        licence: "odc-odbl",
+        licence: "lov2",
         datagouv_title: "offre de transport du réseau de LAVAL Agglomération (GTFS)",
+        custom_title: "Horaires Laval",
         slug: "offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
         type: "public-transit",
         datagouv_id: "5bc493d08b4c416c84a69500",
@@ -80,6 +81,13 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   test "GET /datasets?type=public-transit", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index), %{type: "public-transit"})
     assert html_response(conn, 200) =~ "Jeux de données"
+  end
+
+  test "GET /datasets?type=public-transit&licence=odc-odbl", %{conn: conn} do
+    conn = conn |> get(dataset_path(conn, :index), %{type: "public-transit", licence: "odc-odbl"})
+    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (1)"
+    assert html_response(conn, 200) =~ "Horaires Angers"
+    refute html_response(conn, 200) =~ "Horaires Laval"
   end
 
   test "GET /datasets/aom/4242", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -88,6 +88,10 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (1)"
     assert html_response(conn, 200) =~ "Horaires Angers"
     refute html_response(conn, 200) =~ "Horaires Laval"
+
+    conn = conn |> get(dataset_path(conn, :index), %{type: "public-transit", licence: "licence-ouverte"})
+    assert html_response(conn, 200) =~ "Horaires Laval"
+    refute html_response(conn, 200) =~ "Horaires Angers"
   end
 
   test "GET /datasets/aom/4242", %{conn: conn} do


### PR DESCRIPTION
Lié à https://github.com/etalab/transport-site/issues/2621

Ajoute la possibilité de filter les jeux de données en fonction de leur licence.

Ainsi `https://transport.data.gouv.fr/datasets?licence=licence-ouverte` donnera les jeux de données ayant comme licence la licence ouverte.