### PR TITLE
Ajout unique pour ResourceUnavailableJob

### DIFF
--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -13,7 +13,6 @@ defmodule Transport.Jobs.ResourcesUnavailableDispatcherJob do
 
     Logger.debug("Dispatching #{Enum.count(resource_ids)} ResourceUnavailableJob jobs")
 
-
     Enum.each(resource_ids, fn resource_id ->
       %{resource_id: resource_id}
       |> Transport.Jobs.ResourceUnavailableJob.new()

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -13,11 +13,12 @@ defmodule Transport.Jobs.ResourcesUnavailableDispatcherJob do
 
     Logger.debug("Dispatching #{Enum.count(resource_ids)} ResourceUnavailableJob jobs")
 
-    resource_ids
-    |> Enum.map(fn resource_id ->
-      %{resource_id: resource_id} |> Transport.Jobs.ResourceUnavailableJob.new()
+
+    Enum.each(resource_ids, fn resource_id ->
+      %{resource_id: resource_id}
+      |> Transport.Jobs.ResourceUnavailableJob.new()
+      |> Oban.insert()
     end)
-    |> Oban.insert_all()
 
     :ok
   end
@@ -48,7 +49,7 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
   - is_available (if the availability of the resource changes)
   - url (if lastest_url points to a new URL)
   """
-  use Oban.Worker, max_attempts: 5
+  use Oban.Worker, unique: [period: 60 * 9], max_attempts: 5
   require Logger
   alias DB.{Repo, Resource, ResourceUnavailability}
 

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -17,7 +17,7 @@ defmodule Transport.Jobs.ResourcesUnavailableDispatcherJob do
     Enum.each(resource_ids, fn resource_id ->
       %{resource_id: resource_id}
       |> Transport.Jobs.ResourceUnavailableJob.new()
-      |> Oban.insert()
+      |> Oban.insert!()
     end)
 
     :ok


### PR DESCRIPTION
Ajoute un paramètre `unique` pour ce job pour éviter un blast de jobs dans le cas où Oban a été congestionné.

![image](https://user-images.githubusercontent.com/295709/201115134-884279ad-caf5-4d66-9566-8ea5e7f9fcc7.png)


Je mets à 9 minutes car ça peut être exécuté toutes les 10 minutes.

https://github.com/etalab/transport-site/blob/ec61255fd3ac4c3cf1bdfe993969d35847427f02/config/runtime.exs#L106

[`Oban.insert_all` ne regarde pas le `unique`](https://github.com/etalab/transport-site/pull/2773), je passe donc à `Oban.insert!`