### PR TITLE
Réparation de l'import du dataset 38 (cityway)

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -382,12 +382,21 @@ defmodule Transport.ImportData do
   "https://exs.sismo2.cityway.fr/GTFS.aspx?key=SISMO&OperatorCode=CG60L3"
   iex> cleaned_url("http://example.com/file.zip")
   "http://example.com/file.zip"
+  iex> cleaned_url("http://exs.sismo2.cityway.fr")
+  "https://exs.sismo2.cityway.fr"
   """
   def cleaned_url(url) do
     uri = URI.parse(url)
 
     if is_binary(uri.host) and String.match?(uri.host, ~r/^exs\.(\w)+\.cityway\.fr$/) do
-      URI.to_string(%{uri | scheme: "https", query: uri.query |> String.replace("&amp;", "&"), port: 443})
+      cleaned_query =
+        if is_nil(uri.query) do
+          nil
+        else
+          uri.query |> String.replace("&amp;", "&")
+        end
+
+      %{uri | scheme: "https", query: cleaned_query, port: 443} |> URI.to_string()
     else
       url
     end


### PR DESCRIPTION
L'import de ce [dataset](https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-mobibreizh-gtfs) échouait à cause d'une sombre histoire de cas `nil` non géré. Je connais des gens qui diraient que ça ne serait jamais arrivé en R**t.

Voir les problèmes d'import [ici](https://transport.data.gouv.fr/backoffice/datasets/38/edit#imports_history).
