### PR TITLE
Affichage de la description des ressources

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -483,6 +483,10 @@
   padding: 12px;
 }
 
+.mt-24 {
+  margin-top: 24px;
+}
+
 .mb-24 {
   margin-bottom: 24px;
 }
@@ -550,4 +554,8 @@
 
 .container_max_700px {
   max-width: 700px;
+}
+
+.panel > :first-child {
+  margin-top: 0;
 }

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -15,6 +15,9 @@
         <div>
           <%= dgettext("resource", "Format") %><%= dgettext("helper", ":") %><span class="label"><%= @resource.format %></span>
         </div>
+        <div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
+          <%= description(@resource) %>
+        </div>
         <p>
           <%= dgettext("validations", "This resource file is part of the dataset") %> <%= link(
             @resource.dataset.custom_title,

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -11,6 +11,9 @@
             <strong><%= @resource.title %></strong>
           </a>
         </p>
+        <div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
+          <%= description(@resource) %>
+        </div>
         <p>
           <%= dgettext("validations", "This resource file is part of the dataset") %> <%= link(
             @resource.dataset.custom_title,

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -7,7 +7,7 @@ defmodule TransportWeb.ResourceView do
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
 
   import TransportWeb.DatasetView,
-    only: [documentation_url: 1, errors_count: 1, warnings_count: 1, multi_validation_performed?: 1]
+    only: [documentation_url: 1, errors_count: 1, warnings_count: 1, multi_validation_performed?: 1, description: 1]
 
   import DB.ResourceUnavailability, only: [floor_float: 2]
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
@@ -221,6 +221,25 @@ defmodule TransportWeb.ResourceView do
     |> Jason.Formatter.pretty_print()
   rescue
     _ -> dgettext("page-dataset-details", "Feed decoding failed")
+  end
+
+  @doc """
+  iex> should_display_description?(%DB.Resource{description: nil})
+  false
+  iex> should_display_description?(%DB.Resource{description: "foo", title: nil})
+  false
+  iex> should_display_description?(%DB.Resource{description: nil, title: "Foo"})
+  false
+  iex> should_display_description?(%DB.Resource{description: "Bonjour", title: "Foo"})
+  true
+  iex> should_display_description?(%DB.Resource{description: "Bonjour", title: "Export au format CSV"})
+  false
+  """
+  def should_display_description?(%DB.Resource{description: nil}), do: false
+  def should_display_description?(%DB.Resource{title: nil}), do: false
+
+  def should_display_description?(%DB.Resource{title: title}) do
+    not String.starts_with?(title, "Export au format")
   end
 
   def networks_start_end_dates(assigns) do

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -22,6 +22,7 @@ defmodule TransportWeb.ResourceControllerTest do
           %Resource{
             url: "https://link.to/angers.zip",
             datagouv_id: "1",
+            format: "GTFS",
             title: "GTFS",
             description: "Une _très_ belle ressource"
           },

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -21,7 +21,9 @@ defmodule TransportWeb.ResourceControllerTest do
         resources: [
           %Resource{
             url: "https://link.to/angers.zip",
-            datagouv_id: "1"
+            datagouv_id: "1",
+            title: "GTFS",
+            description: "Une _très_ belle ressource"
           },
           %Resource{
             url: "http://link.to/angers.zip?foo=bar",
@@ -129,6 +131,14 @@ defmodule TransportWeb.ResourceControllerTest do
 
     conn = conn |> get(resource_path(conn, :details, resource.id))
     assert conn |> html_response(200) =~ "1 erreur"
+  end
+
+  test "resource has its description displayed", %{conn: conn} do
+    resource = Resource |> Repo.get_by(datagouv_id: "1")
+
+    assert resource.description == "Une _très_ belle ressource"
+    html = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
+    assert html =~ "Une <em>très</em> belle ressource"
   end
 
   test "resource has download availability displayed", %{conn: conn} do


### PR DESCRIPTION
Fixes #2842, voir détails dans l'issue.

Exemple d'UI avec une description assez longue.

![image](https://user-images.githubusercontent.com/295709/206193967-404aa496-32ac-42f9-a817-7f2a5cdcbbb0.png)
