### PR TITLE
Fix temporaire et incomplet pour #2752

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -87,7 +87,8 @@ defmodule TransportWeb.API.DatasetController do
     if is_nil(dataset) do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
-      result =
+      # TODO: proper fix for https://github.com/etalab/transport-site/issues/2752
+      records =
         Transport.Validators.GTFSTransport.validator_name()
         |> Dataset.join_from_dataset_to_metadata()
         |> where([dataset: d], d.datagouv_id == ^id)
@@ -98,7 +99,11 @@ defmodule TransportWeb.API.DatasetController do
           multi_validation: {mv.id, mv.resource_history_id},
           resource_history: {rh.id, rh.resource_id}
         })
-        |> Repo.one()
+        |> DB.Repo.all()
+
+      # the query above returns more than one record ; for now and without proper time
+      # to fix the code to return the correct one, I'm returning nothing
+      result = if records |> Enum.count() > 1, do: nil, else: records |> Enum.at(0)
 
       data =
         if is_nil(result) do

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -87,7 +87,7 @@ defmodule TransportWeb.API.DatasetController do
     if is_nil(dataset) do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
-      # TODO: proper fix for https://github.com/etalab/transport-site/issues/2752
+      # This is just a temporary hotfix for https://github.com/etalab/transport-site/issues/2752
       records =
         Transport.Validators.GTFSTransport.validator_name()
         |> Dataset.join_from_dataset_to_metadata()

--- a/scripts/api_datasets_check.exs
+++ b/scripts/api_datasets_check.exs
@@ -1,0 +1,33 @@
+Mix.install([
+  {:req, ">= 0.0.0"}
+])
+
+require Logger
+Logger.info("Starting...")
+
+%{body: datasets} = Req.get!("http://localhost:5000/api/datasets")
+
+datasets
+|> Enum.map(& &1["id"])
+|> Task.async_stream(
+  fn id ->
+    %{body: body, status: status} =
+      Req.get!("http://localhost:5000/api/datasets/#{id}", retry: :never)
+
+    cond do
+      status == 500 ->
+        {status, body |> String.split("\n") |> List.first() |> String.split("at") |> List.first()}
+
+      true ->
+        status
+    end
+  end,
+  max_concurrency: 50
+)
+|> Enum.map(fn {:ok, id} -> id end)
+|> Enum.group_by(& &1)
+|> Enum.map(fn {k, v} -> {k, Enum.count(v)} end)
+|> Enum.into(%{})
+|> IO.inspect(IEx.inspect_opts())
+
+Logger.info("Done...")

--- a/scripts/api_datasets_check.exs
+++ b/scripts/api_datasets_check.exs
@@ -11,8 +11,7 @@ datasets
 |> Enum.map(& &1["id"])
 |> Task.async_stream(
   fn id ->
-    %{body: body, status: status} =
-      Req.get!("http://localhost:5000/api/datasets/#{id}", retry: :never)
+    %{body: body, status: status} = Req.get!("http://localhost:5000/api/datasets/#{id}", retry: :never)
 
     cond do
       status == 500 ->

--- a/scripts/api_datasets_check.exs
+++ b/scripts/api_datasets_check.exs
@@ -21,7 +21,7 @@ datasets
         status
     end
   end,
-  max_concurrency: 50
+  max_concurrency: 30
 )
 |> Enum.map(fn {:ok, id} -> id end)
 |> Enum.group_by(& &1)


### PR DESCRIPTION
Voir:
- #2752

Je supprime une partie de la donnée sortante côté API qui pose problème, car je n'ai pas pour l'instant le temps matériel pour investiguer correctement.

Cela permet de corriger les nombreux appels en 500 (26% de datasets) sur l'API, en attendant mieux.

:warning: Je vais déployer directement sur la production sans merger. Il sera préférable de remplacer cela par un correctif propre lundi !