### PR TITLE
Filtrage simple des requêtes SIRI

### DIFF
--- a/apps/unlock/lib/siri.ex
+++ b/apps/unlock/lib/siri.ex
@@ -13,6 +13,43 @@ defmodule Unlock.SIRI do
     parsed_request
   end
 
+  @doc """
+  The current version just ignores XML namespaces for now. This method helps extracting
+  the tag name without its namespace, to achieve comparison based on that.
+
+  iex> Unlock.SIRI.tag_without_namespace("siri:RequestorRef")
+  "RequestorRef"
+
+  iex> Unlock.SIRI.tag_without_namespace("Hello")
+  "Hello"
+  """
+  def tag_without_namespace(tag) do
+    tag |> String.split(":") |> List.last()
+  end
+
+  defmodule ServicesFinder do
+    @moduledoc """
+    Finds the services requested in an XML request.
+    """
+
+    @spec parse(Saxy.XML.element()) :: list(binary())
+    def parse({"S:Body", _attributes, children} = _node) do
+      children
+      |> Enum.reject(&is_binary(&1))
+      |> Enum.map(fn {tag, _attributes, _childen} -> Unlock.SIRI.tag_without_namespace(tag) end)
+    end
+
+    def parse({_tag, _attributes, children}) do
+      children = children |> Enum.reject(&is_binary(&1))
+
+      if Enum.empty?(children) do
+        []
+      else
+        children |> hd() |> parse()
+      end
+    end
+  end
+
   defmodule RequestorRefReplacer do
     @moduledoc """
     A module able to replace `RequestorRef` tags found in a
@@ -54,7 +91,7 @@ defmodule Unlock.SIRI do
 
     def replace_requestor_ref({tag, attributes, [text]} = node, new_requestor_ref, seen_requestor_refs)
         when is_binary(text) do
-      if tag_without_namespace(tag) == "RequestorRef" do
+      if Unlock.SIRI.tag_without_namespace(tag) == "RequestorRef" do
         {{tag, attributes, [new_requestor_ref]}, [text | seen_requestor_refs]}
       else
         {node, seen_requestor_refs}
@@ -74,22 +111,6 @@ defmodule Unlock.SIRI do
         end)
 
       {{tag, attributes, children}, seen_requestor_refs}
-    end
-
-    @doc """
-    The current version just ignores XML namespaces for now. This method helps extracting
-    the tag name without its namespace, to achieve comparison based on that.
-
-    iex> Unlock.SIRI.RequestorRefReplacer.tag_without_namespace("siri:RequestorRef")
-    "RequestorRef"
-
-    iex> Unlock.SIRI.RequestorRefReplacer.tag_without_namespace("Hello")
-    "Hello"
-    """
-    def tag_without_namespace(tag) do
-      tag
-      |> String.split(":")
-      |> List.last()
     end
   end
 end

--- a/apps/unlock/lib/siri.ex
+++ b/apps/unlock/lib/siri.ex
@@ -33,19 +33,17 @@ defmodule Unlock.SIRI do
     """
 
     @spec parse(Saxy.XML.element()) :: list(binary())
-    def parse({"S:Body", _attributes, children} = _node) do
-      children
-      |> Enum.reject(&is_binary(&1))
-      |> Enum.map(fn {tag, _attributes, _childen} -> Unlock.SIRI.tag_without_namespace(tag) end)
-    end
-
-    def parse({_tag, _attributes, children}) do
+    def parse({tag, _attributes, children}) do
       children = children |> Enum.reject(&is_binary(&1))
 
       if Enum.empty?(children) do
         []
       else
-        children |> hd() |> parse()
+        if tag |> Unlock.SIRI.tag_without_namespace() |> String.downcase() == "body" do
+          Enum.map(children, fn {tag, _attributes, _childen} -> Unlock.SIRI.tag_without_namespace(tag) end)
+        else
+          children |> hd() |> parse()
+        end
       end
     end
   end

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -1,5 +1,5 @@
 defmodule Unlock.ConfigFetcherTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   def parse_config(yaml), do: Unlock.Config.Fetcher.convert_yaml_to_config_items(yaml)
 
@@ -61,15 +61,56 @@ defmodule Unlock.ConfigFetcherTest do
           type: "siri"
           target_url: "https://httpbin.org/get"
           requestor_ref: the-ref
