### PR TITLE
GTFSRTEntitiesJob : ne plus stocker dans resource.metadata

### DIFF
--- a/apps/transport/lib/jobs/gtfs_rt_entities.ex
+++ b/apps/transport/lib/jobs/gtfs_rt_entities.ex
@@ -27,16 +27,12 @@ end
 defmodule Transport.Jobs.GTFSRTEntitiesJob do
   @moduledoc """
   Job in charge of keeping track of which entities are present
-  in a GTFS-RT feed over the last 7 days by leveraging what has
-  been seen and stored in the metadata and decoding
-  the feed when the job is performed.
+  in a GTFS-RT feed.
   """
   use Oban.Worker, max_attempts: 3
   require Logger
   alias DB.{Repo, Resource}
   alias Transport.GTFSRT
-
-  @entities_metadata_key "entities_last_seen"
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"resource_id" => id}}) do
@@ -47,34 +43,27 @@ defmodule Transport.Jobs.GTFSRTEntitiesJob do
     :ok
   end
 
-  defp present_entities(count_entities) do
+  @doc """
+  Identifies which entities are present in a feed from a count of entities.
+
+  ## Examples
+
+  iex> present_entities(%{})
+  []
+  iex> present_entities(%{service_alerts: 0, vehicle_positions: 1})
+  ["vehicle_positions"]
+  iex> present_entities(%{service_alerts: 2, vehicle_positions: 1})
+  ["service_alerts", "vehicle_positions"]
+  """
+  def present_entities(count_entities) do
     count_entities |> Map.filter(fn {_, v} -> v > 0 end) |> Enum.map(fn {k, _} -> Atom.to_string(k) end)
   end
 
-  def process_feed({:ok, feed}, %Resource{metadata: metadata} = resource) do
-    metadata = metadata || %{}
+  def process_feed({:ok, %TransitRealtime.FeedMessage{} = feed}, %Resource{id: resource_id}) do
     count_entities = feed |> GTFSRT.count_entities()
 
-    # this will be deleted later
-    # ⬇️⬇️⬇️
-    new_entities =
-      compute_new_entities(
-        Map.get(metadata, @entities_metadata_key, %{}),
-        count_entities,
-        DateTime.utc_now()
-      )
-
-    resource
-    |> Resource.changeset(%{
-      metadata: Map.put(metadata, @entities_metadata_key, new_entities),
-      features: Map.keys(new_entities)
-    })
-    |> Repo.update!()
-
-    # ⬆️⬆️⬆️
-
     %DB.ResourceMetadata{
-      resource_id: resource.id,
+      resource_id: resource_id,
       metadata: count_entities,
       features: present_entities(count_entities)
     }
@@ -83,28 +72,6 @@ defmodule Transport.Jobs.GTFSRTEntitiesJob do
 
   def process_feed({:error, _}, %Resource{id: id}) do
     Logger.error("Cannot decode GTFS-RT feed for resource##{id}")
-  end
-
-  @doc """
-  Compute entities that have been seen in the feed over the last
-  `days_to_keep()` days, using:
-  - existing_entities: `%{"trip_updates" => "2022-03-18 15:43:40.963443Z", "vehicle_positions" => "2022-03-18 15:43:40.963443Z"}`
-  - entities_in_feed: `%{trip_updates: 4, vehicle_positions: 0, service_alerts: 0}`
-
-  Will return the same type as `existing_entities`.
-  """
-  def compute_new_entities(existing_entities, entities_in_feed, now) do
-    entities_present = present_entities(entities_in_feed)
-
-    entities_still_valid =
-      existing_entities
-      |> Map.filter(fn {_, v} ->
-        {:ok, dt, 0} = DateTime.from_iso8601(v)
-        period_start = datetime_limit()
-        DateTime.compare(dt, period_start) == :gt
-      end)
-
-    Map.merge(entities_still_valid, entities_present |> Enum.into(%{}, &{&1, now |> DateTime.to_string()}))
   end
 
   def days_to_keep, do: 7

--- a/apps/transport/test/transport/jobs/gtfs_rt_entities_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_rt_entities_test.exs
@@ -6,6 +6,8 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTEntitiesJobTest do
   alias Transport.Jobs.{GTFSRTEntitiesDispatcherJob, GTFSRTEntitiesJob}
   import ExUnit.CaptureLog
 
+  doctest GTFSRTEntitiesJob, import: true
+
   @url "https://example.com/gtfs-rt"
   @sample_file "#{__DIR__}/../../fixture/files/bibus-brest-gtfs-rt-alerts.pb"
 
@@ -34,114 +36,21 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTEntitiesJobTest do
       assert 7 == GTFSRTEntitiesJob.days_to_keep()
     end
 
