### PR TITLE
DataChecker : envoi d'un unique e-mail pour JDD supprimés et archivés

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -60,6 +60,7 @@ defmodule DB.Dataset do
   end
 
   def base_query, do: from(d in DB.Dataset, as: :dataset, where: d.is_active == true)
+  def archived, do: base_query() |> where([dataset: d], not is_nil(d.archived_at))
 
   @doc """
   Creates a query with the following inner joins:

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -110,8 +110,7 @@ defmodule TransportWeb.Backoffice.PageController do
   end
 
   def index(%Plug.Conn{} = conn, %{"filter" => "archived"} = params) do
-    Dataset.base_query()
-    |> where([dataset: d], not is_nil(d.archived_at))
+    Dataset.archived()
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -23,7 +23,7 @@ defmodule Transport.DataCheckerTest do
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
         assert from_email == "contact@transport.beta.gouv.fr"
         assert to_email == "deploiement@transport.beta.gouv.fr"
-        assert subject == "Jeux de données qui disparaissent"
+        assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données disparus sont réapparus sur data.gouv.fr/
         :ok
       end)
@@ -55,7 +55,7 @@ defmodule Transport.DataCheckerTest do
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
         assert from_email == "contact@transport.beta.gouv.fr"
         assert to_email == "deploiement@transport.beta.gouv.fr"
-        assert subject == "Jeux de données qui disparaissent"
+        assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données ont disparus de data.gouv.fr/
         :ok
       end)
@@ -87,7 +87,7 @@ defmodule Transport.DataCheckerTest do
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
         assert from_email == "contact@transport.beta.gouv.fr"
         assert to_email == "deploiement@transport.beta.gouv.fr"
-        assert subject == "Jeux de données archivés"
+        assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données sont indiqués comme archivés/
         :ok
       end)
@@ -391,5 +391,15 @@ defmodule Transport.DataCheckerTest do
     end)
 
     assert [0, 7, 14, 30, 42] == Transport.DataChecker.possible_delays()
+  end
+
+  test "count_archived_datasets" do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+
+    insert(:dataset, is_active: true, archived_at: nil)
+    insert(:dataset, is_active: true, archived_at: DateTime.utc_now())
+    insert(:dataset, is_active: false, archived_at: DateTime.utc_now())
+
+    assert 1 == Transport.DataChecker.count_archived_datasets()
   end
 end


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2797 et #2816

- Envoi un e-mail unique pour JDD supprimés, réapparus et archivés
- Ajout d'un lien vers le backoffice pour les JDD archivés