### PR TITLE
Validation à la demande NeTEx : ajoute texte explicatif

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -188,7 +188,7 @@ defmodule TransportWeb.ValidationController do
       |> Enum.map(fn {k, v} -> {Map.fetch!(v, "title"), k} end)
       |> Enum.sort_by(&elem(&1, 0))
 
-    ["GTFS", "GTFS-RT", "GBFS"] |> Enum.map(&{&1, String.downcase(&1)}) |> Kernel.++(schemas)
+    ["GTFS", "NeTEx", "GTFS-RT", "GBFS"] |> Enum.map(&{&1, String.downcase(&1)}) |> Kernel.++(schemas)
   end
 
   def is_valid_type?(type), do: type in (select_options() |> Enum.map(&elem(&1, 1)))

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
@@ -44,11 +44,16 @@ defmodule TransportWeb.Live.OnDemandValidationSelectLive do
   def socket_data(socket, data \\ nil) do
     socket = socket |> assign(data || %{})
 
-    socket |> assign(input_type: determine_input_type(form_value(socket, :type)))
+    socket
+    |> assign(
+      input_type: determine_input_type(form_value(socket, :type)),
+      type: form_value(socket, :type)
+    )
   end
 
   def determine_input_type(type) when type in ["gbfs"], do: "link"
   def determine_input_type(type) when type in ["gtfs-rt"], do: "gtfs-rt"
+  def determine_input_type(type) when type in ["netex"], do: nil
   def determine_input_type(_), do: "file"
 
   def handle_event("form_changed", %{"upload" => params, "_target" => target}, socket) do

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -38,13 +38,28 @@
             type: "url"
           ) %>
         <% end %>
-        <%= unless @input_type == "file" do %>
+        <%= unless @input_type == "file" or @type == "netex" do %>
           <%= submit(dgettext("validations", "Validate"), nodiv: true) %>
         <% end %>
       </.form>
       <p :if={@trigger_submit} class="small">
         <%= TransportWeb.Gettext.dgettext("validations", "Upload in progress") %>
       </p>
+      <div :if={@type == "netex"} class="container section section-grey" id="netex-explanations">
+        <p>
+          <%= raw(
+            TransportWeb.Gettext.dgettext("validations", "netex-siri-validator", link: "https://greenlight.atomite.io")
+          ) %>
+        </p>
+
+        <p>
+          <%= raw(
+            TransportWeb.Gettext.dgettext("validations", "doc-eu-formats",
+              link: "https://doc.transport.data.gouv.fr/documentation/normes-europeennes"
+            )
+          ) %>
+        </p>
+      </div>
     </div>
   </div>
 </section>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -319,7 +319,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "doc-eu-formats"
-msgstr "To access informations related to european standards, you can browse <a href=\"%{link}\" target=\"_blank\">our documentation</a>."
+msgstr "To access information related to European standards, you can browse <a href=\"%{link}\" target=\"_blank\">our documentation</a>."
 
 #, elixir-autogen, elixir-format
 msgid "netex-siri-validator"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -316,3 +316,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "doc-eu-formats"
+msgstr "To access documents related to European formats, you can browse <a href=\"%{link}\" target=\"_blank\">our documentation</a>."
+
+#, elixir-autogen, elixir-format
+msgid "netex-siri-validator"
+msgstr "The European program DATA4PT is in charge of deploying the NeTEx and SIRI formats. They publish a NeTEx validator <a href=\"%{link}\" target=\"_blank\">available online</a>."

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -319,8 +319,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "doc-eu-formats"
-msgstr "To access documents related to European formats, you can browse <a href=\"%{link}\" target=\"_blank\">our documentation</a>."
+msgstr "To access informations related to european standards, you can browse <a href=\"%{link}\" target=\"_blank\">our documentation</a>."
 
 #, elixir-autogen, elixir-format
 msgid "netex-siri-validator"
-msgstr "The European program DATA4PT is in charge of deploying the NeTEx and SIRI formats. They publish a NeTEx validator <a href=\"%{link}\" target=\"_blank\">available online</a>."
+msgstr "The European program DATA4PT is in charge of deploying the NeTEx and SIRI standards. They publish a NeTEx validator <a href=\"%{link}\" target=\"_blank\">available online</a>."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -316,3 +316,11 @@ msgstr "couverture calendaire par réseau"
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr "du"
+
+#, elixir-autogen, elixir-format
+msgid "doc-eu-formats"
+msgstr "Pour accéder aux ressources autour des normes européennes, vous pouvez consulter <a href=\"%{link}\" target=\"_blank\">notre documentation</a>."
+
+#, elixir-autogen, elixir-format
+msgid "netex-siri-validator"
+msgstr "Le projet européen DATA4PT assure aujourd'hui l'accompagnement au déploiement des normes européennes NeTEx et SIRI. Dans ce cadre, il est mis à disposition un outil de validation NeTEx <a href=\"%{link}\" target=\"_blank\">accessible en ligne</a>."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -315,3 +315,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "doc-eu-formats"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "netex-siri-validator"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -44,6 +44,18 @@ defmodule TransportWeb.ValidationControllerTest do
       assert view |> has_element?("input[name='upload[feed_url]']")
     end
 
+    test "no inputs but explanations when selecting NeTEx", %{conn: conn} do
+      Transport.Shared.Schemas.Mock |> expect(:transport_schemas, 2, fn -> %{} end)
+      {:ok, view, _html} = conn |> get(live_path(conn, OnDemandValidationSelectLive)) |> live()
+
+      render_change(view, "form_changed", %{"upload" => %{"type" => "netex"}, "_target" => ["upload", "type"]})
+      assert_patched(view, live_path(conn, OnDemandValidationSelectLive, type: "netex"))
+      refute view |> has_element?("input[name='upload[url]']")
+      refute view |> has_element?("input[name='upload[file]']")
+      refute view |> has_element?("input[type='submit']")
+      assert view |> has_element?("#netex-explanations")
+    end
+
     test "takes into account query params", %{conn: conn} do
       Transport.Shared.Schemas.Mock |> expect(:transport_schemas, 2, fn -> %{} end)
 


### PR DESCRIPTION
Adapte la page de validation à la demande pour inclure un texte de présentation pour le NeTEx.

![image](https://user-images.githubusercontent.com/295709/205333139-0ca81b5d-55f8-41f5-b27a-30dd2bcd5c75.png)
