### PR TITLE
Adapte label producteur de la donnée

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -335,7 +335,7 @@
         <i class="icon fa fa-map-marker-alt" /><%= Dataset.get_territory_or_nil(@dataset) %>
       </div>
       <div class="pt-12">
-        <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "Data producer") %></span>
+        <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "Data published by") %></span>
         <div class="dataset-type-info">
           <b><%= @dataset.organization %></b>
         </div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -347,10 +347,6 @@ msgid "Reuses are temporarily unavailable"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Data producer"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Resource declared schema"
 msgstr ""
 
@@ -552,4 +548,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data published by"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -347,10 +347,6 @@ msgid "Reuses are temporarily unavailable"
 msgstr "Les réutilisations sont temporairement indisponibles"
 
 #, elixir-autogen, elixir-format
-msgid "Data producer"
-msgstr "Producteur de la donnée"
-
-#, elixir-autogen, elixir-format
 msgid "Resource declared schema"
 msgstr "La ressource déclare utiliser ce schéma"
 
@@ -553,3 +549,7 @@ msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une
 #, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
 msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT car il y a plusieurs fichiers GTFS."
+
+#, elixir-autogen, elixir-format
+msgid "Data published by"
+msgstr "Données publiées par"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -347,10 +347,6 @@ msgid "Reuses are temporarily unavailable"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Data producer"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Resource declared schema"
 msgstr ""
 
@@ -552,4 +548,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation because there are multiple GTFS files."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data published by"
 msgstr ""


### PR DESCRIPTION
Fixes #2772

Remplace "Producteur de la donnée" par "Données publiées par".

![image](https://user-images.githubusercontent.com/295709/201920439-10d8507b-df17-4ba0-9c6c-745c99e444ee.png)
