### PR TITLE
Répare pagination quand filtré par AOM ou Région

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -62,7 +62,7 @@ defmodule TransportWeb.DatasetView do
   end
 
   def pagination_links(%{path_info: ["datasets", "region", region]} = conn, datasets) do
-    kwargs = [path: &Helpers.dataset_path/4, action: :by_region] |> add_order_by(conn.params)
+    kwargs = [path: &Helpers.dataset_path/4, action: :by_region] |> add_query_params(conn.query_params)
 
     PaginationHelpers.pagination_links(
       conn,
@@ -73,7 +73,7 @@ defmodule TransportWeb.DatasetView do
   end
 
   def pagination_links(%{path_info: ["datasets", "aom", aom]} = conn, datasets) do
-    kwargs = [path: &Helpers.dataset_path/4, action: :by_aom] |> add_order_by(conn.params)
+    kwargs = [path: &Helpers.dataset_path/4, action: :by_aom] |> add_query_params(conn.query_params)
 
     PaginationHelpers.pagination_links(
       conn,
@@ -206,8 +206,9 @@ defmodule TransportWeb.DatasetView do
   def display_all_types_links?(%{params: %{"type" => type}}) when not is_nil(type), do: true
   def display_all_types_links?(_), do: false
 
-  defp add_order_by(kwargs, %{"order_by" => order}), do: Keyword.put(kwargs, :order_by, order)
-  defp add_order_by(kwargs, _), do: kwargs
+  defp add_query_params(kwargs, params) do
+    kwargs |> Keyword.merge(for {key, value} <- params, do: {String.to_atom(key), value})
+  end
 
   def gbfs_documentation_link(version) when is_binary(version) do
     "https://github.com/NABSA/gbfs/blob/v#{version}/gbfs.md"


### PR DESCRIPTION
Les liens de pagination sont actuellement mauvais quand il y a un filtre en place avec une AOM ou une région, les filtres passés en query params ne sont pas conservés.

Ainsi https://transport.data.gouv.fr/datasets/region/2?q=auvergne (qui contient un `?q`), est perdu dans les liens vers les autres pages en bas de page. Ceci se retrouve aussi avec `features` / `modes` etc.

Cette PR répare ceci. J'ai l'impression de refaire ce qui existe dans [pagination_helper](https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport_web/controllers/pagination_helpers.ex) mais j'ai pas réussi à réutiliser du code, si vous voyez une opportunité.