### PR TITLE
Ajout bannière si le jeu de données est archivé

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -61,6 +61,10 @@ defmodule DB.Dataset do
 
   def base_query, do: from(d in DB.Dataset, as: :dataset, where: d.is_active == true)
 
+  @spec is_archived?(__MODULE__.t()) :: boolean()
+  def is_archived?(%__MODULE__{archived_at: nil}), do: false
+  def is_archived?(%__MODULE__{archived_at: %DateTime{}}), do: true
+
   @doc """
   Creates a query with the following inner joins:
   datasets <> Resource <> ResourceHistory <> MultiValidation <> ResourceMetadata
@@ -125,7 +129,7 @@ defmodule DB.Dataset do
   @spec preload_without_validations() :: Ecto.Query.t()
   defp preload_without_validations do
     s = no_validations_query()
-    base_query() |> preload(resources: ^s)
+    __MODULE__ |> preload(resources: ^s)
   end
 
   @spec preload_without_validations(Ecto.Query.t()) :: Ecto.Query.t()

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -4,6 +4,13 @@
     <%= dgettext("page-dataset-details", "This dataset has been removed from data.gouv.fr") %>
   </div>
 <% end %>
+<%= if @dataset.is_active and DB.Dataset.is_archived?(@dataset) do %>
+  <div class="notification error full-width">
+    <%= dgettext("page-dataset-details", "This dataset has been archived from data.gouv.fr on %{date}",
+      date: DateTimeDisplay.format_datetime_to_date(@dataset.archived_at, locale)
+    ) %>
+  </div>
+<% end %>
 <div class="dataset-title-div" id="dataset-top">
   <%= dgettext("page-dataset-details", "dataset") %>
   <h1>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -553,3 +553,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Data published by"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This dataset has been archived from data.gouv.fr on %{date}"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -553,3 +553,7 @@ msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une
 #, elixir-autogen, elixir-format
 msgid "Data published by"
 msgstr "Données publiées par"
+
+#, elixir-autogen, elixir-format
+msgid "This dataset has been archived from data.gouv.fr on %{date}"
+msgstr "Ce jeu de données a été archivé de data.gouv.fr le %{date}"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -553,3 +553,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Data published by"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This dataset has been archived from data.gouv.fr on %{date}"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -182,6 +182,24 @@ defmodule TransportWeb.DatasetControllerTest do
     conn |> get(dataset_path(conn, :details, slug)) |> html_response(200)
   end
 
+  test "with an inactive dataset", %{conn: conn} do
+    insert(:dataset, is_active: false, slug: slug = "dataset-slug")
+
+    set_empty_mocks()
+
+    assert conn |> get(dataset_path(conn, :details, slug)) |> html_response(404) =~
+             "Ce jeu de données a été supprimé de data.gouv.fr"
+  end
+
+  test "with an archived dataset", %{conn: conn} do
+    insert(:dataset, is_active: true, slug: slug = "dataset-slug", archived_at: DateTime.utc_now())
+
+    set_empty_mocks()
+
+    assert conn |> get(dataset_path(conn, :details, slug)) |> html_response(200) =~
+             "Ce jeu de données a été archivé de data.gouv.fr"
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2793

Dernière étape liée à cette issue : afficher une bannière lorsqu'un jeu de donnée a été archivé sur data.gouv.fr. Informe les réutilisateurs que les données peuvent ne pas être fiables et donne une indication claire aux bizdevs.

Répare en même temps le code qui permet d'afficher la bannière indiquant qu'un jeu de données a été supprimé.

![image](https://user-images.githubusercontent.com/295709/205017780-2c5d6733-2177-44b7-994c-a1e5a33bf009.png)
