### PR TITLE
Nettoyage de liens "/js/app.js"

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/gbfs_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/gbfs_live.ex
@@ -3,7 +3,6 @@ defmodule TransportWeb.Backoffice.GBFSLive do
   A view able to display the current running configuration of the proxy.
   """
   use Phoenix.LiveView
-  use Phoenix.HTML
   alias Transport.Telemetry
   import TransportWeb.Backoffice.JobsLive, only: [ensure_admin_auth_or_redirect: 3]
   import TransportWeb.Router.Helpers

--- a/apps/transport/lib/transport_web/live/backoffice/gbfs_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/gbfs_live.ex
@@ -3,8 +3,10 @@ defmodule TransportWeb.Backoffice.GBFSLive do
   A view able to display the current running configuration of the proxy.
   """
   use Phoenix.LiveView
+  use Phoenix.HTML
   alias Transport.Telemetry
   import TransportWeb.Backoffice.JobsLive, only: [ensure_admin_auth_or_redirect: 3]
+  import TransportWeb.Router.Helpers
 
   @stats_days 7
 

--- a/apps/transport/lib/transport_web/live/backoffice/gbfs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/gbfs_live.html.heex
@@ -22,6 +22,4 @@
   </table>
   <p class="small">Dernière mise à jour: <%= @last_updated_at %></p>
 </section>
-<script defer type="text/javascript" src="/js/app.js" ) %>
-  >
-</script>
+<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>

--- a/apps/transport/lib/transport_web/live/backoffice/gbfs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/gbfs_live.html.heex
@@ -22,4 +22,5 @@
   </table>
   <p class="small">Dernière mise à jour: <%= @last_updated_at %></p>
 </section>
-<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
+</script>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -49,4 +49,5 @@
   <%= live_component(JobsTableComponent, jobs: @last_discarded_jobs, state: "discarded") %>
   <p class="small">Total: <%= Helpers.format_number(@count_discarded_jobs, locale: "en") %></p>
 </section>
-<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@conn, "/js/app.js")) %>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
+</script>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -49,5 +49,4 @@
   <%= live_component(JobsTableComponent, jobs: @last_discarded_jobs, state: "discarded") %>
   <p class="small">Total: <%= Helpers.format_number(@count_discarded_jobs, locale: "en") %></p>
 </section>
-<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
-</script>
+<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@conn, "/js/app.js")) %>

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -3,7 +3,6 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
   A view able to display the current running configuration of the proxy.
   """
   use Phoenix.LiveView
-  use Phoenix.HTML
   alias Transport.Telemetry
   import TransportWeb.Router.Helpers
 

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -3,7 +3,9 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
   A view able to display the current running configuration of the proxy.
   """
   use Phoenix.LiveView
+  use Phoenix.HTML
   alias Transport.Telemetry
+  import TransportWeb.Router.Helpers
 
   # The number of past days we want to report on (as a positive integer).
   # This is a DRYed ref we are using in multiple places.

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
@@ -48,4 +48,5 @@
   </table>
   <p class="small">Dernière mise à jour: <%= @last_updated_at %></p>
 </section>
-<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
+</script>

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
@@ -48,6 +48,4 @@
   </table>
   <p class="small">Dernière mise à jour: <%= @last_updated_at %></p>
 </section>
-<script defer type="text/javascript" src="/js/app.js" ) %>
-  >
-</script>
+<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.ex
@@ -9,6 +9,7 @@ defmodule TransportWeb.Live.OnDemandValidationLive do
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 3]
   import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]
   import Ecto.Query
+  import TransportWeb.Router.Helpers
 
   def mount(
         _params,

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -164,5 +164,4 @@
     </div>
   </div>
 </section>
-<script defer type="text/javascript" src="/js/app.js">
-</script>
+<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -164,4 +164,5 @@
     </div>
   </div>
 </section>
-<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
+</script>

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -42,4 +42,5 @@
     </div>
   </div>
 </section>
-<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
+</script>

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -42,4 +42,4 @@
     </div>
   </div>
 </section>
-<script defer type="text/javascript" src="/js/app.js" />
+<%= tag(:script, defer: true, type: "text/javascript", src: static_path(@socket, "/js/app.js")) %>


### PR DESCRIPTION
En travaillant sur #2556, je me suis rendu compte (en voulant faire un copier coller de lien vers `js/app.js`) que les différents travaux sur #2538 ont introduit des liens bizarrement formatés (mais qui marchent peut-être quand même).

Du coup dans cette PR :
- Je traite #2402
- Je corrige ces liens formatés curieusement

~~Ce n'est pas finalisé~~ (c'est OK à présent), je voudrais vérifier que je ne casse rien (il y a des `@conn` versus des `@socket` selon les endroits). 

Pour vérifier cela, je me suis demandé si le coverage pourrait détecter quels templates HEEX sont exécutés par les tests (car ces templates sont compilés en fonctions, et au final à terme on devrait pouvoir les voir apparaître dans les rapports de couverture), toutefois j'ai l'impression que ce n'est pas supporté (j'ai ouvert un ticket ici https://github.com/parroty/excoveralls/issues/288).

~~Je procèderai à un peu plus de tests avant de sortir du mode brouillon~~ (tests réalisés, voir dans les commentaires).