### PR TITLE
Ajout champ licence pour dataset dans l'API

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -157,6 +157,7 @@ defmodule TransportWeb.API.DatasetController do
       "aom" => transform_aom(dataset.aom),
       "covered_area" => covered_area(dataset),
       "type" => dataset.type,
+      "licence" => dataset.licence,
       "publisher" => get_publisher(dataset)
     }
 

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -301,7 +301,7 @@ defmodule TransportWeb.API.Schemas do
         |> Map.put(:original_resource_url, %Schema{
           type: :string,
           description: """
-          some community resources have been generated from another dataset (like the generated NeTEx / GeoJson). 
+          some community resources have been generated from another dataset (like the generated NeTEx / GeoJson).
           Those resources have a `original_resource_url` equals to the original resource's `original_url`
           """
         })
@@ -319,6 +319,7 @@ defmodule TransportWeb.API.Schemas do
       properties: %{
         updated: %Schema{type: :string, description: "The last update of any resource of that dataset"},
         name: %Schema{type: :string},
+        licence: %Schema{type: :string, description: "The licence of the dataset"},
         created_at: %Schema{type: :string, description: "Date of creation of the dataset"},
         aom: %Schema{type: :string, description: "Transit authority responsible of this authority"},
         resources: %Schema{

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -78,6 +78,7 @@ defmodule TransportWeb.DatasetControllerTest do
       %DB.Dataset{
         custom_title: "title",
         type: "public-transit",
+        licence: "lov2",
         datagouv_id: "datagouv",
         slug: "slug-1",
         resources: [
@@ -149,6 +150,7 @@ defmodule TransportWeb.DatasetControllerTest do
              "slug" => "slug-1",
              "title" => "title",
              "type" => "public-transit",
+             "licence" => "lov2",
              "updated" => ""
            } == conn |> get(path) |> json_response(200)
   end


### PR DESCRIPTION
Fixes #2622, similaire à la demande dans #2621 : identifier des jeux de données publiés avec une licence spécifique.

Étonné qu'on n'expose pas ce champ encore !