### PR TITLE
workflow : queue dédiée

### DIFF
--- a/apps/transport/lib/jobs/workflow.ex
+++ b/apps/transport/lib/jobs/workflow.ex
@@ -51,7 +51,7 @@ defmodule Transport.Jobs.Workflow do
   It would have been more natural for `custom_options` to be a keyword list, but Oban can just accept maps as job arguments, as keyword list cannot
   be Jason encoded. There is the kw_to_map helper function to transform a keword list to a map if needed.
   """
-  use Oban.Worker, tags: ["workflow"], max_attempts: 3
+  use Oban.Worker, tags: ["workflow"], max_attempts: 3, queue: :workflow
   alias Transport.Jobs.Workflow.Notifier
 
   @impl Oban.Worker

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,7 +136,7 @@ extra_oban_conf =
     [queues: false, plugins: false]
   else
     [
-      queues: [default: 2, heavy: 1, on_demand_validation: 1, resource_validation: 1],
+      queues: [default: 2, heavy: 1, on_demand_validation: 1, resource_validation: 1, workflow: 2],
       plugins: [
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
         {Oban.Plugins.Cron, crontab: List.flatten(oban_crontab_all_envs, production_server_crontab)}


### PR DESCRIPTION
Pour l'instant les workflow sont dans la queue par défaut, qui est limitée à 2 jobs à la fois.
Donc si 2 workflow sont traités, ils bloquent la queue, et plus aucun autre job ne peut tourner, ce qui empeche le workflow de finir...embouteillage garanti.

Merci @AntoineAugusti d'avoir repéré l'embouteillage !