### PR TITLE
Prise en compte de 2 nouvelles issues du validateur

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_invalid_shape_id_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_invalid_shape_id_issue.html.heex
@@ -1,0 +1,19 @@
+<p>
+  <%= dgettext("validations-explanations", "Impacted file:") %> <tt>trips.txt</tt>
+</p>
+<p>
+  <%= dgettext("validations-explanations", "Some shape id used in trips.txt are not defined in shapes.txt") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Trip ID") %></th>
+    <th><%= dgettext("validations-explanations", "Details") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_id"] %></td>
+      <td><%= issue["details"] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/templates/resource/_speed_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_speed_issue.html.heex
@@ -9,7 +9,7 @@
     <th><%= dgettext("validations-explanations", "Stop ID") %></th>
     <th><%= dgettext("validations-explanations", "Stop name") %></th>
     <th><%= dgettext("validations-explanations", "Next stop and service") %></th>
-    <th><%= dgettext("validations-explanations", "details") %></th>
+    <th><%= dgettext("validations-explanations", "Details") %></th>
   </tr>
 
   <%= for issue <- @issues do %>

--- a/apps/transport/lib/transport_web/templates/resource/_unused_shape_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_unused_shape_issue.html.heex
@@ -1,0 +1,17 @@
+<p>
+  <%= dgettext("validations-explanations", "Impacted file:") %> <tt>shapes.txt</tt>
+</p>
+<p>
+  <%= dgettext("validations-explanations", "Some shapes defined in shapes.txt are not used in trips.txt") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Shape ID") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_id"] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -35,7 +35,9 @@ defmodule TransportWeb.ResourceView do
         "Slow" => "_speed_issue.html",
         "UnusedStop" => "_unused_stop_issue.html",
         "InvalidCoordinates" => "_coordinates_issue.html",
-        "MissingCoordinates" => "_coordinates_issue.html"
+        "MissingCoordinates" => "_coordinates_issue.html",
+        "UnusedShapeId" => "_unused_shape_issue.html",
+        "InvalidShapeId" => "_invalid_shape_id_issue.html"
       },
       issue_type(issues.entries),
       "_generic_issue.html"

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -215,7 +215,9 @@ defmodule Transport.Validators.GTFSTransport do
         dgettext("gtfs-transport-validator", "Impossible to interpolate stop times"),
       "InvalidStopLocationTypeInTrip" => dgettext("gtfs-transport-validator", "Invalid stop location type in trip"),
       "InvalidStopParent" => dgettext("gtfs-transport-validator", "Invalid stop parent"),
-      "IdNotAscii" => dgettext("gtfs-transport-validator", "ID is not ASCII-encoded")
+      "IdNotAscii" => dgettext("gtfs-transport-validator", "ID is not ASCII-encoded"),
+      "InvalidShapeId" => dgettext("gtfs-transport-validator", "Invalid shape ID"),
+      "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID")
     }
 
   @spec is_gtfs_outdated(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -158,3 +158,11 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid stop parent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid shape ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Unused shape ID"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -79,6 +79,22 @@ msgstr ""
 msgid "Error on file"
 msgstr ""
 
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Details"
+msgstr ""
+
 #, elixir-autogen, elixir-format
-msgid "details"
+msgid "Shape ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Some shape id used in trips.txt are not defined in shapes.txt"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Some shapes defined in shapes.txt are not used in trips.txt"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip ID"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -158,3 +158,11 @@ msgstr "Type d'arrêt invalide dans un trajet"
 #, elixir-autogen, elixir-format
 msgid "Invalid stop parent"
 msgstr "Arrêt parent invalide"
+
+#, elixir-autogen, elixir-format
+msgid "Invalid shape ID"
+msgstr "Shape ID invalide"
+
+#, elixir-autogen, elixir-format
+msgid "Unused shape ID"
+msgstr "Shape ID inutilisé"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -80,5 +80,21 @@ msgid "Error on file"
 msgstr "Erreur sur le fichier"
 
 #, elixir-autogen, elixir-format
-msgid "details"
-msgstr "détails"
+msgid "Details"
+msgstr "Détails"
+
+#, elixir-autogen, elixir-format
+msgid "Shape ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Some shape id used in trips.txt are not defined in shapes.txt"
+msgstr "Certains shape id utilisés dans trips.txt ne sont pas définis dans shapes.txt"
+
+#, elixir-autogen, elixir-format
+msgid "Some shapes defined in shapes.txt are not used in trips.txt"
+msgstr "Certaines shapes définies dans shapes.txt ne sont pas utilisées dans trips.txt"
+
+#, elixir-autogen, elixir-format
+msgid "Trip ID"
+msgstr ""

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -157,3 +157,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Invalid stop parent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid shape ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Unused shape ID"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -79,5 +79,21 @@ msgid "Error on file"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "details"
+msgid "Details"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Shape ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Some shape id used in trips.txt are not defined in shapes.txt"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Some shapes defined in shapes.txt are not used in trips.txt"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip ID"
 msgstr ""


### PR DESCRIPTION
closes #2548 

Fait suite à https://github.com/etalab/transport-validator/pull/148

Cette PR rajoute le code qui permet d'afficher joliment ces 2 nouvelles issues

![image](https://user-images.githubusercontent.com/15341118/202485630-7aca55bb-d228-4044-8d2b-3d8acbf78313.png)

remarque : la colonne détails va être remplie grâce à https://github.com/etalab/transport-validator/pull/149