### PR TITLE
Page stats : répare affichage stats flux GTFS-RT

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -128,7 +128,7 @@ defmodule TransportWeb.PageController do
 
   defp count_aoms_with_dataset, do: Repo.aggregate(aoms_with_dataset(), :count, :id)
 
-  defp population_with_dataset, do: Repo.aggregate(aoms_with_dataset(), :sum, :population_totale_2014)
+  defp population_with_dataset, do: Repo.aggregate(aoms_with_dataset(), :sum, :population_totale_2014) || 0
 
   defp population_totale, do: Repo.aggregate(AOM, :sum, :population_totale_2014)
 

--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -246,9 +246,9 @@
             <div>jeux de données<br />en <strong>GTFS-RT</strong></div>
             <div>
               <ul class="small">
-                <%= for el <- @gtfs_rt_types do %>
+                <%= for {type, count} <- @gtfs_rt_types do %>
                   <li>
-                    <span title={el.type}><%= friendly_gtfs_type(el.type) %></span> : <%= format_number(el.count) %>
+                    <span title={type}><%= friendly_gtfs_type(type) %></span> : <%= format_number(count) %>
                   </li>
                 <% end %>
               </ul>

--- a/apps/transport/test/support/database_case.ex
+++ b/apps/transport/test/support/database_case.ex
@@ -39,6 +39,7 @@ defmodule TransportWeb.DatabaseCase do
           insee_commune_principale: "53130",
           nom: "Laval",
           region: Repo.get_by(Region, nom: "Pays de la Loire"),
+          population_totale_2014: 42,
           composition_res_id: 1
         })
 
@@ -46,6 +47,7 @@ defmodule TransportWeb.DatabaseCase do
           insee_commune_principale: "38185",
           nom: "Grenoble",
           region: Repo.get_by(Region, nom: "Auvergne-Rhône-Alpes"),
+          population_totale_2014: 43,
           composition_res_id: 2
         })
 
@@ -53,6 +55,7 @@ defmodule TransportWeb.DatabaseCase do
           insee_commune_principale: "36044",
           nom: "Châteauroux",
           region: Repo.get_by(Region, nom: "Auvergne-Rhône-Alpes"),
+          population_totale_2014: 44,
           composition_res_id: 3
         })
 
@@ -81,6 +84,7 @@ defmodule TransportWeb.DatabaseCase do
           insee_commune_principale: "75056",
           nom: "Île-de-France Mobilités",
           region: Repo.get_by(Region, nom: "Île-de-France"),
+          population_totale_2014: 45,
           composition_res_id: 4
         })
 

--- a/apps/transport/test/transport_web/controllers/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/stats_controller_test.exs
@@ -167,4 +167,16 @@ defmodule TransportWeb.API.StatsControllerTest do
                TransportWeb.API.StatsController.quality_features_query() |> DB.Repo.get(aom1.id)
     end
   end
+
+  test "can load the /stats page", %{conn: conn} do
+    insert(:resource_metadata, features: ["service_alerts"], resource: insert(:resource, format: "gtfs-rt"))
+
+    insert(:resource_metadata,
+      features: ["service_alerts", "vehicle_positions"],
+      resource: insert(:resource, format: "gtfs-rt")
+    )
+
+    conn2 = conn |> get(TransportWeb.Router.Helpers.stats_path(conn, :index))
+    assert conn2 |> html_response(200) =~ ~s(<span title="service_alerts">Info trafic</span> : 2)
+  end
 end


### PR DESCRIPTION
Le format des stats a changé suite à #2706, ce qui fait crasher la page. [Voir Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3665664039/?environment=prod&project=6197733&query=is%3Aunresolved#exception).

Je répare et j'ajoute un test basique pour charger la page `/stats`.