### PR TITLE
Nouveaux JDD : ajout catégorie de données, titre custom

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -85,6 +85,10 @@ defmodule Transport.DataChecker do
   def send_new_dataset_notifications([]), do: :ok
 
   def send_new_dataset_notifications(datasets) do
+    dataset_link_fn = fn %Dataset{} = dataset ->
+      "* #{dataset.custom_title} - (#{Dataset.type_to_str(dataset.type)}) - #{link(dataset)}"
+    end
+
     Transport.Notifications.config()
     |> Transport.Notifications.emails_for_reason(:new_dataset)
     |> Enum.each(fn email ->
@@ -99,7 +103,7 @@ defmodule Transport.DataChecker do
 
         Les jeux de données suivants ont été référencés récemment :
 
-        #{datasets |> Enum.map_join("\n", &link_and_name/1)}
+        #{datasets |> Enum.sort_by(& &1.type) |> Enum.map_join("\n", &dataset_link_fn.(&1))}
 
         L’équipe transport.data.gouv.fr
 

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -361,7 +361,7 @@ defmodule TransportWeb.DatasetView do
   ## Examples
 
   iex> licence(%Dataset{licence: "fr-lo"})
-  "fr-lo"
+  "Licence ouverte"
   iex> licence(%Dataset{licence: "Libertarian"})
   "Libertarian"
   """

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -261,7 +261,11 @@ defmodule Transport.DataCheckerTest do
                                "Nouveaux jeux de données référencés" = _subject,
                                plain_text_body,
                                "" = _html_part ->
-        assert plain_text_body =~ ~r/Bonjour/
+        assert plain_text_body =~ ~r/^Bonjour/
+
+        assert plain_text_body =~
+                 "* Super JDD - (Transport public collectif - horaires théoriques) - http://127.0.0.1:5100/datasets/slug"
+
         :ok
       end)
 
@@ -279,7 +283,7 @@ defmodule Transport.DataCheckerTest do
         ]
       end)
 
-      dataset = %DB.Dataset{slug: dataset_slug, datagouv_title: "title"}
+      dataset = %DB.Dataset{slug: dataset_slug, custom_title: "Super JDD", type: "public-transit"}
 
       Transport.DataChecker.send_new_dataset_notifications([dataset])
 

--- a/apps/transport/test/transport_web/views/error_view_test.exs
+++ b/apps/transport/test/transport_web/views/error_view_test.exs
@@ -4,6 +4,6 @@ defmodule TransportWeb.ErrorViewTest do
   alias TransportWeb.ErrorView
 
   test "render 500.html" do
-    assert render_to_string(ErrorView, "500.html", []) =~ "End of the road!"
+    assert render_to_string(ErrorView, "500.html", []) =~ "Erreur sur la ligne 500 !"
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -174,6 +174,9 @@ config :ex_aws, :database_backup_destination,
   host: System.get_env("DATABASE_BACKUP_DESTINATION_HOST"),
   region: System.get_env("DATABASE_BACKUP_DESTINATION_REGION")
 
+# https://hexdocs.pm/gettext/Gettext.html#module-default-locale
+config :gettext, :default_locale, "fr"
+
 config :transport,
   domain_name: System.get_env("DOMAIN_NAME", "transport.data.gouv.fr"),
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),


### PR DESCRIPTION
Petite amélioration suite à https://github.com/etalab/transport-site/pull/2740

- Tri par catégorie de données
- Utilisation du titre du PAN et non de data.gouv.fr
- Ajout du type de données dans l'e-mail

cc @cyrilmorin 