### PR TITLE
ImportData: détection de documentation pour public-transit

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -786,11 +786,15 @@ defmodule Transport.ImportData do
 
       iex> formated_format(%{"format" => "siri-lite"}, "public-transit", false)
       "SIRI Lite"
+
+      iex> formated_format(%{"format" => "pdf", "type" => "documentation"}, "public-transit", false)
+      "pdf"
   """
   @spec formated_format(map(), binary(), bool()) :: binary()
   # credo:disable-for-next-line
   def formated_format(resource, type, is_community_resource) do
     format = Map.get(resource, "format", "")
+    is_documentation = Map.get(resource, "type", "") == "documentation"
 
     cond do
       is_gtfs_rt?(format) -> "gtfs-rt"
@@ -800,7 +804,7 @@ defmodule Transport.ImportData do
       is_siri_lite?(format) -> "SIRI Lite"
       is_siri?(format) -> "SIRI"
       is_geojson?(resource, format) -> "geojson"
-      type == "public-transit" and not is_community_resource -> "GTFS"
+      type == "public-transit" and not is_documentation and not is_community_resource -> "GTFS"
       type == "bike-scooter-sharing" and is_gbfs?(resource) -> "gbfs"
       true -> format
     end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -410,10 +410,18 @@ defmodule Transport.ImportData do
     |> Enum.concat(get_valid_gtfs_rt_resources(resources))
     |> Enum.concat(get_valid_siri_resources(resources))
     |> Enum.concat(get_valid_siri_lite_resources(resources))
+    |> Enum.concat(get_valid_documentation_resources(resources))
   end
 
   def get_valid_resources(%{"resources" => resources}, _type) do
     resources
+  end
+
+  @spec get_valid_documentation_resources([map()]) :: [map()]
+  def get_valid_documentation_resources(resources) do
+    resources
+    |> Enum.filter(&is_documentation?/1)
+    |> Enum.map(fn resource -> %{resource | "type" => "documentation"} end)
   end
 
   @spec get_valid_gtfs_resources([map()]) :: [map()]
@@ -552,6 +560,25 @@ defmodule Transport.ImportData do
 
   def is_gtfs_rt?(str) when is_binary(str), do: String.match?(str, ~r/\b(gtfs-rt|gtfsrt|gtfs rt)\b/i)
   def is_gtfs_rt?(_), do: false
+
+  @doc """
+  iex> is_documentation?(%{"format" => "gtfs"})
+  false
+  iex> is_documentation?(%{"format" => "csv"})
+  false
+  iex> is_documentation?(%{"format" => "PDF"})
+  true
+  iex> is_documentation?(%{"type" => "documentation", "format" => "docx"})
+  true
+  """
+  @spec is_documentation?(map()) :: boolean()
+  def is_documentation?(%{} = params) do
+    cond do
+      params["type"] == "documentation" -> true
+      is_format?(params["format"], ["pdf", "svg", "html"]) -> true
+      true -> false
+    end
+  end
 
   @doc """
   iex> is_siri?("siri lite")

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -338,4 +338,17 @@ defmodule Transport.ImportDataTest do
              "siri lite" => 1
            }
   end
+
+  test "get_valid_resources for public-transit detects documentation resources" do
+    resources = %{
+      "resources" => [
+        %{"type" => "main", "format" => "gtfs"},
+        %{"type" => "main", "format" => "geojson"},
+        %{"type" => "main", "format" => "svg"}
+      ]
+    }
+
+    assert [%{"format" => "gtfs", "type" => "main"}, %{"format" => "svg", "type" => "documentation"}] ==
+             ImportData.get_valid_resources(resources, "public-transit")
+  end
 end


### PR DESCRIPTION
Adapte l'import de données pour détecter des ressources de documentation pour le type `public-transit` qui ne retient que certains types de ressources.

Le premier cas d'usage est [pour le JDD de Lille](https://www.data.gouv.fr/fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia/) qui comporte un PDF avec des logos sur datagouv et pas sur le PAN.

![image](https://user-images.githubusercontent.com/295709/203973160-fd5fefd5-859d-42a2-8b82-0d4c601ad9c5.png)
