### PR TITLE
Correction de la taille des fichiers des conversions GTFS > NeTEx

### DIFF
--- a/apps/transport/lib/jobs/backfill/backfill_data_conversion_netex_filesize.ex
+++ b/apps/transport/lib/jobs/backfill/backfill_data_conversion_netex_filesize.ex
@@ -1,0 +1,54 @@
+defmodule Transport.Jobs.Backfill.DataConversionNeTExFilesize do
+  @moduledoc """
+  Backfill of `DB.DataConversion.payload` to fix the filesize for NeTEx conversions
+
+  See https://github.com/etalab/transport-site/issues/2134
+  """
+  use Oban.Worker
+  import Ecto.Query
+  alias DB.{DataConversion, Repo}
+
+  @backfill_delay 1
+
+  @impl true
+  def perform(%{args: %{"data_conversion_id" => data_conversion_id, "backfill" => true}}) do
+    with :ok <- perform(%{args: %{"data_conversion_id" => data_conversion_id}}) do
+      case fetch_next(data_conversion_id) do
+        next_id when is_integer(next_id) ->
+          %{data_conversion_id: next_id, backfill: true} |> new(schedule_in: @backfill_delay) |> Oban.insert()
+
+        nil ->
+          :ok
+      end
+    end
+  end
+
+  def perform(%{args: %{"data_conversion_id" => data_conversion_id}}) do
+    update_data_conversion(data_conversion_id)
+    :ok
+  end
+
+  defp fetch_next(data_conversion_id) do
+    DataConversion
+    |> where([dc], dc.id > ^data_conversion_id and dc.convert_to == "NeTEx")
+    |> order_by(asc: :id)
+    |> limit(1)
+    |> select([dc], dc.id)
+    |> Repo.one()
+  end
+
+  defp update_data_conversion(data_conversion_id) do
+    DataConversion |> Repo.get!(data_conversion_id) |> do_update()
+  end
+
+  defp do_update(
+         %DataConversion{convert_from: "GTFS", convert_to: "NeTEx", payload: %{"permanent_url" => url} = payload} = dc
+       ) do
+    http_client = Transport.Shared.Wrapper.HTTPoison.impl()
+
+    {:ok, %{headers: headers}} = http_client.head(url)
+    {_, filesize} = headers |> Enum.find(fn {h, _} -> h == "content-length" end)
+
+    dc |> Ecto.Changeset.change(%{payload: %{payload | "filesize" => String.to_integer(filesize)}}) |> Repo.update!()
+  end
+end

--- a/apps/transport/test/transport/jobs/backfill/backfill_data_conversion_netex_filesize_test.exs
+++ b/apps/transport/test/transport/jobs/backfill/backfill_data_conversion_netex_filesize_test.exs
@@ -1,0 +1,70 @@
+defmodule Transport.Jobs.Backfill.DataConversionNeTExFilesizeTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.Backfill.DataConversionNeTExFilesize
+  import DB.Factory
+  import Mox
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  setup :verify_on_exit!
+
+  test "perform" do
+    data_conversion =
+      insert(:data_conversion, %{
+        convert_to: "NeTEx",
+        convert_from: "GTFS",
+        resource_history_uuid: Ecto.UUID.generate(),
+        payload: %{"permanent_url" => url = "https//example.com", "filesize" => 1, "other_field" => "other_value"}
+      })
+
+    # Ignored because it's a conversion GTFS > GeoJSON
+    insert(:data_conversion, %{
+      convert_to: "GeoJSON",
+      convert_from: "GTFS",
+      resource_history_uuid: Ecto.UUID.generate(),
+      payload: %{}
+    })
+
+    %{id: next_data_conversion} =
+      insert(:data_conversion, %{
+        convert_to: "NeTEx",
+        convert_from: "GTFS",
+        resource_history_uuid: Ecto.UUID.generate(),
+        payload: %{}
+      })
+
+    size = "1000"
+    size_int = String.to_integer(size)
+
+    expect(Transport.HTTPoison.Mock, :head, 1, fn ^url ->
+      {:ok, %{headers: [{"coucou", "toi"}, {"content-length", size}]}}
+    end)
+
+    assert {:ok,
+            %Oban.Job{
+              state: "scheduled",
+              queue: "default",
+              worker: "Transport.Jobs.Backfill.DataConversionNeTExFilesize",
+              args: %{backfill: true, data_conversion_id: ^next_data_conversion}
+            }} =
+             perform_job(DataConversionNeTExFilesize, %{"data_conversion_id" => data_conversion.id, "backfill" => true})
+
+    assert %DB.DataConversion{
+             payload: %{
+               "permanent_url" => ^url,
+               "filesize" => ^size_int,
+               "other_field" => "other_value"
+             }
+           } = DB.Repo.reload!(data_conversion)
+
+    assert [
+             %Oban.Job{
+               worker: "Transport.Jobs.Backfill.DataConversionNeTExFilesize",
+               args: %{"backfill" => true, "data_conversion_id" => ^next_data_conversion}
+             }
+           ] = all_enqueued()
+  end
+end

--- a/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
@@ -63,12 +63,12 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
              perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
 
     # a data_conversion row is recorded ✌️‍
-    DB.DataConversion
-    |> DB.Repo.get_by!(
-      convert_from: "GTFS",
-      convert_to: "GeoJSON",
-      resource_history_uuid: uuid
-    )
+    assert %DB.DataConversion{payload: %{"filesize" => 23, "filename" => "conversions/gtfs-to-geojson/fff.geojson"}} =
+             DB.Repo.get_by!(DB.DataConversion,
+               convert_from: "GTFS",
+               convert_to: "GeoJSON",
+               resource_history_uuid: uuid
+             )
 
     Transport.Test.TestUtils.ensure_no_tmp_files!("conversion_gtfs_geojson_")
   end

--- a/apps/transport/test/transport/jobs/single_gtfs_to_netex_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/single_gtfs_to_netex_converter_job_test.exs
@@ -69,12 +69,12 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJobTest do
              perform_job(SingleGtfsToNetexConverterJob, %{"resource_history_id" => resource_history_id})
 
     # a data_conversion row is recorded ✌️‍
-    DB.DataConversion
-    |> DB.Repo.get_by!(
-      convert_from: "GTFS",
-      convert_to: "NeTEx",
-      resource_history_uuid: uuid
-    )
+    assert %DB.DataConversion{payload: %{"filesize" => 41, "filename" => "conversions/gtfs-to-netex/fff.netex.zip"}} =
+             DB.Repo.get_by!(DB.DataConversion,
+               convert_from: "GTFS",
+               convert_to: "NeTEx",
+               resource_history_uuid: uuid
+             )
 
     Transport.Test.TestUtils.ensure_no_tmp_files!("conversion_gtfs_netex_")
   end


### PR DESCRIPTION
Fixes #2134

- Répare le calcul de la taille du fichier dans le job
- Ajoute un job de backfill

Lancer le job de backfill avec

```elixir
import Ecto.Query
id = (from dc in DB.DataConversion, where: dc.convert_from == "GTFS" and dc.convert_to == "NeTEx", select: min(dc.id)) |> DB.Repo.one!()
%{"data_conversion_id" => id, "backfill" => true} |> Transport.Jobs.Backfill.DataConversionNeTExFilesize.new() |> Oban.insert!()
```