### PR TITLE
Envoi d'e-mails lorsqu'un jeu de données passe en licence ouverte

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -15,6 +15,8 @@ defmodule DB.Dataset do
   use Ecto.Schema
   use TypedEctoSchema
 
+  @licences_ouverte ["fr-lo", "lov2"]
+
   typed_schema "dataset" do
     field(:datagouv_id, :string)
     field(:custom_title, :string)
@@ -285,7 +287,7 @@ defmodule DB.Dataset do
 
   @spec filter_by_licence(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_licence(query, %{"licence" => "licence-ouverte"}),
-    do: where(query, [d], d.licence in ["fr-lo", "lov2"])
+    do: where(query, [d], d.licence in @licences_ouverte)
 
   defp filter_by_licence(query, %{"licence" => licence}), do: where(query, [d], d.licence == ^licence)
   defp filter_by_licence(query, _), do: query
@@ -377,6 +379,7 @@ defmodule DB.Dataset do
     |> cast_assoc(:region)
     |> cast_assoc(:aom)
     |> validate_territory_mutual_exclusion()
+    |> maybe_dataset_now_licence_ouverte(dataset)
     |> has_real_time()
     |> case do
       %{valid?: false, changes: changes} = changeset when changes == %{} ->
@@ -812,6 +815,17 @@ defmodule DB.Dataset do
     |> change
     |> put_assoc(:communes, communes)
   end
+
+  defp maybe_dataset_now_licence_ouverte(%Ecto.Changeset{changes: %{licence: new_licence}} = changeset, %__MODULE__{
+         id: dataset_id,
+         licence: old_licence
+       })
+       when new_licence in @licences_ouverte and old_licence not in @licences_ouverte and not is_nil(dataset_id) do
+    %{"dataset_id" => dataset_id} |> Transport.Jobs.DatasetNowLicenceOuverteJob.new() |> Oban.insert!()
+    changeset
+  end
+
+  defp maybe_dataset_now_licence_ouverte(%Ecto.Changeset{} = changeset, %__MODULE__{}), do: changeset
 
   defp has_real_time(changeset) do
     has_realtime = changeset |> get_field(:resources) |> Enum.any?(&Resource.is_real_time?/1)

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -15,7 +15,7 @@ defmodule DB.Dataset do
   use Ecto.Schema
   use TypedEctoSchema
 
-  @licences_ouverte ["fr-lo", "lov2"]
+  @licences_ouvertes ["fr-lo", "lov2"]
 
   typed_schema "dataset" do
     field(:datagouv_id, :string)
@@ -287,7 +287,7 @@ defmodule DB.Dataset do
 
   @spec filter_by_licence(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_licence(query, %{"licence" => "licence-ouverte"}),
-    do: where(query, [d], d.licence in @licences_ouverte)
+    do: where(query, [d], d.licence in @licences_ouvertes)
 
   defp filter_by_licence(query, %{"licence" => licence}), do: where(query, [d], d.licence == ^licence)
   defp filter_by_licence(query, _), do: query
@@ -820,7 +820,7 @@ defmodule DB.Dataset do
          id: dataset_id,
          licence: old_licence
        })
-       when new_licence in @licences_ouverte and old_licence not in @licences_ouverte and not is_nil(dataset_id) do
+       when new_licence in @licences_ouvertes and old_licence not in @licences_ouvertes and not is_nil(dataset_id) do
     %{"dataset_id" => dataset_id} |> Transport.Jobs.DatasetNowLicenceOuverteJob.new() |> Oban.insert!()
     changeset
   end

--- a/apps/transport/lib/jobs/dataset_now_licence_ouverte_job.ex
+++ b/apps/transport/lib/jobs/dataset_now_licence_ouverte_job.ex
@@ -1,0 +1,44 @@
+defmodule Transport.Jobs.DatasetNowLicenceOuverteJob do
+  @moduledoc """
+  Job in charge of sending notifications when the dataset switches to the "licence ouverte".
+  """
+  use Oban.Worker, max_attempts: 3
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) do
+    dataset = DB.Repo.get!(DB.Dataset, dataset_id)
+
+    dataset_link_fn = fn %DB.Dataset{} = dataset ->
+      "* #{dataset.custom_title} - (#{DB.Dataset.type_to_str(dataset.type)}) - #{link(dataset)}"
+    end
+
+    Transport.Notifications.config()
+    |> Transport.Notifications.emails_for_reason(:dataset_now_licence_ouverte)
+    |> Enum.each(fn email ->
+      Transport.EmailSender.impl().send_mail(
+        "transport.data.gouv.fr",
+        Application.get_env(:transport, :contact_email),
+        email,
+        Application.get_env(:transport, :contact_email),
+        "Jeu de données maintenant en licence ouverte",
+        """
+        Bonjour,
+
+        Le jeu de données suivant est désormais disponible en licence ouverte :
+
+        #{dataset_link_fn.(dataset)}
+
+        L’équipe transport.data.gouv.fr
+
+        ---
+        Si vous souhaitez modifier ou supprimer ces alertes, vous pouvez répondre à cet e-mail.
+        """,
+        ""
+      )
+    end)
+
+    :ok
+  end
+
+  defp link(%DB.Dataset{slug: slug}), do: TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
+end

