### PR TITLE
Ajouter les entités gtfs-rt dans l'API en tant que features

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -63,7 +63,12 @@ defmodule DB.Resource do
     field(:display_position, :integer)
 
     belongs_to(:dataset, Dataset)
+    # validation v1, to be deleted later
+    # https://github.com/etalab/transport-site/issues/2390
     has_one(:validation, Validation, on_replace: :delete)
+    has_many(:validations, DB.MultiValidation)
+    has_many(:resource_metadata, DB.ResourceMetadata)
+
     has_many(:logs_validation, LogsValidation, on_replace: :delete, on_delete: :delete_all)
 
     has_many(:resource_unavailabilities, ResourceUnavailability,

--- a/apps/transport/lib/db/resource_metadata.ex
+++ b/apps/transport/lib/db/resource_metadata.ex
@@ -25,6 +25,11 @@ defmodule DB.ResourceMetadata do
     |> join(:left, [multi_validation: mv], m in DB.ResourceMetadata, on: m.multi_validation_id == mv.id, as: :metadata)
   end
 
+  def join_resource_with_metadata(query) do
+    query
+    |> join(:left, [resource: r], m in DB.ResourceMetadata, on: r.id == m.resource_id, as: :metadata)
+  end
+
   def where_gtfs_up_to_date(query) do
     today = Date.utc_today()
 

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -262,7 +262,7 @@ defmodule TransportWeb.API.DatasetController do
     )
   end
 
-  defp get_metadata(%Resource{format: "GTFS", resource_history: %DB.ResourceHistory{} = resource_history}) do
+  defp get_metadata(%Resource{format: "GTFS", resource_history: resource_history}) do
     resource_history
     |> Enum.at(0)
     |> Map.get(:validations)
@@ -272,7 +272,7 @@ defmodule TransportWeb.API.DatasetController do
     _ -> nil
   end
 
-  defp get_metadata(%Resource{format: "gtfs-rt", resource_metadata: %DB.ResourceMetadata{} = resource_metadata}) do
+  defp get_metadata(%Resource{format: "gtfs-rt", resource_metadata: resource_metadata}) do
     features =
       resource_metadata
       |> Enum.map(& &1.features)

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -262,7 +262,7 @@ defmodule TransportWeb.API.DatasetController do
     )
   end
 
-  defp get_metadata(%{format: "GTFS", resource_history: resource_history}) do
+  defp get_metadata(%Resource{format: "GTFS", resource_history: %DB.ResourceHistory{} = resource_history}) do
     resource_history
     |> Enum.at(0)
     |> Map.get(:validations)

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -272,7 +272,7 @@ defmodule TransportWeb.API.DatasetController do
     _ -> nil
   end
 
-  defp get_metadata(%{format: "gtfs-rt", resource_metadata: resource_metadata}) do
+  defp get_metadata(%Resource{format: "gtfs-rt", resource_metadata: %DB.ResourceMetadata{} = resource_metadata}) do
     features =
       resource_metadata
       |> Enum.map(& &1.features)


### PR DESCRIPTION
Suite à la demande de l'ART de rajouter cette information à notre API. 

![image](https://user-images.githubusercontent.com/15341118/203118436-b483b082-66d5-4fb8-8fe3-046d0593b867.png)

Je ne suis pas particulièrement content du code que je trouve trop compliqué. C'est le même que la dernière fois.
Le problème ici étant que les métadonnées des gtfs-rt sont directement rattachées aux ressources, et non pas à des resource history. De plus il faut observer plusieurs métadonnées de la ressource pour aggréger les entités vues au cours des 7 derniers jours, ce qui rajoutte de la complexité.

J'ai rajouté un test pour me rassurer.