### PR TITLE
Suppression de resource.features

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -25,8 +25,6 @@ defmodule DB.Resource do
     field(:latest_url, :string)
     field(:is_available, :boolean, default: true)
     field(:content_hash, :string)
-    # automatically discovered tags
-    field(:features, {:array, :string}, default: [])
     # all the detected modes of the ressource
     field(:modes, {:array, :string}, default: [])
 
@@ -372,7 +370,6 @@ defmodule DB.Resource do
           validation_latest_content_hash: r.content_hash,
           data_vis: data_vis
         },
-        features: find_tags(r, metadata),
         modes: find_modes(metadata),
         start_date: str_to_date(metadata["start_date"]),
         end_date: str_to_date(metadata["end_date"])
@@ -403,113 +400,6 @@ defmodule DB.Resource do
     Sentry.capture_message("validation_save_failed", extra: url)
   end
 
-  # Deprecation notice, all the tags and modes related functions now live in gtfs_transport_validator.ex
-  # Function here will be deleted when validation v1 will be unpluged
-  # ⬇️⬇️⬇️
-  @spec find_tags(__MODULE__.t(), map()) :: [binary()]
-  def find_tags(%__MODULE__{} = r, metadata) do
-    r
-    |> base_tag()
-    |> Enum.concat(find_tags_from_metadata(metadata))
-    |> Enum.uniq()
-  end
-
-  def find_tags_from_metadata(metadata) do
-    tags =
-      metadata
-      |> has_fares_tag()
-      |> Enum.concat(has_shapes_tag(metadata))
-      |> Enum.concat(has_odt_tag(metadata))
-      |> Enum.concat(has_route_colors_tag(metadata))
-      |> Enum.concat(has_pathways_tag(metadata))
-      |> Enum.concat(has_bike_accessibility(metadata))
-      |> Enum.concat(has_wheelchair_accessibility(metadata))
-
-    Enum.each(tags, fn tag ->
-      if tag not in existing_gtfs_tags() do
-        raise "`#{tag}` is not a known tag"
-      end
-    end)
-
-    tags
-  end
-
-  def existing_gtfs_tags,
-    do: [
-      "tarifs",
-      "tracés de lignes",
-      "transport à la demande",
-      "couleurs des lignes",
-      "description des correspondances",
-      "informations sur l'accessibilité à vélo",
-      "informations sur l'accessibilité en fauteuil roulant"
-    ]
-
-  @spec find_modes(map()) :: [binary()]
-  def find_modes(%{"modes" => modes}), do: modes
-  def find_modes(_), do: []
-
-  # These tags are not translated because we'll need to be able to search for those tags
-  @spec has_fares_tag(map()) :: [binary()]
-  def has_fares_tag(%{"has_fares" => true}), do: ["tarifs"]
-  def has_fares_tag(_), do: []
-
-  @spec has_shapes_tag(map()) :: [binary()]
-  def has_shapes_tag(%{"has_shapes" => true}), do: ["tracés de lignes"]
-  def has_shapes_tag(_), do: []
-
-  # check if the resource contains some On Demand Transport (odt) tags
-  @spec has_odt_tag(map()) :: [binary()]
-  def has_odt_tag(%{"some_stops_need_phone_agency" => true}), do: ["transport à la demande"]
-  def has_odt_tag(%{"some_stops_need_phone_driver" => true}), do: ["transport à la demande"]
-  def has_odt_tag(_), do: []
-
-  @doc """
-  Outputs a tag if at least 80% of GTFS routes have a custom color.
-
-  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 8, "lines_count" => 10})
-  ["couleurs des lignes"]
-  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 7, "lines_count" => 10})
-  []
-  iex> has_route_colors_tag(%{"lines_with_custom_color_count" => 0, "lines_count" => 0})
-  []
-  """
-  @spec has_route_colors_tag(map()) :: [binary()]
-  def has_route_colors_tag(%{"lines_with_custom_color_count" => with_colors_count, "lines_count" => lines_count})
-      when with_colors_count / lines_count * 100 >= 80,
-      do: ["couleurs des lignes"]
-
-  def has_route_colors_tag(_), do: []
-
-  @spec has_pathways_tag(map()) :: [binary()]
-  def has_pathways_tag(%{"has_pathways" => true}), do: ["description des correspondances"]
-  def has_pathways_tag(_), do: []
-
-  @spec has_bike_accessibility(map()) :: [binary()]
-  def has_bike_accessibility(%{"trips_with_bike_info_count" => n}) when is_integer(n) and n > 0,
-    do: ["informations sur l'accessibilité à vélo"]
-
-  def has_bike_accessibility(_), do: []
-
-  @spec has_wheelchair_accessibility(map()) :: [binary()]
-  def has_wheelchair_accessibility(%{"trips_with_wheelchair_info_count" => n1, "stops_with_wheelchair_info_count" => n2})
-      when is_integer(n1) and is_integer(n2) and (n1 > 0 or n2 > 0),
-      do: ["informations sur l'accessibilité en fauteuil roulant"]
-
-  def has_wheelchair_accessibility(_), do: []
-
-  @spec base_tag(__MODULE__.t()) :: [binary()]
-  def base_tag(%__MODULE__{format: "GTFS"}),
-    do: ["position des stations", "horaires théoriques", "topologie du réseau"]
-
-  def base_tag(%__MODULE__{format: "NeTEx"}),
-    do: ["position des stations", "horaires théoriques", "topologie du réseau"]
-
-  def base_tag(_), do: []
-
-  # ⬆️⬆️⬆️
-  # end of deprecation notice
-
   def changeset(resource, params) do
     resource
     |> cast(
@@ -525,7 +415,6 @@ defmodule DB.Resource do
         :last_update,
         :latest_url,
         :is_available,
-        :features,
         :modes,
         :is_community_resource,
         :schema_name,

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -370,7 +370,6 @@ defmodule DB.Resource do
           validation_latest_content_hash: r.content_hash,
           data_vis: data_vis
         },
