### PR TITLE
on_delete: nilify_all

### DIFF
--- a/apps/transport/priv/repo/migrations/20221206132945_on_delete_nilify.exs
+++ b/apps/transport/priv/repo/migrations/20221206132945_on_delete_nilify.exs
@@ -1,0 +1,17 @@
+defmodule DB.Repo.Migrations.OnDeleteNilify do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataset_history) do
+      modify :dataset_id, references(:dataset, on_delete: :nilify_all), from: references(:dataset, on_delete: :nothing)
+    end
+
+    alter table(:dataset_history_resources) do
+      modify :resource_id, references(:resource, on_delete: :nilify_all), from: references(:resource, on_delete: :nothing)
+      modify :resource_history_id, references(:resource_history, on_delete: :nilify_all), from: references(:resource_history, on_delete: :nothing)
+      modify :resource_metadata_id, references(:resource_metadata, on_delete: :nilify_all), from: references(:resource_metadata, on_delete: :nothing)
+      modify :validation_id, references(:multi_validation, on_delete: :nilify_all), from: references(:multi_validation, on_delete: :nothing)
+    end
+
+  end
+end


### PR DESCRIPTION
Merci @AntoineAugusti  d'avoir repéré le problème, l'option que j'avais mise `on_delete: :nothing` empechait la suppression de resources history, de resources, de validations et de métadata. En particulier cela faisait planter l'import dès qu'une suppression de ressource a lieu.