### PR TITLE
Dataset#details : regroupe GTFS et NeTEx

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -101,7 +101,7 @@
         resources: gtfs_official_resources(@dataset) ++ netex_official_resources(@dataset),
         resources_related_files: @resources_related_files,
         dataset: @dataset,
-        title: dgettext("page-dataset-details", "Theoretical data")
+        title: dgettext("page-dataset-details", "Static data")
       ) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -95,26 +95,19 @@
       </section>
     <% end %>
     <section id="dataset-resources" class="pt-48">
-      <% gtfs_official_resources = gtfs_official_resources(@dataset) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,
         resources_infos: @resources_infos,
-        resources: gtfs_official_resources,
+        resources: gtfs_official_resources(@dataset) ++ netex_official_resources(@dataset),
         resources_related_files: @resources_related_files,
         dataset: @dataset,
-        title: dgettext("page-dataset-details", "GTFS resources")
+        title: dgettext("page-dataset-details", "Static resources")
       ) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,
         resources_infos: @resources_infos,
         resources: real_time_official_resources(@dataset),
-        title: dgettext("page-dataset-details", "Real time resources")
-      ) %>
-      <%= render(TransportWeb.DatasetView, "_resources_container.html",
-        conn: @conn,
-        resources_infos: @resources_infos,
-        resources: netex_official_resources(@dataset),
-        title: dgettext("page-dataset-details", "NeTEx resources")
+        title: dgettext("page-dataset-details", "Real-time feeds")
       ) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -107,7 +107,7 @@
         conn: @conn,
         resources_infos: @resources_infos,
         resources: real_time_official_resources(@dataset),
-        title: dgettext("page-dataset-details", "Real-time feeds")
+        title: dgettext("page-dataset-details", "Real-time data")
       ) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -101,7 +101,7 @@
         resources: gtfs_official_resources(@dataset) ++ netex_official_resources(@dataset),
         resources_related_files: @resources_related_files,
         dataset: @dataset,
