### PR TITLE
Correction CSP headers en prod

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
 
     csp_content =
       case app_env do
-        :prod ->
+        :production ->
           """
           default-src 'none';
           connect-src 'self' https://static.data.gouv.fr/ https://raw.githubusercontent.com/etalab/ #{s3_domains} https://*.ingest.sentry.io;


### PR DESCRIPTION
La variable d'environnement vaut `:production` et non pas `:prod`, merci @AntoineAugusti 