### PR TITLE
Pages ressources et datasets : brancher les flux gtfs sur resource_metadata

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -163,9 +163,7 @@ defmodule DB.Dataset do
   @spec filter_by_feature(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_feature(query, %{"features" => [feature]})
        when feature in ["service_alerts", "trip_updates", "vehicle_positions"] do
-    recent_limit =
-      DateTime.utc_now()
-      |> DateTime.add(-Transport.Jobs.GTFSRTEntitiesJob.days_to_keep() * 24 * 60 * 60)
+    recent_limit = Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()
 
     query
     |> join(:inner, [dataset: d], r in DB.Resource, on: r.dataset_id == d.id, as: :resource)

--- a/apps/transport/lib/jobs/gtfs_rt_entities.ex
+++ b/apps/transport/lib/jobs/gtfs_rt_entities.ex
@@ -100,7 +100,7 @@ defmodule Transport.Jobs.GTFSRTEntitiesJob do
       existing_entities
       |> Map.filter(fn {_, v} ->
         {:ok, dt, 0} = DateTime.from_iso8601(v)
-        period_start = DateTime.add(now, -1 * 60 * 60 * 24 * days_to_keep(), :second)
+        period_start = datetime_limit()
         DateTime.compare(dt, period_start) == :gt
       end)
 
@@ -108,4 +108,6 @@ defmodule Transport.Jobs.GTFSRTEntitiesJob do
   end
 
   def days_to_keep, do: 7
+
+  def datetime_limit, do: DateTime.utc_now() |> DateTime.add(-days_to_keep() * 24 * 60 * 60)
 end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -85,9 +85,7 @@ defmodule TransportWeb.DatasetController do
   end
 
   def gtfs_rt_entities(%Dataset{id: dataset_id, type: "public-transit"}) do
-    recent_limit =
-      DateTime.utc_now()
-      |> DateTime.add(-Transport.Jobs.GTFSRTEntitiesJob.days_to_keep() * 24 * 60 * 60)
+    recent_limit = Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()
 
     DB.Dataset.base_query()
     |> DB.Resource.join_dataset_with_resource()

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -41,9 +41,7 @@ defmodule TransportWeb.ResourceController do
   end
 
   defp gtfs_rt_entities(%Resource{format: "gtfs-rt", id: id}) do
-    recent_limit =
-      DateTime.utc_now()
-      |> DateTime.add(-Transport.Jobs.GTFSRTEntitiesJob.days_to_keep() * 24 * 60 * 60)
+    recent_limit = Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()
 
     DB.ResourceMetadata
     |> where([rm], rm.resource_id == ^id and rm.inserted_at > ^recent_limit)

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -40,7 +40,7 @@ defmodule TransportWeb.ResourceController do
     end
   end
 
-  defp gtfs_rt_entities(%Resource{format: "gtfs-rt", id: id}) do
+  def gtfs_rt_entities(%Resource{format: "gtfs-rt", id: id}) do
     recent_limit = Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()
 
     DB.ResourceMetadata
@@ -49,7 +49,7 @@ defmodule TransportWeb.ResourceController do
     |> DB.Repo.all()
   end
 
-  defp gtfs_rt_entities(%Resource{}), do: nil
+  def gtfs_rt_entities(%Resource{}), do: nil
 
   defp gtfs_rt_feed(conn, %Resource{format: "gtfs-rt", url: url, id: id}) do
     lang = get_session(conn, :locale)

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -5,6 +5,7 @@ defmodule TransportWeb.ResourceController do
   alias Transport.DataVisualization
   alias Transport.ImportData
   require Logger
+  import Ecto.Query
 
   import TransportWeb.ResourceView, only: [issue_type: 1]
   import TransportWeb.DatasetView, only: [availability_number_days: 0]
@@ -28,6 +29,7 @@ defmodule TransportWeb.ResourceController do
       )
       |> assign(:resource_history_infos, DB.ResourceHistory.latest_resource_history_infos(id))
       |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
+      |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
       |> assign(:multi_validation, latest_validation(resource))
       |> put_resource_flash(resource.dataset.is_active)
 
@@ -37,6 +39,19 @@ defmodule TransportWeb.ResourceController do
       conn |> assign(:resource, resource) |> render("details.html")
     end
   end
