### PR TITLE
Adapte stockage stats pour GTFS-RT

### DIFF
--- a/apps/transport/lib/db/resource_metadata.ex
+++ b/apps/transport/lib/db/resource_metadata.ex
@@ -18,6 +18,8 @@ defmodule DB.ResourceMetadata do
     timestamps(type: :utc_datetime_usec)
   end
 
+  def base_query, do: from(rm in DB.ResourceMetadata, as: :metadata)
+
   def join_validation_with_metadata(query) do
     query
     |> join(:left, [multi_validation: mv], m in DB.ResourceMetadata, on: m.multi_validation_id == mv.id, as: :metadata)

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -103,7 +103,7 @@ defmodule Transport.StatsHandler do
       Ecto.Adapters.SQL.query!(DB.Repo, query, [Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()])
 
     # rows example value: [["trip_updates", 63], ["service_alerts", 12]]
-    Enum.into(rows, %{}, fn r -> {List.first(r), List.last(r)} end)
+    Enum.into(rows, %{}, &List.to_tuple/1)
   end
 
   defp get_population(datasets) do

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -94,7 +94,7 @@ defmodule Transport.StatsHandler do
       select distinct resource_id, unnest(rm.features) as gtfs_rt_feature
       from resource_metadata rm
       join resource r on r.id = rm.resource_id and r.format = 'gtfs-rt'
-      where inserted_at > $1
+      where inserted_at > $1 and rm.features is not null
     ) t
     group by gtfs_rt_feature
     """

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -26,6 +26,7 @@ defmodule Transport.StatsHandlerTest do
     insert(:resource_metadata, features: nil, resource_id: resource.id)
 
     # latest metadata for the resource
+    insert(:resource_metadata, features: ["vehicle_positions", "trap"], resource_id: resource.id)
     insert(:resource_metadata, features: ["vehicle_positions", "trip_updates"], resource_id: resource.id)
 
     # another resource linked to a single metadata

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -41,6 +41,9 @@ defmodule Transport.StatsHandlerTest do
     resource = insert(:resource, format: "gtfs-rt")
     insert(:resource_metadata, features: ["vehicle_positions"], resource_id: resource.id)
     insert(:resource_metadata, features: ["trip_updates"], resource_id: resource.id)
+
+    insert(:resource_metadata, features: ["vehicle_positions"], resource: insert(:resource, format: "gtfs-rt"))
+
     stats = compute_stats()
     store_stats()
     assert DB.Repo.aggregate(DB.StatsHistory, :count, :id) >= Enum.count(stats)
@@ -53,6 +56,9 @@ defmodule Transport.StatsHandlerTest do
     assert MapSet.subset?(MapSet.new(stats_metrics), MapSet.new(all_metrics))
     assert Enum.member?(all_metrics, "gtfs_rt_types::vehicle_positions")
     assert Enum.member?(all_metrics, "gtfs_rt_types::trip_updates")
+
+    expected = Decimal.new("2")
+    assert %{value: ^expected} = DB.Repo.get_by!(DB.StatsHistory, metric: "gtfs_rt_types::vehicle_positions")
   end
 
   test "count dataset per format" do

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -35,7 +35,8 @@ defmodule Transport.StatsHandlerTest do
       resource: insert(:resource, format: "gtfs-rt")
     )
 
-    assert %{"service_alerts" => 1, "trip_updates" => 1, "vehicle_positions" => 2, "entity" => 1} == count_feed_types_gtfs_rt()
+    assert %{"service_alerts" => 1, "trip_updates" => 1, "vehicle_positions" => 2, "entity" => 1} ==
+             count_feed_types_gtfs_rt()
   end
 
   test "store_stats" do

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -25,8 +25,8 @@ defmodule Transport.StatsHandlerTest do
     insert(:resource_metadata, features: [], resource_id: resource.id)
     insert(:resource_metadata, features: nil, resource_id: resource.id)
 
-    # latest metadata for the resource
-    insert(:resource_metadata, features: ["vehicle_positions", "trap"], resource_id: resource.id)
+    # recent metadata for the resource
+    insert(:resource_metadata, features: ["vehicle_positions", "entity"], resource_id: resource.id)
     insert(:resource_metadata, features: ["vehicle_positions", "trip_updates"], resource_id: resource.id)
 
     # another resource linked to a single metadata
@@ -35,7 +35,7 @@ defmodule Transport.StatsHandlerTest do
       resource: insert(:resource, format: "gtfs-rt")
     )
 
-    assert %{"service_alerts" => 1, "trip_updates" => 1, "vehicle_positions" => 2} == count_feed_types_gtfs_rt()
+    assert %{"service_alerts" => 1, "trip_updates" => 1, "vehicle_positions" => 2, "entity" => 1} == count_feed_types_gtfs_rt()
   end
 
   test "store_stats" do

--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -12,8 +12,35 @@ defmodule Transport.StatsHandlerTest do
     assert is_map(compute_stats())
   end
 
+  test "count_feed_types_gtfs_rt" do
+    resource = insert(:resource, format: "gtfs-rt")
+    # should not be used as this is too old
+    insert(:resource_metadata,
+      features: ["foo"],
+      resource_id: resource.id,
+      inserted_at: Transport.Jobs.GTFSRTEntitiesJob.datetime_limit() |> DateTime.add(-5)
+    )
+
+    # Empty cases, should not crash
+    insert(:resource_metadata, features: [], resource_id: resource.id)
+    insert(:resource_metadata, features: nil, resource_id: resource.id)
+
+    # latest metadata for the resource
+    insert(:resource_metadata, features: ["vehicle_positions", "trip_updates"], resource_id: resource.id)
+
+    # another resource linked to a single metadata
+    insert(:resource_metadata,
+      features: ["vehicle_positions", "service_alerts"],
+      resource: insert(:resource, format: "gtfs-rt")
+    )
+
+    assert %{"service_alerts" => 1, "trip_updates" => 1, "vehicle_positions" => 2} == count_feed_types_gtfs_rt()
+  end
+
   test "store_stats" do
-    insert(:resource, format: "gtfs-rt", features: ["trip_updates", "vehicle_positions"])
+    resource = insert(:resource, format: "gtfs-rt")
+    insert(:resource_metadata, features: ["vehicle_positions"], resource_id: resource.id)
+    insert(:resource_metadata, features: ["trip_updates"], resource_id: resource.id)
     stats = compute_stats()
     store_stats()
     assert DB.Repo.aggregate(DB.StatsHistory, :count, :id) >= Enum.count(stats)


### PR DESCRIPTION
Retravaille le stockage de statistiques de flux GTFS-RT, qui avait été effectué dans https://github.com/etalab/transport-site/pull/2352, pour utiliser désormais `DB.ResourceMetadata.features` comme introduit dans https://github.com/etalab/transport-site/pull/2683