### PR TITLE
Enregistre erreurs fatales pour les conversions GTFS

### DIFF
--- a/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
@@ -75,4 +75,52 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
 
     Transport.Test.TestUtils.ensure_no_tmp_files!("conversion_gtfs_geojson_")
   end
+
+  test "a failing GeoJSON conversion" do
+    permanent_url = "https://resource.fr"
+    uuid = Ecto.UUID.generate()
+
+    # add a resource history
+    %{id: resource_history_id} =
+      resource_history =
+      insert(:resource_history,
+        payload: %{"uuid" => uuid, "format" => "GTFS", "permanent_url" => permanent_url, "filename" => "fff"}
+      )
+
+    # mock for the resource download
+    Transport.HTTPoison.Mock
+    |> expect(:get!, 1, fn ^permanent_url ->
+      %{status_code: 200, body: "this is my GTFS file"}
+    end)
+
+    # mock for the failing conversion
+    Transport.Rambo.Mock
+    |> expect(:run, 1, fn _binary_path, ["--input", _file_path, "--output", _geojson_file_path], _opts ->
+      {:error, "conversion failed"}
+    end)
+
+    assert :ok == perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
+
+    # ResourceHistory's payload is updated with the error information
+    expected_payload =
+      Map.merge(resource_history.payload, %{
+        "conversion_GeoJSON_error" => "conversion failed",
+        "conversion_GeoJSON_fatal_error" => true
+      })
+
+    assert %DB.ResourceHistory{payload: ^expected_payload} = DB.Repo.reload!(resource_history)
+
+    # no data_conversion row is recorded
+    assert_raise(Ecto.NoResultsError, fn ->
+      DB.DataConversion
+      |> DB.Repo.get_by!(
+        convert_from: "GTFS",
+        convert_to: "GeoJSON",
+        resource_history_uuid: uuid
+      )
+    end)
+
+    # all temp files have been cleaned
+    Transport.Test.TestUtils.ensure_no_tmp_files!("conversion_gtfs_geojson_")
+  end
 end


### PR DESCRIPTION
Fixes #2761

Lorsque la conversion retourne `:error`, enregistre une erreur fatale dans `DB.ResourceHistory.payload` de manière à ne pas répéter en permanence d'effectuer une conversion.

Le job qui se charge d'identifier les conversions à effectuer regarde désormais la présence de cette clé pour ignorer les lignes correspondantes.