### PR TITLE
Page de backoffice pour les URLs cassées

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -104,6 +104,7 @@ defmodule TransportWeb.Router do
       pipe_through([:admin_rights])
       get("/", PageController, :index)
       get("/dashboard", DashboardController, :index)
+      get("/broken-urls", BrokenUrlsController, :index)
 
       live_session :backoffice_proxy_config, root_layout: {TransportWeb.LayoutView, :app} do
         live("/proxy-config", ProxyConfigLive)

--- a/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
@@ -1,32 +1,47 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th>dataset_id</th>
-      <th>change detected at</th>
-      <th>deleted urls</th>
-      <th>new urls</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= for broken_url <- @broken_urls do %>
-      <tr>
-        <td><%= link(broken_url.dataset_id, to: dataset_path(@conn, :details, broken_url.dataset_id)) %></td>
-        <td><%= format_datetime_to_paris(broken_url.inserted_at, "fr") %></td>
-        <td>
-          <ul>
-            <%= for url <- broken_url.previous_urls -- broken_url.urls do %>
-              <li><%= url %></li>
-            <% end %>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <%= for url <- broken_url.urls -- broken_url.previous_urls do %>
-              <li><%= url %></li>
-            <% end %>
-          </ul>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="container pt-48 pb-24">
+  <h1>Détection de changements d'urls stables</h1>
+  <p>Voici la liste des derniers changements d'urls détectés sur les datasets référencés par le PAN.</p>
+  <p>
+    Apparaissent ici les datasets pour lesquels sont simultanément détectées une suppression d'url existante et l'apparition d'une nouvelle url, ce qui laisse penser qu'une url vient d'être modifiée.
+  </p>
+  <p>
+    Les urls que nous surveillons sont les urls que nous proposons au téléchargement sur notre page dataset, et sont donc celles que nous considérons comme étant les plus stables.
+  </p>
+</div>
+
+<section class="section-grey">
+  <div class="container pt-48 pb-48">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>dataset_id</th>
+          <th>change detected at</th>
+          <th>deleted urls</th>
+          <th>new urls</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for broken_url <- @broken_urls do %>
+          <tr>
+            <td><%= link(broken_url.dataset_id, to: dataset_path(@conn, :details, broken_url.dataset_id)) %></td>
+            <td><%= format_datetime_to_paris(broken_url.inserted_at, "fr") %></td>
+            <td>
+              <ul>
+                <%= for url <- broken_url.previous_urls -- broken_url.urls do %>
+                  <li><%= url %></li>
+                <% end %>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <%= for url <- broken_url.urls -- broken_url.previous_urls do %>
+                  <li><%= url %></li>
+                <% end %>
+              </ul>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
@@ -1,11 +1,11 @@
 <div class="container pt-48 pb-24">
-  <h1>Détection de changements d'urls stables</h1>
-  <p>Voici la liste des derniers changements d'urls détectés sur les datasets référencés par le PAN.</p>
+  <h1>Détection de changements d'URLs stables</h1>
+  <p>Voici la liste des derniers changements d'URLs détectés sur les jeux de données référencés par le PAN.</p>
   <p>
-    Apparaissent ici les datasets pour lesquels sont simultanément détectées une suppression d'url existante et l'apparition d'une nouvelle url, ce qui laisse penser qu'une url vient d'être modifiée.
+    Apparaissent ici les jeux de données pour lesquels sont simultanément détectées une suppression d'URL existante et l'apparition d'une nouvelle URL, ce qui laisse penser qu'une URL vient d'être modifiée.
   </p>
   <p>
-    Les urls que nous surveillons sont les urls que nous proposons au téléchargement sur notre page dataset, et sont donc celles que nous considérons comme étant les plus stables.
+    Les URLs que nous surveillons sont les URLs que nous proposons au téléchargement sur notre page d'un jeu de donnée, et sont donc celles que nous considérons comme étant les plus stables.
   </p>
 </div>
 
@@ -14,16 +14,18 @@
     <table class="table">
       <thead>
         <tr>
-          <th>dataset_id</th>
-          <th>change detected at</th>
-          <th>deleted urls</th>
-          <th>new urls</th>
+          <th>Jeu de données</th>
+          <th>Détection du changement</th>
+          <th>URLs supprimées</th>
+          <th>Nouvelles URLs</th>
         </tr>
       </thead>
       <tbody>
         <%= for broken_url <- @broken_urls do %>
           <tr>
-            <td><%= link(broken_url.dataset_id, to: dataset_path(@conn, :details, broken_url.dataset_id)) %></td>
+            <td>
+              <%= link(broken_url.dataset_custom_title, to: dataset_path(@conn, :details, broken_url.dataset_id)) %>
+            </td>
             <td><%= format_datetime_to_paris(broken_url.inserted_at, "fr") %></td>
             <td>
               <ul>

