### PR TITLE
Afficher les headers CORS bruts pour la validation GBFS

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -75,41 +75,6 @@ defmodule Transport.Shared.GBFSMetadata do
     Map.get(headers, "access-control-allow-origin")
   end
 
-  @doc """
-  Find the value of the `Access-Control-Allow-Origin` header
-
-  iex> Transport.Shared.GBFSMetadata.has_cors?(%HTTPoison.Response{headers: []})
-  false
-
-  iex> Transport.Shared.GBFSMetadata.has_cors?(%HTTPoison.Response{headers: [{"access-control-allow-origin", "*"}]})
-  true
-
-  iex> Transport.Shared.GBFSMetadata.has_cors?(%HTTPoison.Response{headers: [{"Access-Control-Allow-Origin", "*"}]})
-  true
-  """
-  def has_cors?(%HTTPoison.Response{} = response) do
-    not is_nil(cors_header_value(response))
-  end
-
-  @doc """
-  Determines if the CORS header allows transport.data.gouv.fr
-
-  iex> Transport.Shared.GBFSMetadata.cors_headers_allows_self?("http://example.com", %HTTPoison.Response{headers: []})
-  false
-
-  iex> Transport.Shared.GBFSMetadata.cors_headers_allows_self?("http://example.com", %HTTPoison.Response{headers: [{"access-control-allow-origin", "*"}]})
-  true
-
-  iex> Transport.Shared.GBFSMetadata.cors_headers_allows_self?("http://example.com", %HTTPoison.Response{headers: [{"Access-Control-Allow-Origin", "*"}]})
-  true
-
-  iex> Transport.Shared.GBFSMetadata.cors_headers_allows_self?("http://example.com", %HTTPoison.Response{headers: [{"Access-Control-Allow-Origin", "http://example.com"}]})
-  true
-  """
-  def cors_headers_allows_self?(cors_base_url, %HTTPoison.Response{} = response) do
-    Enum.member?([cors_base_url, "*"], cors_header_value(response))
-  end
-
   defp ttl(%{"data" => _data} = payload) do
     feed_name = feed_to_use_for_ttl(types(payload))
 

--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -28,8 +28,7 @@ defmodule Transport.Shared.GBFSMetadata do
 
     %{
       validation: validation(url),
-      has_cors: has_cors?(response),
-      is_cors_allowed: cors_headers_allows_self?(cors_base_url, response),
+      cors_header_value: cors_header_value(response),
       feeds: feeds(json),
       versions: versions(json),
       languages: languages(json),

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -31,8 +31,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
           validator_version: "31c5325",
           validator: :validator_module
         },
-        has_cors: true,
-        is_cors_allowed: true
+        cors_header_value: "*"
       }
 
       assert expected == compute_feed_metadata(@gbfs_url, "http://example.com")
@@ -71,8 +70,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
           "geofencing_zones",
           "gbfs_versions"
         ],
-        has_cors: true,
-        is_cors_allowed: true
+        cors_header_value: "*"
       }
 
       assert expected == compute_feed_metadata(@gbfs_url, "http://example.com")

--- a/apps/transport/lib/transport_web/templates/gbfs_analyzer/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/gbfs_analyzer/index.html.heex
@@ -121,18 +121,18 @@
           <% end %>
 
           <% cors_header_value = Map.get(@metadata, :cors_header_value) %>
-            <tr>
-              <td>
-                <%= dgettext("gbfs_analyzer", "CORS headers") %>
-              </td>
-              <td>
-                <%= if cors_header_value do %>
-                  Access-Control-Allow-Origin: <%= cors_header_value %>
-                <% else %>
-                  <%= dgettext("gbfs_analyzer", "None") %>
-                <% end %>
-              </td>
-            </tr>
+          <tr>
+            <td>
+              <%= dgettext("gbfs_analyzer", "CORS headers") %>
+            </td>
+            <td>
+              <%= if cors_header_value do %>
+                Access-Control-Allow-Origin: <%= cors_header_value %>
+              <% else %>
+                <%= dgettext("gbfs_analyzer", "None") %>
+              <% end %>
+            </td>
+          </tr>
         </table>
 
         <h2><%= dgettext("gbfs_analyzer", "Visualization") %></h2>

--- a/apps/transport/lib/transport_web/templates/gbfs_analyzer/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/gbfs_analyzer/index.html.heex
@@ -120,37 +120,19 @@
             </tr>
           <% end %>
 
-          <% has_cors = Map.get(@metadata, :has_cors) %>
-          <%= unless is_nil(has_cors) do %>
+          <% cors_header_value = Map.get(@metadata, :cors_header_value) %>
             <tr>
               <td>
-                <%= dgettext("gbfs_analyzer", "CORS headers available") %>
+                <%= dgettext("gbfs_analyzer", "CORS headers") %>
               </td>
               <td>
-                <%= if @metadata.has_cors do %>
-                  <%= dgettext("gbfs_analyzer", "Yes") %>
+                <%= if cors_header_value do %>
+                  Access-Control-Allow-Origin: <%= cors_header_value %>
                 <% else %>
-                  <%= dgettext("gbfs_analyzer", "No") %>
+                  <%= dgettext("gbfs_analyzer", "None") %>
                 <% end %>
               </td>
             </tr>
