### PR TITLE
Dataset#details : gère changement de slug et redirections

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -271,17 +271,8 @@ defmodule TransportWeb.DatasetController do
 
   defp refresh_dataset_from_datagouv(%Plug.Conn{} = conn, slug_or_id) do
     case Datagouvfr.Client.Datasets.get(slug_or_id) do
-      {:ok, %{"id" => datagouv_id, "slug" => slug}} ->
-        case Repo.get_by(Dataset, datagouv_id: datagouv_id) do
-          %Dataset{} ->
-            dataset =
-              %{"datagouv_id" => datagouv_id, "slug" => slug} |> Dataset.changeset() |> elem(1) |> DB.Repo.update!()
-
-            redirect_to_dataset(conn, dataset)
-
-          nil ->
-            redirect_to_dataset(conn, nil)
-        end
+      {:ok, %{"id" => datagouv_id}} ->
+        redirect_to_dataset(conn, Repo.get_by(Dataset, datagouv_id: datagouv_id))
 
       _ ->
         redirect_to_dataset(conn, nil)

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -3,6 +3,7 @@ defmodule TransportWeb.DatasetControllerTest do
   use TransportWeb.ExternalCase
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   import DB.Factory
+  import ExUnit.CaptureLog
 
   import Mock
   import Mox
@@ -198,6 +199,46 @@ defmodule TransportWeb.DatasetControllerTest do
 
     assert conn |> get(dataset_path(conn, :details, slug)) |> html_response(200) =~
              "Ce jeu de données a été archivé de data.gouv.fr"
+  end
+
+  test "redirects and updates the slug when it changed on data.gouv.fr", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, slug: "old_slug", datagouv_id: datagouv_id = Ecto.UUID.generate())
+    new_slug = "new_slug"
+    url = "https://demo.data.gouv.fr/api/1/datasets/#{new_slug}/"
+
+    Transport.HTTPoison.Mock
+    |> expect(:request, fn :get, ^url, "", [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{id: datagouv_id, slug: new_slug})}}
+    end)
+
+    {path, _} = with_log(fn -> conn |> get(dataset_path(conn, :details, new_slug)) |> redirected_to(302) end)
+
+    assert path == dataset_path(conn, :details, new_slug)
+
+    assert %Dataset{slug: ^new_slug} = DB.Repo.reload!(dataset)
+  end
+
+  test "404 when data.gouv.fr's API returns a 404", %{conn: conn} do
+    insert(:dataset, is_active: true, slug: "old_slug")
+    slug_404 = "slug_404"
+    url = "https://demo.data.gouv.fr/api/1/datasets/#{slug_404}/"
+
+    Transport.HTTPoison.Mock
+    |> expect(:request, fn :get, ^url, "", [], [follow_redirect: true] ->
+      {:ok, %HTTPoison.Response{status_code: 404, body: ""}}
+    end)
+
+    with_log(fn -> conn |> get(dataset_path(conn, :details, slug_404)) |> html_response(404) end)
+  end
+
+  test "dataset#details with an ID or datagouv_id redirects to slug", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, slug: Ecto.UUID.generate(), datagouv_id: Ecto.UUID.generate())
+
+    [dataset.id, dataset.datagouv_id]
+    |> Enum.each(fn param ->
+      {path, _} = with_log(fn -> conn |> get(dataset_path(conn, :details, param)) |> redirected_to(302) end)
+      assert path == dataset_path(conn, :details, dataset.slug)
+    end)
   end
 
   test "gtfs-rt entities" do

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -201,8 +201,10 @@ defmodule TransportWeb.DatasetControllerTest do
              "Ce jeu de données a été archivé de data.gouv.fr"
   end
 
-  test "redirects and updates the slug when it changed on data.gouv.fr", %{conn: conn} do
-    dataset = insert(:dataset, is_active: true, slug: "old_slug", datagouv_id: datagouv_id = Ecto.UUID.generate())
+  test "redirects when the slug changed on data.gouv.fr", %{conn: conn} do
+    dataset =
+      insert(:dataset, is_active: true, slug: old_slug = "old_slug", datagouv_id: datagouv_id = Ecto.UUID.generate())
+
     new_slug = "new_slug"
     url = "https://demo.data.gouv.fr/api/1/datasets/#{new_slug}/"
 
@@ -213,9 +215,9 @@ defmodule TransportWeb.DatasetControllerTest do
 
     {path, _} = with_log(fn -> conn |> get(dataset_path(conn, :details, new_slug)) |> redirected_to(302) end)
 
-    assert path == dataset_path(conn, :details, new_slug)
+    assert path == dataset_path(conn, :details, old_slug)
 
-    assert %Dataset{slug: ^new_slug} = DB.Repo.reload!(dataset)
+    assert %Dataset{slug: ^old_slug} = DB.Repo.reload!(dataset)
   end
 
   test "404 when data.gouv.fr's API returns a 404", %{conn: conn} do


### PR DESCRIPTION
Met à jour le code `DatasetController#details` pour gérer un possible changement de slug d'un jeu de données sur data.gouv.fr. Quand ceci survient, d'anciennes URLs du PAN enregistrées précédemment ne sont plus valides (car le slug a changé). De même si le slug change sur data.gouv.fr le nouveau slug ne sera fonctionnel qu'après un import.

Cette PR améliore la situation en mettant à jour le slug à partir de l'API de data.gouv.fr. Le maintien des anciennes URLs est assuré par le fait que l'API de data.gouv.fr redirige lorsqu'on utilise un précédent slug.

Je rajoute des tests pour les cas supportés mais non testés (redirections en utilisant l'identifiant en base de données et le `datagouv_id`).