### PR TITLE
Envoi de notifications lors de l'ajout d'un jeu de données

### DIFF
--- a/apps/transport/lib/jobs/new_dataset_job.ex
+++ b/apps/transport/lib/jobs/new_dataset_job.ex
@@ -1,0 +1,13 @@
+defmodule Transport.Jobs.NewDatasetJob do
+  @moduledoc """
+  Job dispatched when a dataset is created from the backoffice.
+  """
+  use Oban.Worker, max_attempts: 3, unique: [period: :infinity]
+
+  @impl true
+  def perform(%{args: %{"dataset_id" => dataset_id}}) do
+    DB.Dataset
+    |> DB.Repo.get!(dataset_id)
+    |> Transport.DataChecker.send_new_dataset_notifications()
+  end
+end

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -81,6 +81,33 @@ defmodule Transport.DataChecker do
     |> Enum.sort()
   end
 
+  def send_new_dataset_notifications(%Dataset{} = dataset) do
+    Transport.Notifications.config()
+    |> Transport.Notifications.emails_for_reason(:new_dataset)
+    |> Enum.each(fn email ->
+      Transport.EmailSender.impl().send_mail(
+        "transport.data.gouv.fr",
+        Application.get_env(:transport, :contact_email),
+        email,
+        Application.get_env(:transport, :contact_email),
+        "Nouveau jeu de données référencé",
+        """
+        Bonjour,
+
+        Un jeu de données vient d'être référencé :
+
+        #{link_and_name(dataset)}
+
+        L’équipe transport.data.gouv.fr
+
+        ---
+        Si vous souhaitez modifier ou supprimer ces alertes, vous pouvez répondre à cet e-mail.
+        """,
+        ""
+      )
+    end)
+  end
+
   def send_outdated_data_notifications({delay, datasets} = payload) do
     notifications_config = Transport.Notifications.config()
 

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
          {:ok, changeset} <- Dataset.changeset(params),
          {:ok, dataset} <- insert_dataset(changeset) do
       if params["action"] == "new" do
-        %{"dataset_id" => dataset.id} |> Transport.Jobs.NewDatasetJob.new() |> Oban.insert!()
+        %{"dataset_id" => dataset.id} |> Transport.Jobs.NewDatasetJob.new(schedule_in: 60 * 5) |> Oban.insert!()
       end
 
       dataset

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -26,6 +26,10 @@ defmodule TransportWeb.Backoffice.DatasetController do
          params <- Map.merge(params, dg_dataset),
          {:ok, changeset} <- Dataset.changeset(params),
          {:ok, dataset} <- insert_dataset(changeset) do
+      if params["action"] == "new" do
+        %{"dataset_id" => dataset.id} |> Transport.Jobs.NewDatasetJob.new() |> Oban.insert!()
+      end
+
       dataset
       |> Dataset.validate()
       |> flash(

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -60,7 +60,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
     |> redirect_to_index()
   end
 
-  @spec insert_dataset(Ecto.Changeset.t()) :: {:ok, binary} | {:error, binary}
+  @spec insert_dataset(Ecto.Changeset.t()) :: {:ok, Dataset.t()} | {:error, binary}
   defp insert_dataset(changeset) do
     Repo.insert_or_update(changeset)
   rescue

--- a/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJob do
+defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJobTest do
   use ExUnit.Case, async: true
   import DB.Factory
   import Mox

--- a/apps/transport/test/transport/jobs/new_dataset_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_dataset_job_test.exs
@@ -1,0 +1,41 @@
+defmodule Transport.Test.Transport.Jobs.NewDatasetJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  alias Transport.Jobs.NewDatasetJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr" = _subject,
+                             "contact@transport.beta.gouv.fr",
+                             "foo@example.com" = _to,
+                             "contact@transport.beta.gouv.fr",
+                             "Nouveau jeu de données référencé",
+                             plain_text_body,
+                             "" = _html_part ->
+      assert plain_text_body =~ ~r/Bonjour/
+      :ok
+    end)
+
+    Transport.Notifications.FetcherMock
+    |> expect(:fetch_config!, fn ->
+      [
+        %Transport.Notifications.Item{
+          dataset_slug: nil,
+          emails: ["foo@example.com"],
+          reason: :new_dataset,
+          extra_delays: []
+        }
+      ]
+    end)
+
+    assert :ok == perform_job(NewDatasetJob, %{"dataset_id" => insert(:dataset).id})
+  end
+end

--- a/config/notifications-config.sample.yml
+++ b/config/notifications-config.sample.yml
@@ -1,5 +1,7 @@
-# can be useful in some occasions ; must be kept in sync with the format at 
+# can be useful in some occasions ; must be kept in sync with the format at
 # https://github.com/etalab/transport-notifications/
+new_dataset:
+  - hello@example.com
 expiration:
   offre-2022-de-transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs:
     emails:


### PR DESCRIPTION
Retravaille les notifications pour ajouter un motif permettant d'avoir une liste d'adresses e-mails intéressées par l'ajout de jeux de données.

Envoie ces notifications lorsqu'un jeu de données est ajouté depuis le backoffice.
