### PR TITLE
Gère nil pour networks_start_end_dates

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
@@ -19,7 +19,7 @@
       <% end %>
       <% networks_start_end_dates = Map.get(@metadata, "networks_start_end_dates", %{}) %>
       <% networks = Map.get(@metadata, "networks", []) %>
-      <%= if Enum.count(networks) > 1 && networks_start_end_dates != %{} do %>
+      <%= if Enum.count(networks) > 1 and networks_start_end_dates not in [nil, %{}] do %>
         <li>
           <div>
             <div class="networks-list">

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -354,7 +354,10 @@ defmodule TransportWeb.ResourceControllerTest do
              ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le fichier GTFS en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
 
     # we remove "networks_start_end_dates" content
-    DB.Repo.update!(Ecto.Changeset.change(metadata, %{metadata: %{"networks_start_end_dates" => nil, "networks" => ["foo", "bar"]}}))
+    DB.Repo.update!(
+      Ecto.Changeset.change(metadata, %{metadata: %{"networks_start_end_dates" => nil, "networks" => ["foo", "bar"]}})
+    )
+
     conn3 = conn |> get(resource_path(conn, :details, resource_id))
     refute conn3 |> html_response(200) =~ "couverture calendaire par réseau"
   end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -354,7 +354,7 @@ defmodule TransportWeb.ResourceControllerTest do
              ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le fichier GTFS en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
 
     # we remove "networks_start_end_dates" content
-    DB.Repo.update!(Ecto.Changeset.change(metadata, %{metadata: %{"networks_start_end_dates" => nil}}))
+    DB.Repo.update!(Ecto.Changeset.change(metadata, %{metadata: %{"networks_start_end_dates" => nil, "networks" => ["foo", "bar"]}}))
     conn3 = conn |> get(resource_path(conn, :details, resource_id))
     refute conn3 |> html_response(200) =~ "couverture calendaire par réseau"
   end


### PR DESCRIPTION
Petit bug introduit dans #2785, le cas `nil` n'est pas géré correctement et cause [quelques exceptions](https://sentry.io/organizations/transport-data-gouv-fr/issues/3747513153/activity/?project=6197733)