### PR TITLE
Test de disponibilité différencié pour ressources SIRI

### DIFF
--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -64,18 +64,8 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
     |> update_availability()
   end
 
-  defp check_availability({check_url, %Resource{format: "SIRI"} = resource}) do
-    case http_client().get(check_url) do
-      {:ok, %HTTPoison.Response{status_code: code}} when (code >= 200 and code < 300) or code == 401 ->
-        {true, resource}
-
-      _ ->
-        {false, resource}
-    end
-  end
-
-  defp check_availability({check_url, %Resource{} = resource}) do
-    {Transport.AvailabilityChecker.Wrapper.available?(check_url), resource}
+  defp check_availability({check_url, %Resource{format: format} = resource}) do
+    {Transport.AvailabilityChecker.Wrapper.available?(format, check_url), resource}
   end
 
   defp update_url(%Resource{filetype: "file", url: url, latest_url: latest_url} = resource) do

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -64,6 +64,16 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
     |> update_availability()
   end
 
+  defp check_availability({check_url, %Resource{format: "SIRI"} = resource}) do
+    case http_client().get(check_url) do
+      {:ok, %HTTPoison.Response{status_code: code}} when (code >= 200 and code < 300) or code == 401 ->
+        {true, resource}
+
+      _ ->
+        {false, resource}
+    end
+  end
+
   defp check_availability({check_url, %Resource{} = resource}) do
     {Transport.AvailabilityChecker.Wrapper.available?(check_url), resource}
   end

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -3,9 +3,9 @@ defmodule Transport.AvailabilityChecker.Wrapper do
   Defines a behavior
   """
 
-  @callback available?(binary()) :: boolean
+  @callback available?(binary(), binary()) :: boolean
   def impl, do: Application.get_env(:transport, :availability_checker_impl)
-  def available?(x), do: impl().available?(x)
+  def available?(resource_format, url), do: impl().available?(resource_format, url)
 end
 
 defmodule Transport.AvailabilityChecker.Dummy do
@@ -15,7 +15,7 @@ defmodule Transport.AvailabilityChecker.Dummy do
   @behaviour Transport.AvailabilityChecker.Wrapper
 
   @impl Transport.AvailabilityChecker.Wrapper
-  def available?(_), do: true
+  def available?(_, _), do: true
 end
 
 defmodule Transport.AvailabilityChecker do
@@ -28,18 +28,33 @@ defmodule Transport.AvailabilityChecker do
   @behaviour Transport.AvailabilityChecker.Wrapper
 
   @impl Transport.AvailabilityChecker.Wrapper
-  @spec available?(binary()) :: boolean
-  def available?(target, use_http_streaming \\ false)
+  @spec available?(binary(), binary()) :: boolean
+  def available?(format, target, use_http_streaming \\ false)
 
-  def available?(url, false) when is_binary(url) do
-    case HTTPoison.head(url, [], follow_redirect: true) do
-      {:ok, %Response{status_code: code}} when code >= 200 and code < 300 -> true
-      {:ok, %Response{status_code: code}} when code in [401, 403, 405] -> available?(url, _use_http_streaming = true)
-      _ -> false
+  def available?("SIRI", url, _) when is_binary(url) do
+    case HTTPoison.get(url, [], follow_redirect: true) do
+      {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code == 401 ->
+        true
+
+      _ ->
+        false
     end
   end
 
-  def available?(url, true = _use_http_streaming) do
+  def available?(format, url, false) when is_binary(url) do
+    case HTTPoison.head(url, [], follow_redirect: true) do
+      {:ok, %Response{status_code: code}} when code >= 200 and code < 300 ->
+        true
+
+      {:ok, %Response{status_code: code}} when code in [401, 403, 405] ->
+        available?(format, url, _use_http_streaming = true)
+
+      _ ->
+        false
+    end
+  end
+
+  def available?(_format, url, true = _use_http_streaming) do
     case HTTPStreamV2.fetch_status_follow_redirect(url) do
       {:ok, 200} -> true
       _ -> false

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -32,7 +32,7 @@ defmodule Transport.AvailabilityChecker do
   def available?(format, target, use_http_streaming \\ false)
 
   def available?("SIRI", url, _) when is_binary(url) do
-    case HTTPoison.get(url, [], follow_redirect: true) do
+    case http_client().get(url, [], follow_redirect: true) do
       {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code == 401 ->
         true
 
@@ -42,7 +42,7 @@ defmodule Transport.AvailabilityChecker do
   end
 
   def available?(format, url, false) when is_binary(url) do
-    case HTTPoison.head(url, [], follow_redirect: true) do
+    case http_client().head(url, [], follow_redirect: true) do
       {:ok, %Response{status_code: code}} when code >= 200 and code < 300 ->
         true
 
@@ -60,4 +60,6 @@ defmodule Transport.AvailabilityChecker do
       _ -> false
     end
   end
+
+  defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
 end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -361,7 +361,6 @@ defmodule Transport.ImportData do
     |> Enum.uniq_by(fn resource -> resource["url"] end)
     |> Enum.map_reduce(0, fn resource, display_position ->
       is_community_resource = resource["is_community_resource"] == true
-
       existing_resource = get_existing_resource(resource, dataset["id"]) || %{}
 
       resource =
@@ -369,9 +368,11 @@ defmodule Transport.ImportData do
         |> Map.put("metadata", existing_resource[:metadata])
         |> Map.put("url", cleaned_url(resource["url"]))
 
+      format = formated_format(resource, type, is_community_resource)
+
       {%{
          "url" => resource["url"],
-         "format" => formated_format(resource, type, is_community_resource),
+         "format" => format,
          "title" => get_title(resource),
          "last_import" => DateTime.utc_now() |> DateTime.to_string(),
          "last_update" => resource["last_modified"],
@@ -382,7 +383,7 @@ defmodule Transport.ImportData do
          "type" => resource["type"],
          "id" => existing_resource[:id],
          "datagouv_id" => resource["id"],
-         "is_available" => availability_checker().available?(resource["url"]),
+         "is_available" => availability_checker().available?(format, resource["url"]),
          "is_community_resource" => is_community_resource,
          "community_resource_publisher" => get_publisher(resource),
          "description" => resource["description"],

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -9,7 +9,7 @@ defmodule Transport.AvailabilityCheckerTest do
     end
 
     with_mock HTTPoison, head: mock do
-      assert AvailabilityChecker.available?("url200")
+      assert AvailabilityChecker.available?("GTFS", "url200")
       assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
     end
   end
@@ -20,7 +20,7 @@ defmodule Transport.AvailabilityCheckerTest do
     end
 
     with_mock HTTPoison, head: mock do
-      refute AvailabilityChecker.available?("url400")
+      refute AvailabilityChecker.available?("GTFS", "url400")
       assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
     end
   end
@@ -31,7 +31,7 @@ defmodule Transport.AvailabilityCheckerTest do
     end
 
     with_mock HTTPoison, head: mock do
-      refute AvailabilityChecker.available?("url500")
+      refute AvailabilityChecker.available?("GTFS", "url500")
       assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
     end
   end
@@ -56,7 +56,7 @@ defmodule Transport.AvailabilityCheckerTest do
 
     with_mock HTTPoison, head: httpoison_mock do
       with_mock HTTPStreamV2, fetch_status_follow_redirect: streamer_mock do
-        assert AvailabilityChecker.available?("url")
+        assert AvailabilityChecker.available?("GTFS", "url")
         assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
         assert_called_exactly(HTTPStreamV2.fetch_status_follow_redirect(:_), 1)
       end

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -4,7 +4,7 @@ defmodule Transport.AvailabilityCheckerTest do
   alias Transport.AvailabilityChecker
 
   test "head supported, 200", _ do
-    mock = fn _url, [], _options ->
+    mock = fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
     end
 
@@ -15,7 +15,7 @@ defmodule Transport.AvailabilityCheckerTest do
   end
 
   test "head supported, 400", _ do
-    mock = fn _url, [], _options ->
+    mock = fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{body: "{}", status_code: 400}}
     end
 
@@ -26,13 +26,24 @@ defmodule Transport.AvailabilityCheckerTest do
   end
 
   test "head supported, 500", _ do
-    mock = fn _url, [], _options ->
+    mock = fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{body: "{}", status_code: 500}}
     end
 
     with_mock HTTPoison, head: mock do
       refute AvailabilityChecker.available?("GTFS", "url500")
       assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
+    end
+  end
+
+  test "SIRI resource, 401", _ do
+    mock = fn _url, [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 401}}
+    end
+
+    with_mock HTTPoison, get: mock do
+      assert AvailabilityChecker.available?("SIRI", "url401")
+      assert_called_exactly(HTTPoison.get(:_, :_, :_), 1)
     end
   end
 
@@ -46,7 +57,7 @@ defmodule Transport.AvailabilityCheckerTest do
   end
 
   defp test_fallback_to_stream(status_code) do
-    httpoison_mock = fn _url, [], _options ->
+    httpoison_mock = fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{body: "{}", status_code: status_code}}
     end
 

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -1,76 +1,69 @@
 defmodule Transport.AvailabilityCheckerTest do
   use ExUnit.Case, async: false
   import Mock
+  import Mox
   alias Transport.AvailabilityChecker
 
-  test "head supported, 200", _ do
-    mock = fn _url, [], [follow_redirect: true] ->
-      {:ok, %HTTPoison.Response{body: "{}", status_code: 200}}
-    end
+  setup :verify_on_exit!
 
-    with_mock HTTPoison, head: mock do
-      assert AvailabilityChecker.available?("GTFS", "url200")
-      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
-    end
+  test "head supported, 200" do
+    Transport.HTTPoison.Mock
+    |> expect(:head, fn _url, [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 200}}
+    end)
+
+    assert AvailabilityChecker.available?("GTFS", "url200")
   end
 
-  test "head supported, 400", _ do
-    mock = fn _url, [], [follow_redirect: true] ->
-      {:ok, %HTTPoison.Response{body: "{}", status_code: 400}}
-    end
+  test "head supported, 400" do
+    Transport.HTTPoison.Mock
+    |> expect(:head, fn _url, [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 400}}
+    end)
 
-    with_mock HTTPoison, head: mock do
-      refute AvailabilityChecker.available?("GTFS", "url400")
-      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
-    end
+    refute AvailabilityChecker.available?("GTFS", "url400")
   end
 
-  test "head supported, 500", _ do
-    mock = fn _url, [], [follow_redirect: true] ->
-      {:ok, %HTTPoison.Response{body: "{}", status_code: 500}}
-    end
+  test "head supported, 500" do
+    Transport.HTTPoison.Mock
+    |> expect(:head, fn _url, [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 500}}
+    end)
 
-    with_mock HTTPoison, head: mock do
-      refute AvailabilityChecker.available?("GTFS", "url500")
-      assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
-    end
+    refute AvailabilityChecker.available?("GTFS", "url500")
   end
 
-  test "SIRI resource, 401", _ do
-    mock = fn _url, [], [follow_redirect: true] ->
+  test "SIRI resource, 401" do
+    Transport.HTTPoison.Mock
+    |> expect(:get, fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{status_code: 401}}
-    end
+    end)
 
-    with_mock HTTPoison, get: mock do
-      assert AvailabilityChecker.available?("SIRI", "url401")
-      assert_called_exactly(HTTPoison.get(:_, :_, :_), 1)
-    end
+    assert AvailabilityChecker.available?("SIRI", "url401")
   end
 
-  test "head NOT supported, fallback on stream method", _ do
+  test "head NOT supported, fallback on stream method" do
     test_fallback_to_stream(405)
   end
 
-  test "head requires auth, fallback on stream method", _ do
+  test "head requires auth, fallback on stream method" do
     test_fallback_to_stream(401)
     test_fallback_to_stream(403)
   end
 
   defp test_fallback_to_stream(status_code) do
-    httpoison_mock = fn _url, [], [follow_redirect: true] ->
-      {:ok, %HTTPoison.Response{body: "{}", status_code: status_code}}
-    end
+    Transport.HTTPoison.Mock
+    |> expect(:head, fn _url, [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: status_code}}
+    end)
 
     streamer_mock = fn _url ->
       {:ok, 200}
     end
 
-    with_mock HTTPoison, head: httpoison_mock do
-      with_mock HTTPStreamV2, fetch_status_follow_redirect: streamer_mock do
-        assert AvailabilityChecker.available?("GTFS", "url")
-        assert_called_exactly(HTTPoison.head(:_, :_, :_), 1)
-        assert_called_exactly(HTTPStreamV2.fetch_status_follow_redirect(:_), 1)
-      end
+    with_mock HTTPStreamV2, fetch_status_follow_redirect: streamer_mock do
+      assert AvailabilityChecker.available?("GTFS", "url")
+      assert_called_exactly(HTTPStreamV2.fetch_status_follow_redirect(:_), 1)
     end
   end
 end

--- a/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
@@ -115,7 +115,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
           datagouv_id: "foo"
         )
 
-      Transport.AvailabilityChecker.Mock |> expect(:available?, fn ^latest_url -> true end)
+      Transport.AvailabilityChecker.Mock |> expect(:available?, fn _format, ^latest_url -> true end)
 
       assert DB.Resource.download_url(resource) == latest_url
 
@@ -148,7 +148,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
         {:ok, %HTTPoison.Response{status_code: 500}}
       end)
 
-      Transport.AvailabilityChecker.Mock |> expect(:available?, fn ^new_url -> false end)
+      Transport.AvailabilityChecker.Mock |> expect(:available?, fn _format, ^new_url -> false end)
 
       assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
 
@@ -178,10 +178,8 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
           datagouv_id: "foo"
         )
 
-      Transport.HTTPoison.Mock
-      |> expect(:get, fn ^url ->
-        {:ok, %HTTPoison.Response{status_code: 401}}
-      end)
+      Transport.AvailabilityChecker.Mock
+      |> expect(:available?, fn "SIRI", ^url -> true end)
 
       assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
 
@@ -201,14 +199,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
     url = @resource_url
 
     Transport.AvailabilityChecker.Mock
-    |> expect(:available?, fn ^url -> false end)
+    |> expect(:available?, fn _format, ^url -> false end)
   end
 
   defp setup_mock_available do
     url = @resource_url
 
     Transport.AvailabilityChecker.Mock
-    |> expect(:available?, fn ^url -> true end)
+    |> expect(:available?, fn _format, ^url -> true end)
   end
 
   defp count_resources do


### PR DESCRIPTION
Fixes #2818

Pour les ressources SIRI, faire une requête `GET` et autoriser les réponses 2XX ou une 401 car l'authentification est classique.

On pourrait à terme aller plus loin et tester en s'authentifiant, pour le moment on n'a pas ces informations. Ce fix est immédiatement utile pour [les SIRI d'IDFM](https://transport.data.gouv.fr/datasets/horaires-prevus-sur-les-lignes-de-transport-en-commun-dile-de-france-gtfs-datahub#dataset-resources).