### PR TITLE
Page d'accueil : compter régions et AOMs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -35,6 +35,8 @@ defmodule TransportWeb.PageController do
       count_train: Dataset.count_by_mode("rail"),
       count_boat: Dataset.count_by_mode("ferry"),
       count_coach: Dataset.count_coach(),
+      count_regions: count_regions(),
+      count_aoms: Repo.aggregate(AOM, :count, :id),
       count_aoms_with_dataset: count_aoms_with_dataset(),
       count_regions_completed: count_regions_completed(),
       count_public_transport_has_realtime: Dataset.count_public_transport_has_realtime(),
@@ -138,10 +140,12 @@ defmodule TransportWeb.PageController do
   defp percent(_a, nil), do: 0
   defp percent(a, b), do: Float.round(a / b * 100, 1)
 
+  defp count_regions do
+    Region |> where([r], r.nom != "National") |> select([r], count(r.id)) |> Repo.one!()
+  end
+
   defp count_regions_completed do
-    Region
-    |> where([r], r.is_completed == true)
-    |> Repo.aggregate(:count, :id)
+    Region |> where([r], r.is_completed == true) |> Repo.aggregate(:count, :id)
   end
 
   defmodule Tile do

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -122,14 +122,14 @@
             <div>
               <%= dgettext("page-index", "Territories covered") |> raw() %>
               <br />
-              <%= dgettext("page-index", "on") %> 330
+              <%= dgettext("page-index", "on") %> <%= @count_aoms %>
             </div>
           </div>
           <div class="key-number__item">
             <strong><%= @count_regions_completed %></strong>
             <div>
               <%= dgettext("page-index", "Regions covered") %><br />
-              <%= dgettext("page-index", "on") %> 18
+              <%= dgettext("page-index", "on") %> <%= @count_regions %>
             </div>
           </div>
           <div class="key-number__item">


### PR DESCRIPTION
On avait des chiffres mis directement dans la vue auparavant, ceux-ci ne sont plus bons suite à l'import des AOMs millésime 2022.