--- a/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/broken_urls/index.html.heex
@@ -1,0 +1,32 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>dataset_id</th>
+      <th>change detected at</th>
+      <th>deleted urls</th>
+      <th>new urls</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for broken_url <- @broken_urls do %>
+      <tr>
+        <td><%= link(broken_url.dataset_id, to: dataset_path(@conn, :details, broken_url.dataset_id)) %></td>
+        <td><%= format_datetime_to_paris(broken_url.inserted_at, "fr") %></td>
+        <td>
+          <ul>
+            <%= for url <- broken_url.previous_urls -- broken_url.urls do %>
+              <li><%= url %></li>
+            <% end %>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <%= for url <- broken_url.urls -- broken_url.previous_urls do %>
+              <li><%= url %></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -19,6 +19,10 @@
     <%= dgettext("backoffice", "Rapport de complétude des imports") %>
   </a>
 
+  <a class="button" href={backoffice_broken_urls_path(@conn, :index)}>
+    <%= dgettext("backoffice", "Changements d'URLs stables") %>
+  </a>
+
   <h2>Actions</h2>
 
   <a class="button" href={backoffice_page_path(@conn, :new)}>

--- a/apps/transport/lib/transport_web/views/backoffice/broken_urls_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/broken_urls_view.ex
@@ -1,0 +1,4 @@
+defmodule TransportWeb.Backoffice.BrokenUrlsView do
+  use TransportWeb, :view
+  import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
+end

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -204,3 +204,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Changements d'URLs stables"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -204,3 +204,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Changements d'URLs stables"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -204,3 +204,7 @@ msgstr "Validations"
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr "Archivés"
+
+#, elixir-autogen, elixir-format
+msgid "Changements d'URLs stables"
+msgstr ""

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -108,6 +108,14 @@ defmodule DB.Factory do
     %DB.ResourceMetadata{}
   end
 
+  def dataset_history_factory do
+    %DB.DatasetHistory{}
+  end
+
+  def dataset_history_resources_factory do
+    %DB.DatasetHistoryResources{}
+  end
+
   # Non-Ecto stuff, for now kept here for convenience
 
   def datagouv_api_get_factory do

--- a/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
@@ -8,8 +8,16 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "detect a broken url", %{conn: conn} do
-    dataset = insert(:dataset)
+  test "denies access to dashboard if not logged", %{conn: conn} do
+    conn = get(conn, request_path = backoffice_broken_urls_path(conn, :index))
+    target_uri = URI.parse(redirected_to(conn, 302))
+    assert target_uri.path == "/login/explanation"
+    assert target_uri.query == URI.encode_query(redirect_path: request_path)
+    assert get_flash(conn, :info) =~ "Vous devez être préalablement connecté"
+  end
+
+  test "detects a broken URL", %{conn: conn} do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
 
     dataset_history = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
@@ -24,20 +32,21 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
       |> get(backoffice_broken_urls_path(conn, :index))
 
     res = conn |> html_response(200)
-    assert res =~ "Détection de changements d'urls stables"
+    assert res =~ "Détection de changements d'URLs stables"
+    assert res =~ dataset.custom_title
     assert res =~ "/datasets/#{dataset.id}"
     assert res =~ "url1"
     assert res =~ "url2"
   end
 
-  test "detect multiple broken urls" do
-    dataset = insert(:dataset)
+  test "detects multiple broken URLs" do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
     dataset_history = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
     dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url2"})
 
-    dataset_2 = insert(:dataset)
+    dataset_2 = insert(:dataset, custom_title: "Dataset custom title 2")
     dataset_history_3 = insert(:dataset_history, dataset_id: dataset_2.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history_3.id, payload: %{"download_url" => "url3"})
     dataset_history_4 = insert(:dataset_history, dataset_id: dataset_2.id)
@@ -53,7 +62,8 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
              urls: ["url4", "url5"],
              previous_urls: ["url3"],
              disappeared_urls: true,
-             new_urls: true
+             new_urls: true,
+             dataset_custom_title: dataset_2.custom_title
            } == broken_1
 
     assert %{
@@ -62,12 +72,13 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
              urls: ["url2"],
              previous_urls: ["url1"],
              disappeared_urls: true,
-             new_urls: true
+             new_urls: true,
+             dataset_custom_title: dataset.custom_title
            } == broken_2
   end
 
-  test "don't detect an unchanged url", %{conn: conn} do
-    dataset = insert(:dataset)
+  test "doesn't detect an unchanged URL", %{conn: conn} do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
 
     dataset_history = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
@@ -86,8 +97,8 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
     refute res =~ "/datasets/#{dataset.id}"
   end
 
