### PR TITLE
Lien vers la doc du schéma de comptage des mobilités

### DIFF
--- a/apps/transport/client/stylesheets/home.scss
+++ b/apps/transport/client/stylesheets/home.scss
@@ -155,9 +155,17 @@ a.tile:hover {
         height: 3em;
       }
     }
+
+    a {
+      color: $grey;
+    }
+
+    a .text-center {
+      margin-top: .5em;
+    }
   }
 
-  a {
+  a.mailing-list {
     margin-top: 2em;
     display: inline-block;
   }

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -101,12 +101,12 @@
           <%= img_tag(icon_type_path("car-motorbike-sharing"), class: "tile__icon", alt: "") %>
           <h3 class="text-center"><%= dgettext("page-index", "Car and motorbike sharing") %></h3>
         </div>
-        <div class="tile">
+        <a class="tile" href="https://doc.transport.data.gouv.fr/producteurs/comptage-des-mobilites" target="_blank">
           <%= img_tag(icon_type_path("mobility-counting"), class: "tile__icon", alt: "") %>
           <h3 class="text-center"><%= dgettext("page-index", "Mobility counting") %></h3>
-        </div>
+        </a>
       </div>
-      <a href="#mailing-list"><%= dgettext("page-index", "I'd like to be informed") %></a>
+      <a class="mailing-list" href="#mailing-list"><%= dgettext("page-index", "I'd like to be informed") %></a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Ajout du lien vers la documentation spécifique dans la partie "Données à venir"

Image (au hover)

![image](https://user-images.githubusercontent.com/295709/203812036-e444d538-ae78-4687-81e7-15322622df7e.png)