--- a/apps/transport/lib/transport/notifications.ex
+++ b/apps/transport/lib/transport/notifications.ex
@@ -6,10 +6,11 @@ defmodule Transport.Notifications do
   alias Transport.Notifications.Item
   @type configuration :: list(Item)
 
-  @reasons [:expiration, :new_dataset]
+  @reasons [:expiration, :new_dataset, :dataset_now_licence_ouverte]
+  @emails_list_reasons [:new_dataset, :dataset_now_licence_ouverte]
 
   @spec emails_for_reason(configuration, atom()) :: list(binary())
-  def emails_for_reason(config, reason) when reason in [:new_dataset] do
+  def emails_for_reason(config, reason) when reason in @emails_list_reasons do
     Enum.find_value(config, [], fn item ->
       if item.reason == reason, do: item.emails
     end)
@@ -76,7 +77,7 @@ defmodule Transport.Notifications do
       end)
     end
 
-    defp create_items(:new_dataset = reason, content) do
+    defp create_items(reason, content) do
       [
         %Item{
           reason: reason,

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -146,13 +146,13 @@ defmodule DB.DatasetDBTest do
       assert {:ok, %Ecto.Changeset{changes: %{has_realtime: false}}} = changeset
     end
 
-    test "when license changes from lov2 to fr-lo" do
+    test "when license changes from lov2 to fr-lo (both licence ouverte)" do
       %{datagouv_id: datagouv_id} = insert(:dataset, licence: "lov2", datagouv_id: Ecto.UUID.generate())
       assert {:ok, _} = Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
       assert [] == all_enqueued()
     end
 
-    test "when license changes from odbl to licence-ouverte" do
+    test "when license changes from odbl to licence ouverte" do
       %{datagouv_id: datagouv_id, id: dataset_id} =
         insert(:dataset, licence: "odc-odbl", datagouv_id: Ecto.UUID.generate())
 

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -145,6 +145,34 @@ defmodule DB.DatasetDBTest do
 
       assert {:ok, %Ecto.Changeset{changes: %{has_realtime: false}}} = changeset
     end
+
+    test "when license changes from lov2 to fr-lo" do
+      %{datagouv_id: datagouv_id} = insert(:dataset, licence: "lov2", datagouv_id: Ecto.UUID.generate())
+      assert {:ok, _} = Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
+      assert [] == all_enqueued()
+    end
+
+    test "when license changes from odbl to licence-ouverte" do
+      %{datagouv_id: datagouv_id, id: dataset_id} =
+        insert(:dataset, licence: "odc-odbl", datagouv_id: Ecto.UUID.generate())
+
+      assert {:ok, _} = Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
+
+      assert [%Oban.Job{worker: "Transport.Jobs.DatasetNowLicenceOuverteJob", args: %{"dataset_id" => ^dataset_id}}] =
+               all_enqueued()
+    end
+
+    test "when dataset does not exist yet and the license is licence ouverte" do
+      assert {:ok, _} =
+               Dataset.changeset(%{
+                 "datagouv_id" => Ecto.UUID.generate(),
+                 "licence" => "fr-lo",
+                 "national_dataset" => "true",
+                 "slug" => "ma_limace"
+               })
+
+      assert [] == all_enqueued()
+    end
   end
 
   describe "resources last content update time" do

--- a/apps/transport/test/transport/jobs/dataset_now_licence_ouverte_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_now_licence_ouverte_job_test.exs
@@ -1,0 +1,43 @@
+defmodule Transport.Test.Transport.Jobs.DatasetNowLicenceOuverteJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  alias Transport.Jobs.DatasetNowLicenceOuverteJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    %{id: dataset_id} = insert(:dataset, is_active: true)
+
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "foo@example.com" = _to,
+                             "contact@transport.beta.gouv.fr",
+                             "Jeu de données maintenant en licence ouverte" = _subject,
+                             plain_text_body,
+                             "" = _html_part ->
+      assert plain_text_body =~ ~r/Bonjour/
+      :ok
+    end)
+
+    Transport.Notifications.FetcherMock
+    |> expect(:fetch_config!, fn ->
+      [
+        %Transport.Notifications.Item{
+          dataset_slug: nil,
+          emails: ["foo@example.com"],
+          reason: :dataset_now_licence_ouverte,
+          extra_delays: []
+        }
+      ]
+    end)
+
+    assert :ok == perform_job(DatasetNowLicenceOuverteJob, %{"dataset_id" => dataset_id})
+  end
+end

--- a/apps/transport/test/transport/notifications_test.exs
+++ b/apps/transport/test/transport/notifications_test.exs
@@ -18,6 +18,8 @@ defmodule Transport.NotificationsTest do
     new_dataset:
       - bar@baz.com
       - foo@baz.com
+    dataset_now_licence_ouverte:
+      - bar@foo.com
     expiration:
       my_slug:
         emails:
@@ -32,7 +34,8 @@ defmodule Transport.NotificationsTest do
     expected = [
       %Item{reason: :expiration, dataset_slug: "my_slug", emails: ["foo@bar.com", "foo@bar.fr"], extra_delays: []},
       %Item{reason: :expiration, dataset_slug: "other", emails: ["foo@example.com"], extra_delays: [30]},
-      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["bar@baz.com", "foo@baz.com"], extra_delays: nil}
+      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["bar@baz.com", "foo@baz.com"], extra_delays: nil},
+      %Item{reason: :dataset_now_licence_ouverte, dataset_slug: nil, emails: ["bar@foo.com"], extra_delays: nil}
     ]
 
     assert expected == parse_config(yaml_config)
