### PR TITLE
Compte les entités GTFS-RT par ressource

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -84,21 +84,28 @@ defmodule TransportWeb.DatasetController do
     }
   end
 
+  @spec gtfs_rt_entities(Dataset.t()) :: map()
   def gtfs_rt_entities(%Dataset{id: dataset_id, type: "public-transit"}) do
     recent_limit = Transport.Jobs.GTFSRTEntitiesJob.datetime_limit()
 
-    DB.Dataset.base_query()
-    |> DB.Resource.join_dataset_with_resource()
+    DB.Resource.base_query()
     |> join(:inner, [resource: r], rm in DB.ResourceMetadata, on: r.id == rm.resource_id, as: :metadata)
     |> where(
-      [dataset: d, resource: r, metadata: rm],
-      d.id == ^dataset_id and r.format == "gtfs-rt" and rm.inserted_at > ^recent_limit
+      [resource: r, metadata: rm],
+      r.dataset_id == ^dataset_id and r.format == "gtfs-rt" and rm.inserted_at > ^recent_limit
     )
-    |> select([metadata: rm], fragment("DISTINCT(UNNEST(?))", rm.features))
+    |> select([metadata: rm], %{resource_id: rm.resource_id, feed_type: fragment("UNNEST(?)", rm.features)})
+    |> distinct(true)
     |> DB.Repo.all()
+    |> Enum.reduce(%{}, fn %{resource_id: resource_id, feed_type: feed_type}, acc ->
+      # See https://hexdocs.pm/elixir/Map.html#update/4
+      # > If key is not present in map, default is inserted as the value of key.
+      # The default value **will not be passed through the update function**.
+      Map.update(acc, resource_id, MapSet.new([feed_type]), fn old_val -> MapSet.put(old_val, feed_type) end)
+    end)
   end
 
-  def gtfs_rt_entities(%Dataset{}), do: []
+  def gtfs_rt_entities(%Dataset{}), do: %{}
 
   @spec by_aom(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def by_aom(%Plug.Conn{} = conn, %{"aom" => id} = params) do

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -142,10 +142,10 @@
           <% end %>
         </div>
       <% end %>
-      <%= if Resource.is_gtfs_rt?(@resource) and length(@resources_infos.gtfs_rt_entities) > 0 do %>
+      <%= if Resource.is_gtfs_rt?(@resource) and not Enum.empty?(Map.get(@resources_infos.gtfs_rt_entities, @resource.id, [])) do %>
         <%= dgettext("page-dataset-details", "Features available in the resource:") %>
         <div>
-          <%= for entity <- @resources_infos.gtfs_rt_entities do %>
+          <%= for entity <- Map.fetch!(@resources_infos.gtfs_rt_entities, @resource.id) do %>
             <span class="label mode"><%= entity %></span>
           <% end %>
         </div>

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -285,9 +285,15 @@ defmodule TransportWeb.DatasetControllerTest do
 
     # too old
     %{id: resource_id_3} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")
-    insert(:resource_metadata, resource_id: resource_id_3, features: ["e"], inserted_at: ~U[2020-01-01 00:00:00Z])
 
-    assert ["a", "b", "c", "d"] = dataset |> TransportWeb.DatasetController.gtfs_rt_entities() |> Enum.sort()
+    insert(:resource_metadata,
+      resource_id: resource_id_3,
+      features: ["e"],
+      inserted_at: Transport.Jobs.GTFSRTEntitiesJob.datetime_limit() |> DateTime.add(-5)
+    )
+
+    assert %{resource_id_1 => MapSet.new(["a", "b"]), resource_id_2 => MapSet.new(["a", "c", "d"])} ==
+             dataset |> TransportWeb.DatasetController.gtfs_rt_entities()
   end
 
   defp set_empty_mocks do


### PR DESCRIPTION
Suite de #2693

Compte les types de flux GTFS-RT par ressource, et non par dataset. Évite d'afficher l'ensemble des différents flux pour toutes les ressources d'un dataset.