### PR TITLE
Dataset validation : ignore ressources communautaires

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -595,7 +595,10 @@ defmodule DB.Dataset do
   def validate(id) when is_integer(id) do
     dataset = __MODULE__ |> Repo.get!(id) |> Repo.preload(:resources)
 
-    {real_time_resources, static_resources} = Enum.split_with(dataset.resources, &Resource.is_real_time?/1)
+    {real_time_resources, static_resources} =
+      dataset.resources
+      |> official_resources()
+      |> Enum.split_with(&Resource.is_real_time?/1)
 
     # unique period is set to nil, to force the resource history job to be executed
     static_resources

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -291,6 +291,8 @@ defmodule DB.DatasetDBTest do
     dataset = insert(:dataset)
     %{id: gtfs_resource_id} = insert(:resource, format: "GTFS", dataset: dataset)
     %{id: gbfs_resource_id} = insert(:resource, format: "gbfs", dataset: dataset)
+    # Ignored because it's a community resource
+    insert(:resource, format: "GTFS", dataset: dataset, is_community_resource: true)
 
     Dataset.validate(dataset)
 


### PR DESCRIPTION
Certaines ressources communautaires ont été historisées par erreur suite à un clic sur "Valider" dans le backoffice qui n'excluait pas ces ressources. Le job `ResourceHistoryJob` n'a pas de mécanisme de protection non plus contre ce cas, dommage.