### PR TITLE
Validation à la demande : submit avec phx-trigger-action

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
@@ -18,6 +18,7 @@ defmodule TransportWeb.Live.OnDemandValidationSelectLive do
     {:ok,
      socket
      |> socket_data(%{
+       trigger_submit: false,
        select_options: select_options(),
        changeset: cast(%{})
      })}
@@ -50,8 +51,8 @@ defmodule TransportWeb.Live.OnDemandValidationSelectLive do
   def determine_input_type(type) when type in ["gtfs-rt"], do: "gtfs-rt"
   def determine_input_type(_), do: "file"
 
-  def handle_event("form_changed", %{"upload" => params}, socket) do
-    socket = socket |> socket_data(%{changeset: cast(params)})
+  def handle_event("form_changed", %{"upload" => params, "_target" => target}, socket) do
+    socket = socket |> socket_data(%{changeset: cast(params), trigger_submit: "file" in target})
     {:noreply, socket |> push_patch(to: self_path(socket))}
   end
 

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -10,6 +10,7 @@
         multipart={true}
         as={:upload}
         phx-change="form_changed"
+        phx-trigger-action={@trigger_submit}
       >
         <%= select(f, :type, @select_options, label: dgettext("validations", "Data type"), required: true) %>
         <%= if @input_type == "file" do %>

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -29,17 +29,17 @@ defmodule TransportWeb.ValidationControllerTest do
       assert view |> has_element?("input[name='upload[file]']")
       refute view |> has_element?("input[name='upload[url]']")
 
-      render_change(view, "form_changed", %{"upload" => %{"type" => "gbfs"}})
+      render_change(view, "form_changed", %{"upload" => %{"type" => "gbfs"}, "_target" => ["upload", "type"]})
       assert_patched(view, live_path(conn, OnDemandValidationSelectLive, type: "gbfs"))
       assert view |> has_element?("input[name='upload[url]']")
       refute view |> has_element?("input[name='upload[file]']")
 
-      render_change(view, "form_changed", %{"upload" => %{"type" => "gtfs"}})
+      render_change(view, "form_changed", %{"upload" => %{"type" => "gtfs"}, "_target" => ["upload", "type"]})
       assert_patched(view, live_path(conn, OnDemandValidationSelectLive, type: "gtfs"))
       refute view |> has_element?("input[name='upload[url]']")
       assert view |> has_element?("input[name='upload[file]']")
 
-      render_change(view, "form_changed", %{"upload" => %{"type" => "gtfs-rt"}})
+      render_change(view, "form_changed", %{"upload" => %{"type" => "gtfs-rt"}, "_target" => ["upload", "type"]})
       assert view |> has_element?("input[name='upload[url]']")
       assert view |> has_element?("input[name='upload[feed_url]']")
     end


### PR DESCRIPTION
Fixes #2678 

Utilise [`phx-trigger-action`](https://hexdocs.pm/phoenix_live_view/form-bindings.html#submitting-the-form-action-over-http) pour envoyer le formulaire.

Envoie le formulaire dès lors qu'on sélectionne un fichier (le champ qui a changé est disponible dans [`_target`](https://hexdocs.pm/phoenix_live_view/form-bindings.html#javascript-client-specifics))

J'ai tenté de suivre l'exemple donné dans la documentation, avec un event `phx-submit` qui ensuite trigger `phx-trigger-action` sans succès, dommage.