### PR TITLE
Dataset : stockage date d'archivage

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -37,6 +37,7 @@ defmodule DB.Dataset do
     field(:population, :integer)
     field(:nb_reuses, :integer)
     field(:latest_data_gouv_comment_timestamp, :naive_datetime_usec)
+    field(:archived_at, :utc_datetime_usec)
 
     # When the dataset is linked to some cities
     # we ask in the backoffice for a name to display
@@ -369,7 +370,8 @@ defmodule DB.Dataset do
       :nb_reuses,
       :is_active,
       :associated_territory_name,
-      :latest_data_gouv_comment_timestamp
+      :latest_data_gouv_comment_timestamp,
+      :archived_at
     ])
     |> cast_aom(params)
     |> cast_datagouv_zone(params, territory_name)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -177,12 +177,31 @@ defmodule Transport.ImportData do
       |> Map.put("resources", get_resources(data_gouv_resp, type))
       |> Map.put("nb_reuses", get_nb_reuses(data_gouv_resp))
       |> Map.put("licence", licence(data_gouv_resp))
+      |> Map.put("archived_at", archived(data_gouv_resp["archived"]))
       |> Map.put("zones", get_associated_zones_insee(data_gouv_resp))
 
     case Map.get(data_gouv_resp, "resources") do
       nil -> {:error, "dataset #{data_gouv_resp["id"]} has no resource"}
       _ -> {:ok, dataset}
     end
+  end
+
+  @spec archived(nil | binary()) :: DateTime.t() | nil
+  @doc """
+  Set the `archived_at` field from the `archived` API key.
+
+  iex>archived(nil)
+  nil
+  iex>archived("2022-09-28T03:08:59.782000")
+  ~U[2022-09-28 03:08:59.782000Z]
+  iex>archived("2022-09-28T03:08:59.782000Z")
+  ~U[2022-09-28 03:08:59.782000Z]
+  """
+  def archived(nil), do: nil
+
+  def archived(datetime_str) when is_binary(datetime_str) do
+    {:ok, datetime, 0} = DateTime.from_iso8601(String.replace_suffix(datetime_str, "Z", "") <> "Z")
+    datetime
   end
 
   @doc """

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -109,6 +109,13 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render_index(conn, params)
   end
 
+  def index(%Plug.Conn{} = conn, %{"filter" => "archived"} = params) do
+    Dataset.base_query()
+    |> where([dataset: d], not is_nil(d.archived_at))
+    |> query_order_by_from_params(params)
+    |> render_index(conn, params)
+  end
+
   def index(%Plug.Conn{} = conn, %{"dataset_id" => dataset_id} = params) do
     conn =
       Dataset

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -76,6 +76,11 @@
           ) %>
         </div>
         <div>
+          <%= link(dgettext("backoffice", "Archived"),
+            to: backoffice_page_path(@conn, :index, %{"filter" => "archived"}) <> "#list_datasets"
+          ) %>
+        </div>
+        <div>
           <%= link(dgettext("backoffice", "With unidentified resources"),
             to: backoffice_page_path(@conn, :index, %{"filter" => "other_resources"}) <> "#list_datasets"
           ) %>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -200,3 +200,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Validations"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Archived"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -200,3 +200,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Validations"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Archived"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -200,3 +200,7 @@ msgstr "Validateur GTFS Transport - Validation forcée"
 #, elixir-autogen, elixir-format
 msgid "Validations"
 msgstr "Validations"
+
+#, elixir-autogen, elixir-format
+msgid "Archived"
+msgstr "Archivés"

--- a/apps/transport/priv/repo/migrations/20221129131631_dataset_add_archived_at_field.exs
+++ b/apps/transport/priv/repo/migrations/20221129131631_dataset_add_archived_at_field.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.DatasetAddArchivedAtField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataset) do
+      add(:archived_at, :utc_datetime_usec)
+    end
+  end
+end


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/2793

- Ajoute un nouveau champ `archived_at` contenant la date d'archivage dans data.gouv.fr
- Ajoute un nouveau filtre dans le backoffice pour identifier les JDD actuellement archivés

![image](https://user-images.githubusercontent.com/295709/204544234-d8b903a2-15e9-4c0e-8566-04a89dbdb6e8.png)