+
+  defp gtfs_rt_entities(%Resource{format: "gtfs-rt", id: id}) do
+    recent_limit =
+      DateTime.utc_now()
+      |> DateTime.add(-Transport.Jobs.GTFSRTEntitiesJob.days_to_keep() * 24 * 60 * 60)
+
+    DB.ResourceMetadata
+    |> where([rm], rm.resource_id == ^id and rm.inserted_at > ^recent_limit)
+    |> select([rm], fragment("DISTINCT(UNNEST(features))"))
+    |> DB.Repo.all()
+  end
+
+  defp gtfs_rt_entities(%Resource{}), do: nil
 
   defp gtfs_rt_feed(conn, %Resource{format: "gtfs-rt", url: url, id: id}) do
     lang = get_session(conn, :locale)

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -141,11 +141,11 @@
           <% end %>
         </div>
       <% end %>
-      <%= if Resource.is_gtfs_rt?(@resource) and length(@resource.features) > 0 do %>
+      <%= if Resource.is_gtfs_rt?(@resource) and length(@resources_infos.gtfs_rt_entities) > 0 do %>
         <%= dgettext("page-dataset-details", "Features available in the resource:") %>
         <div>
-          <%= for feature <- @resource.features do %>
-            <span class="label mode"><%= feature %></span>
+          <%= for entity <- @resources_infos.gtfs_rt_entities do %>
+            <span class="label mode"><%= entity %></span>
           <% end %>
         </div>
       <% end %>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -54,7 +54,7 @@
           gtfs_rt_feed: @gtfs_rt_feed,
           conn: @conn,
           locale: get_session(@conn, :locale),
-          entities_seen_recently: @resource.features
+          entities_seen_recently: @gtfs_rt_entities
         ) %>
       <% end %>
     </div>

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -274,6 +274,21 @@ defmodule TransportWeb.DatasetControllerTest do
     conn |> get(dataset_path(conn, :details, slug)) |> html_response(200)
   end
 
+  test "gtfs-rt entities" do
+    dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
+    %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")
+    insert(:resource_metadata, resource_id: resource_id_1, features: ["a", "b"])
+    %{id: resource_id_2} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")
+    insert(:resource_metadata, resource_id: resource_id_2, features: ["a", "c"])
+    insert(:resource_metadata, resource_id: resource_id_2, features: ["d"])
+
+    # too old
+    %{id: resource_id_3} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")
+    insert(:resource_metadata, resource_id: resource_id_3, features: ["e"], inserted_at: ~U[2020-01-01 00:00:00Z])
+
+    assert ["a", "b", "c", "d"] = TransportWeb.DatasetController.gtfs_rt_entities(dataset) |> Enum.sort()
+  end
+
   defp set_empty_mocks do
     Datagouvfr.Client.Reuses.Mock |> expect(:get, fn _ -> {:ok, []} end)
     Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _ -> %{} end)

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -286,7 +286,7 @@ defmodule TransportWeb.DatasetControllerTest do
     %{id: resource_id_3} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")
     insert(:resource_metadata, resource_id: resource_id_3, features: ["e"], inserted_at: ~U[2020-01-01 00:00:00Z])
 
-    assert ["a", "b", "c", "d"] = TransportWeb.DatasetController.gtfs_rt_entities(dataset) |> Enum.sort()
+    assert ["a", "b", "c", "d"] = dataset |> TransportWeb.DatasetController.gtfs_rt_entities() |> Enum.sort()
   end
 
   defp set_empty_mocks do

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -487,6 +487,16 @@ defmodule TransportWeb.ResourceControllerTest do
     assert conn2 |> html_response(200) =~ "Pas de validation disponible"
   end
 
+  test "gtfs-rt entities" do
+    resource = %{id: resource_id} = insert(:resource, format: "gtfs-rt")
+    insert(:resource_metadata, resource_id: resource_id, features: ["a", "b"])
+    insert(:resource_metadata, resource_id: resource_id, features: ["c"])
+    # too old
+    insert(:resource_metadata, resource_id: resource_id, features: ["d"], inserted_at: ~U[2020-01-01 00:00:00Z])
+
+    assert ["a", "b", "c"] = TransportWeb.ResourceController.gtfs_rt_entities(resource)
+  end
+
   defp test_remote_download_error(%Plug.Conn{} = conn, mock_status_code) do
     resource = Resource |> Repo.get_by(datagouv_id: "2")
     refute Resource.can_direct_download?(resource)


### PR DESCRIPTION
Dans la suite de #2683 

Maintenant que les gtfs_rt_entities sont sauvegardées proprement en base dans la table `resource_metadata`, je débranche les pages datasets et resources qui allaient encore lire dans les champs de la table `resource` directement, pour les brancher aux `resources_metadata`. Ca se fait plus facilement que ce que je craignais :relieved: 

Reste à faire :

- [x] mise sous test
- [x] un peu de DRY sur le calcul de `recent_limit`