### PR TITLE
Pas de rapport de validation pour type documentation

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -25,7 +25,9 @@
       <h2 id="download-availability"><%= dgettext("page-dataset-details", "Download availability") %></h2>
       <%= render("_download_availability.html", uptime_per_day: @uptime_per_day, conn: @conn) %>
 
-      <%= render("_validation_report.html", resource: @resource, multi_validation: @multi_validation, conn: @conn) %>
+      <%= unless DB.Resource.is_documentation?(@resource) do %>
+        <%= render("_validation_report.html", resource: @resource, multi_validation: @multi_validation, conn: @conn) %>
+      <% end %>
 
       <%= if geojson_with_viz?(@resource, @resource_history_infos) do %>
         <h2 class="mt-48" id="visualization"><%= dgettext("validations", "Visualization") %></h2>

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -300,6 +300,20 @@ defmodule TransportWeb.ResourceControllerTest do
     refute conn |> html_response(200) =~ "supprimé de data.gouv.fr"
   end
 
+  test "no validation report section for documentation resources", %{conn: conn} do
+    resource =
+      insert(:resource, %{
+        dataset: insert(:dataset),
+        format: "pdf",
+        url: "https://example.com/file",
+        type: "documentation"
+      })
+
+    assert DB.Resource.is_documentation?(resource)
+
+    refute conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200) =~ "Rapport de validation"
+  end
+
   test "GTFS Transport validation is shown", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset)
 


### PR DESCRIPTION
Il n'est pas nécessaire d'afficher un rapport de validation sur `resource#details` pour [une ressource de documentation](https://transport.data.gouv.fr/resources/80098)