### PR TITLE
Données possibles à modéliser en GTFS : lien vers doc

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
@@ -46,7 +46,15 @@
           <span class="label mode"><%= tag %></span>
         <% end %>
 
-        <li><%= dgettext("page-dataset-details", "Missing features that can be specified in GTFS:") %></li>
+        <li>
+          <%= dgettext(
+            "page-dataset-details",
+            "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:",
+            doc_link:
+              "https://doc.transport.data.gouv.fr/producteurs/operateurs-de-transport-regulier-de-personnes/mise-en-qualite-des-donnees-gtfs"
+          )
+          |> raw() %>
+        </li>
         <%= for tag <- DB.Resource.existing_gtfs_tags() -- found_tags do %>
           <span class="label"><%= tag %></span>
         <% end %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -323,10 +323,6 @@ msgid "Features available in the resource:"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Missing features that can be specified in GTFS:"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "unavailable resources"
 msgstr ""
 
@@ -544,4 +540,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Displaying the last %{nb} backed up resources."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -323,10 +323,6 @@ msgid "Features available in the resource:"
 msgstr "Données présentes dans la ressource :"
 
 #, elixir-autogen, elixir-format
-msgid "Missing features that can be specified in GTFS:"
-msgstr "Données absentes mais possibles à modéliser en GTFS :"
-
-#, elixir-autogen, elixir-format
 msgid "unavailable resources"
 msgstr "Ressources non disponibles"
 
@@ -545,3 +541,7 @@ msgstr "Le <a href=\"%{link}\">champ timestamp</a> contient une valeur ancienne 
 #, elixir-autogen, elixir-format
 msgid "Displaying the last %{nb} backed up resources."
 msgstr "Affiche les %{nb} dernières ressources historisées."
+
+#, elixir-autogen, elixir-format
+msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
+msgstr "Données absentes mais <a href=\"%{doc_link}\" target=\"_blank\">possibles à modéliser en GTFS</a> :"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -323,10 +323,6 @@ msgid "Features available in the resource:"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Missing features that can be specified in GTFS:"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "unavailable resources"
 msgstr ""
 
@@ -544,4 +540,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Displaying the last %{nb} backed up resources."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
 msgstr ""


### PR DESCRIPTION
En lien avec #2581 

Ajout d'un lien vers [notre doc](https://doc.transport.data.gouv.fr/producteurs/operateurs-de-transport-regulier-de-personnes/mise-en-qualite-des-donnees-gtfs) pour les données possibles à modéliser en GTFS.

![image](https://user-images.githubusercontent.com/295709/193605915-f81e0597-7ac8-4d73-8bd4-e56bb150dd35.png)
