### PR TITLE
Route jobs de validation vers queue appropriée

### DIFF
--- a/apps/transport/lib/jobs/gbfs_multi_validation_job.ex
+++ b/apps/transport/lib/jobs/gbfs_multi_validation_job.ex
@@ -2,7 +2,7 @@ defmodule Transport.Jobs.GBFSMultiValidationDispatcherJob do
   @moduledoc """
   Job in charge of validating multiple GBFS resources.
   """
-  use Oban.Worker, max_attempts: 3, tags: ["validation"]
+  use Oban.Worker, max_attempts: 3, queue: :resource_validation, tags: ["validation"]
   alias Transport.Jobs.GBFSMultiValidationJob
   import Ecto.Query
 
@@ -27,7 +27,7 @@ defmodule Transport.Jobs.GBFSMultiValidationJob do
   @moduledoc """
   Job in charge of validating a GBFS resource.
   """
-  use Oban.Worker, max_attempts: 3, tags: ["validation"]
+  use Oban.Worker, max_attempts: 3, queue: :resource_validation, tags: ["validation"]
   alias Transport.Validators.GBFSValidator
 
   @impl Oban.Worker

--- a/apps/transport/lib/jobs/gtfs_rt_multi_validation_job.ex
+++ b/apps/transport/lib/jobs/gtfs_rt_multi_validation_job.ex
@@ -2,7 +2,7 @@ defmodule Transport.Jobs.GTFSRTMultiValidationDispatcherJob do
   @moduledoc """
   Job in charge of dispatching multiple `GTFSRTMultiValidationJob`.
   """
-  use Oban.Worker, max_attempts: 3, tags: ["validation"]
+  use Oban.Worker, max_attempts: 3, queue: :resource_validation, tags: ["validation"]
   import Ecto.Query
   alias DB.{Repo, Resource}
   alias Transport.Validators.GTFSTransport
@@ -45,7 +45,7 @@ defmodule Transport.Jobs.GTFSRTMultiValidationJob do
   Job validating gtfs-rt resources and saving validation
   results.
   """
-  use Oban.Worker, max_attempts: 5, tags: ["validation"]
+  use Oban.Worker, max_attempts: 5, queue: :resource_validation, tags: ["validation"]
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) do


### PR DESCRIPTION
Quelques jobs de validations sont dans la queue `default` au lieu de celle dédiée. Voilà un peu de ménage.