### PR TITLE
RemoveHistoryJob : suppression en 2 temps

### DIFF
--- a/apps/transport/lib/jobs/remove_history_job.ex
+++ b/apps/transport/lib/jobs/remove_history_job.ex
@@ -2,6 +2,10 @@ defmodule Transport.Jobs.RemoveHistoryJob do
   @moduledoc """
   This job removes `DB.ResourceHistory` rows and deletes S3 objects for a given dataset type or a dataset ID.
 
+  It does so in 2 steps:
+  - it marks relevant rows up for deletion
+  - the same job (but another `perform`) takes care of removing rows and deleting objects
+
   This can be used to clean historicized resources that should not exist anymore.
   """
   import Ecto.Query
@@ -19,19 +23,37 @@ defmodule Transport.Jobs.RemoveHistoryJob do
     :ok
   end
 
-  @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) when is_integer(dataset_id) do
-    if DB.Dataset.should_skip_history?(DB.Repo.get!(DB.Dataset, dataset_id)) do
-      objects =
-        DB.ResourceHistory
-        |> where([rh], fragment("cast(payload->>'dataset_id' as bigint) = ?", ^dataset_id))
-        |> DB.Repo.all()
+  def perform(%Oban.Job{args: %{"action" => "remove", "dataset_id" => dataset_id} = args})
+      when is_integer(dataset_id) do
+    objects =
+      DB.ResourceHistory
+      |> where(
+        [rh],
+        fragment("payload \\? 'mark_for_deletion'") and
+          fragment("cast(payload->>'dataset_id' as bigint) = ?", ^dataset_id)
+      )
+      |> limit(50)
+      |> DB.Repo.all()
 
-      ids = objects |> Enum.map(& &1.id)
-
-      mark_for_deletion(ids)
+    unless Enum.empty?(objects) do
       remove_s3_objects(objects |> Enum.map(&Map.fetch!(&1.payload, "filename")))
-      remove_resource_history_rows(ids)
+      remove_resource_history_rows(objects |> Enum.map(& &1.id))
+      args |> __MODULE__.new(schedule_in: 60 * 60 * 3) |> Oban.insert!()
+    end
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id} = args}) when is_integer(dataset_id) do
+    if DB.Dataset.should_skip_history?(DB.Repo.get!(DB.Dataset, dataset_id)) do
+      DB.ResourceHistory
+      |> where([rh], fragment("cast(payload->>'dataset_id' as bigint) = ?", ^dataset_id))
+      |> select([rh], rh.id)
+      |> DB.Repo.all()
+      |> mark_for_deletion()
+
+      args |> Map.put("action", "remove") |> __MODULE__.new() |> Oban.insert!()
 
       :ok
     else


### PR DESCRIPTION
Retravaille https://github.com/etalab/transport-site/pull/2700 pour effectuer la suppression en 2 temps :

- indiquer ce qui doit être supprimé
- lancer des jobs de suppression, qui tournent au fur et à mesure de manière récursive

Le problème est qu'en production certains jobs passent en timeout, car il y a des milliers d'objets à supprimer pour certains JDD.

```sql
select *
from resource_history
where payload ? 'mark_for_deletion'
```

retourne 12k lignes actuellement, montrant le nombre important de lignes à supprimer en BDD, mais surtout sur Cellar.

|dataset_id|count|
|--- | ---|
|752 | 2876|
|508 | 2031|
|567 | 1899|
|751 | 1439|
|131 | 1356|
|231 | 1356|
|759 | 661|
|250 | 584|
