### PR TITLE
Bouton multi-validation depuis le backoffice

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -552,17 +552,16 @@ defmodule DB.Dataset do
   def validate(id) when is_binary(id), do: id |> String.to_integer() |> validate()
 
   def validate(id) when is_integer(id) do
-    Resource
-    |> preload(:validation)
-    |> where([r], r.dataset_id == ^id)
-    |> Repo.all()
-    |> Enum.map(fn r -> Resource.validate_and_save(r, true) end)
-    |> Enum.any?(fn r -> match?({:error, _}, r) end)
-    |> if do
-      {:error, "Unable to validate dataset #{id}"}
-    else
-      {:ok, nil}
-    end
+    dataset = __MODULE__ |> Repo.get!(id) |> Repo.preload(:resources)
+
+    {_real_time_resources, static_resources} = Enum.split_with(dataset.resources, &Resource.is_real_time?/1)
+
+    # Oban.insert_all does not enforce `unique` params
+    # https://hexdocs.pm/oban/Oban.html#insert_all/3
+    # This is something we rely on
+    static_resources |> Enum.map(&Transport.Jobs.ResourceHistoryJob.new(%{"resource_id" => &1.id})) |> Oban.insert_all()
+
+    {:ok, nil}
   end
 
   @doc """

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -1,7 +1,7 @@
 defmodule TransportWeb.Backoffice.PageController do
   use TransportWeb, :controller
 
-  alias DB.{Dataset, LogsImport, LogsValidation, Region, Repo, Resource}
+  alias DB.{Dataset, LogsImport, Region, Repo, Resource}
   import Ecto.Query
   require Logger
 
@@ -165,16 +165,6 @@ defmodule TransportWeb.Backoffice.PageController do
       |> where([v], v.dataset_id == ^dataset_id)
       |> order_by([v], desc: v.timestamp)
       |> Repo.all()
-    )
-    |> assign(
-      :validation_logs,
-      LogsValidation
-      |> preload(:resource)
-      |> join(:left, [v, r], r in Resource, on: r.id == v.resource_id)
-      |> where([_v, r], r.dataset_id == ^dataset_id)
-      |> order_by([v, _r], desc: v.timestamp)
-      |> Repo.all()
-      |> Enum.group_by(fn v -> v.resource end)
     )
     |> render("form_dataset.html")
   end

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -119,84 +119,54 @@
         <%= link(dgettext("backoffice", "Cancel"), to: backoffice_page_path(@conn, :index)) %>
       </div>
     </div>
-    <%= unless is_nil(@dataset) do %>
-      <div class="is-centered mt-48">
-        <%= dgettext("backoffice", "Other actions on the dataset") %>
-      </div>
-      <div class="backoffice_dataset_actions_buttons">
-        <div>
-          <%= form_for @conn, backoffice_dataset_path(@conn, :import_from_data_gouv_fr, @dataset.id, Map.put(@conn.params, "stay_on_page", true)), [nodiv: true], fn _ -> %>
-            <%= submit("Importer", class: "button", nodiv: true) %>
-          <% end %>
-        </div>
-
-        <div>
-          <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView,
-            session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
-          ) %>
-        </div>
-
-        <div>
-          <%= form_for @conn, backoffice_dataset_path(@conn, :delete, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
-            <%= submit("Supprimer", class: "button", nodiv: true) %>
-          <% end %>
-        </div>
-      </div>
-      <%= if Dataset.should_skip_history?(@dataset) do %>
-        <div class="dashboard-description mt-48">
-          <p class="notification">
-            <%= dgettext("backoffice", "This dataset is not historicized on purpose.") %>
-          </p>
-        </div>
-      <% end %>
-      <div class="dataset_import_validations_logs" id="imports_history">
-        <h3><%= dgettext("backoffice", "Imports history") %></h3>
-        <table>
-          <tr>
-            <th><%= dgettext("backoffice", "date / time") %></th>
-            <th><%= dgettext("backoffice", "success") %></th>
-            <th><%= dgettext("backoffice", "error message") %></th>
-          </tr>
-          <%= for row <- @import_logs do %>
-            <tr>
-              <td><%= row.timestamp %></td>
-              <td><%= if row.is_success, do: "✔", else: "" %></td>
-              <td><%= row.error_msg %></td>
-            </tr>
-          <% end %>
-        </table>
-      </div>
-      <div class="dataset_import_validations_logs">
-        <h3><%= dgettext("backoffice", "Validations history") %></h3>
-        <%= for {resource, validations} <- @validation_logs do %>
-          <%= if resource.format == "GTFS" do %>
-            <h2>
-              <a href={resource_path(@conn, :details, resource.id)}><%= resource.title %></a> (#<%= resource.id %>)
-            </h2>
-          <% else %>
-            <h2><%= resource.title %> (#<%= resource.id %>)</h2>
-          <% end %>
-          <table>
-            <tr>
-              <th><%= dgettext("backoffice", "date / time") %></th>
-              <th><%= dgettext("backoffice", "success") %></th>
-              <th><%= dgettext("backoffice", "error message") %></th>
-              <th><%= dgettext("backoffice", "validation needed") %></th>
-              <th><%= dgettext("backoffice", "explanation") %></th>
-            </tr>
-            <%= for row <- validations do %>
-              <tr>
-                <td><%= row.timestamp %></td>
-                <td><%= if row.is_success, do: "✔", else: "" %></td>
-                <td><%= row.error_msg %></td>
-                <td><%= if !row.skipped, do: "✔", else: "" %></td>
-                <td><%= row.skipped_reason %></td>
-              </tr>
-            <% end %>
-          </table>
+  <% end %>
+  <%= unless is_nil(@dataset) do %>
+    <div class="is-centered mt-48">
+      <%= dgettext("backoffice", "Other actions on the dataset") %>
+    </div>
+    <div class="backoffice_dataset_actions_buttons">
+      <div>
+        <%= form_for @conn, backoffice_dataset_path(@conn, :import_from_data_gouv_fr, @dataset.id, Map.put(@conn.params, "stay_on_page", true)), [nodiv: true], fn _ -> %>
+          <%= submit("Importer", class: "button", nodiv: true) %>
         <% end %>
       </div>
+
+      <div>
+        <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView,
+          session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
+        ) %>
+      </div>
+
+      <div>
+        <%= form_for @conn, backoffice_dataset_path(@conn, :delete, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>
+          <%= submit("Supprimer", class: "button", nodiv: true) %>
+        <% end %>
+      </div>
+    </div>
+    <%= if Dataset.should_skip_history?(@dataset) do %>
+      <div class="dashboard-description mt-48">
+        <p class="notification">
+          <%= dgettext("backoffice", "This dataset is not historicized on purpose.") %>
+        </p>
+      </div>
     <% end %>
+    <div class="dataset_import_validations_logs" id="imports_history">
+      <h3><%= dgettext("backoffice", "Imports history") %></h3>
+      <table>
+        <tr>
+          <th><%= dgettext("backoffice", "date / time") %></th>
+          <th><%= dgettext("backoffice", "success") %></th>
+          <th><%= dgettext("backoffice", "error message") %></th>
+        </tr>
+        <%= for row <- @import_logs do %>
+          <tr>
+            <td><%= row.timestamp %></td>
+            <td><%= if row.is_success, do: "✔", else: "" %></td>
+            <td><%= row.error_msg %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
   <% end %>
 </div>
 <script src={static_path(@conn, "/js/app.js")} />

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -138,10 +138,6 @@ msgid "Imports history"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Validations history"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "date / time"
 msgstr ""
 
@@ -150,15 +146,7 @@ msgid "error message"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "explanation"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "success"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "validation needed"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -138,10 +138,6 @@ msgid "Imports history"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Validations history"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "date / time"
 msgstr ""
 
@@ -150,15 +146,7 @@ msgid "error message"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "explanation"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "success"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "validation needed"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -138,10 +138,6 @@ msgid "Imports history"
 msgstr "Historique des imports"
 
 #, elixir-autogen, elixir-format
-msgid "Validations history"
-msgstr "Historique des validations"
-
-#, elixir-autogen, elixir-format
 msgid "date / time"
 msgstr "date / heure"
 
@@ -150,16 +146,8 @@ msgid "error message"
 msgstr "message d'erreur"
 
 #, elixir-autogen, elixir-format
-msgid "explanation"
-msgstr "raison"
-
-#, elixir-autogen, elixir-format
 msgid "success"
 msgstr "succès"
-
-#, elixir-autogen, elixir-format
-msgid "validation needed"
-msgstr "validation nécessaire"
 
 #, elixir-autogen, elixir-format
 msgid "Rapport de complétude des imports"


### PR DESCRIPTION
Retravaille le bouton "Valider" depuis le backoffice pour permettre de lancer des tâches de multi-validation.

- Ajuste `Dataset.valide` pour créer des jobs Oban d'historisation (puis validation)
- Supprime les logs de validation de l'interface