### PR TITLE
Liste datasets : bases nationales en premier

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -288,7 +288,10 @@ defmodule DB.Dataset do
         asc: :custom_title
       )
 
-  def order_datasets(datasets, _params), do: datasets
+  def order_datasets(datasets, _params) do
+    pan_publisher = Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+    order_by(datasets, desc: fragment("case when organization = ? and custom_title ilike 'base nationale%' then 1 else 0 end", ^pan_publisher))
+  end
 
   @spec changeset(map()) :: {:error, binary()} | {:ok, Ecto.Changeset.t()}
   def changeset(%{"datagouv_id" => datagouv_id} = params) when is_binary(datagouv_id) do

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -2,6 +2,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   use TransportWeb.ConnCase, async: false
   use TransportWeb.ExternalCase
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
+  import DB.Factory
   alias DB.{AOM, Dataset, Repo, Resource, Validation}
 
   doctest TransportWeb.DatasetController
@@ -104,5 +105,23 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     # searching for an unknown AOM should lead to a 404
     conn = conn |> get(dataset_path(conn, :by_aom, 999_999))
     assert html_response(conn, 404)
+  end
+
+  test "a dataset labelled as base nationale published by us is first without filters" do
+    %{id: base_nationale_dataset_id} =
+      insert(:dataset,
+        type: "public-transit",
+        custom_title: "Base nationale des GTFS",
+        organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+      )
+
+    results = %{"type" => "public-transit"} |> Dataset.list_datasets() |> Repo.all()
+    assert Enum.count(results) == 3
+    assert %Dataset{id: ^base_nationale_dataset_id} = hd(results)
+
+    %{id: first_dataset_id} =
+      %{"type" => "public-transit", "q" => "angers"} |> Dataset.list_datasets() |> Repo.all() |> hd()
+
+    assert first_dataset_id != base_nationale_dataset_id
   end
 end


### PR DESCRIPTION
Si une base nationale est publiée par le PAN, faire en sorte qu'elle sorte en tant que 1er résultat, dès lors qu'on a pas d'autres filtres influençant le tri (comme plus récent, ordre alphabétique ou recherche par mots clés).

Le premier cas d'usage est pour les ZFE, voir https://transport.data.gouv.fr/datasets?type=low-emission-zones