-        modes: find_modes(metadata),
         start_date: str_to_date(metadata["start_date"]),
         end_date: str_to_date(metadata["end_date"])
       )

--- a/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
@@ -58,7 +58,7 @@
 
       <li><%= dgettext("page-dataset-details", "Features available in the resource:") %></li>
       <div>
-        <% found_tags = DB.Resource.find_tags_from_metadata(@metadata) %>
+        <% found_tags = Transport.Validators.GTFSTransport.find_tags_from_metadata(@metadata) %>
         <%= for tag <- found_tags do %>
           <span class="label mode"><%= tag %></span>
         <% end %>
@@ -72,7 +72,7 @@
           )
           |> raw() %>
         </li>
-        <%= for tag <- DB.Resource.existing_gtfs_tags() -- found_tags do %>
+        <%= for tag <- Transport.Validators.GTFSTransport.existing_gtfs_tags() -- found_tags do %>
           <span class="label"><%= tag %></span>
         <% end %>
       </div>

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -191,39 +191,6 @@ defmodule DB.ResourceTest do
     assert reasons == %{"content hash has changed" => 1, "no previous validation" => 1}
   end
 
-  # to be deleted later, when validation v1 has disappeared
-  # ⬇️⬇️⬇️
-  test "find_tags_from_metadata" do
-    # Can detect all available tags
-    assert ["transport à la demande"] == Resource.find_tags_from_metadata(%{"some_stops_need_phone_agency" => true})
-    assert ["transport à la demande"] == Resource.find_tags_from_metadata(%{"some_stops_need_phone_driver" => true})
-    assert ["description des correspondances"] == Resource.find_tags_from_metadata(%{"has_pathways" => true})
-    assert ["tracés de lignes"] == Resource.find_tags_from_metadata(%{"has_shapes" => true})
-
-    assert ["couleurs des lignes"] ==
-             Resource.find_tags_from_metadata(%{"lines_with_custom_color_count" => 4, "lines_count" => 5})
-
-    assert Resource.find_tags_from_metadata(%{"lines_with_custom_color_count" => 0, "has_fares" => false}) == []
-
-    # Can find multiple tags
-    assert Resource.find_tags_from_metadata(%{"has_fares" => true, "has_pathways" => true}) == [
-             "tarifs",
-             "description des correspondances"
-           ]
-
-    assert Resource.find_tags_from_metadata(%{
-             "some_stops_need_phone_driver" => true,
-             "some_stops_need_phone_agency" => true
-           }) == ["transport à la demande"]
-
-    # Does not crash when map is empty or some keys are not recognised
-    assert Resource.find_tags_from_metadata(%{}) == []
-    assert Resource.find_tags_from_metadata(%{"foo" => "bar"}) == []
-  end
-
-  # ⬆️⬆️⬆️
-  # end of deprecation notice
-
   test "get resource related geojson infos" do
     now = DateTime.now!("Etc/UTC")
 

--- a/apps/transport/test/transport/validation_cleaner_test.exs
+++ b/apps/transport/test/transport/validation_cleaner_test.exs
@@ -26,8 +26,7 @@ defmodule Transport.ValidationCleanerTest do
         },
         metadata: %{},
         title: "angers.zip",
-        modes: ["ferry"],
-        features: ["tarifs"]
+        modes: ["ferry"]
       }
       |> Repo.insert()
 
@@ -43,8 +42,7 @@ defmodule Transport.ValidationCleanerTest do
         },
         metadata: %{},
         title: "another_gtfs.zip",
-        modes: ["bus"],
-        features: []
+        modes: ["bus"]
       }
       |> Repo.insert()
 

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -26,8 +26,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
             validation: %Validation{},
             metadata: %{},
             title: "angers.zip",
-            modes: ["ferry"],
-            features: ["tarifs"]
+            modes: ["ferry"]
           }
         ],
         aom: %AOM{id: 4242, nom: "Angers Métropôle"}


### PR DESCRIPTION
Celui là je m'attendais à un gros morceau, en fait il était déjà presque plus utilisé :relieved: 
Par contre vu que le mot `features` est utilisé partout, j'ai du tout scanner manuellement pour vérifier qu'on n'utilisait plus ce champ.

lié à #2390 