### PR TITLE
Répare identifiant de div pour commentaire sur dataset

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
@@ -30,7 +30,7 @@
       <a href={"#reply-#{@discussion["id"]}"}>
         <%= dgettext("page-dataset-details", "Respond") %>
       </a>
-      <div id={"reply-#{@discussion["id"]} "} class="discussion-modal">
+      <div id={"reply-#{@discussion["id"]}"} class="discussion-modal">
         <%= form_for @conn, discussion_path(@conn, :post_answer, @dataset.datagouv_id, @discussion["id"]), fn f -> %>
           <%= textarea(f, :comment) %>
           <%= hidden_input(f, :dataset_slug, value: @dataset.slug) %>


### PR DESCRIPTION
Bug introduit dans https://github.com/etalab/transport-site/pull/2616

L'espace à la fin de `id` empêche le lien de se faire entre l'ancre et le div, permettant l'apparition du formulaire de réponse au clic sur le lien.