### PR TITLE
Mise à jour transport-tools (couleurs), Elixir et Erlang (mineures)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ default_docker: &default_docker
 defaults: &defaults
   parameters:
     base_image:
-      default: ghcr.io/etalab/transport-ops:elixir-1.14.0-erlang-24.3.4.5-ubuntu-focal-20211006-transport-tools-1.0.4
+      default: ghcr.io/etalab/transport-ops:elixir-1.14.1-erlang-24.3.4.6-ubuntu-focal-20211006-transport-tools-1.0.5
       type: string
     # useful to invalidate the build cache manually by bumping the version
     build_cache_key:

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,12 +7,12 @@
 # - https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 # - https://github.com/elixir-lang/elixir/releases
 # - `asdf list all elixir`
-elixir 1.14.0-otp-24
+elixir 1.14.1-otp-24
 
 # See:
 # - https://github.com/erlang/otp/releases
 # - https://github.com/erlang/otp/blob/master/otp_versions.table
 # - `asdf list all erlang`
-erlang 24.3.4.5
+erlang 24.3.4.6
 
 nodejs 16.17.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/etalab/transport-ops:elixir-1.14.0-erlang-24.3.4.5-ubuntu-focal-20211006-transport-tools-1.0.4
+FROM ghcr.io/etalab/transport-ops:elixir-1.14.1-erlang-24.3.4.6-ubuntu-focal-20211006-transport-tools-1.0.5
 
 RUN mkdir phoenixapp
 WORKDIR /phoenixapp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ghcr.io/etalab/transport-ops:elixir-1.14.0-erlang-24.3.4.5-ubuntu-focal-20211006-transport-tools-1.0.4
+FROM ghcr.io/etalab/transport-ops:elixir-1.14.1-erlang-24.3.4.6-ubuntu-focal-20211006-transport-tools-1.0.5
 
 RUN apt-get install -y git inotify-tools postgresql-client>=11
 


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-ops/releases/tag/elixir-1.14.1-erlang-24.3.4.6-ubuntu-focal-20211006-transport-tools-1.0.5

Désolé au passage pour @AntoineAugusti chez qui je sais que ça rame particulièrement pour la partie compilation Erlang, mais j'avais déjà commis ma boulette.