### PR TITLE
Recherche de datasets : utilisation de la multivalidation

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -124,7 +124,7 @@ defmodule DB.Dataset do
   @spec preload_without_validations() :: Ecto.Query.t()
   defp preload_without_validations do
     s = no_validations_query()
-    preload(__MODULE__, resources: ^s)
+    base_query() |> preload(resources: ^s)
   end
 
   @spec filter_by_fulltext(Ecto.Query.t(), map()) :: Ecto.Query.t()
@@ -175,10 +175,12 @@ defmodule DB.Dataset do
   @spec filter_by_mode(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_mode(query, %{"modes" => mode}) do
     query
-    |> where(
-      [d],
-      fragment("(? IN (SELECT DISTINCT(dataset_id) FROM resource r where r.modes @> ?::varchar[]))", d.id, ^mode)
+    |> DB.ResourceHistory.join_dataset_with_latest_resource_history()
+    |> DB.MultiValidation.join_resource_history_with_latest_validation(
+      Transport.Validators.GTFSTransport.validator_name()
     )
+    |> DB.ResourceMetadata.join_validation_with_metadata()
+    |> where([metadata: rm], fragment("? @> ?::varchar[]", rm.modes, ^mode))
   end
 
   defp filter_by_mode(query, _), do: query

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -398,7 +398,9 @@ defmodule DB.Resource do
     Sentry.capture_message("validation_save_failed", extra: url)
   end
 
-  # for the moment the tag detection is very simple, we only add the modes
+  # Deprecation notice, all the tags and modes related functions now live in gtfs_transport_validator.ex
+  # Function here will be deleted when validation v1 will be unpluged
+  # ⬇️⬇️⬇️
   @spec find_tags(__MODULE__.t(), map()) :: [binary()]
   def find_tags(%__MODULE__{} = r, metadata) do
     r
@@ -499,6 +501,9 @@ defmodule DB.Resource do
     do: ["position des stations", "horaires théoriques", "topologie du réseau"]
 
   def base_tag(_), do: []
+
+  # ⬆️⬆️⬆️
+  # end of deprecation notice
 
   def changeset(resource, params) do
     resource

--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -35,6 +35,12 @@ defmodule DB.ResourceHistory do
     |> join(:inner_lateral, [resource_history: rh], latest in subquery(last_resource_history), on: latest.id == rh.id)
   end
 
+  def join_dataset_with_latest_resource_history(query) do
+    query
+    |> join(:inner, [dataset: d], r in DB.Resource, on: r.dataset_id == d.id, as: :resource)
+    |> join_resource_with_latest_resource_history()
+  end
+
   defp latest_resource_history_query(resource_id) do
     DB.ResourceHistory
     |> where([rh], rh.resource_id == ^resource_id)

--- a/apps/transport/lib/db/resource_metadata.ex
+++ b/apps/transport/lib/db/resource_metadata.ex
@@ -12,6 +12,8 @@ defmodule DB.ResourceMetadata do
     belongs_to(:resource_history, DB.ResourceHistory)
     belongs_to(:multi_validation, DB.MultiValidation)
     field(:metadata, :map)
+    field(:modes, {:array, :string}, default: [])
+    field(:features, {:array, :string}, default: [])
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -165,8 +165,8 @@ defmodule TransportWeb.DatasetController do
       params
       |> clean_datasets_query("region")
       |> exclude(:order_by)
-      |> join(:left, [d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id)
-      |> select([d, d_geo], %{id: d.id, region_id: d_geo.region_id})
+      |> join(:left, [dataset: d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id, as: :geo_view)
+      |> select([dataset: d, geo_view: d_geo], %{id: d.id, region_id: d_geo.region_id})
 
     Region
     |> join(:left, [r], d in subquery(sub), on: d.region_id == r.id)

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -249,10 +249,9 @@ defmodule Transport.Validators.GTFSTransport do
   def is_gtfs_outdated(_), do: nil
 
   # all those functions come from resource.ex, but now live here as they are related to this validator
-  @spec find_tags(__MODULE__.t(), map()) :: [binary()]
-  def find_tags(%__MODULE__{} = r, metadata) do
-    r
-    |> base_tag()
+  @spec find_tags(map()) :: [binary()]
+  def find_tags(metadata) do
+    gtfs_base_tags()
     |> Enum.concat(find_tags_from_metadata(metadata))
     |> Enum.uniq()
   end
@@ -341,12 +340,7 @@ defmodule Transport.Validators.GTFSTransport do
 
   def has_wheelchair_accessibility(_), do: []
 
-  @spec base_tag(__MODULE__.t()) :: [binary()]
-  def base_tag(%__MODULE__{format: "GTFS"}),
+  @spec gtfs_base_tags() :: [binary()]
+  def gtfs_base_tags(),
     do: ["position des stations", "horaires théoriques", "topologie du réseau"]
-
-  def base_tag(%__MODULE__{format: "NeTEx"}),
-    do: ["position des stations", "horaires théoriques", "topologie du réseau"]
-
-  def base_tag(_), do: []
 end

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -25,7 +25,9 @@ defmodule Transport.Validators.GTFSTransport do
          data_vis <- Transport.DataVisualization.validation_data_vis(validations) do
       resource_metadata = %DB.ResourceMetadata{
         resource_history_id: resource_history_id,
-        metadata: metadata
+        metadata: metadata,
+        modes: find_modes(metadata),
+        features: find_tags(metadata)
       }
 
       %DB.MultiValidation{

--- a/apps/transport/priv/repo/migrations/20220930122054_add_metadata_modes_features.exs
+++ b/apps/transport/priv/repo/migrations/20220930122054_add_metadata_modes_features.exs
@@ -1,0 +1,10 @@
+defmodule DB.Repo.Migrations.AddMetadataModesFeatures do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_metadata) do
+      add(:features, {:array, :string}, default: [])
+      add(:modes, {:array, :string}, default: [])
+    end
+  end
+end


### PR DESCRIPTION
Comme remonté par @ChristinaLaumond , il y a un décalage entre les tags qu'on peut voir au niveau d'une page resource (modes de transport, features) et les résultats donnés par le moteur de recherche.

Ceci est dû à l'état de transition de notre validation. La page resource va lire les infos dans la multi_validation tandis que le moteur de recherche est branche sur la validation v1 qui remplit des infos directement au niveau de la ressource.

Après réflexion, et bien que ce soit moins de travail, il nous a paru dangeureux de continuer à aller écrire dans la ressource directement. C'est en effet le dernier qui remplit le champ qui a le dernier mot, et il suffirait qu'on aille valider une resource_history ancienne pour se retrouver avec des infos contradictoires.

J'essaye ici de modifier la query de requetage, en utilisant les fonctions composables existantes, et ça a l'air de marcher...

Reste à faire :

- [ ] créer des champs modes et features au niveau des resource_metadata
- [ ] remplir ces champs lors de la multi validation GTFS
- [ ] modifier la requêtes des modes
- [ ] modifier aussi la requêtes des features
- [ ] tester que ça marche bien, parce que je suis pas 100% sûr de moi. Ca fait **beaucoup** de joins.
- [ ] vérifier ce que ça donne en perfs, et voir s'il faut rajouter un index quelque part.