### PR TITLE
Début de script d'exploitation des IRVE (avant consolidation)

### DIFF
--- a/scripts/irve/.gitignore
+++ b/scripts/irve/.gitignore
@@ -1,0 +1,1 @@
+cache-dir

--- a/scripts/irve/irve.exs
+++ b/scripts/irve/irve.exs
@@ -1,0 +1,62 @@
+# the basis of a mass-analysis script for IRVE files,
+# inspired by https://github.com/etalab/notebooks/blob/master/irve-v2/consolidation-irve-v2.ipynb
+
+Mix.install([
+  {:req, "~> 0.3.0"}
+])
+
+Code.require_file("req_custom_cache.exs")
+
+defmodule Streamer do
+  def cache_dir, do: Path.join(__ENV__.file, "../cache-dir") |> Path.expand()
+
+  @doc """
+  Execute HTTP query, unless the file is already in the disk cache.
+  """
+  def get!(url) do
+    url = URI.encode(url)
+    # use the cache plugin
+    req = Req.new() |> CustomCache.attach()
+    %{body: body, status: 200} = Req.get!(req, url: url, custom_cache_dir: cache_dir())
+    body
+  end
+
+  @doc """
+  Query one page, and use that to infer the list of all urls (for index-based pagination like data gouv)
+  """
+  def pages(base_url) do
+    data = get!(base_url <> "&page_size=100")
+    %{"total" => total, "page_size" => page_size} = data
+    nb_pages = div(total, page_size) + 1
+
+    1..nb_pages
+    |> Stream.map(&%{url: base_url <> "&page=#{&1}", source: base_url})
+  end
+end
+
+# NOTE: currently not deduping, because I saw weird things while doing it
+[
+  "https://www.data.gouv.fr/api/1/datasets/?tag=irve",
+  "https://www.data.gouv.fr/api/1/datasets/?schema=etalab/schema-irve",
+  "https://www.data.gouv.fr/api/1/datasets/?q=recharge+véhicules+électriques",
+  "https://www.data.gouv.fr/api/1/datasets/?q=irve"
+]
+|> Enum.map(&Streamer.pages(&1))
+|> Stream.concat()
+|> Stream.map(fn %{url: url} = page -> Map.put(page, :data, Streamer.get!(url)) end)
+|> Stream.flat_map(fn page -> page[:data]["data"] end)
+|> Stream.map(fn dataset ->
+  for resource <- dataset["resources"] do
+    %{
+      dataset_id: Map.fetch!(dataset, "id"),
+      dataset_slug: Map.fetch!(dataset, "slug"),
+      dataset_page: Map.fetch!(dataset, "page"),
+      resource_id: Map.fetch!(resource, "id"),
+      resource_title: Map.fetch!(resource, "title"),
+      resource_last_modified: Map.fetch!(resource, "last_modified")
+    }
+  end
+end)
+|> Stream.concat()
+|> Stream.map(fn x -> IO.inspect(x, IEx.inspect_opts()) end)
+|> Stream.run()

--- a/scripts/irve/irve.exs
+++ b/scripts/irve/irve.exs
@@ -58,5 +58,5 @@ end
   end
 end)
 |> Stream.concat()
-|> Stream.map(fn x -> IO.inspect(x, IEx.inspect_opts()) end)
+|> Stream.each(fn x -> IO.inspect(x, IEx.inspect_opts()) end)
 |> Stream.run()

--- a/scripts/irve/req_custom_cache.exs
+++ b/scripts/irve/req_custom_cache.exs
@@ -1,0 +1,70 @@
+defmodule CustomCache do
+  @moduledoc """
+  A simple HTTP cache for `req` that do not use headers. If the file is not found
+  on disk, the download will occur, otherwise response will be read from disk.
+  """
+  require Logger
+
+  def attach(%Req.Request{} = request, options \\ []) do
+    request
+    |> Req.Request.register_options([:custom_cache_dir])
+    |> Req.Request.merge_options(options)
+    |> Req.Request.append_request_steps(custom_cache: &request_local_cache_step/1)
+    |> Req.Request.prepend_response_steps(custom_cache: &response_local_cache_step/1)
+  end
+
+  def request_local_cache_step(request) do
+    # TODO: handle a form of expiration - for now it is acceptable to wipe out the whole folder manually for me
+    # NOTE: race condition here, for parallel queries
+    if File.exists?(path = cache_path(request)) do
+      Logger.info("File found in cache (#{path})")
+      {request, load_cache(path)}
+    else
+      request
+    end
+  end
+
+  def response_local_cache_step({request, response}) do
+    unless File.exists?(path = cache_path(request)) do
+      if response.status == 200 do
+        Logger.info("Saving file to cache (#{path})")
+        write_cache(path, response)
+      else
+        Logger.info("Status is #{response.status}, not saving file to disk")
+      end
+    end
+
+    {request, response}
+  end
+
+  # https://github.com/wojtekmach/req/blob/102b9aa6c6ff66f00403054a0093c4f06f6abc2f/lib/req/steps.ex#L1268
+  def cache_path(cache_dir, request = %{method: :get}) do
+    cache_key =
+      Enum.join(
+        [
+          request.url.host,
+          Atom.to_string(request.method),
+          :crypto.hash(:sha256, :erlang.term_to_binary(request.url))
+          |> Base.encode16(case: :lower)
+        ],
+        "-"
+      )
+
+    Path.join(cache_dir, cache_key)
+  end
+
+  def cache_path(request) do
+    cache_path(request.options[:custom_cache_dir], request)
+  end
+
+  # https://github.com/wojtekmach/req/blob/102b9aa6c6ff66f00403054a0093c4f06f6abc2f/lib/req/steps.ex#L1288-L1290
+  def load_cache(path) do
+    path |> File.read!() |> :erlang.binary_to_term()
+  end
+
+  # https://github.com/wojtekmach/req/blob/102b9aa6c6ff66f00403054a0093c4f06f6abc2f/lib/req/steps.ex#L1283-L1286
+  def write_cache(path, response) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, :erlang.term_to_binary(response))
+  end
+end


### PR DESCRIPTION
En préparant les ateliers IRVE avec @ChristinaLaumond, il nous vient pas mal de questions concrètes sur les données statiques, et on sent bien qu'on va devoir aller comprendre les fichiers sources et les profiler.

Je prépare le terrain en reprenant le principe général de la consolidation (https://github.com/etalab/notebooks/blob/master/irve-v2/consolidation-irve-v2.ipynb) dans un script Elixir, mais sans implémenter une consolidation complète (puisqu'on a acté le principe d'essayer de rester sur la consolidation Python tant que ça suffit et que les besoins ne divergent pas).

Ca pourra servir de base de consolidation v2 si on veut, mais ce n'est pas l'objectif poursuivi pour l'instant.

J'ai pu faire quelque chose d'assez efficient (installation très simple, cache local, rapide), et ça va me servir pour aller extirper les données avant consolidation et les analyser, sans m'inquiéter de diverger des besoins de la consolidation.

J'ai aussi collé au passage un plugin Req qui sert à mettre en cache disque indépendamment des headers, truc qui me manquait régulièrement sur ce type de travaux d'analyse (où je veux pouvoir faire un replay efficace), pour l'instant vite fait dans un fichier à part.

Pour l'instant rien de bien indispensable, mais ça fait une PR plus petite, et je modifierai en fonction des questions qui viendront.