-    test "compute_new_entities with nothing in the database" do
-      now = DateTime.utc_now()
-
-      assert %{"trip_updates" => now |> DateTime.to_string(), "service_alerts" => now |> DateTime.to_string()} ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{},
-                 %{trip_updates: 4, vehicle_positions: 0, service_alerts: 1},
-                 now
-               )
-    end
-
-    test "compute_new_entities with things in the database" do
-      now = DateTime.utc_now()
-      trip_updates_dt = days_ago(now, 4)
-
-      assert %{
-               "trip_updates" => trip_updates_dt |> DateTime.to_string(),
-               "service_alerts" => now |> DateTime.to_string()
-             } ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{"trip_updates" => trip_updates_dt |> DateTime.to_string()},
-                 %{trip_updates: 0, vehicle_positions: 0, service_alerts: 1},
-                 now
-               )
-
-      assert %{"trip_updates" => now |> DateTime.to_string(), "service_alerts" => now |> DateTime.to_string()} ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{"trip_updates" => trip_updates_dt |> DateTime.to_string()},
-                 %{trip_updates: 5, vehicle_positions: 0, service_alerts: 1},
-                 now
-               )
-    end
-
-    test "removes data over 7 days old" do
-      now = DateTime.utc_now()
-
-      assert %{} ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{"trip_updates" => now |> days_ago(8) |> DateTime.to_string()},
-                 %{trip_updates: 0, vehicle_positions: 0, service_alerts: 0},
-                 now
-               )
-
-      assert %{"vehicle_positions" => now |> DateTime.to_string()} ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{"trip_updates" => now |> days_ago(8) |> DateTime.to_string()},
-                 %{trip_updates: 0, vehicle_positions: 2, service_alerts: 0},
-                 now
-               )
-
-      dt_trip_updates = now |> days_ago(5)
-
-      assert %{
-               "vehicle_positions" => now |> DateTime.to_string(),
-               "trip_updates" => dt_trip_updates |> DateTime.to_string()
-             } ==
-               GTFSRTEntitiesJob.compute_new_entities(
-                 %{
-                   "trip_updates" => dt_trip_updates |> DateTime.to_string(),
-                   "service_alerts" => now |> days_ago(8) |> DateTime.to_string()
-                 },
-                 %{trip_updates: 0, vehicle_positions: 2, service_alerts: 0},
-                 now
-               )
-    end
-
-    test "perform with nothing in the metadata" do
+    test "perform with a feed with service_alerts" do
       setup_gtfs_rt_feed(@url)
       resource = insert(:resource, is_available: true, format: "gtfs-rt", url: @url, datagouv_id: "foo")
 
       assert :ok == perform_job(GTFSRTEntitiesJob, %{"resource_id" => resource.id})
 
-      assert %{metadata: %{"entities_last_seen" => %{"service_alerts" => _}}, features: ["service_alerts"]} =
-               DB.Repo.reload(resource)
-
-      %{metadata: metadata, features: features} = DB.ResourceMetadata |> DB.Repo.get_by!(resource_id: resource.id)
-      assert %{"service_alerts" => _} = metadata
-      assert ["service_alerts"] == features
-    end
-
-    test "perform with stuff in the metadata" do
-      setup_gtfs_rt_feed(@url)
-
-      resource =
-        insert(:resource,
-          is_available: true,
-          format: "gtfs-rt",
-          url: @url,
-          datagouv_id: "foo",
-          metadata: %{
-            "entities_last_seen" => %{"trip_updates" => DateTime.utc_now() |> days_ago(4) |> DateTime.to_string()},
-            "foo" => "bar"
-          }
-        )
-
-      assert :ok == perform_job(GTFSRTEntitiesJob, %{"resource_id" => resource.id})
-
-      assert %{
-               metadata: %{"entities_last_seen" => %{"service_alerts" => _, "trip_updates" => _}, "foo" => "bar"},
-               features: ["service_alerts", "trip_updates"]
-             } = DB.Repo.reload(resource)
+      %{metadata: %{"service_alerts" => _}, features: ["service_alerts"]} =
+        DB.ResourceMetadata |> DB.Repo.get_by!(resource_id: resource.id)
     end
 
     test "perform with a decode error" do
       setup_http_response(@url, {:ok, %HTTPoison.Response{status_code: 502}})
       resource = insert(:resource, is_available: true, format: "gtfs-rt", url: @url, datagouv_id: "foo")
       {:ok, logs} = with_log(fn -> perform_job(GTFSRTEntitiesJob, %{"resource_id" => resource.id}) end)
-      assert %{metadata: nil} = DB.Repo.reload(resource)
+      assert DB.Repo.aggregate(DB.ResourceMetadata, :count, :id) == 0
       assert logs =~ "Cannot decode GTFS-RT feed"
     end
   end
@@ -152,9 +61,5 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTEntitiesJobTest do
 
   defp setup_gtfs_rt_feed(url) do
     setup_http_response(url, {:ok, %HTTPoison.Response{status_code: 200, body: File.read!(@sample_file)}})
-  end
-
-  defp days_ago(dt, days) when days > 0 do
-    dt |> DateTime.add(-1 * days * 86_400)
   end
 end


### PR DESCRIPTION
Depuis que ceci est stocké dans `DB.ResourceMetadata` dans https://github.com/etalab/transport-site/pull/2693 et que le code a été adapté, on peut supprimer cette partie.