### PR TITLE
Construction des requêtes SIRI par "XML builder"

### DIFF
--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -36,20 +36,18 @@ defmodule Transport.SIRI do
   end
 
   def lines_discovery(timestamp, requestor_ref, message_identifier) do
-    """
-    #{prolog()}
-    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-      <S:Body>
-        <sw:LinesDiscovery xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
-          <Request>
-            <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-            <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
-            <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-          </Request>
-        </sw:LinesDiscovery>
-      </S:Body>
-    </S:Envelope>
-    """
+    element("S:Envelope", @top_level_namespaces, [
+      element("S:Body", [], [
+        element("sw:LinesDiscovery", @request_namespaces, [
+          element("Request", [], [
+            element("siri:RequestTimestamp", [], timestamp),
+            element("siri:RequestorRef", [], requestor_ref),
+            element("siri:MessageIdentifier", [], message_identifier)
+          ])
+        ])
+      ])
+    ])
+    |> Saxy.encode!()
   end
 
   def stop_points_discovery(timestamp, requestor_ref, message_identifier) do

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -119,26 +119,30 @@ defmodule Transport.SIRI do
   end
 
   def get_stop_monitoring(timestamp, requestor_ref, message_identifier, stop_ref) do
-    """
-    #{prolog()}
-    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-    <S:Body>
-        <sw:GetStopMonitoring xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
-            <ServiceRequestInfo>
-                <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-                <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
-                <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-            </ServiceRequestInfo>
-            <Request>
-                <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-                <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-                <siri:MonitoringRef>#{stop_ref}</siri:MonitoringRef>
-                <siri:StopVisitTypes>all</siri:StopVisitTypes>
-            </Request>
-        </sw:GetStopMonitoring>
-    </S:Body>
-    </S:Envelope>
-    """
+    doc =
+      element("S:Envelope", @top_level_namespaces, [
+        element("S:Body", [], [
+          element("sw:GetStopMonitoring", @request_namespaces, [
+            element("ServiceRequestInfo", [], [
+              element("siri:RequestTimestamp", [], timestamp),
+              element("siri:RequestorRef", [], requestor_ref),
+              element("siri:MessageIdentifier", [], message_identifier)
+            ]),
+            element(
+              "Request",
+              [],
+              [
+                element("siri:RequestTimestamp", [], timestamp),
+                element("siri:MessageIdentifier", [], message_identifier),
+                element("siri:MonitoringRef", [], stop_ref),
+                element("siri:StopVisitTypes", [], "all")
+              ]
+            )
+          ])
+        ])
+      ])
+
+    Saxy.encode!(doc)
   end
 
   def get_general_message(timestamp, requestor_ref, message_identifier) do

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -51,20 +51,18 @@ defmodule Transport.SIRI do
   end
 
   def stop_points_discovery(timestamp, requestor_ref, message_identifier) do
-    """
-    #{prolog()}
-    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-      <S:Body>
-        <sw:StopPointsDiscovery xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
-          <Request>
-            <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-            <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
-            <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-          </Request>
-        </sw:StopPointsDiscovery>
-      </S:Body>
-    </S:Envelope>
-    """
+    element("S:Envelope", @top_level_namespaces, [
+      element("S:Body", [], [
+        element("sw:StopPointsDiscovery", @request_namespaces, [
+          element("Request", [], [
+            element("siri:RequestTimestamp", [], timestamp),
+            element("siri:RequestorRef", [], requestor_ref),
+            element("siri:MessageIdentifier", [], message_identifier)
+          ])
+        ])
+      ])
+    ])
+    |> Saxy.encode!()
   end
 
   def build_line_refs(line_refs) do

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -146,23 +146,27 @@ defmodule Transport.SIRI do
   end
 
   def get_general_message(timestamp, requestor_ref, message_identifier) do