@@ -42,7 +45,8 @@ defmodule Transport.NotificationsTest do
     config = [
       %Item{reason: :expiration, dataset_slug: "my_slug", emails: ["foo@bar.com", "foo@bar.fr"], extra_delays: []},
       %Item{reason: :expiration, dataset_slug: "other", emails: ["foo@example.com"], extra_delays: []},
-      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["foo@baz.com", "nope@baz.com"], extra_delays: nil}
+      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["foo@baz.com", "nope@baz.com"], extra_delays: nil},
+      %Item{reason: :dataset_now_licence_ouverte, dataset_slug: nil, emails: ["bar@foo.com"], extra_delays: nil}
     ]
 
     assert ["foo@bar.com", "foo@bar.fr"] ==
@@ -55,6 +59,7 @@ defmodule Transport.NotificationsTest do
     assert [] == Notifications.emails_for_reason(config, :expiration, %DB.Dataset{slug: "nope"})
 
     assert ["foo@baz.com", "nope@baz.com"] == Notifications.emails_for_reason(config, :new_dataset)
+    assert ["bar@foo.com"] == Notifications.emails_for_reason(config, :dataset_now_licence_ouverte)
   end
 
   test "is_valid_extra_delay?" do
@@ -79,7 +84,8 @@ defmodule Transport.NotificationsTest do
 
     expected = [
       %Item{dataset_slug: "my_slug", emails: ["foo@bar.com", "foo@bar.fr"], reason: :expiration, extra_delays: []},
-      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["foo@baz.com", "nope@baz.com"], extra_delays: nil}
+      %Item{reason: :new_dataset, dataset_slug: nil, emails: ["foo@baz.com", "nope@baz.com"], extra_delays: nil},
+      %Item{reason: :dataset_now_licence_ouverte, dataset_slug: nil, emails: ["bar@foo.com"], extra_delays: nil}
     ]
 
     assert expected == data
@@ -100,6 +106,8 @@ defmodule Transport.NotificationsTest do
          new_dataset:
           - foo@baz.com
           - nope@baz.com
+         dataset_now_licence_ouverte:
+          - bar@foo.com
          expiration:
            my_slug:
              emails:

--- a/config/notifications-config.sample.yml
+++ b/config/notifications-config.sample.yml
@@ -2,6 +2,8 @@
 # https://github.com/etalab/transport-notifications/
 new_dataset:
   - hello@example.com
+dataset_now_licence_ouverte:
+  - hello@example.com
 expiration:
   offre-2022-de-transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs:
     emails:


### PR DESCRIPTION
Similaire à #2740

Cette PR regarde quand un jeu de données est modifié, détecte quand on passe d'une licence non LO à LO puis envoi un e-mail en utilisant le système de notifications. On introduit une nouvelle raison de notifications `:dataset_now_licence_ouverte`.