### PR TITLE
Ajout de target: _blank

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
@@ -51,7 +51,8 @@
 
     <h2 :if={assigns[:diff_file_url]}>
       <%= dgettext("validations", "Diff is complete") %>, <%= link(dgettext("validations", "download it"),
-        to: @diff_file_url
+        to: @diff_file_url,
+        target: "_blank"
       ) %>.
     </h2>
 


### PR DESCRIPTION
Les subtilités de liveview, quand un utilisateur clique sur "download", ça se fait dans la même page et du coup ça réinitialise toute la liveview. En ajout target="_blank" ça évite le problème.