-          <% end %>
-
-          <% is_cors_allowed = Map.get(@metadata, :has_cors) %>
-          <%= unless is_nil(is_cors_allowed) do %>
-            <tr>
-              <td>
-                <%= dgettext("gbfs_analyzer", "CORS allowed") %>
-              </td>
-              <td>
-                <%= if @metadata.is_cors_allowed do %>
-                  <%= dgettext("gbfs_analyzer", "Yes") %>
-                <% else %>
-                  <%= dgettext("gbfs_analyzer", "No") %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
         </table>
 
         <h2><%= dgettext("gbfs_analyzer", "Visualization") %></h2>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gbfs_analyzer.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gbfs_analyzer.po
@@ -12,14 +12,6 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-autogen, elixir-format
-msgid "CORS allowed"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "CORS headers available"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Detailed validation"
 msgstr ""
 
@@ -76,13 +68,13 @@ msgid "Link"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "No"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Yes"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "validation was not performed"
 msgstr "Validation was not performed. There may be a fatal error with your feed or the GBFS validator is not available."
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "CORS headers"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "None"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gbfs_analyzer.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gbfs_analyzer.po
@@ -12,14 +12,6 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-autogen, elixir-format
-msgid "CORS allowed"
-msgstr "CORS autorisé"
-
-#, elixir-autogen, elixir-format
-msgid "CORS headers available"
-msgstr "Headers CORS présents"
-
-#, elixir-autogen, elixir-format
 msgid "Detailed validation"
 msgstr "Rapport de validation"
 
@@ -76,13 +68,13 @@ msgid "Link"
 msgstr "Lien"
 
 #, elixir-autogen, elixir-format
-msgid "No"
-msgstr "Non"
-
-#, elixir-autogen, elixir-format
-msgid "Yes"
-msgstr "Oui"
-
-#, elixir-autogen, elixir-format
 msgid "validation was not performed"
 msgstr "La validation n'a pas effectuée. Il peut y avoir une erreur fatale dans votre flux ou le validateur GBFS est temporairement indisponible."
+
+#, elixir-autogen, elixir-format
+msgid "CORS headers"
+msgstr "Headers CORS"
+
+#, elixir-autogen, elixir-format
+msgid "None"
+msgstr "Aucun"

--- a/apps/transport/priv/gettext/gbfs_analyzer.pot
+++ b/apps/transport/priv/gettext/gbfs_analyzer.pot
@@ -11,14 +11,6 @@ msgid ""
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "CORS allowed"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "CORS headers available"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Detailed validation"
 msgstr ""
 
@@ -75,13 +67,13 @@ msgid "Link"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "No"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Yes"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "validation was not performed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "CORS headers"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "None"
 msgstr ""

--- a/apps/transport/test/transport/jobs/gbfs_multi_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/gbfs_multi_validation_job_test.exs
@@ -60,8 +60,7 @@ defmodule Transport.Test.Transport.Jobs.GBFSMultiValidationDispatcherJobTest do
           validator_version: "31c5325",
           validator: :validator_module
         },
-        has_cors: true,
-        is_cors_allowed: true
+        cors_header_value: "*"
       }
     end)
 
@@ -71,8 +70,7 @@ defmodule Transport.Test.Transport.Jobs.GBFSMultiValidationDispatcherJobTest do
              metadata: %DB.ResourceMetadata{
                metadata: %{
                  "feeds" => ["system_information", "station_information", "station_status"],
-                 "has_cors" => true,
-                 "is_cors_allowed" => true,
+                 "cors_header_value" => "*",
                  "languages" => ["fr"],
                  "system_details" => %{"name" => "velhop", "timezone" => "Europe/Paris"},
                  "ttl" => 3600,

--- a/apps/transport/test/transport/validators/gbfs_validator_test.exs
+++ b/apps/transport/test/transport/validators/gbfs_validator_test.exs
@@ -34,8 +34,7 @@ defmodule Transport.Validators.GBFSValidatorTest do
           validator_version: "31c5325",
           validator: :validator_module
         },
-        has_cors: true,
-        is_cors_allowed: true
+        cors_header_value: "*"
       }
     end)
 
@@ -45,8 +44,7 @@ defmodule Transport.Validators.GBFSValidatorTest do
              metadata: %DB.ResourceMetadata{
                metadata: %{
                  "feeds" => ["system_information", "station_information", "station_status"],
-                 "has_cors" => true,
-                 "is_cors_allowed" => true,
+                 "cors_header_value" => "*",
                  "languages" => ["fr"],
                  "system_details" => %{"name" => "velhop", "timezone" => "Europe/Paris"},
                  "ttl" => 3600,


### PR DESCRIPTION
Le rapport actuel mettait "CORS autorisé" si on a * ou "transport.data.gouv.fr", mais les gens qui utilisent le validateur veulent à priori juste savoir si eux peuvent faire des requetes Cross Origin.

Du coup je propose d'afficher le header brut et des laisser tirer leurs conclusions.

![image](https://user-images.githubusercontent.com/15341118/188487464-9cb25c3c-713e-4689-8f84-b3590bff01f9.png)
