### PR TITLE
Mobility License to Mobility Licence

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -176,7 +176,7 @@ defmodule Transport.ImportData do
       |> Map.put("organization", data_gouv_resp["organization"]["name"])
       |> Map.put("resources", get_resources(data_gouv_resp, type))
       |> Map.put("nb_reuses", get_nb_reuses(data_gouv_resp))
-      |> Map.put("licence", license(data_gouv_resp))
+      |> Map.put("licence", licence(data_gouv_resp))
       |> Map.put("zones", get_associated_zones_insee(data_gouv_resp))
 
     case Map.get(data_gouv_resp, "resources") do
@@ -186,35 +186,35 @@ defmodule Transport.ImportData do
   end
 
   @doc """
-  Set the license according to the datagouv response with possible overrides.
+  Set the licence according to the datagouv response with possible overrides.
   Context: we're doing this directly on transport.data.gouv.fr because data.gouv.fr does
-  not handle licenses that have not been homologated. Some custom licenses will be
+  not handle licences that have not been homologated. Some custom licences will be
   classified as `notspecified` on the datagouv API response as a result.
 
     ## Examples
 
-      iex> license(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Lyon"}})
-      "mobility-license"
+      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Lyon"}})
+      "mobility-licence"
 
-      iex> license(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Rouen"}})
+      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Rouen"}})
       "notspecified"
 
-      iex> license(%{"license" => "odc-odbl"})
+      iex> licence(%{"license" => "odc-odbl"})
       "odc-odbl"
 
   """
-  def license(%{"license" => "notspecified", "organization" => %{"name" => org_name}}) do
-    orgs_with_mobility_license = ["Métropole de Lyon"]
+  def licence(%{"license" => "notspecified", "organization" => %{"name" => org_name}}) do
+    orgs_with_mobility_licence = ["Métropole de Lyon"]
 
-    if org_name in orgs_with_mobility_license do
-      "mobility-license"
+    if org_name in orgs_with_mobility_licence do
+      "mobility-licence"
     else
       "notspecified"
     end
   end
 
-  def license(%{"license" => datagouv_license}), do: datagouv_license
-  def license(_), do: nil
+  def licence(%{"license" => datagouv_licence}), do: datagouv_licence
+  def licence(_), do: nil
 
   @doc """
   Get logo from datagouv dataset

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -356,7 +356,7 @@ defmodule TransportWeb.DatasetView do
 
   def licence_url("odc-odbl"), do: "https://opendatacommons.org/licenses/odbl/1.0/"
 
-  def licence_url("mobility-license"),
+  def licence_url("mobility-licence"),
     do: "https://download.data.grandlyon.com/licences/Licence_mobilit%C3%A9s_V_02_2021.pdf"
 
   def licence_url(_), do: nil
@@ -389,7 +389,7 @@ defmodule TransportWeb.DatasetView do
       "other-open" -> dgettext("dataset", "other-open")
       "lov2" -> dgettext("dataset", "lov2")
       "notspecified" -> dgettext("dataset", "notspecified")
-      "mobility-license" -> dgettext("dataset", "Mobility license")
+      "mobility-licence" -> dgettext("dataset", "Mobility licence")
       other -> other
     end
   end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -389,7 +389,7 @@ defmodule TransportWeb.DatasetView do
       "other-open" -> dgettext("dataset", "other-open")
       "lov2" -> dgettext("dataset", "lov2")
       "notspecified" -> dgettext("dataset", "notspecified")
-      "mobility-licence" -> dgettext("dataset", "Mobility licence")
+      "mobility-licence" -> dgettext("dataset", "Mobility Licence")
       other -> other
     end
   end

--- a/apps/transport/priv/gettext/dataset.pot
+++ b/apps/transport/priv/gettext/dataset.pot
@@ -77,5 +77,5 @@ msgid "lov2"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Mobility license"
+msgid "Mobility Licence"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -77,5 +77,5 @@ msgid "lov2"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Mobility license"
+msgid "Mobility Licence"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -77,5 +77,5 @@ msgid "lov2"
 msgstr "Licence Ouverte Version 2.0"
 
 #, elixir-autogen, elixir-format
-msgid "Mobility license"
+msgid "Mobility Licence"
 msgstr "Licence mobilités"

--- a/apps/transport/priv/repo/migrations/20221110101806_rename_mobility_license.exs
+++ b/apps/transport/priv/repo/migrations/20221110101806_rename_mobility_license.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.RenameMobilityLicense do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE dataset SET licence = 'mobility-licence' WHERE licence = 'mobility-license'"
+  end
+
+  def down do
+    execute "UPDATE dataset SET licence = 'mobility-license' WHERE licence = 'mobility-licence'"
+  end
+end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -146,13 +146,13 @@ defmodule DB.DatasetDBTest do
       assert {:ok, %Ecto.Changeset{changes: %{has_realtime: false}}} = changeset
     end
 
-    test "when license changes from lov2 to fr-lo (both licence ouverte)" do
+    test "when licence changes from lov2 to fr-lo (both licence ouverte)" do
       %{datagouv_id: datagouv_id} = insert(:dataset, licence: "lov2", datagouv_id: Ecto.UUID.generate())
       assert {:ok, _} = Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
       assert [] == all_enqueued()
     end
 
-    test "when license changes from odbl to licence ouverte" do
+    test "when licence changes from odbl to licence ouverte" do
       %{datagouv_id: datagouv_id, id: dataset_id} =
         insert(:dataset, licence: "odc-odbl", datagouv_id: Ecto.UUID.generate())
 
@@ -162,7 +162,7 @@ defmodule DB.DatasetDBTest do
                all_enqueued()
     end
 
-    test "when dataset does not exist yet and the license is licence ouverte" do
+    test "when dataset does not exist yet and the licence is licence ouverte" do
       assert {:ok, _} =
                Dataset.changeset(%{
                  "datagouv_id" => Ecto.UUID.generate(),


### PR DESCRIPTION
Fixes #2765

On retrouve encore quelques occurences de "license" mais qui ont leur place
- `license` dans les réponses de l'API data.gouv.fr pour les JDD
- "ODbL license" qui correspond à l'appelation officielle