### PR TITLE
Licence Mobilités : ajoute IDFM

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -196,6 +196,12 @@ defmodule Transport.ImportData do
       iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Lyon"}})
       "mobility-licence"
 
+      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Île-de-France Mobilités"}})
+      "mobility-licence"
+
+      iex> licence(%{"license" => "odc-odbl", "organization" => %{"name" => "Île-de-France Mobilités"}})
+      "odc-odbl"
+
       iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Rouen"}})
       "notspecified"
 
@@ -204,9 +210,7 @@ defmodule Transport.ImportData do
 
   """
   def licence(%{"license" => "notspecified", "organization" => %{"name" => org_name}}) do
-    orgs_with_mobility_licence = ["Métropole de Lyon"]
-
-    if org_name in orgs_with_mobility_licence do
+    if org_name in Application.fetch_env!(:transport, :orgs_with_mobility_licence) do
       "mobility-licence"
     else
       "notspecified"

--- a/config/config.exs
+++ b/config/config.exs
@@ -140,6 +140,7 @@ config :transport,
 
 config :transport,
   datagouv_static_hosts: ["static.data.gouv.fr", "demo-static.data.gouv.fr"],
+  orgs_with_mobility_licence: ["Métropole de Lyon", "Île-de-France Mobilités"],
   bison_fute_host: "tipi.bison-fute.gouv.fr"
 
 config :datagouvfr,


### PR DESCRIPTION
Ajoute IDFM au côté de la "Métropole de Lyon" à la liste des organisations pour lesquelles on affichera la "Licence mobilités" comme licence si ils ont comme licence "Autre licence" sur data.gouv.fr