### PR TITLE
Refacto dataset controller de l'API

### DIFF
--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -35,6 +35,22 @@ defmodule DB.ResourceHistory do
     |> join(:inner_lateral, [resource_history: rh], latest in subquery(last_resource_history), on: latest.id == rh.id)
   end
 
+  # def join_resource_with_latest_resource_history(query) do
+  #   latest_rh =
+  #     DB.ResourceHistory
+  #     |> distinct([rh], rh.resource_id)
+  #     |> order_by([rh], desc: rh.inserted_at)
+  #     |> select([rh], rh.id)
+
+  #   query
+  #   |> join(:inner, [resource: r], rh in DB.ResourceHistory,
+  #     on: rh.resource_id == r.id and rh.id in subquery(latest_rh),
+  #     as: :resource_history
+  #   )
+
+  #   # |> join(:inner, [resource: r], rh in subquery(latest_rh), on: rh.resource_id == r.id, as: :resource_history)
+  # end
+
   def join_dataset_with_latest_resource_history(query) do
     query
     |> join(:inner, [dataset: d], r in DB.Resource, on: r.dataset_id == d.id, as: :resource)

--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -35,22 +35,6 @@ defmodule DB.ResourceHistory do
     |> join(:inner_lateral, [resource_history: rh], latest in subquery(last_resource_history), on: latest.id == rh.id)
   end
 
-  # def join_resource_with_latest_resource_history(query) do
-  #   latest_rh =
-  #     DB.ResourceHistory
-  #     |> distinct([rh], rh.resource_id)
-  #     |> order_by([rh], desc: rh.inserted_at)
-  #     |> select([rh], rh.id)
-
-  #   query
-  #   |> join(:inner, [resource: r], rh in DB.ResourceHistory,
-  #     on: rh.resource_id == r.id and rh.id in subquery(latest_rh),
-  #     as: :resource_history
-  #   )
-
-  #   # |> join(:inner, [resource: r], rh in subquery(latest_rh), on: rh.resource_id == r.id, as: :resource_history)
-  # end
-
   def join_dataset_with_latest_resource_history(query) do
     query
     |> join(:inner, [dataset: d], r in DB.Resource, on: r.dataset_id == d.id, as: :resource)

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -54,9 +54,7 @@ defmodule TransportWeb.API.DatasetController do
         if enriched_dataset do
           enriched_resources =
             dataset.resources
-            |> Enum.map(fn r ->
-              enriched_dataset |> Map.get(r.id, r)
-            end)
+            |> Enum.map(fn r -> enriched_dataset |> Map.get(r.id, r) end)
 
           Map.put(dataset, :resources, enriched_resources)
         else
@@ -122,9 +120,7 @@ defmodule TransportWeb.API.DatasetController do
       enriched_resources =
         dataset
         |> Dataset.official_resources()
-        |> Enum.map(fn r ->
-          resources_with_metadata |> Map.get(r.id, r)
-        end)
+        |> Enum.map(fn r -> resources_with_metadata |> Map.get(r.id, r) end)
 
       dataset = dataset |> Map.put(:resources, enriched_resources)
 

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -111,7 +111,9 @@ defmodule TransportWeb.API.DatasetController do
           Transport.Validators.GTFSTransport.validator_name()
         )
         |> DB.ResourceMetadata.join_validation_with_metadata()
-        |> preload(resource_history: [validations: :metadata])
+        |> preload([resource_history: rh, multi_validation: mv, metadata: m],
+          resource_history: {rh, validations: {mv, metadata: m}}
+        )
         |> where([resource: r], r.dataset_id == ^dataset.id)
         |> select([resource: r], {r.id, r})
         |> DB.Repo.all()

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -32,7 +32,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
         aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
       )
 
-    resource =
+    resource_1 =
       insert(:resource,
         dataset_id: dataset.id,
         url: "https://link.to/file.zip",
@@ -43,6 +43,18 @@ defmodule TransportWeb.API.DatasetControllerTest do
         format: "GTFS",
         filesize: 42
       )