+          allowed_queries:
+            - CheckStatus
+            - GetStopMonitoring
       """
 
       assert parse_config(yaml_config) == [
                %Unlock.Config.Item.SIRI{
                  identifier: "httpbin-get",
                  target_url: "https://httpbin.org/get",
-                 requestor_ref: "the-ref"
+                 requestor_ref: "the-ref",
+                 allowed_queries: ["CheckStatus", "GetStopMonitoring"]
                }
              ]
     end
+  end
+
+  test "request_is_allowed" do
+    item = %Unlock.Config.Item.SIRI{
+      identifier: "httpbin-get",
+      target_url: "https://httpbin.org/get",
+      requestor_ref: "the-ref",
+      allowed_queries: []
+    }
+
+    parsed_xml =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+          <sw:CheckStatus xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+              <Request>
+                  <siri:RequestTimestamp>#{DateTime.utc_now() |> DateTime.to_iso8601()}</siri:RequestTimestamp>
+                  <siri:RequestorRef>secret</siri:RequestorRef>
+                  <siri:MessageIdentifier>Test:Message::9d5f99e2-5e6d-4c7b-befc-381a3c592ede</siri:MessageIdentifier>
+              </Request>
+              <RequestExtension/>
+          </sw:CheckStatus>
+      </S:Body>
+      </S:Envelope>
+      """
+      |> Unlock.SIRI.parse_incoming()
+
+    assert Unlock.Config.Item.SIRI.request_is_allowed?(item, parsed_xml)
+    assert Unlock.Config.Item.SIRI.request_is_allowed?(%{item | allowed_queries: ["CheckStatus"]}, parsed_xml)
+
+    assert Unlock.Config.Item.SIRI.request_is_allowed?(
+             %{item | allowed_queries: ["CheckStatus", "LinesDiscovery"]},
+             parsed_xml
+           )
+
+    refute Unlock.Config.Item.SIRI.request_is_allowed?(%{item | allowed_queries: ["LinesDiscovery"]}, parsed_xml)
   end
 end

--- a/apps/unlock/test/siri_test.exs
+++ b/apps/unlock/test/siri_test.exs
@@ -33,7 +33,7 @@ defmodule Unlock.SIRITests do
     xml = """
     <?xml version="1.0" encoding="UTF-8"?>
     <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-    <S:Body>
+    <S:body>
         <sw:CheckStatus xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
             <Request>
                 <siri:RequestTimestamp>#{DateTime.utc_now() |> DateTime.to_iso8601()}</siri:RequestTimestamp>
@@ -42,7 +42,7 @@ defmodule Unlock.SIRITests do
             </Request>
             <RequestExtension/>
         </sw:CheckStatus>
-    </S:Body>
+    </S:body>
     </S:Envelope>
     """
 

--- a/apps/unlock/test/siri_test.exs
+++ b/apps/unlock/test/siri_test.exs
@@ -1,5 +1,5 @@
 defmodule Unlock.SIRITests do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import SIRIQueries
 
   doctest Unlock.SIRI
@@ -27,5 +27,60 @@ defmodule Unlock.SIRITests do
 
     # and the input requestor ref seen in the document must be returned
     assert seen_requestor_refs == [incoming_requestor_ref]
+  end
+
+  test "ServicesFinder parses services" do
+    xml = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <S:Body>
+        <sw:CheckStatus xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+            <Request>
+                <siri:RequestTimestamp>#{DateTime.utc_now() |> DateTime.to_iso8601()}</siri:RequestTimestamp>
+                <siri:RequestorRef>secret</siri:RequestorRef>
+                <siri:MessageIdentifier>Test:Message::9d5f99e2-5e6d-4c7b-befc-381a3c592ede</siri:MessageIdentifier>
+            </Request>
+            <RequestExtension/>
+        </sw:CheckStatus>
+    </S:Body>
+    </S:Envelope>
+    """
+
+    assert ["CheckStatus"] == xml |> Unlock.SIRI.parse_incoming() |> Unlock.SIRI.ServicesFinder.parse()
+
+    xml = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+        <sw:CheckStatus xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+          <Request>
+            <siri:RequestTimestamp>2022-10-25T08:34:59.247129Z</siri:RequestTimestamp>
+            <siri:RequestorRef>transport-data-gouv-fr</siri:RequestorRef>
+            <siri:MessageIdentifier>Test::Message::64026718-3b56-4b93-a37f-7e542097a3e3</siri:MessageIdentifier>
+          </Request>
+        </sw:CheckStatus>
+        <sw:LinesDiscovery xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+          <Request>
+            <siri:RequestTimestamp>2022-10-25T08:34:59.247129Z</siri:RequestTimestamp>
+            <siri:RequestorRef>transport-data-gouv-fr</siri:RequestorRef>
+            <siri:MessageIdentifier>Test::Message::64026718-3b56-4b93-a37f-7e542097a3e3</siri:MessageIdentifier>
+          </Request>
+        </sw:LinesDiscovery>
+      </S:Body>
+    </S:Envelope>
+    """
+
+    assert ["CheckStatus", "LinesDiscovery"] ==
+             xml |> Unlock.SIRI.parse_incoming() |> Unlock.SIRI.ServicesFinder.parse()
+
+    xml = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+      </S:Body>
+    </S:Envelope>
+    """
+
+    assert [] == xml |> Unlock.SIRI.parse_incoming() |> Unlock.SIRI.ServicesFinder.parse()
   end
 end


### PR DESCRIPTION
En lien avec #2476

- Permet de spécifier les types de requêtes acceptées dans la configuration, dans le champ `allowed_queries`
- Inspecte la requête effectuée et renvoie une erreur HTTP 403 si le type de requête n'est pas accepté