### PR TITLE
Validation à la demande : pas de submit pour fichiers

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -38,10 +38,14 @@
             type: "url"
           ) %>
         <% end %>
-        <%= submit(dgettext("validations", "Validate"), nodiv: true) %>
+        <%= unless @input_type == "file" do %>
+          <%= submit(dgettext("validations", "Validate"), nodiv: true) %>
+        <% end %>
       </.form>
+      <p :if={@trigger_submit} class="small">
+        <%= TransportWeb.Gettext.dgettext("validations", "Upload in progress") %>
+      </p>
     </div>
   </div>
 </section>
-<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")}>
-</script>
+<script defer type="text/javascript" src={static_path(@socket, "/js/app.js")} />

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -300,3 +300,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "download it"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Upload in progress"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -300,3 +300,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "download it"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Upload in progress"
+msgstr "Envoi en cours"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -299,3 +299,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "download it"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Upload in progress"
+msgstr ""


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2679

Supprime le bouton submit "Valider" lors de l'envoi de fichiers. En effet, si après avoir choisi un fichier l'utilisateur clique sur ce bouton, il obtiendra une erreur 400. Ce comportement a été reporté par e-mail.

Cette PR supprime donc ce bouton dans ce cas, et ajoute une indication comme quoi l'upload est en cours.


https://user-images.githubusercontent.com/295709/193998089-755d36c9-4afd-464a-93c4-0c03855baeeb.mov