+
+    # resource_2 =
+    #   insert(:resource,
+    #     dataset_id: dataset.id,
+    #     url: "https://link.to/file2.zip",
+    #     latest_url: "https://static.data.gouv.fr/foo2",
+    #     content_hash: "hash2",
+    #     datagouv_id: "2",
+    #     type: "main",
+    #     format: "GTFS",
+    #     filesize: 43
+    #   )
 
     _gbfs_resource =
       insert(:resource,
@@ -56,7 +68,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     insert(:resource_metadata,
       multi_validation:
         insert(:multi_validation,
-          resource_history: insert(:resource_history, resource_id: resource.id),
+          resource_history: insert(:resource_history, resource_id: resource_1.id),
           validator: Transport.Validators.GTFSTransport.validator_name()
         ),
       modes: ["bus"],
@@ -64,7 +76,19 @@ defmodule TransportWeb.API.DatasetControllerTest do
       metadata: %{"foo" => "bar"}
     )
 
+    # insert(:resource_metadata,
+    #   multi_validation:
+    #     insert(:multi_validation,
+    #       resource_history: insert(:resource_history, resource_id: resource_2.id),
+    #       validator: Transport.Validators.GTFSTransport.validator_name()
+    #     ),
+    #   modes: ["skate"],
+    #   features: ["clim"],
+    #   metadata: %{"foo" => "bar2"}
+    # )
+
     path = Helpers.dataset_path(conn, :datasets)
+    IO.inspect(path)
 
     assert [
              %{
@@ -96,6 +120,20 @@ defmodule TransportWeb.API.DatasetControllerTest do
                    "updated" => "",
                    "url" => "https://static.data.gouv.fr/foo"
                  },
+                 #  %{
+                 #    "content_hash" => "hash2",
+                 #    "datagouv_id" => "2",
+                 #    "features" => ["clim"],
+                 #    "filesize" => 43,
+                 #    "format" => "GTFS",
+                 #    "metadata" => %{"foo" => "bar2"},
+                 #    "modes" => ["skate"],
+                 #    "original_url" => "https://link.to/file2.zip",
+                 #    "title" => "GTFS.zip",
+                 #    "type" => "main",
+                 #    "updated" => "",
+                 #    "url" => "https://static.data.gouv.fr/foo"
+                 #  },
                  %{
                    "datagouv_id" => "2",
                    "format" => "gbfs",

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -26,7 +26,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
         custom_title: "title",
         type: "public-transit",
         licence: "lov2",
-        datagouv_id: "datagouv",
+        datagouv_id: datagouv_id = "datagouv",
         slug: "slug-1",
         is_active: true,
         aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
@@ -44,17 +44,17 @@ defmodule TransportWeb.API.DatasetControllerTest do
         filesize: 42
       )
 
-    # resource_2 =
-    #   insert(:resource,
-    #     dataset_id: dataset.id,
-    #     url: "https://link.to/file2.zip",
-    #     latest_url: "https://static.data.gouv.fr/foo2",
-    #     content_hash: "hash2",
-    #     datagouv_id: "2",
-    #     type: "main",
-    #     format: "GTFS",
-    #     filesize: 43
-    #   )
+    resource_2 =
+      insert(:resource,
+        dataset_id: dataset.id,
+        url: "https://link.to/file2.zip",
+        latest_url: "https://static.data.gouv.fr/foo2",
+        content_hash: "hash2",
+        datagouv_id: "2",
+        type: "main",
+        format: "GTFS",
+        filesize: 43
+      )
 
     _gbfs_resource =
       insert(:resource,
@@ -76,80 +76,85 @@ defmodule TransportWeb.API.DatasetControllerTest do
       metadata: %{"foo" => "bar"}
     )
 
-    # insert(:resource_metadata,
-    #   multi_validation:
-    #     insert(:multi_validation,
-    #       resource_history: insert(:resource_history, resource_id: resource_2.id),
-    #       validator: Transport.Validators.GTFSTransport.validator_name()
-    #     ),
-    #   modes: ["skate"],
-    #   features: ["clim"],
-    #   metadata: %{"foo" => "bar2"}
-    # )
+    insert(:resource_metadata,
+      multi_validation:
+        insert(:multi_validation,
+          resource_history: insert(:resource_history, resource_id: resource_2.id),
+          validator: Transport.Validators.GTFSTransport.validator_name()
+        ),
+      modes: ["skate"],
+      features: ["clim"],
+      metadata: %{"foo" => "bar2"}
+    )
 
     path = Helpers.dataset_path(conn, :datasets)
-    IO.inspect(path)
 
-    assert [
-             %{
-               "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-               "community_resources" => [],
-               "covered_area" => %{
-                 "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-                 "name" => "Angers Métropole",
-                 "type" => "aom"
-               },
-               "created_at" => nil,
-               "datagouv_id" => "datagouv",
-               "id" => "datagouv",
-               "licence" => "lov2",
-               "page_url" => "http://127.0.0.1:5100/datasets/slug-1",
-               "publisher" => %{"name" => nil, "type" => "organization"},
-               "resources" => [
-                 %{
-                   "content_hash" => "hash",
-                   "datagouv_id" => "1",
-                   "features" => ["couleurs des lignes"],
-                   "filesize" => 42,
-                   "format" => "GTFS",
-                   "metadata" => %{"foo" => "bar"},
-                   "modes" => ["bus"],
-                   "original_url" => "https://link.to/file.zip",
-                   "title" => "GTFS.zip",
-                   "type" => "main",
-                   "updated" => "",
-                   "url" => "https://static.data.gouv.fr/foo"
-                 },
-                 #  %{
-                 #    "content_hash" => "hash2",
-                 #    "datagouv_id" => "2",
-                 #    "features" => ["clim"],
-                 #    "filesize" => 43,
-                 #    "format" => "GTFS",
-                 #    "metadata" => %{"foo" => "bar2"},
-                 #    "modes" => ["skate"],
-                 #    "original_url" => "https://link.to/file2.zip",
-                 #    "title" => "GTFS.zip",
-                 #    "type" => "main",
-                 #    "updated" => "",
-                 #    "url" => "https://static.data.gouv.fr/foo"
-                 #  },
-                 %{
-                   "datagouv_id" => "2",
-                   "format" => "gbfs",
-                   "original_url" => "https://link.to/gbfs.json",
-                   "title" => "GTFS.zip",
-                   "type" => "main",
-                   "updated" => "",
-                   "url" => "url"
-                 }
-               ],
-               "slug" => "slug-1",
-               "title" => "title",
-               "type" => "public-transit",
-               "updated" => ""
-             }
-           ] == conn |> get(path) |> json_response(200)
+    dataset_res = %{
+      "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
+      "community_resources" => [],
+      "covered_area" => %{
+        "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
+        "name" => "Angers Métropole",
+        "type" => "aom"
+      },
+      "created_at" => nil,
+      "datagouv_id" => "datagouv",
+      "id" => "datagouv",
+      "licence" => "lov2",
+      "page_url" => "http://127.0.0.1:5100/datasets/slug-1",
+      "publisher" => %{"name" => nil, "type" => "organization"},
+      "resources" => [
+        %{
+          "content_hash" => "hash",
+          "datagouv_id" => "1",
+          "features" => ["couleurs des lignes"],
+          "filesize" => 42,
+          "format" => "GTFS",
+          "metadata" => %{"foo" => "bar"},
+          "modes" => ["bus"],
+          "original_url" => "https://link.to/file.zip",
+          "title" => "GTFS.zip",
+          "type" => "main",
+          "updated" => "",
+          "url" => "https://static.data.gouv.fr/foo"
+        },
+        %{
+          "content_hash" => "hash2",
+          "datagouv_id" => "2",
+          "features" => ["clim"],
+          "filesize" => 43,
+          "format" => "GTFS",
+          "metadata" => %{"foo" => "bar2"},
+          "modes" => ["skate"],
+          "original_url" => "https://link.to/file2.zip",
+          "title" => "GTFS.zip",
+          "type" => "main",
+          "updated" => "",
+          "url" => "https://static.data.gouv.fr/foo2"
+        },
+        %{
+          "datagouv_id" => "2",
+          "format" => "gbfs",
+          "original_url" => "https://link.to/gbfs.json",
+          "title" => "GTFS.zip",
+          "type" => "main",
+          "updated" => "",
+          "url" => "url"
+        }
+      ],
+      "slug" => "slug-1",
+      "title" => "title",
+      "type" => "public-transit",
+      "updated" => ""
+    }
+
+    assert [dataset_res] == conn |> get(path) |> json_response(200)
+
+    # check the result is in line with a query on this dataset
+    # only difference: individual dataset call has the resource history
+    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _ -> [] end)
+    dataset_res = dataset_res |> Map.put("history", [])
+    assert dataset_res == conn |> get(Helpers.dataset_path(conn, :by_id, datagouv_id)) |> json_response(200)
   end
 
   test "GET /api/datasets *without* history, multi_validation and resource_metadata", %{conn: conn} do


### PR DESCRIPTION
J'ai réécrit certains passages du controller dataset de l'API.
La différence principale, c'est que je m'appuie sur des proloads nestés, ce qui simplifie la gestion des données de validation.

J'ai essayé de jouer avec les requêtes génériques pour les assouplir et permettre de faire des left joins, mais je n'ai pas réussi !
On pourra en discuter si vous avez des idées. Mais si j'utilise des lateral_join, je ne sais faire que du join `inner`. Si je join sur des subqueries, je ne peux plus preloader, car on ne peut pas preloader quelque chose qui vient d'une subquery.

Du coup je m'en suis tenu à revoir le code du controller et à rajouter un test qui échouait avant cette PR.