### PR TITLE
GTFSRTEntitiesDispatcherJob : suppression de métadonnées anciennes

### DIFF
--- a/apps/transport/lib/jobs/gtfs_rt_metadata.ex
+++ b/apps/transport/lib/jobs/gtfs_rt_metadata.ex
@@ -22,7 +22,7 @@ defmodule Transport.Jobs.GTFSRTMetadataDispatcherJob do
   end
 
   def remove_old_metadata do
-    recent_limit = DateTime.utc_now() |> DateTime.add(-@metadata_max_nb_days * 24 * 60 * 60)
+    recent_limit = DateTime.utc_now() |> DateTime.add(-@metadata_max_nb_days, :day)
 
     ResourceMetadata
     |> join(:inner, [rm], r in Resource, on: rm.resource_id == r.id and r.format == "gtfs-rt")

--- a/apps/transport/lib/jobs/gtfs_rt_metadata.ex
+++ b/apps/transport/lib/jobs/gtfs_rt_metadata.ex
@@ -12,11 +12,11 @@ defmodule Transport.Jobs.GTFSRTMetadataDispatcherJob do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    remove_old_metadata()
-
     relevant_resources()
     |> Enum.map(&(%{resource_id: &1.id} |> Transport.Jobs.GTFSRTMetadataJob.new()))
     |> Oban.insert_all()
+
+    remove_old_metadata()
 
     :ok
   end

--- a/apps/transport/test/transport/jobs/gtfs_rt_entities_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_rt_entities_test.exs
@@ -29,6 +29,20 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTMetadataJobTest do
       assert :ok == perform_job(GTFSRTMetadataDispatcherJob, %{})
       assert [%Oban.Job{args: %{"resource_id" => ^resource_id}}] = all_enqueued(worker: GTFSRTMetadataJob)
     end
+
+    test "removes old metadata" do
+      resource = insert(:resource, format: "gtfs-rt")
+      gtfs_resource = insert(:resource, format: "gtfs")
+      rm1 = insert(:resource_metadata, resource_id: resource.id, inserted_at: days_ago(30))
+      rm2 = insert(:resource_metadata, resource_id: resource.id, inserted_at: days_ago(89))
+      rm3 = insert(:resource_metadata, resource_id: resource.id, inserted_at: days_ago(91))
+      rm4 = insert(:resource_metadata, resource_id: gtfs_resource.id, inserted_at: days_ago(91))
+
+      assert :ok == perform_job(GTFSRTEntitiesDispatcherJob, %{})
+
+      assert [rm1, rm2, nil, rm4] == DB.Repo.reload([rm1, rm2, rm3, rm4])
+      assert resource == DB.Repo.reload(resource)
+    end
   end
 
   describe "GTFSRTMetadataJob" do
@@ -65,5 +79,9 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTMetadataJobTest do
 
   defp setup_gtfs_rt_feed(url) do
     setup_http_response(url, {:ok, %HTTPoison.Response{status_code: 200, body: File.read!(@sample_file)}})
+  end
+
+  defp days_ago(nb) when nb > 0 do
+    DateTime.utc_now() |> DateTime.add(-nb * 24 * 60 * 60)
   end
 end

--- a/apps/transport/test/transport/jobs/gtfs_rt_metadata_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_rt_metadata_test.exs
@@ -38,7 +38,7 @@ defmodule Transport.Test.Transport.Jobs.GTFSRTMetadataJobTest do
       rm3 = insert(:resource_metadata, resource_id: resource.id, inserted_at: days_ago(91))
       rm4 = insert(:resource_metadata, resource_id: gtfs_resource.id, inserted_at: days_ago(91))
 
-      assert :ok == perform_job(GTFSRTEntitiesDispatcherJob, %{})
+      assert :ok == perform_job(GTFSRTMetadataDispatcherJob, %{})
 
       assert [rm1, rm2, nil, rm4] == DB.Repo.reload([rm1, rm2, rm3, rm4])
       assert resource == DB.Repo.reload(resource)


### PR DESCRIPTION
Ajout d'un mécanisme pour ne pas garder le nombre d'entités GTFS-RT tout le temps, ne garder que 3 mois d'historique détaillé parait approprié.