### PR TITLE
Home : alignement centré pour texte en dessous de la recherche

### DIFF
--- a/apps/transport/client/stylesheets/home.scss
+++ b/apps/transport/client/stylesheets/home.scss
@@ -205,6 +205,7 @@ a.tile:hover {
           display: flex;
           flex-direction: column;
           align-items: center;
+          text-align: center;
         }
         img {
           max-width: 75px;


### PR DESCRIPTION
## Avant

![image](https://user-images.githubusercontent.com/295709/205924759-eb70d546-ff6d-4d43-92de-3bcac04404ee.png)

## Après

![image](https://user-images.githubusercontent.com/295709/205924773-fcc7eef4-81b6-4dcd-ab1c-87f04430b7ae.png)

_Images non contractuelles, seul l'alignement du texte est corrigé, ma PR n'ajoute pas la barre de recherche._