-    """
-    #{prolog()}
-    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-    <S:Body>
-     	<sw:GetGeneralMessage xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri" xmlns:sws="http://wsdl.siri.org.uk/siri">
-        	<ServiceRequestInfo>
-    		      <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-    		      <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
-            	<siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-         </ServiceRequestInfo>
-         <Request>
-                <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
-                <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
-      			</Request>
-    		</sw:GetGeneralMessage>
-    </S:Body>
-    </S:Envelope>
-    """
+    doc =
+      element("S:Envelope", @top_level_namespaces, [
+        element("S:Body", [], [
+          element("sw:GetGeneralMessage", @request_namespaces, [
+            element("ServiceRequestInfo", [], [
+              element("siri:RequestTimestamp", [], timestamp),
+              element("siri:RequestorRef", [], requestor_ref),
+              element("siri:MessageIdentifier", [], message_identifier)
+            ]),
+            element(
+              "Request",
+              [],
+              [
+                element("siri:RequestTimestamp", [], timestamp),
+                element("siri:MessageIdentifier", [], message_identifier)
+              ]
+            )
+          ])
+        ])
+      ])
+
+    Saxy.encode!(doc)
   end
 end

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -113,7 +113,7 @@ defmodule Transport.SIRI do
                 <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
                 <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
             </ServiceRequestInfo>
-            <Request version="2.0:FR-IDF-2.4">
+            <Request>
                 <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
                 <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
                 <siri:MonitoringRef>#{stop_ref}</siri:MonitoringRef>

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -21,48 +21,54 @@ defmodule Transport.SIRI do
   end
 
   def check_status(timestamp, requestor_ref, message_identifier) do
