### PR TITLE
ImportData : gère nil pour is_documentation?

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -601,13 +601,9 @@ defmodule Transport.ImportData do
   iex> is_documentation?("pdf")
   false
   """
-  @spec is_documentation?(map() | binary() | nil) :: boolean()
-  def is_documentation?(nil), do: false
-  def is_documentation?(str) when is_binary(str), do: false
-
-  def is_documentation?(%{} = params) do
-    Map.get(params, "type") == "documentation"
-  end
+  @spec is_documentation?(any()) :: boolean()
+  def is_documentation?(%{"type" => "documentation"}), do: true
+  def is_documentation?(_), do: false
 
   @doc """
   Determines if a format is likely a documentation format.

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -596,6 +596,10 @@ defmodule Transport.ImportData do
   false
   iex> is_documentation?(%{"type" => "documentation", "format" => "docx"})
   true
+  iex> is_documentation?(nil)
+  false
+  iex> is_documentation?("pdf")
+  false
   """
   @spec is_documentation?(map() | binary() | nil) :: boolean()
   def is_documentation?(nil), do: false

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -597,7 +597,8 @@ defmodule Transport.ImportData do
   iex> is_documentation?(%{"type" => "documentation", "format" => "docx"})
   true
   """
-  @spec is_documentation?(map() | binary()) :: boolean()
+  @spec is_documentation?(map() | binary() | nil) :: boolean()
+  def is_documentation?(nil), do: false
   def is_documentation?(str) when is_binary(str), do: false
 
   def is_documentation?(%{} = params) do


### PR DESCRIPTION
Fixes #2835

Ce type n'était pas géré, les autres méthodes sont moins strictes sur les types et ont généralement un "catch-all" renvoyant `false`.