### PR TITLE
GeoQueryController : utilise dataset utilisé dans les jobs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -3,6 +3,7 @@ defmodule TransportWeb.ExploreController do
 
   def index(conn, _params) do
     conn
+    |> assign(:bnlc_dataset, Transport.Jobs.BNLCToGeoData.relevant_dataset())
     |> assign(:parcs_relais_dataset, Transport.Jobs.ParkingsRelaisToGeoData.relevant_dataset())
     |> render("explore.html")
   end

--- a/apps/transport/lib/transport_web/templates/explore/explore.html.heex
+++ b/apps/transport/lib/transport_web/templates/explore/explore.html.heex
@@ -1,6 +1,6 @@
 <% real_time_datasets = dataset_path(@conn, :index, type: "public-transit", filter: "has_realtime") %>
-<% bnlc_link = dataset_path(@conn, :details, "base-nationale-des-lieux-de-covoiturage") %>
-<% parcs_relais_link = dataset_path(@conn, :details, "base-nationale-des-parkings-relais-en-cours-de-consolidation") %>
+<% bnlc_link = dataset_path(@conn, :details, @bnlc_dataset.slug) %>
+<% parcs_relais_link = dataset_path(@conn, :details, @parcs_relais_dataset.slug) %>
 <div class="container dataset-page-top">
   <h2><%= dgettext("explore", "Transport Explore") %></h2>
 

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -29,7 +29,7 @@
                 ) %>
                 <%= link(gettext("Service status"), to: "https://stats.uptimerobot.com/q7nqyiO9yQ", target: "_blank") %>
                 <%= link(gettext("SIRI query generator"), to: live_path(@conn, TransportWeb.Live.SIRIQuerierLive)) %>
-                <%= link(gettext("GTFS-RT vehicle positions"), to: explore_path(@conn, :vehicle_positions)) %>
+                <%= link(gettext("Exploration map"), to: explore_path(@conn, :index)) %>
               </div>
             </div>
           </li>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -116,7 +116,7 @@ msgid "Declaration of conformity"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "GTFS-RT vehicle positions"
+msgid "Exploration map"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -116,7 +116,7 @@ msgid "Declaration of conformity"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "GTFS-RT vehicle positions"
+msgid "Exploration map"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -116,8 +116,8 @@ msgid "Declaration of conformity"
 msgstr "Déclaration de conformité"
 
 #, elixir-autogen, elixir-format
-msgid "GTFS-RT vehicle positions"
-msgstr "Positions des véhicules GTFS-RT"
+msgid "Exploration map"
+msgstr "Carte d'exploration"
 
 #, elixir-autogen, elixir-format
 msgid "SIRI query generator"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
@@ -41,7 +41,7 @@ msgstr "jeu de données"
 
 #, elixir-autogen, elixir-format
 msgid "Park and ride database"
-msgstr "P+R issus de la Base Nationale des Lieux de Stationnement"
+msgstr "Base nationale des parcs relais"
 
 #, elixir-autogen, elixir-format
 msgid "park-and-ride-explanation"

--- a/apps/transport/test/transport_web/controllers/api/geo_query_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/geo_query_controller_test.exs
@@ -7,11 +7,8 @@ defmodule TransportWeb.API.GeoQueryControllerTest do
   end
 
   test "a BNLC geo query", %{conn: conn} do
-    %{id: dataset_id} =
-      insert(:dataset, %{
-        type: "carpooling-areas",
-        organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
-      })
+    insert_parcs_relais_dataset()
+    %{id: dataset_id} = insert_bnlc_dataset()
 
     %{id: resource_history_id} = insert(:resource_history, %{payload: %{"dataset_id" => dataset_id}})
     %{id: geo_data_import_id} = insert(:geo_data_import, %{resource_history_id: resource_history_id})
@@ -47,11 +44,8 @@ defmodule TransportWeb.API.GeoQueryControllerTest do
   end
 
   test "a parkings relais geo query", %{conn: conn} do
-    %{id: dataset_id} =
-      insert(:dataset, %{
-        type: "private-parking",
-        organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
-      })
+    insert_bnlc_dataset()
+    %{id: dataset_id} = insert_parcs_relais_dataset()
 
     %{id: resource_history_id} = insert(:resource_history, %{payload: %{"dataset_id" => dataset_id}})
     %{id: geo_data_import_id} = insert(:geo_data_import, %{resource_history_id: resource_history_id})
@@ -99,6 +93,9 @@ defmodule TransportWeb.API.GeoQueryControllerTest do
   end
 
   test "404 cases", %{conn: conn} do
+    insert_bnlc_dataset()
+    insert_parcs_relais_dataset()
+
     conn
     |> get(TransportWeb.API.Router.Helpers.geo_query_path(conn, :index))
     |> json_response(404)
@@ -106,5 +103,20 @@ defmodule TransportWeb.API.GeoQueryControllerTest do
     conn
     |> get(TransportWeb.API.Router.Helpers.geo_query_path(conn, :index, data: Ecto.UUID.generate()))
     |> json_response(404)
+  end
+
+  defp insert_bnlc_dataset do
+    insert(:dataset, %{
+      type: "carpooling-areas",
+      organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+    })
+  end
+
+  defp insert_parcs_relais_dataset do
+    insert(:dataset, %{
+      type: "private-parking",
+      custom_title: "Base nationale des parcs relais",
+      organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+    })
   end
 end

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -6,6 +6,11 @@ defmodule TransportWeb.ExploreControllerTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
 
     insert(:dataset, %{
+      type: "carpooling-areas",
+      organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+    })
+
+    insert(:dataset, %{
       type: "private-parking",
       custom_title: "Base nationale des parcs relais",
       organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)


### PR DESCRIPTION
J'ai été un peu trop vite dans https://github.com/etalab/transport-site/pull/2723

Je refactor le code pour utiliser `relevant_dataset` dans les jobs de `GeoData` dans `ExploreController` et `GeoQueryController` pour être certain de parler du même jeu de données à chaque endroit.

Je change aussi le titre du menu dans le header.