-    element("S:Envelope", @top_level_namespaces, [
-      element("S:Body", [], [
-        element("sw:CheckStatus", @request_namespaces, [
-          element("Request", [], [
-            element("siri:RequestTimestamp", [], timestamp),
-            element("siri:RequestorRef", [], requestor_ref),
-            element("siri:MessageIdentifier", [], message_identifier)
+    doc =
+      element("S:Envelope", @top_level_namespaces, [
+        element("S:Body", [], [
+          element("sw:CheckStatus", @request_namespaces, [
+            element("Request", [], [
+              element("siri:RequestTimestamp", [], timestamp),
+              element("siri:RequestorRef", [], requestor_ref),
+              element("siri:MessageIdentifier", [], message_identifier)
+            ])
           ])
         ])
       ])
-    ])
-    |> Saxy.encode!()
+
+    Saxy.encode!(doc)
   end
 
   def lines_discovery(timestamp, requestor_ref, message_identifier) do
-    element("S:Envelope", @top_level_namespaces, [
-      element("S:Body", [], [
-        element("sw:LinesDiscovery", @request_namespaces, [
-          element("Request", [], [
-            element("siri:RequestTimestamp", [], timestamp),
-            element("siri:RequestorRef", [], requestor_ref),
-            element("siri:MessageIdentifier", [], message_identifier)
+    doc =
+      element("S:Envelope", @top_level_namespaces, [
+        element("S:Body", [], [
+          element("sw:LinesDiscovery", @request_namespaces, [
+            element("Request", [], [
+              element("siri:RequestTimestamp", [], timestamp),
+              element("siri:RequestorRef", [], requestor_ref),
+              element("siri:MessageIdentifier", [], message_identifier)
+            ])
           ])
         ])
       ])
-    ])
-    |> Saxy.encode!()
+
+    Saxy.encode!(doc)
   end
 
   def stop_points_discovery(timestamp, requestor_ref, message_identifier) do
-    element("S:Envelope", @top_level_namespaces, [
-      element("S:Body", [], [
-        element("sw:StopPointsDiscovery", @request_namespaces, [
-          element("Request", [], [
-            element("siri:RequestTimestamp", [], timestamp),
-            element("siri:RequestorRef", [], requestor_ref),
-            element("siri:MessageIdentifier", [], message_identifier)
+    doc =
+      element("S:Envelope", @top_level_namespaces, [
+        element("S:Body", [], [
+          element("sw:StopPointsDiscovery", @request_namespaces, [
+            element("Request", [], [
+              element("siri:RequestTimestamp", [], timestamp),
+              element("siri:RequestorRef", [], requestor_ref),
+              element("siri:MessageIdentifier", [], message_identifier)
+            ])
           ])
         ])
       ])
-    ])
-    |> Saxy.encode!()
+
+    Saxy.encode!(doc)
   end
 
   def build_line_refs(line_refs) do

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -136,7 +136,7 @@ defmodule Transport.SIRI do
     		      <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
             	<siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
          </ServiceRequestInfo>
-         <Request version="2.0:FR-IDF-2.4">
+         <Request>
                 <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
                 <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
       			</Request>

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -82,7 +82,7 @@ defmodule Transport.SIRI do
     """
   end
 
-  def line_refs_element(_line_refs = []), do: nil
+  def line_refs_element([] = _line_refs), do: nil
 
   def line_refs_element(line_refs) do
     line_refs = line_refs |> Enum.map(&element("siri:LineRef", [], &1))

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -52,11 +52,53 @@ defmodule Transport.SIRITest do
     assert parse_xml(request) == parse_xml(expected_response)
   end
 
-  @tag :skip
-  test "LinesDiscovery"
+  test "LinesDiscovery" do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    requestor_ref = "the-ref"
+    message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
+    request = Transport.SIRI.lines_discovery(timestamp, requestor_ref, message_identifier)
 
-  @tag :skip
-  test "StopPointsDiscovery"
+    expected_response = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+        <sw:LinesDiscovery xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+          <Request>
+            <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+            <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
+            <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+          </Request>
+        </sw:LinesDiscovery>
+      </S:Body>
+    </S:Envelope>
+    """
+
+    assert parse_xml(request) == parse_xml(expected_response)
+  end
+
+  test "StopPointsDiscovery" do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    requestor_ref = "the-ref"
+    message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
+    request = Transport.SIRI.stop_points_discovery(timestamp, requestor_ref, message_identifier)
+
+    expected_response = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+        <sw:StopPointsDiscovery xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+          <Request>
+            <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+            <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
+            <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+          </Request>
+        </sw:StopPointsDiscovery>
+      </S:Body>
+    </S:Envelope>
+    """
+
+    assert parse_xml(request) == parse_xml(expected_response)
+  end
 
   test "GetEstimatedTimetable" do
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -137,6 +137,34 @@ defmodule Transport.SIRITest do
   @tag :skip
   test "GetGeneralMessage"
 
-  @tag :skip
-  test "GetStopMonitoring"
+  test "GetStopMonitoring" do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    requestor_ref = "the-ref"
+    message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
+    stop_ref = "STOP:001"
+    request = Transport.SIRI.get_stop_monitoring(timestamp, requestor_ref, message_identifier, stop_ref)
+
+    expected_response = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <S:Body>
+      <sw:GetStopMonitoring xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+        <ServiceRequestInfo>
+          <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+          <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
+          <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+        </ServiceRequestInfo>
+        <Request>
+          <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+          <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+          <siri:MonitoringRef>#{stop_ref}</siri:MonitoringRef>
+          <siri:StopVisitTypes>all</siri:StopVisitTypes>
+        </Request>
+      </sw:GetStopMonitoring>
+    </S:Body>
+    </S:Envelope>
+    """
+
+    assert parse_xml(request) == parse_xml(expected_response)
+  end
 end

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -174,7 +174,7 @@ defmodule Transport.SIRITest do
     <?xml version="1.0" encoding="UTF-8"?>
     <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
     <S:Body>
-     	<sw:GetGeneralMessage xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri" xmlns:sws="http://wsdl.siri.org.uk/siri">
+     	<sw:GetGeneralMessage xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
         <ServiceRequestInfo>
           <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
           <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -134,8 +134,33 @@ defmodule Transport.SIRITest do
     assert parse_xml(request) == parse_xml(expected_response)
   end
 
-  @tag :skip
-  test "GetGeneralMessage"
+  test "GetGeneralMessage" do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    requestor_ref = "the-ref"
+    message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
+    request = Transport.SIRI.get_general_message(timestamp, requestor_ref, message_identifier)
+
+    expected_response = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <S:Body>
+     	<sw:GetGeneralMessage xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri" xmlns:sws="http://wsdl.siri.org.uk/siri">
+        <ServiceRequestInfo>
+          <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+          <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
+          <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+        </ServiceRequestInfo>
+        <Request>
+          <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+          <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+        </Request>
+      </sw:GetGeneralMessage>
+    </S:Body>
+    </S:Envelope>
+    """
+
+    assert parse_xml(request) == parse_xml(expected_response)
+  end
 
   test "GetStopMonitoring" do
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -100,7 +100,7 @@ defmodule Transport.SIRITest do
     assert parse_xml(request) == parse_xml(expected_response)
   end
 
-  test "GetEstimatedTimetable" do
+  test "GetEstimatedTimetable (with line references)" do
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
     requestor_ref = "the-ref"
     message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
@@ -125,6 +125,36 @@ defmodule Transport.SIRITest do
                 <siri:LineRef>#{line_001}</siri:LineRef>
                 <siri:LineRef>#{line_002}</siri:LineRef>
               </siri:Lines>
+            </Request>
+        </sw:GetEstimatedTimetable>
+      </S:Body>
+    </S:Envelope>
+    """
+
+    assert parse_xml(request) == parse_xml(expected_response)
+  end
+
+  # NOTE: there are apparently differently ways to create this ("ALL" vs "nothing")
+  # and different servers exhibit different behaviours (to be verified).
+  test "GetEstimatedTimetable (without line references)" do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    requestor_ref = "the-ref"
+    message_identifier = "Test::Message::#{Ecto.UUID.generate()}"
+    request = Transport.SIRI.get_estimated_timetable(timestamp, requestor_ref, message_identifier, [])
+
+    expected_response = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <S:Body>
+        <sw:GetEstimatedTimetable xmlns:sw="http://wsdl.siri.org.uk" xmlns:siri="http://www.siri.org.uk/siri">
+            <ServiceRequestInfo>
+              <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+              <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
+              <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
+            </ServiceRequestInfo>
+            <Request>
+              <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
+              <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
             </Request>
         </sw:GetEstimatedTimetable>
       </S:Body>

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,13 @@ defmodule Transport.MixProject do
       # :test to ensure CI can run it with a single compilation (in test target),
       # to reduce build time
       {:dialyxir, "~> 1.2.0", only: [:dev, :test], runtime: false},
-      {:excoveralls, "~> 0.10", only: :test}
+      {:excoveralls, "~> 0.10", only: :test},
+      # temporary dialyzer fix on master until
+      # a new release https://github.com/qcam/saxy/issues/116 is cut
+      {:saxy,
+       git: "git@github.com:qcam/saxy.git",
+       override: true,
+       ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Transport.MixProject do
       {:excoveralls, "~> 0.10", only: :test},
       # temporary dialyzer fix on master until
       # a new release https://github.com/qcam/saxy/issues/116 is cut
-      {:saxy, git: "git@github.com:qcam/saxy.git", override: true, ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"}
+      {:saxy, git: "https://github.com/qcam/saxy", override: true, ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,10 +29,7 @@ defmodule Transport.MixProject do
       {:excoveralls, "~> 0.10", only: :test},
       # temporary dialyzer fix on master until
       # a new release https://github.com/qcam/saxy/issues/116 is cut
-      {:saxy,
-       git: "git@github.com:qcam/saxy.git",
-       override: true,
-       ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"}
+      {:saxy, git: "git@github.com:qcam/saxy.git", override: true, ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -88,7 +88,7 @@
   "rambo": {:hex, :rambo, "0.3.4", "8962ac3bd1a633ee9d0e8b44373c7913e3ce3d875b4151dcd060886092d2dce7", [:mix], [], "hexpm", "0cc54ed089fbbc84b65f4b8a774224ebfe60e5c80186fafc7910b3e379ad58f1"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
-  "saxy": {:hex, :saxy, "1.4.0", "c7203ad20001f72eaaad07d08f82be063fa94a40924e6bb39d93d55f979abcba", [:mix], [], "hexpm", "3fe790354d3f2234ad0b5be2d99822a23fa2d4e8ccd6657c672901dac172e9a9"},
+  "saxy": {:git, "git@github.com:qcam/saxy.git", "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c", [ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"]},
   "scrivener": {:hex, :scrivener, "2.7.2", "1d913c965ec352650a7f864ad7fd8d80462f76a32f33d57d1e48bc5e9d40aba2", [:mix], [], "hexpm", "7866a0ec4d40274efbee1db8bead13a995ea4926ecd8203345af8f90d2b620d9"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.7.0", "cf64b8cb8a96cd131cdbcecf64e7fd395e21aaa1cb0236c42a7c2e34b0dca580", [:mix], [{:ecto, "~> 3.3", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm", "e809f171687806b0031129034352f5ae44849720c48dd839200adeaf0ac3e260"},
   "scrivener_html": {:git, "https://github.com/mgwidmann/scrivener_html.git", "9224d1f3315e47cb13fa1ed403d3985474a58afa", [ref: "9224d1"]},

--- a/mix.lock
+++ b/mix.lock
@@ -88,7 +88,7 @@
   "rambo": {:hex, :rambo, "0.3.4", "8962ac3bd1a633ee9d0e8b44373c7913e3ce3d875b4151dcd060886092d2dce7", [:mix], [], "hexpm", "0cc54ed089fbbc84b65f4b8a774224ebfe60e5c80186fafc7910b3e379ad58f1"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
-  "saxy": {:git, "git@github.com:qcam/saxy.git", "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c", [ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"]},
+  "saxy": {:git, "https://github.com/qcam/saxy", "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c", [ref: "c15c2c6c17aee0a6f9be78a6d0f79ca930644b2c"]},
   "scrivener": {:hex, :scrivener, "2.7.2", "1d913c965ec352650a7f864ad7fd8d80462f76a32f33d57d1e48bc5e9d40aba2", [:mix], [], "hexpm", "7866a0ec4d40274efbee1db8bead13a995ea4926ecd8203345af8f90d2b620d9"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.7.0", "cf64b8cb8a96cd131cdbcecf64e7fd395e21aaa1cb0236c42a7c2e34b0dca580", [:mix], [{:ecto, "~> 3.3", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm", "e809f171687806b0031129034352f5ae44849720c48dd839200adeaf0ac3e260"},
   "scrivener_html": {:git, "https://github.com/mgwidmann/scrivener_html.git", "9224d1f3315e47cb13fa1ed403d3985474a58afa", [ref: "9224d1"]},


### PR DESCRIPTION
Pour préparer mon travail sur :
- #2741 (la partie requête "à paramètres" en particulier)

je modifie dans cette PR la façon de générer les requêtes SIRI, pour ne plus utiliser une interpolation de chaîne, et à la place nous appuyer sur l'API de `Saxy`. Le but premier est d'éviter de risquer de former du XML mal formé lorsqu'on va injecter des éléments saisis par un utilisateur extérieur.

J'ai mis par ailleurs le générateur de requêtes sous tests, pour me faciliter ce refactoring, et faciliter les suivants (ex: mise en commun d'éléments partagés, ou correctifs).

Au passage j'ai corrigé quelques points dans les templates:
- suppression de références à "IDF" dans les requêtes
- suppression de namespaces non nécessaires

Je partirai de cette branche pour travailler sur la deuxième itération du requêteur.

### Reste à faire

- [x] Dialyzer n'est pas content ! Edit j'ai trouvé, problème déjà signalé par moi (https://github.com/qcam/saxy/issues/111) et corrigé par l'auteur de Saxy depuis
- [x] ~~Attendre un peu voir si l'auteur pousse une nouvelle version et supprimer l'override GitHub https://github.com/qcam/saxy/issues/116~~ ça ne va pas venir assez vite, on déploie comme ça.