### PR TITLE
Affiche un message quand on affiche le max de ressources historisées

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -246,56 +246,64 @@
       <% has_validity_period_col = has_validity_period?(@history_resources) %>
       <section class="white pt-48" id="backed-up-resources">
         <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
-        <div class="">
-          <div class="panel">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th><%= dgettext("page-dataset-details", "File") %></th>
-                  <th><%= dgettext("page-dataset-details", "Publication date") %></th>
-                  <%= if has_validity_period_col do %>
-                    <th>
-                      <%= dgettext("page-dataset-details", "Validity period") %>
-                    </th>
-                  <% end %>
-                  <th><%= dgettext("page-dataset-details", "Format") %></th>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for resource_history <- @history_resources do %>
-                  <tr>
-                    <td>
-                      <%= link(resource_history.payload["title"], to: resource_history.payload["permanent_url"]) %>
-                    </td>
-                    <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
-                    <%= if has_validity_period_col do %>
-                      <%= if has_validity_period?(resource_history) do %>
-                        <td>
-                          <%= dgettext(
-                            "page-dataset-details",
-                            "%{start} to %{end}",
-                            start:
-                              DateTimeDisplay.format_date(
-                                resource_history.payload["resource_metadata"]["start_date"],
-                                locale
-                              ),
-                            end:
-                              DateTimeDisplay.format_date(
-                                resource_history.payload["resource_metadata"]["end_date"],
-                                locale
-                              )
-                          ) %>
-                        </td>
-                      <% else %>
-                        <td></td>
-                      <% end %>
-                    <% end %>
-                    <td><span class="label"><%= resource_history.payload["format"] %></span></td>
-                  </tr>
+        <div class="panel">
+          <table class="table">
+            <thead>
+              <tr>
+                <th><%= dgettext("page-dataset-details", "File") %></th>
+                <th><%= dgettext("page-dataset-details", "Publication date") %></th>
+                <%= if has_validity_period_col do %>
+                  <th>
+                    <%= dgettext("page-dataset-details", "Validity period") %>
+                  </th>
                 <% end %>
-              </tbody>
-            </table>
-          </div>
+                <th><%= dgettext("page-dataset-details", "Format") %></th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for resource_history <- @history_resources do %>
+                <tr>
+                  <td>
+                    <%= link(resource_history.payload["title"],
+                      to: resource_history.payload["permanent_url"],
+                      rel: "nofollow"
+                    ) %>
+                  </td>
+                  <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
+                  <%= if has_validity_period_col do %>
+                    <%= if has_validity_period?(resource_history) do %>
+                      <td>
+                        <%= dgettext(
+                          "page-dataset-details",
+                          "%{start} to %{end}",
+                          start:
+                            DateTimeDisplay.format_date(
+                              resource_history.payload["resource_metadata"]["start_date"],
+                              locale
+                            ),
+                          end:
+                            DateTimeDisplay.format_date(
+                              resource_history.payload["resource_metadata"]["end_date"],
+                              locale
+                            )
+                        ) %>
+                      </td>
+                    <% else %>
+                      <td></td>
+                    <% end %>
+                  <% end %>
+                  <td><span class="label"><%= resource_history.payload["format"] %></span></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
+            <p class="small">
+              <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up ressources.",
+                nb: max_nb_history_resources()
+              ) %>
+            </p>
+          <% end %>
         </div>
       </section>
     <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -299,7 +299,7 @@
           </table>
           <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
             <p class="small">
-              <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up ressources.",
+              <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
                 nb: max_nb_history_resources()
               ) %>
             </p>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -543,5 +543,5 @@ msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to 
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Displaying the last %{nb} backed up ressources."
+msgid "Displaying the last %{nb} backed up resources."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -541,3 +541,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to be too old compared to the current time: the delay is %{seconds} seconds. Try to update your feed at most every 30 seconds."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Displaying the last %{nb} backed up ressources."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -541,3 +541,7 @@ msgstr "Lien vers l'API"
 #, elixir-autogen, elixir-format
 msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to be too old compared to the current time: the delay is %{seconds} seconds. Try to update your feed at most every 30 seconds."
 msgstr "Le <a href=\"%{link}\">champ timestamp</a> contient une valeur ancienne par rapport à la date courante : l'écart est de %{seconds} secondes. Essayez de mettre à jour le flux toutes les 30 secondes au plus."
+
+#, elixir-autogen, elixir-format
+msgid "Displaying the last %{nb} backed up ressources."
+msgstr "Affiche les %{nb} dernières ressources historisées."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -543,5 +543,5 @@ msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to 
 msgstr "Le <a href=\"%{link}\">champ timestamp</a> contient une valeur ancienne par rapport à la date courante : l'écart est de %{seconds} secondes. Essayez de mettre à jour le flux toutes les 30 secondes au plus."
 
 #, elixir-autogen, elixir-format
-msgid "Displaying the last %{nb} backed up ressources."
+msgid "Displaying the last %{nb} backed up resources."
 msgstr "Affiche les %{nb} dernières ressources historisées."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -543,5 +543,5 @@ msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to 
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Displaying the last %{nb} backed up ressources."
+msgid "Displaying the last %{nb} backed up resources."
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -541,3 +541,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "The <a href=\"%{link}\" target=\"_blank\">timestamp field</a> appears to be too old compared to the current time: the delay is %{seconds} seconds. Try to update your feed at most every 30 seconds."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Displaying the last %{nb} backed up ressources."
+msgstr ""


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/2588

- Affiche les 25 dernières ressources historisées
- Ajoute un `rel="nofollow"` pour les liens vers Cellar (peut-être que des robots tentent d'indexer ça et consomment notre bande passante ?!?)

![image](https://user-images.githubusercontent.com/295709/190149747-51a7bf9e-9064-4eef-a620-30f720321169.png)