-  test "don't detect just a new url" do
-    dataset = insert(:dataset)
+  test "doesn't detect just a new URL" do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
 
     dataset_history = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
@@ -98,13 +109,26 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
     assert [] == BrokenUrlsController.broken_urls()
   end
 
-  test "don't detect just a deleted url" do
-    dataset = insert(:dataset)
+  test "doesn't detect just a deleted URL" do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
 
     dataset_history = insert(:dataset_history, dataset_id: dataset.id)
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
     insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url2"})
     dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url1"})
+
+    assert [] == BrokenUrlsController.broken_urls()
+  end
+
+  test "doesn't detect a change of order for URLs" do
+    dataset = insert(:dataset, custom_title: "Dataset custom title")
+
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url2"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url2"})
     insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url1"})
 
     assert [] == BrokenUrlsController.broken_urls()

--- a/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
@@ -1,0 +1,112 @@
+defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
+  use TransportWeb.ConnCase, async: true
+  import Plug.Test
+  import DB.Factory
+  alias TransportWeb.Backoffice.BrokenUrlsController
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "detect a broken url", %{conn: conn} do
+    dataset = insert(:dataset)
+
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url2"})
+
+    conn =
+      conn
+      |> init_test_session(%{
+        current_user: %{"organizations" => [%{"slug" => "equipe-transport-data-gouv-fr"}]}
+      })
+      |> get(backoffice_broken_urls_path(conn, :index))
+
+    res = conn |> html_response(200)
+    assert res =~ "Détection de changements d'urls stables"
+    assert res =~ "/datasets/#{dataset.id}"
+    assert res =~ "url1"
+    assert res =~ "url2"
+  end
+
+  test "detect multiple broken urls" do
+    dataset = insert(:dataset)
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url2"})
+
+    dataset_2 = insert(:dataset)
+    dataset_history_3 = insert(:dataset_history, dataset_id: dataset_2.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_3.id, payload: %{"download_url" => "url3"})
+    dataset_history_4 = insert(:dataset_history, dataset_id: dataset_2.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_4.id, payload: %{"download_url" => "url4"})
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_4.id, payload: %{"download_url" => "url5"})
+
+    [broken_1, broken_2] = BrokenUrlsController.broken_urls()
+
+    # we show recent events first => dataset_2 comes first
+    assert %{
+             dataset_id: dataset_2.id,
+             inserted_at: dataset_history_4.inserted_at,
+             urls: ["url4", "url5"],
+             previous_urls: ["url3"],
+             disappeared_urls: true,
+             new_urls: true
+           } == broken_1
+
+    assert %{
+             dataset_id: dataset.id,
+             inserted_at: dataset_history_2.inserted_at,
+             urls: ["url2"],
+             previous_urls: ["url1"],
+             disappeared_urls: true,
+             new_urls: true
+           } == broken_2
+  end
+
+  test "don't detect an unchanged url", %{conn: conn} do
+    dataset = insert(:dataset)
+
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url1"})
+
+    conn =
+      conn
+      |> init_test_session(%{
+        current_user: %{"organizations" => [%{"slug" => "equipe-transport-data-gouv-fr"}]}
+      })
+      |> get(backoffice_broken_urls_path(conn, :index))
+
+    # check we get a 200 if list is empty
+    res = conn |> html_response(200)
+    refute res =~ "/datasets/#{dataset.id}"
+  end
+
+  test "don't detect just a new url" do
+    dataset = insert(:dataset)
+
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url1"})
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url2"})
+
+    assert [] == BrokenUrlsController.broken_urls()
+  end
+
+  test "don't detect just a deleted url" do
+    dataset = insert(:dataset)
+
+    dataset_history = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url1"})
+    insert(:dataset_history_resources, dataset_history_id: dataset_history.id, payload: %{"download_url" => "url2"})
+    dataset_history_2 = insert(:dataset_history, dataset_id: dataset.id)
+    insert(:dataset_history_resources, dataset_history_id: dataset_history_2.id, payload: %{"download_url" => "url1"})
+
+    assert [] == BrokenUrlsController.broken_urls()
+  end
+end


### PR DESCRIPTION
Suite à #2827 , je fais une première requête qui détecte quand dans un dataset, une url disparait et une autre apparait simultanément et je met le résultat dans une page du backoffice pour commencer à jouer avec.

Je vais déployer sur prochainement pour voir ce que ça donne.

L'url est `/backoffice/broken-urls`, pour prochainement ce sera [ici](https://prochainement.transport.data.gouv.fr/backoffice/broken-urls).

![image](https://user-images.githubusercontent.com/15341118/205973963-0a3904af-012c-4b04-8e7d-90f2dd2d1e46.png)
![image](https://user-images.githubusercontent.com/15341118/205974175-e82d8353-2b6d-445c-b94c-52962de6b43b.png)