-        title: dgettext("page-dataset-details", "Static resources")
+        title: dgettext("page-dataset-details", "Theoretical data")
       ) %>
       <%= render(TransportWeb.DatasetView, "_resources_container.html",
         conn: @conn,

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -446,7 +446,15 @@ defmodule TransportWeb.DatasetView do
     Enum.sort_by(resources, &(validations |> Map.get(&1.id) |> hd() |> get_metadata_info("end_date")), &>=/2)
   end
 
-  def order_resources_by_format(resources), do: resources |> Enum.sort_by(& &1.format, &>=/2)
+  def order_resources_by_format(resources) do
+    formats = resources |> Enum.map(& &1.format) |> MapSet.new()
+
+    if MapSet.equal?(formats, MapSet.new(["GTFS", "NeTEx"])) do
+      resources
+    else
+      resources |> Enum.sort_by(& &1.format, &>=/2)
+    end
+  end
 
   def documentation_url(%Resource{schema_name: schema_name, schema_version: schema_version}) do
     Transport.Shared.Schemas.documentation_url(schema_name, schema_version)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Theoretical data"
+msgid "Static data"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Static resources"
+msgid "Theoretical data"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -175,14 +175,6 @@ msgid "Community resources"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "GTFS resources"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "NeTEx resources"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Reuses"
 msgstr ""
 
@@ -462,10 +454,6 @@ msgstr ""
 msgid "Other datasets of %{name}"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Real time resources"
-msgstr ""
-
 #, elixir-autogen, elixir-format
 msgid "Could not decode the GTFS-RT feed."
 msgstr ""
@@ -560,4 +548,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Try me!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Real-time feeds"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Static resources"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -551,7 +551,7 @@ msgid "Try me!"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Real-time feeds"
+msgid "Real-time data"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr "Flux temps réel"
 
 #, elixir-autogen, elixir-format
-msgid "Static resources"
-msgstr "Ressources statiques"
+msgid "Theoretical data"
+msgstr "Données théoriques"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr "Flux temps réel"
 
 #, elixir-autogen, elixir-format
-msgid "Theoretical data"
+msgid "Static data"
 msgstr "Données théoriques"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -175,14 +175,6 @@ msgid "Community resources"
 msgstr "Ressources communautaires"
 
 #, elixir-autogen, elixir-format
-msgid "GTFS resources"
-msgstr "Ressources GTFS"
-
-#, elixir-autogen, elixir-format
-msgid "NeTEx resources"
-msgstr "Ressources NeTEx"
-
-#, elixir-autogen, elixir-format
 msgid "Reuses"
 msgstr "Réutilisations"
 
@@ -463,10 +455,6 @@ msgid "Other datasets of %{name}"
 msgstr "Autres jeux de données de %{name}"
 
 #, elixir-autogen, elixir-format
-msgid "Real time resources"
-msgstr "Ressources temps réel"
-
-#, elixir-autogen, elixir-format
 msgid "Could not decode the GTFS-RT feed."
 msgstr "Impossible de décoder le flux GTFS-RT"
 
@@ -561,3 +549,11 @@ msgstr "Ce jeu de données a été archivé de data.gouv.fr le %{date}"
 #, elixir-autogen, elixir-format
 msgid "Try me!"
 msgstr "Essayez-moi !"
+
+#, elixir-autogen, elixir-format
+msgid "Real-time feeds"
+msgstr "Flux temps réel"
+
+#, elixir-autogen, elixir-format
+msgid "Static resources"
+msgstr "Ressources statiques"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -551,9 +551,9 @@ msgid "Try me!"
 msgstr "Essayez-moi !"
 
 #, elixir-autogen, elixir-format
-msgid "Real-time feeds"
-msgstr "Flux temps réel"
+msgid "Real-time data"
+msgstr "Données temps réel"
 
 #, elixir-autogen, elixir-format
 msgid "Static data"
-msgstr "Données théoriques"
+msgstr "Données statiques"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Theoretical data"
+msgid "Static data"
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -555,5 +555,5 @@ msgid "Real-time feeds"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Static resources"
+msgid "Theoretical data"
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -175,14 +175,6 @@ msgid "Community resources"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "GTFS resources"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "NeTEx resources"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Reuses"
 msgstr ""
 
@@ -463,10 +455,6 @@ msgid "Other datasets of %{name}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Real time resources"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Could not decode the GTFS-RT feed."
 msgstr ""
 
@@ -560,4 +548,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Try me!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Real-time feeds"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Static resources"
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -551,7 +551,7 @@ msgid "Try me!"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Real-time feeds"
+msgid "Real-time data"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -136,7 +136,7 @@ defmodule TransportWeb.DatasetControllerTest do
     set_empty_mocks()
 
     conn = conn |> get(dataset_path(conn, :details, slug))
-    assert conn |> html_response(200) =~ "Ressources temps réel"
+    assert conn |> html_response(200) =~ "Flux temps réel"
   end
 
   test "ODbL licence with specific conditions", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -137,7 +137,7 @@ defmodule TransportWeb.DatasetControllerTest do
     set_empty_mocks()
 
     conn = conn |> get(dataset_path(conn, :details, slug))
-    assert conn |> html_response(200) =~ "Flux temps réel"
+    assert conn |> html_response(200) =~ "Données temps réel"
   end
 
   test "ODbL licence with specific conditions", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -171,6 +171,14 @@ defmodule TransportWeb.DatasetViewTest do
     end
   end
 
+  test "order_resources_by_format does not reorder GTFS and NeTEx" do
+    gtfs = insert(:resource, format: "GTFS")
+    netex = insert(:resource, format: "NeTEx")
+    resources = [gtfs, netex]
+
+    assert resources == order_resources_by_format(resources)
+  end
+
   defp to_html(%Phoenix.LiveView.Rendered{} = rendered) do
     rendered |> Phoenix.HTML.Safe.to_iodata() |> IO.iodata_to_binary()
   end


### PR DESCRIPTION
- Regroupe les GTFS et NeTEx au sein d'une même section "Données théoriques". Les GTFS seront placés avant les NeTEx (et triés par ordre de validité)
- Renomme la section "Ressources temps réel" en "Flux temps réel" (contient GTFS-RT, SIRI, SIRI-Lite)