### PR TITLE
Import communes : enable trigger ne doit pas désactiver un trigger

### DIFF
--- a/apps/transport/lib/mix/tasks/transport/import_communes.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_communes.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
   defp disable_trigger, do: Repo.query!("ALTER TABLE commune DISABLE TRIGGER refresh_places_commune_trigger;")
 
   defp enable_trigger do
-    Repo.query!("ALTER TABLE commune DISABLE TRIGGER refresh_places_commune_trigger;")
+    Repo.query!("ALTER TABLE commune ENABLE TRIGGER refresh_places_commune_trigger;")
     Repo.query!("REFRESH MATERIALIZED VIEW places;")
   end
 end

--- a/apps/transport/priv/repo/migrations/20221004135750_enable_trigger_refresh_places_commune_trigger.exs
+++ b/apps/transport/priv/repo/migrations/20221004135750_enable_trigger_refresh_places_commune_trigger.exs
@@ -1,0 +1,7 @@
+defmodule DB.Repo.Migrations.EnableTriggerRefreshPlacesCommuneTrigger do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE commune ENABLE TRIGGER refresh_places_commune_trigger;"
+  end
+end


### PR DESCRIPTION
Un erreur dans https://github.com/etalab/transport-site/pull/2665, un trigger n'avait pas été activé à la fin de l'import.

Je ne pense pas que ça crée de problème, surtout que la tache force la mise à jour à la fin et que la table `commune` n'a pas changé depuis.