### PR TITLE
Suppression méthodes utilisant métadonnées des ressources

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -398,14 +398,6 @@ defmodule DB.Dataset do
   @spec format_error(any()) :: binary()
   defp format_error(changeset), do: "#{inspect(Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end))}"
 
-  @spec valid_gtfs(DB.Dataset.t()) :: [Resource.t()]
-  def valid_gtfs(%__MODULE__{resources: nil}), do: []
-
-  def valid_gtfs(%__MODULE__{resources: r, type: "public-transit"}),
-    do: Enum.filter(r, &Resource.valid_and_available?/1)
-
-  def valid_gtfs(%__MODULE__{resources: r}), do: r
-
   @spec link_to_datagouv(DB.Dataset.t()) :: any()
   def link_to_datagouv(%__MODULE__{} = dataset) do
     Link.link(

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -538,19 +538,6 @@ defmodule DB.Resource do
     |> validate_required([:url, :datagouv_id])
   end
 
-  @spec valid_and_available?(__MODULE__.t()) :: boolean()
-  def valid_and_available?(%__MODULE__{
-        is_available: available,
-        metadata: %{
-          "start_date" => s,
-          "end_date" => e
-        }
-      })
-      when not is_nil(s) and not is_nil(e),
-      do: available
-
-  def valid_and_available?(%__MODULE__{}), do: false
-
   @spec is_outdated?(__MODULE__.t()) :: boolean
   def is_outdated?(%__MODULE__{
         metadata: %{

--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -14,7 +14,7 @@
     <p>
       <%= dgettext(
         "page-dataset-details",
-        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
       ) %>
     </p>
   </div>

--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -1,14 +1,25 @@
 <% gtfs_resources = Enum.filter(@resource.dataset.resources, &DB.Resource.is_gtfs?/1) %>
-<%= if Enum.count(gtfs_resources) > 1 do %>
-  <div class="notification error full-width mt-0">
+<%= if Enum.empty?(gtfs_resources) do %>
+  <div class="notification error full-width">
     <p>
       <%= dgettext(
         "page-dataset-details",
-        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
       ) %>
     </p>
   </div>
-<% else %>
+<% end %>
+<%= if Enum.count(gtfs_resources) > 1 do %>
+  <div class="notification error full-width">
+    <p>
+      <%= dgettext(
+        "page-dataset-details",
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+      ) %>
+    </p>
+  </div>
+<% end %>
+<%= if Enum.count(gtfs_resources) == 1 do %>
   <% validation_path =
     live_path(@conn, TransportWeb.Live.OnDemandValidationSelectLive,
       type: "gtfs-rt",

--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -4,7 +4,7 @@
     <p>
       <%= dgettext(
         "page-dataset-details",
-        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
       ) %>
     </p>
   </div>
@@ -14,7 +14,7 @@
     <p>
       <%= dgettext(
         "page-dataset-details",
-        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
       ) %>
     </p>
   </div>

--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -1,10 +1,18 @@
-<% current_gtfs =
-  @resource.dataset |> DB.Dataset.valid_gtfs() |> Enum.reject(&DB.Resource.is_outdated?/1) |> List.first() %>
-<%= unless is_nil(current_gtfs) do %>
+<% gtfs_resources = Enum.filter(@resource.dataset.resources, &DB.Resource.is_gtfs?/1) %>
+<%= if Enum.count(gtfs_resources) > 1 do %>
+  <div class="notification error full-width mt-0">
+    <p>
+      <%= dgettext(
+        "page-dataset-details",
+        "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+      ) %>
+    </p>
+  </div>
+<% else %>
   <% validation_path =
     live_path(@conn, TransportWeb.Live.OnDemandValidationSelectLive,
       type: "gtfs-rt",
-      url: current_gtfs.url,
+      url: List.first(gtfs_resources).url,
       feed_url: DB.Resource.download_url(@resource)
     ) %>
   <a class="button" href={validation_path} target="_blank" role="link">

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -36,17 +36,9 @@ defmodule TransportWeb.DatasetView do
   def count_discussions(nil), do: '-'
   def count_discussions(discussions), do: Enum.count(discussions)
 
-  # NOTE: this method (and more here) are unused and
-  # were referred to by unused partials
-  def first_gtfs(dataset) do
-    dataset
-    |> Dataset.valid_gtfs()
-    |> List.first()
-  end
-
   def end_date(dataset) do
-    dataset
-    |> Dataset.valid_gtfs()
+    dataset.resources
+    |> Enum.filter(&Resource.is_gtfs?/1)
     |> Enum.max_by(
       fn
         %{metadata: nil} -> ""
@@ -429,9 +421,7 @@ defmodule TransportWeb.DatasetView do
   def resource_class(_, _), do: ""
 
   def order_resources_by_validity(resources, %{validations: validations}) do
-    resources
-    |> Enum.sort_by(&(validations |> Map.get(&1.id) |> hd() |> get_metadata_info("end_date")), &>=/2)
-    |> Enum.sort_by(&Resource.valid_and_available?(&1), &>=/2)
+    Enum.sort_by(resources, &(validations |> Map.get(&1.id) |> hd() |> get_metadata_info("end_date")), &>=/2)
   end
 
   def order_resources_by_format(resources), do: resources |> Enum.sort_by(& &1.format, &>=/2)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -545,3 +545,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -551,5 +551,5 @@ msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT valid
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -547,9 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
 msgstr ""
 
-#, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -547,5 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -548,8 +548,8 @@ msgstr "Données absentes mais <a href=\"%{doc_link}\" target=\"_blank\">possibl
 
 #, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
-msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT comme il y a plusieurs fichiers GTFS."
+msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il y a plusieurs fichiers GTFS."
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
-msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT comme il n'y a aucun fichier GTFS."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
+msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il n'y a aucun fichier GTFS."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -547,5 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr "Données absentes mais <a href=\"%{doc_link}\" target=\"_blank\">possibles à modéliser en GTFS</a> :"
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
 msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT comme il y a plusieurs fichiers GTFS."
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
+msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT comme il n'y a aucun fichier GTFS."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -547,9 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr "Données absentes mais <a href=\"%{doc_link}\" target=\"_blank\">possibles à modéliser en GTFS</a> :"
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
-msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il y a plusieurs fichiers GTFS."
-
-#, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
 msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il n'y a aucun fichier GTFS."
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il y a plusieurs fichiers GTFS."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -545,3 +545,7 @@ msgstr "Affiche les %{nb} dernières ressources historisées."
 #, elixir-autogen, elixir-format
 msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
 msgstr "Données absentes mais <a href=\"%{doc_link}\" target=\"_blank\">possibles à modéliser en GTFS</a> :"
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT comme il y a plusieurs fichiers GTFS."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -545,3 +545,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be specified in GTFS</a>:"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -547,9 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -551,5 +551,5 @@ msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT valid
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there is no GTFS file."
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -547,5 +547,9 @@ msgid "Missing features that <a href=\"%{doc_link}\" target=\"_blank\">can be sp
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS."
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are no GTFS files."
 msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -206,7 +206,8 @@ defmodule TransportWeb.ResourceControllerTest do
       validation_result["files"]["gtfs_permanent_url"],
       validation_result["files"]["gtfs_rt_permanent_url"],
       "Prolongation des travaux rue de Kermaria",
-      "comme il n'y a aucun fichier GTFS"
+      "Impossible de déterminer le fichier GTFS à utiliser",
+      "a aucun fichier GTFS"
     ]
     |> Enum.each(&assert content =~ &1)
   end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -205,7 +205,8 @@ defmodule TransportWeb.ResourceControllerTest do
       "sample 2",
       validation_result["files"]["gtfs_permanent_url"],
       validation_result["files"]["gtfs_rt_permanent_url"],
-      "Prolongation des travaux rue de Kermaria"
+      "Prolongation des travaux rue de Kermaria",
+      "comme il n'y a aucun fichier GTFS"
     ]
     |> Enum.each(&assert content =~ &1)
   end
@@ -335,6 +336,7 @@ defmodule TransportWeb.ResourceControllerTest do
 
   test "GTFS-RT validation is shown", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset)
+    insert(:resource, format: "GTFS", dataset_id: dataset_id)
 
     %{id: resource_id} =
       insert(:resource, %{
@@ -378,6 +380,7 @@ defmodule TransportWeb.ResourceControllerTest do
     {conn2, _} = with_log(fn -> conn |> get(resource_path(conn, :details, resource_id)) end)
     assert conn2 |> html_response(200) =~ "Rapport de validation"
     assert conn2 |> html_response(200) =~ "1 erreur"
+    assert conn2 |> html_response(200) =~ "Valider ce GTFS-RT maintenant"
     refute conn2 |> html_response(200) =~ "Pas de validation disponible"
   end
 


### PR DESCRIPTION
Suppression/refactor de quelques méthodes utilisant les métadonnées stockées directement dans les ressources.

J'en profite pour afficher un message explicite d'erreur pour les ressources GTFS-RT quand on ne peut pas déterminer automatiquement quel fichier GTFS utiliser.