### PR TITLE
Handle AmbiguousDateTime for convert_to_paris_time

### DIFF
--- a/apps/shared/lib/date_time_display.ex
+++ b/apps/shared/lib/date_time_display.ex
@@ -111,8 +111,20 @@ defmodule Shared.DateTimeDisplay do
 
   def format_datetime_to_paris(nil, _, _), do: ""
 
-  defp convert_to_paris_time(%DateTime{} = dt), do: dt |> Timex.Timezone.convert("Europe/Paris")
-  defp convert_to_paris_time(%NaiveDateTime{} = ndt), do: ndt |> Timex.Timezone.convert("Europe/Paris")
+  @spec convert_to_paris_time(DateTime.t() | NaiveDateTime.t()) :: DateTime.t()
+  defp convert_to_paris_time(%DateTime{} = dt) do
+    case Timex.Timezone.convert(dt, "Europe/Paris") do
+      %Timex.AmbiguousDateTime{after: dt} -> dt
+      %DateTime{} = dt -> dt
+    end
+  end
+
+  defp convert_to_paris_time(%NaiveDateTime{} = ndt) do
+    case Timex.Timezone.convert(ndt, "Europe/Paris") do
+      %Timex.AmbiguousDateTime{after: dt} -> dt
+      %DateTime{} = dt -> dt
+    end
+  end
 
   @doc """
   Converts a binary naive date time to a binary date time having the Paris timezone.
@@ -120,6 +132,8 @@ defmodule Shared.DateTimeDisplay do
 
   iex> format_naive_datetime_to_paris_tz("2022-03-01T15:30:00")
   "2022-03-01T15:30:00+01:00"
+  iex> format_naive_datetime_to_paris_tz("2022-10-30T02:03:54")
+  "2022-10-30T02:03:54+01:00"
   """
   @spec format_naive_datetime_to_paris_tz(nil | binary) :: binary
   def format_naive_datetime_to_paris_tz(nil), do: ""


### PR DESCRIPTION
See [Sentry issue](https://sentry.io/organizations/transport-data-gouv-fr/issues/3706252664/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream)

On this fine Sunday morning, I had a chance to discover and read the [Timex.AmbiguousDateTime](https://hexdocs.pm/timex/Timex.AmbiguousDateTime.html) page.

Discovered because at 3am in Europe/Paris, we went back to 2am today.

```elixir
"2022-10-30T02:03:54.322000" |> Timex.parse!("{ISO:Extended}") |> Timex.Timezone.convert("Europe/Paris")
#<Ambiguous(#DateTime<2022-10-30 02:03:54.322000+02:00 CEST Europe/Paris> ~ #DateTime<2022-10-30 02:03:54.322000+01:00 CET Europe/Paris>)>
```

This is documented as [Ambiguity #2 - Times with more than one valid timezone](https://hexdocs.pm/timex/Timex.AmbiguousDateTime.html#module-ambiguity-2-times-with-more-than-one-valid-zone-period).

> It is up to you as the programmer to decide which DateTime is the one to use, but my recommendation is to choose :after, unless you have a specific reason to use :before.