### PR TITLE
Déplace bannière flux GTFS-RT avec timestamp trop ancien

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.heex
@@ -28,7 +28,6 @@
         <%= "#{entity} (#{format_number(count)})" %>
       </span>
     <% end %>
-
     <%= if @gtfs_rt_feed.feed_is_too_old do %>
       <p class="notification message--error">
         <%= raw(
@@ -41,7 +40,6 @@
         ) %>
       </p>
     <% end %>
-
     <%= unless is_nil(@entities_seen_recently) or Enum.empty?(@entities_seen_recently) do %>
       <p>
         <%= dgettext("page-dataset-details", "Entities seen in the last %{nb} days.", nb: nb_days_entities()) %>

--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_rt.html.heex
@@ -29,6 +29,19 @@
       </span>
     <% end %>
 
+    <%= if @gtfs_rt_feed.feed_is_too_old do %>
+      <p class="notification message--error">
+        <%= raw(
+          dgettext(
+            "page-dataset-details",
+            ~s(The <a href="%{link}" target="_blank">timestamp field</a> appears to be too old compared to the current time: the delay is %{seconds} seconds. Try to update your feed at most every 30 seconds.),
+            link: "https://developers.google.com/transit/gtfs-realtime/reference#message-feedheader",
+            seconds: format_number(@gtfs_rt_feed.feed_timestamp_delay)
+          )
+        ) %>
+      </p>
+    <% end %>
+
     <%= unless is_nil(@entities_seen_recently) or Enum.empty?(@entities_seen_recently) do %>
       <p>
         <%= dgettext("page-dataset-details", "Entities seen in the last %{nb} days.", nb: nb_days_entities()) %>
@@ -102,18 +115,6 @@
           )
         ) %>
       </p>
-      <%= if @gtfs_rt_feed.feed_is_too_old do %>
-        <p class="notification message--error">
-          <%= raw(
-            dgettext(
-              "page-dataset-details",
-              ~s(The <a href="%{link}" target="_blank">timestamp field</a> appears to be too old compared to the current time: the delay is %{seconds} seconds. Try to update your feed at most every 30 seconds.),
-              link: "https://developers.google.com/transit/gtfs-realtime/reference#message-feedheader",
-              seconds: format_number(@gtfs_rt_feed.feed_timestamp_delay)
-            )
-          ) %>
-        </p>
-      <% end %>
       <button class="button" data-clipboard-target="#feed_payload">
         <i class="fa fa-copy"></i>
         <%= dgettext("page-dataset-details", "Copy to clipboard") %>


### PR DESCRIPTION
Retravaille ce qui avait été fait dans https://github.com/etalab/transport-site/pull/2610

![image](https://user-images.githubusercontent.com/295709/190369585-1e3d5cb0-e536-4a25-86c1-6706c9980855.png)

La bannière n'est pas suffisamment visible, voir par exemple pour [Bourges](https://transport.data.gouv.fr/resources/79180) actuellement : la bannière n'est affichée que si on clique sur le flux GTFS-RT décodé.