### PR TITLE
WIP Suppression de Resource start_date et end_date

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -45,7 +45,9 @@ defmodule DB.Resource do
     field(:datagouv_id, :string)
 
     # we add 2 fields, that are already in the metadata json, in order to be able to add some indices
+    ###!
     field(:start_date, :date)
+    ###!
     field(:end_date, :date)
 
     field(:filesize, :integer)
@@ -368,7 +370,9 @@ defmodule DB.Resource do
           validation_latest_content_hash: r.content_hash,
           data_vis: data_vis
         },
+        ###!
         start_date: str_to_date(metadata["start_date"]),
+        ###!
         end_date: str_to_date(metadata["end_date"])
       )
       |> Repo.update()
@@ -428,6 +432,7 @@ defmodule DB.Resource do
     |> validate_required([:url, :datagouv_id])
   end
 
+  ###!
   @spec is_outdated?(__MODULE__.t()) :: boolean
   def is_outdated?(%__MODULE__{
         metadata: %{

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -193,6 +193,7 @@ defmodule Transport.StatsHandler do
     |> join(:left, [_, dataset], _r in assoc(dataset, :resources))
     |> join(:left, [_, _, r], v in subquery(validations), on: v.resource_id == r.id)
     |> where([_a, _d, r, _v], r.format == "GTFS")
+    ###!
     |> where([_a, _d, r, _v], r.end_date >= ^dt)
     |> group_by([a, _d, _r, v], a.id)
     |> select([a, d, r, v], %{

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -368,6 +368,7 @@ defmodule TransportWeb.API.StatsController do
             )
         },
         quality: %{
+          ###!
           expired_from: fragment("TO_DATE(?, 'YYYY-MM-DD') - max(?)", ^dt, expired_info.end_date),
           error_level: fragment("case max(CASE max_error::text
               WHEN 'Fatal' THEN 1

--- a/apps/transport/lib/transport_web/controllers/aoms.ex
+++ b/apps/transport/lib/transport_web/controllers/aoms.ex
@@ -66,7 +66,8 @@ defmodule TransportWeb.AOMSController do
 
   @spec valid_dataset?(Dataset.t()) :: boolean()
   defp valid_dataset?(dataset),
-    do: Enum.any?(Dataset.official_resources(dataset), fn r -> !Resource.is_outdated?(r) end)
+    do: ###!
+    Enum.any?(Dataset.official_resources(dataset), fn r -> !Resource.is_outdated?(r) end)
 
   @spec up_to_date?([Dataset.t()], Dataset.t() | nil) :: boolean()
   defp up_to_date?([], nil), do: false
@@ -77,6 +78,7 @@ defmodule TransportWeb.AOMSController do
     |> Enum.filter(fn d -> d.type == "public-transit" end)
     |> case do
       [] -> false
+      ###!
       transit_datasets -> Enum.any?(transit_datasets, &valid_dataset?/1)
     end
   end

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -23,10 +23,13 @@ defmodule TransportWeb.Backoffice.PageController do
 
     sub =
       Resource
+      ###!
       |> where([r], fragment("metadata->>'end_date' IS NOT NULL"))
       |> group_by([r], r.dataset_id)
+      ###!
       |> having([_q], fragment("max(metadata->>'end_date') <= ?", ^dt))
       |> distinct([r], r.dataset_id)
+      ###!
       |> select([r], %{dataset_id: r.dataset_id, end_date: fragment("max(metadata->>'end_date')")})
 
     Dataset
@@ -43,6 +46,7 @@ defmodule TransportWeb.Backoffice.PageController do
         fragment("SUM(CASE WHEN format='GTFS' or format='gbfs' or format='NeTEx' THEN 1 ELSE 0 END) > 0")
       )
       |> group_by([r], r.dataset_id)
+      ###!
       |> select([r], %{dataset_id: r.dataset_id, end_date: fragment("max(metadata->>'end_date')")})
 
     Dataset
@@ -56,6 +60,7 @@ defmodule TransportWeb.Backoffice.PageController do
       Resource
       |> having([r], fragment("MAX(CAST(metadata->'issues_count'->>'UnloadableModel' as INT)) > 0"))
       |> group_by([r], r.dataset_id)
+      ###!
       |> select([r], %{dataset_id: r.dataset_id, end_date: fragment("max(metadata->>'end_date')")})
 
     Dataset
@@ -129,6 +134,7 @@ defmodule TransportWeb.Backoffice.PageController do
     resources =
       Resource
       |> group_by([r], r.dataset_id)
+      ###!
       |> select([r], %{dataset_id: r.dataset_id, end_date: fragment("max(metadata->>'end_date')")})
 
     Dataset
@@ -227,6 +233,7 @@ defmodule TransportWeb.Backoffice.PageController do
 
     order_by =
       case params do
+        ###!
         %{"order_by" => "end_date"} -> :end_date
         %{"order_by" => "custom_title"} -> :custom_title
         _ -> nil
@@ -240,6 +247,7 @@ defmodule TransportWeb.Backoffice.PageController do
     %{direction: dir, field: field} = get_order_by_from_params(params)
 
     case field do
+      ###!
       :end_date -> order_by(query, [d, r], {^dir, field(r, :end_date)})
       :custom_title -> order_by(query, [d, r], {^dir, field(d, :custom_title)})
       _ -> query

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
@@ -29,6 +29,7 @@
     end %>
   </td>
   <td>
+  ###!
     <%= end_date(@dataset) %>
   </td>
   <td class="bo_dataset_button">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -121,6 +121,7 @@
       <th>data.gouv.fr</th>
       <th>Region</th>
       <th>Commune principale</th>
+      ###!
       <th class="sortable"><%= backoffice_sort_link(@conn, "Fin de validité", :end_date, @order_by) %></th>
       <th class="bo_dataset_button"></th>
       <th class="bo_dataset_button"></th>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -272,18 +272,22 @@
                   </td>
                   <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
                   <%= if has_validity_period_col do %>
-                    <%= if has_validity_period?(resource_history) do %>
+
+                    <%= ###!
+                    if has_validity_period?(resource_history) do %>
                       <td>
                         <%= dgettext(
                           "page-dataset-details",
                           "%{start} to %{end}",
                           start:
                             DateTimeDisplay.format_date(
+                              ###!
                               resource_history.payload["resource_metadata"]["start_date"],
                               locale
                             ),
                           end:
                             DateTimeDisplay.format_date(
+                              ###!
                               resource_history.payload["resource_metadata"]["end_date"],
                               locale
                             )

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -2,6 +2,7 @@ defmodule TransportWeb.Backoffice.PageView do
   use TransportWeb, :view
   alias Plug.Conn.Query
   alias TransportWeb.PaginationHelpers
+  ###!
   import TransportWeb.DatasetView, only: [end_date: 1]
   alias DB.Dataset
 

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -36,6 +36,7 @@ defmodule TransportWeb.DatasetView do
   def count_discussions(nil), do: '-'
   def count_discussions(discussions), do: Enum.count(discussions)
 
+  ###!
   def end_date(dataset) do
     dataset.resources
     |> Enum.filter(&Resource.is_gtfs?/1)


### PR DESCRIPTION
J'ai mis des `###!` à tous les endroits où des changements sont nécessaires. Il est possible que certains endroits soient en fait ok, mais à vérifier.

ce qu'il reste à traiter :

- [x] dans le backoffice
- [x] dans la page /aoms
- [x] pour afficher les dates de validités des ressources historisées
- [x] pour stocker des stats