### PR TITLE
Validation à la demande GTFS : ajout de modes

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -116,6 +116,7 @@ defmodule TransportWeb.ValidationController do
         # to be updated when PR 2371 is merged
         |> assign(:severities_count, DB.Validation.count_by_severity(%{details: validation.result}))
         |> assign(:metadata, validation.metadata.metadata)
+        |> assign(:modes, validation.metadata.modes)
         |> assign(:data_vis, data_vis(validation, issue_type))
         |> assign(:token, token)
         |> render("show.html")

--- a/apps/transport/lib/transport_web/templates/validation/show.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.heex
@@ -16,7 +16,7 @@
     <div class="container">
       <%= unless is_nil(@metadata) do %>
         <div class="panel validation-metadata">
-          <%= render("_resources_details.html", metadata: @metadata, conn: @conn) %>
+          <%= render("_resources_details.html", metadata: @metadata, conn: @conn, modes: @modes) %>
         </div>
       <% end %>
 


### PR DESCRIPTION
Voir [sur Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3662273809/?environment=prod&project=6197733&query=is%3Aunresolved).

Le template a été modifié dans https://github.com/etalab/transport-site/pull/2701, mais le code n'a pas été mis à jour ici. Visiblement la couverture de tests n'est pas adéquate, je vais ouvrir une issue.