### PR TITLE
Suppression de resource.modes

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -417,21 +417,20 @@ defmodule DB.Dataset do
 
   @spec count_by_mode(binary()) :: number()
   def count_by_mode(tag) do
-    __MODULE__
-    |> join(:inner, [d], r in Resource, on: r.dataset_id == d.id)
-    |> where([d, r], d.is_active and ^tag in r.modes)
-    |> distinct([d], d.id)
+    Transport.Validators.GTFSTransport.validator_name()
+    |> join_from_dataset_to_metadata()
+    |> where([metadata: m], ^tag in m.modes)
+    |> distinct([dataset: d], d.id)
     |> Repo.aggregate(:count, :id)
   end
 
   @spec count_coach() :: number()
   def count_coach do
-    __MODULE__
-    |> join(:inner, [d], r in Resource, on: r.dataset_id == d.id)
-    |> join(:inner, [d], d_geo in DatasetGeographicView, on: d.id == d_geo.dataset_id)
-    |> distinct([d], d.id)
-    |> where([d, r, d_geo], d.is_active and "bus" in r.modes and d_geo.region_id == 14)
+    Transport.Validators.GTFSTransport.validator_name()
+    |> join_from_dataset_to_metadata()
     # 14 is the national "region". It means that it is not bound to a region or local territory
+    |> where([metadata: m, dataset: d], d.region_id == 14 and "bus" in m.modes)
+    |> distinct([dataset: d], d.id)
     |> Repo.aggregate(:count, :id)
   end
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -27,8 +27,6 @@ defmodule DB.Resource do
     field(:content_hash, :string)
     # automatically discovered tags
     field(:features, {:array, :string}, default: [])
-    # all the detected modes of the ressource
-    field(:modes, {:array, :string}, default: [])
 
     field(:is_community_resource, :boolean)
 
@@ -373,7 +371,6 @@ defmodule DB.Resource do
           data_vis: data_vis
         },
         features: find_tags(r, metadata),
-        modes: find_modes(metadata),
         start_date: str_to_date(metadata["start_date"]),
         end_date: str_to_date(metadata["end_date"])
       )
@@ -444,10 +441,6 @@ defmodule DB.Resource do
       "informations sur l'accessibilité à vélo",
       "informations sur l'accessibilité en fauteuil roulant"
     ]
-
-  @spec find_modes(map()) :: [binary()]
-  def find_modes(%{"modes" => modes}), do: modes
-  def find_modes(_), do: []
 
   # These tags are not translated because we'll need to be able to search for those tags
   @spec has_fares_tag(map()) :: [binary()]
@@ -526,7 +519,6 @@ defmodule DB.Resource do
         :latest_url,
         :is_available,
         :features,
-        :modes,
         :is_community_resource,
         :schema_name,
         :schema_version,

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -420,4 +420,22 @@ defmodule DB.DatasetDBTest do
              r3.id => %{geojson: nil, netex: nil}
            } == related_resources
   end
+
+  test "count dataset by mode" do
+    insert(:region, id: 14, nom: "France")
+    region = insert(:region)
+
+    %{dataset: dataset} = insert_resource_and_friends(Date.utc_today(), region_id: region.id, modes: ["bus"])
+    insert_resource_and_friends(Date.utc_today(), dataset: dataset, modes: ["ski"])
+
+    %{dataset: dataset_2} = insert_resource_and_friends(Date.utc_today(), region_id: 14, modes: ["bus"])
+    insert_resource_and_friends(Date.utc_today(), dataset: dataset_2, modes: ["ski"])
+
+    insert_resource_and_friends(Date.utc_today(), region_id: 14)
+
+    assert DB.Dataset.count_by_mode("bus") == 2
+    assert DB.Dataset.count_by_mode("ski") == 2
+    # this counts national datasets (region id = 14) with bus resources
+    assert DB.Dataset.count_coach() == 1
+  end
 end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -144,7 +144,7 @@ defmodule DB.Factory do
     def_opts = [resource_available: true, is_active: true, resource_history_payload: %{}]
     opts = Keyword.merge(def_opts, opts)
 
-    dataset_opts = [is_active: Keyword.get(opts, :is_active)]
+    dataset_opts = [is_active: Keyword.get(opts, :is_active), region_id: Keyword.get(opts, :region_id)]
 
     dataset_opts =
       case Keyword.get(opts, :aom) do

--- a/apps/transport/test/transport/validation_cleaner_test.exs
+++ b/apps/transport/test/transport/validation_cleaner_test.exs
@@ -26,7 +26,6 @@ defmodule Transport.ValidationCleanerTest do
         },
         metadata: %{},
         title: "angers.zip",
-        modes: ["ferry"],
         features: ["tarifs"]
       }
       |> Repo.insert()
@@ -43,7 +42,6 @@ defmodule Transport.ValidationCleanerTest do
         },
         metadata: %{},
         title: "another_gtfs.zip",
-        modes: ["bus"],
         features: []
       }
       |> Repo.insert()

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -26,7 +26,6 @@ defmodule TransportWeb.DatasetSearchControllerTest do
             validation: %Validation{},
             metadata: %{},
             title: "angers.zip",
-            modes: ["ferry"],
             features: ["tarifs"]
           }
         ],


### PR DESCRIPTION
Allez, c'est le grand saut, je supprime le champ `modes` de `DB.Resource`. Maintenant toutes les informations concernant les modes sont stockées dans des `ResourceMetadata`.

Pour l'instant je ne fais pas la migration associée, parce que si ça se passe mal je veux pouvoir revenir en arrière facilement.

lié à #2390 