### PR TITLE
Améliore les explications des tests de disponibilité

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -118,4 +118,8 @@ details .button {
 
 details > code {
   width: 100%;
+
+  &.inline {
+    display: inline;
+  }
 }

--- a/apps/transport/lib/transport_web/templates/resource/_download_availability.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_download_availability.html.heex
@@ -17,11 +17,6 @@
   </div>
   <details class="pt-24">
     <summary><%= dgettext("page-dataset-details", "Learn more") %></summary>
-    <%= raw(
-      dgettext(
-        "page-dataset-details",
-        "We test this resource download availability every hour by making an HTTP <code>HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online."
-      )
-    ) %>
+    <%= raw(dgettext("page-dataset-details", "availability-test-explanations")) %>
   </details>
 </div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -375,8 +375,8 @@ msgid "Learn more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "We test this resource download availability every hour by making an HTTP <code>HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online."
-msgstr ""
+msgid "availability-test-explanations"
+msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 status code will be considered successful."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -376,7 +376,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 status code will be considered successful."
+msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 status code is considered successful."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -375,8 +375,8 @@ msgid "Learn more"
 msgstr "En savoir plus"
 
 #, elixir-autogen, elixir-format
-msgid "We test this resource download availability every hour by making an HTTP <code>HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online."
-msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code>HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible."
+msgid "availability-test-explanations"
+msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 comme étant disponible."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -375,7 +375,7 @@ msgid "Learn more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "We test this resource download availability every hour by making an HTTP <code>HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online."
+msgid "availability-test-explanations"
 msgstr ""
 
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
Suite à https://github.com/etalab/transport-site/pull/2821, je retravaille les explications des tests de disponibilité pour clarifier le traitement différencié des ressources SIRI.

![image](https://user-images.githubusercontent.com/295709/205297835-bbfe8cbc-fe6a-47b5-843a-f6d8d83fc8ac.png)
