### PR TITLE
ImportData: ajuste détection pour ressources documentation

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -575,6 +575,7 @@ defmodule Transport.ImportData do
   """
   @spec is_documentation?(map() | binary()) :: boolean()
   def is_documentation?(str) when is_binary(str), do: false
+
   def is_documentation?(%{} = params) do
     cond do
       params["type"] == "documentation" -> true

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -509,12 +509,14 @@ defmodule Transport.ImportData do
   true
   iex> is_gtfs?(%{"description" => "gtfs", "title" => "Export au format CSV"})
   false
+  iex> is_gtfs?(%{"url" => "https://example.com/documentation-gtfs.pdf", "type" => "documentation"})
+  false
   """
   @spec is_gtfs?(map()) :: boolean()
   # credo:disable-for-next-line
   def is_gtfs?(%{} = params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_gtfs?(params["format"]) -> true
       is_gtfs_rt?(params) -> false
       is_format?(params["url"], ["json", "csv", "shp", "pdf", "7z"]) -> false
@@ -549,7 +551,7 @@ defmodule Transport.ImportData do
   @spec is_gtfs_rt?(binary() | map()) :: boolean()
   def is_gtfs_rt?(%{} = params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_gtfs_rt?(params["format"]) -> true
       is_gtfs_rt?(params["description"]) -> true
       is_gtfs_rt?(params["title"]) -> true
@@ -571,7 +573,8 @@ defmodule Transport.ImportData do
   iex> is_documentation?(%{"type" => "documentation", "format" => "docx"})
   true
   """
-  @spec is_documentation?(map()) :: boolean()
+  @spec is_documentation?(map() | binary()) :: boolean()
+  def is_documentation?(str) when is_binary(str), do: false
   def is_documentation?(%{} = params) do
     cond do
       params["type"] == "documentation" -> true
@@ -593,7 +596,7 @@ defmodule Transport.ImportData do
   @spec is_siri?(binary() | map()) :: boolean()
   def is_siri?(params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_format?(params, "siri") and not is_siri_lite?(params) -> true
       true -> false
     end
@@ -612,7 +615,7 @@ defmodule Transport.ImportData do
   @spec is_siri_lite?(binary() | map()) :: boolean()
   def is_siri_lite?(params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_format?(params, "SIRI Lite") -> true
       true -> false
     end
@@ -687,11 +690,13 @@ defmodule Transport.ImportData do
   true
   iex> is_netex?(%{"url" => "https://example.com/gtfs.zip", "format" => "zip"})
   false
+  iex> is_netex?(%{"url" => "https://example.com/doc-netex.pdf", "type" => "documentation"})
+  false
   """
   @spec is_netex?(binary() | map()) :: boolean()
   def is_netex?(%{} = params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_netex?(params["format"]) -> true
       is_netex?(params["title"]) -> true
       is_netex?(params["description"]) -> true
@@ -705,7 +710,7 @@ defmodule Transport.ImportData do
   @spec is_neptune?(binary() | map()) :: boolean()
   def is_neptune?(params) do
     cond do
-      is_ods_title?(params) -> false
+      is_ods_title?(params) or is_documentation?(params) -> false
       is_format?(params, "neptune") -> true
       true -> false
     end


### PR DESCRIPTION
Certaines ressources nommées "Documentation NeTEx" avec `type = 'documentation'` ont été mal détectées par le script d'import et se voient attribuées le format `NeTEx`.

Exemple [sur le JDD IDFM](https://transport.data.gouv.fr/datasets/horaires-prevus-sur-les-lignes-de-transport-en-commun-dile-de-france-gtfs-datahub) où on retrouve ces ressources dans la section NeTEx et documentation.