### PR TITLE
Répare un test instable

### DIFF
--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -37,7 +37,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert [%{args: %{"resource_id" => first_id}}, %{args: %{"resource_id" => second_id}}] =
                all_enqueued(worker: ResourceHistoryJob)
 
-      assert MapSet.new([second_id, first_id]) == MapSet.new(ids)
+      assert Enum.sort([second_id, first_id]) == Enum.sort(ids)
 
       refute_enqueued(worker: ResourceHistoryDispatcherJob)
     end

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -37,7 +37,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert [%{args: %{"resource_id" => first_id}}, %{args: %{"resource_id" => second_id}}] =
                all_enqueued(worker: ResourceHistoryJob)
 
-      assert [second_id, first_id] == ids
+      assert MapSet.new([second_id, first_id]) == MapSet.new(ids)
 
       refute_enqueued(worker: ResourceHistoryDispatcherJob)
     end


### PR DESCRIPTION
Répare un test qui échoue de temps en temps, [comme ici](https://app.circleci.com/pipelines/github/etalab/transport-site/5226/workflows/1f6f7cdd-3adc-455f-93fa-b896ecbbc6f5/jobs/38389).

```
1) test ResourceHistoryDispatcherJob a simple successful case (Transport.Test.Transport.Jobs.ResourceHistoryJobTest)
     apps/transport/test/transport/jobs/resource_history_job_test.exs:31
     Assertion with == failed
     code:  assert [second_id, first_id] == ids
     left:  [133, 125]
     right: [125, 133]
     stacktrace:
       test/transport/jobs/resource_history_job_test.exs:40: (test)
```