### PR TITLE
CSP : autorise tout pour font-src et connect-src

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -23,15 +23,13 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
   true
   """
   def csp_headers(app_env) do
-    s3_domains = Transport.S3.all_permanent_urls_domains() |> Enum.join(" ")
-
     csp_content =
       case app_env do
         :production ->
           """
           default-src 'none';
-          connect-src 'self' https://static.data.gouv.fr/ https://raw.githubusercontent.com/etalab/ #{s3_domains} https://*.ingest.sentry.io;
-          font-src 'self';
+          connect-src *;
+          font-src *;
           img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr;
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
           style-src 'self';
@@ -42,8 +40,8 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           # prochainement is currently making calls to both data.gouv.fr and demo.data.gouv.fr, which is probably not expected
           """
             default-src 'none';
-            connect-src 'self' https://static.data.gouv.fr/ https://demo-static.data.gouv.fr/ https://raw.githubusercontent.com/etalab/ #{s3_domains} https://*.ingest.sentry.io;
-            font-src 'self';
+            connect-src *;
+            font-src *;
             img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr;
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
             style-src 'self';


### PR DESCRIPTION
Sentry rapport des erreurs de navigateurs qui essaient de télécharger des fonts depuis diverses origines, pour le moment j'autorise tout.

On ne peut pas vraiment restreindre `connect-src`, parce que le site essaie d'affficher une carte dès qu'il voit une ressource geojson, et que ces geojsons peuvent être hébergés sur n'importe quel site d'open data.