### PR TITLE
Enlever le css inline résiduel

### DIFF
--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -64,7 +64,7 @@ function GeojsonMap (fillMapFunction, mapDivId, infoDivId, geojsonUrl, filesize,
         mapDiv.outerHTML = `<div id="${mapDivId}"></div>`
     } else {
         infoDiv.outerHTML = ''
-        mapDiv.outerHTML = `<div id="${mapDivId}" style="height: 600px; max-height: 80vh;"></div>`
+        mapDiv.outerHTML = `<div id="${mapDivId}" class="geojson-map"></div>`
         fillMapFunction(mapDivId, geojsonUrl)
     }
 }

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -551,11 +551,11 @@ function addRealTimePtFormatMap (id, view) {
             return null
         }
 
-        let bind = `<div style="padding-bottom: 6px;"><strong>${name}</strong><br/>${type}</div>`
+        let bind = `<div class="pb-6"><strong>${name}</strong><br/>${type}</div>`
         if (countOfficial) {
             const text = countOfficial === 1 ? 'Une ressource standardisée' : `${countOfficial} ressources standardisées`
             const commune = feature.properties.id
-            bind += `<div style="padding-bottom: 6px;"><a href="/datasets/aom/${commune}">${text}</a>`
+            bind += `<div class="pb-6"><a href="/datasets/aom/${commune}">${text}</a>`
             bind += '<br/>formats :'
             const formats = []
             if (gtfsRT) {

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -45,7 +45,7 @@ const getLegend = (title, colorClasses, labels) => {
         div.innerHTML += title
         // loop through our density intervals and generate a label with a colored square for each interval
         for (let i = 0; i < colorClasses.length; i++) {
-            div.innerHTML += `<i class="map-legend-${colorClasses[i]}"></i>${labels[i]}<br/>`
+            div.innerHTML += `<i class="map-bg-${colorClasses[i]}"></i>${labels[i]}<br/>`
         }
         return div
     }

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -38,14 +38,14 @@ const makeMapOnView = (id, view) => {
 }
 
 // helper function to add legends
-const getLegend = (title, colors, labels) => {
+const getLegend = (title, colorClasses, labels) => {
     const legend = Leaflet.control({ position: 'bottomright' })
     legend.onAdd = (_map) => {
         const div = Leaflet.DomUtil.create('div', 'info legend')
         div.innerHTML += title
         // loop through our density intervals and generate a label with a colored square for each interval
-        for (let i = 0; i < colors.length; i++) {
-            div.innerHTML += `<i style="background:${colors[i]}"></i>${labels[i]}<br/>`
+        for (let i = 0; i < colorClasses.length; i++) {
+            div.innerHTML += `<i class="map-legend-${colorClasses[i]}"></i>${labels[i]}<br/>`
         }
         return div
     }
@@ -191,7 +191,7 @@ function addStaticPTMapRegions (id, view) {
     if (view.display_legend) {
         getLegend(
             '<h4>Disponibilité des horaires théoriques</h4>',
-            ['green', lightGreen, 'grey'],
+            ['green', 'light-green', 'grey'],
             ['Données publiées et région partenaire', 'Données publiées', 'Aucune donnée publiée']
         ).addTo(map)
     }
@@ -278,7 +278,7 @@ function addStaticPTMapAOMS (id, view) {
     if (view.display_legend) {
         getLegend(
             '<h4>Disponibilité des horaires théoriques :</h4>',
-            ['green', lightGreen, `repeating-linear-gradient(-45deg,green,green 3px,${lightGreen} 3px,${lightGreen} 6px)`, 'grey'],
+            ['green', 'light-green', 'stripes-green-light-green', 'grey'],
             ['Pour l\'AOM spécifiquement', 'Dans un jeu de données agrégé', 'Pour l\'AOM <strong>et</strong> dans un jeu de données agrégé', 'Aucune donnée disponible']
         ).addTo(map)
     }
@@ -429,7 +429,7 @@ function addStaticPTQuality (id, view) {
     if (view.display_legend) {
         getLegend(
             '<h4>Qualité des données courantes</h4>',
-            ['red', 'orange', lightGreen, 'green', 'grey'],
+            ['red', 'orange', 'light-green', 'green', 'grey'],
             ['Non conforme', 'Erreur', 'Satisfaisante', 'Bonne', 'Pas de données à jour']
         ).addTo(map)
     }
@@ -519,7 +519,7 @@ function addRealTimePTMap (id, view) {
     if (view.display_legend) {
         const legend = getLegend(
             '<h4>Disponibilité des horaires temps réel</h4>',
-            ['green', lightGreen, 'red'],
+            ['green', 'light-green', 'red'],
             [
                 'Données intégralement ouvertes sur transport.data.gouv.fr',
                 'Données partiellement ouvertes sur transport.data.gouv.fr',
@@ -582,8 +582,8 @@ function addRealTimePtFormatMap (id, view) {
     bigStripes.addTo(map)
     const legends = {
         gtfs_rt: { label: 'GTFS RT', color: 'blue' },
-        siri: { label: 'SIRI', color: lightGreen },
-        gtfs_rt_siri: { label: 'GTFS RT + SIRI', color: `repeating-linear-gradient(-45deg,blue,blue 3px,${lightGreen} 3px,${lightGreen} 6px)` },
+        siri: { label: 'SIRI', color: 'light-green' },
+        gtfs_rt_siri: { label: 'GTFS RT + SIRI', color: 'stripes-green-light-green' },
         siri_lite: { label: 'SIRI Lite', color: 'green' },
         non_standard_rt: { label: 'Non standard', color: 'red' },
         multiple: { label: 'Multiple', color: 'orange' }

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -129,21 +129,21 @@ function setGBFSFreeFloatingStyle (feature, layer) {
         layer
             .unbindTooltip()
             .setStyle({ fillColor: color })
-        popupContent = JSON.stringify(properties, null, 2).replace('"is_disabled": true', `<strong style="color: ${color};">"is_disabled": true</strong>`)
+        popupContent = JSON.stringify(properties, null, 2).replace('"is_disabled": true', `<strong class="map-color-${color}">"is_disabled": true</strong>`)
     } else if (properties.is_reserved) {
         const color = 'orange'
         layer
             .unbindTooltip()
             .setStyle({ fillColor: color })
-        popupContent = JSON.stringify(properties, null, 2).replace('"is_reserved": true', `<strong style="color: ${color};">"is_reserved": true</strong>`)
+        popupContent = JSON.stringify(properties, null, 2).replace('"is_reserved": true', `<strong class="map-color-${color}">"is_reserved": true</strong>`)
     } else {
         const color = 'blue'
         layer
             .unbindTooltip()
             .setStyle({ fillColor: 'blue' })
         popupContent = JSON.stringify(properties, null, 2)
-            .replace('"is_reserved": false', `<strong style="color: ${color};">"is_reserved": false</strong>`)
-            .replace('"is_disabled": false', `<strong style="color: ${color};">"is_disabled": false</strong>`)
+            .replace('"is_reserved": false', `<strong class="map-color-${color}">"is_reserved": false</strong>`)
+            .replace('"is_disabled": false', `<strong class="map-color-${color}">"is_disabled": false</strong>`)
     }
     layer.bindPopup(`<pre>${popupContent}</pre>`)
 }
@@ -157,17 +157,17 @@ function setGBFSGeofencingStyle (feature, layer) {
         if (rule.ride_through_allowed === false) {
             color = 'red'
             opacity = 0.6
-            popupContent = JSON.stringify(feature.properties, null, 2).replace('"ride_through_allowed": false', `<strong style="color: ${color};">"ride_through_allowed": false</strong>`)
+            popupContent = JSON.stringify(feature.properties, null, 2).replace('"ride_through_allowed": false', `<strong class="map-color-${color}">"ride_through_allowed": false</strong>`)
         } else if (rule.ride_allowed === false) {
             color = 'orange'
             opacity = 0.6
-            popupContent = JSON.stringify(feature.properties, null, 2).replace('"ride_allowed": false', `<strong style="color: ${color};">"ride_allowed": false</strong>`)
+            popupContent = JSON.stringify(feature.properties, null, 2).replace('"ride_allowed": false', `<strong class="map-color-${color}">"ride_allowed": false</strong>`)
         } else {
             color = 'green'
             opacity = 0.4
             popupContent = JSON.stringify(feature.properties, null, 2)
-                .replace('"ride_through_allowed": true', `<strong style="color: ${color};">"ride_through_allowed": true</strong>`)
-                .replace('"ride_allowed": true', `<strong style="color: ${color};">"ride_allowed": true</strong>`)
+                .replace('"ride_through_allowed": true', `<strong class="map-color-${color}">"ride_through_allowed": true</strong>`)
+                .replace('"ride_allowed": true', `<strong class="map-color-${color}">"ride_allowed": true</strong>`)
         }
     }
     layer

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -450,6 +450,10 @@
   padding-bottom: 24px;
 }
 
+.pb-6 {
+  padding-bottom: 6px;
+}
+
 .pt-48 {
   padding-top: 48px;
 }

--- a/apps/transport/client/stylesheets/components/_map-js.scss
+++ b/apps/transport/client/stylesheets/components/_map-js.scss
@@ -5,19 +5,23 @@
 
 $light-green: #bce954;
 
-.map-legend-green {
+.map-bg-green {
   background-color: green;
 }
 
-.map-legend-light-green {
+.map-color-green {
+  color: green;
+}
+
+.map-bg-light-green {
   background-color: $light-green;
 }
 
-.map-legend-grey {
+.map-bg-grey {
   background-color: grey;
 }
 
-.map-legend-stripes-green-light-green {
+.map-bg-stripes-green-light-green {
   background-image: repeating-linear-gradient(
     -45deg,
     green,
@@ -27,19 +31,31 @@ $light-green: #bce954;
   );
 }
 
-.map-legend-orange {
+.map-bg-orange {
   background-color: orange;
 }
 
-.map-legend-red {
+.map-color-orange {
+  color: orange;
+}
+
+.map-bg-red {
   background-color: red;
 }
 
-.map-legend-blue {
+.map-color-red {
+  color: red;
+}
+
+.map-bg-blue {
   background-color: blue;
 }
 
-.map-legend-stripes-blue-light-green {
+.map-color-blue {
+  color: blue;
+}
+
+.map-bg-stripes-blue-light-green {
   background-image: repeating-linear-gradient(
     -45deg,
     blue,

--- a/apps/transport/client/stylesheets/components/_map-js.scss
+++ b/apps/transport/client/stylesheets/components/_map-js.scss
@@ -3,7 +3,7 @@
   max-height: 80vh;
 }
 
-$light-green: #bce954;
+$light-green: #bce954 !default;
 
 .map-bg-green {
   background-color: green;

--- a/apps/transport/client/stylesheets/components/_map-js.scss
+++ b/apps/transport/client/stylesheets/components/_map-js.scss
@@ -2,3 +2,49 @@
   height: 600px;
   max-height: 80vh;
 }
+
+$light-green: #bce954;
+
+.map-legend-green {
+  background-color: green;
+}
+
+.map-legend-light-green {
+  background-color: $light-green;
+}
+
+.map-legend-grey {
+  background-color: grey;
+}
+
+.map-legend-stripes-green-light-green {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    green,
+    green 3px,
+    $light-green 3px,
+    $light-green 6px
+  );
+}
+
+.map-legend-orange {
+  background-color: orange;
+}
+
+.map-legend-red {
+  background-color: red;
+}
+
+.map-legend-blue {
+  background-color: blue;
+}
+
+.map-legend-stripes-blue-light-green {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    blue,
+    blue 3px,
+    $light-green 3px,
+    $light-green 6px
+  );
+}

--- a/apps/transport/client/stylesheets/components/_map-js.scss
+++ b/apps/transport/client/stylesheets/components/_map-js.scss
@@ -1,0 +1,4 @@
+.geojson-map {
+  height: 600px;
+  max-height: 80vh;
+}

--- a/apps/transport/test/no_css_inline_style_test.exs
+++ b/apps/transport/test/no_css_inline_style_test.exs
@@ -5,9 +5,11 @@ defmodule NoCSSInlineStyleTest do
   use ExUnit.Case, async: true
 
   test "Do not use inline CSS styles, except for emails" do
+    heex_files = "../../apps/**/*.heex" |> Path.wildcard()
+    js_files = "../../apps/transport/client/javascripts/*.js" |> Path.wildcard()
+
     files =
-      "../../apps/**/*.heex"
-      |> Path.wildcard()
+      heex_files ++ js_files
       |> Enum.reject(&ignore_filepath?/1)
       |> Enum.filter(&potential_css_inline?/1)
       |> Enum.map(&Path.relative_to(&1, "../.."))

--- a/apps/transport/test/no_css_inline_style_test.exs
+++ b/apps/transport/test/no_css_inline_style_test.exs
@@ -9,7 +9,7 @@ defmodule NoCSSInlineStyleTest do
     js_files = "../../apps/transport/client/javascripts/*.js" |> Path.wildcard()
 
     files =
-      heex_files ++ js_files
+      (heex_files ++ js_files)
       |> Enum.reject(&ignore_filepath?/1)
       |> Enum.filter(&potential_css_inline?/1)
       |> Enum.map(&Path.relative_to(&1, "../.."))


### PR DESCRIPTION
Il en restait dans les fichiers js, pour les légendes de la carte stats et dans le style des popups (carte stats et cartes des GBFS).
J'ai mis à jour le test correspondant (et j'ai changé son nom, car il faut que le nom du fichier se termine par `_test` pour être reconnu comme tel).
