### PR TITLE
Gtfs diff : quelques fix et améliorations

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
@@ -112,7 +112,7 @@ defmodule Transport.Beta.GTFS do
       "agency.txt" => ["agency_id", "agency_name"],
       "stops.txt" => ["stop_id"],
       "routes.txt" => ["route_id"],
-      # "trips.txt" => ["trip_id"],
+      "trips.txt" => ["trip_id"],
       "stop_times.txt" => ["trip_id", "stop_id", "stop_sequence"],
       "calendar.txt" => ["service_id"],
       "calendar_dates.txt" => ["service_id", "date"],

--- a/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
@@ -109,16 +109,21 @@ defmodule Transport.Beta.GTFS do
 
   def primary_key(file_name) do
     keys = %{
-      "agency.txt" => ["agency_id"],
+      "agency.txt" => ["agency_id", "agency_name"],
+      "stops.txt" => ["stop_id"],
+      "routes.txt" => ["route_id"],
+      # "trips.txt" => ["trip_id"],
+      "stop_times.txt" => ["trip_id", "stop_id", "stop_sequence"],
       "calendar.txt" => ["service_id"],
       "calendar_dates.txt" => ["service_id", "date"],
-      "levels.txt" => ["level_id"],
-      "routes.txt" => ["route_id"],
-      "shapes.txt" => ["shape_id"],
-      "stops.txt" => ["stop_id"],
-      "stop_times.txt" => ["trip_id", "stop_id", "stop_sequence"],
+      "shapes.txt" => ["shape_id", "shape_pt_sequence"],
+      "frequencies.txt" => ["trip_id", "start_time", "end_time"],
       "transfers.txt" => ["from_stop_id", "to_stop_id"],
-      "trips.txt" => ["trip_id"]
+      "pathways.txt" => ["pathway_id"],
+      "levels.txt" => ["level_id"],
+      "feed_info.txt" => ["feed_publisher_name"],
+      "translations.txt" => ["table_name", "field_name", "language", "record_id", "record_sub_id", "field_value"],
+      "attributions.txt" => ["organization_name"]
     }
 
     Map.get(keys, file_name)

--- a/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
@@ -245,9 +245,9 @@ defmodule Transport.Beta.GTFS do
   end
 
   def column_diff(unzip_1, unzip_2) do
-    %{same_files: same_files} = compare_files(unzip_1, unzip_2)
+    %{same_files: same_files, added_files: added_files} = compare_files(unzip_1, unzip_2)
 
-    same_files
+    (same_files ++ added_files)
     |> Enum.flat_map(fn file_name ->
       column_name_1 = get_headers(unzip_1, file_name)
 

--- a/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_beta_diff.ex
@@ -156,7 +156,6 @@ defmodule Transport.Beta.GTFS do
   def get_update_messages(update_ids, file_a, file_b, file_name) do
     check_value = fn a_value, key, b_value ->
       case a_value do
-        nil -> nil
         ^b_value -> nil
         _new_value -> %{initial_value: {key, a_value}, new_value: {key, b_value}}
       end
@@ -174,7 +173,7 @@ defmodule Transport.Beta.GTFS do
         |> Enum.map(fn key ->
           b_value = row_b |> Map.fetch!(key)
 
-          row_a |> Map.get(key) |> check_value.(key, b_value)
+          row_a |> Map.get(key, "") |> check_value.(key, b_value)
         end)
         |> Enum.reject(&is_nil/1)
 

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -16,7 +16,7 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
      |> allow_upload(:gtfs,
        accept: ~w(.zip),
        max_entries: 2,
-       max_file_size: 2_000_000,
+       max_file_size: 4_000_000,
        auto_upload: true
      )}
   end


### PR DESCRIPTION
* augmentation de la taille max des GTFS à 4Mo
* avoir un mode fallback quand un fichier est trouvé dans une archive et pour lequelle on n'a pas renseigné de primary key => pas de diff, toute modification de ligne revient à supprimer + ajouter la ligne.
* bug : quand une nouvelle colonne est ajoutée dans un fichier, on ne détectait pas la modification des lignes modifiées
* plus explicite : quand on fichier est ajouté, on liste les headers de ce fichier en tant que créations de colonnes.

Pour l'instant le code n'est pas testé, j'attendais de voir si on avait beaucoup de retours sur le format et qu'il risquait de changer ou pas.