### PR TITLE
Dataset history : rendre la query plus rapide

### DIFF
--- a/apps/transport/priv/repo/migrations/20221208083708_add_indexes_resource.exs
+++ b/apps/transport/priv/repo/migrations/20221208083708_add_indexes_resource.exs
@@ -1,0 +1,10 @@
+defmodule DB.Repo.Migrations.AddIndexesResource do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index(:resource_history, [:resource_id]))
+    create_if_not_exists(index(:multi_validation, [:resource_id]))
+    create_if_not_exists(index(:resource_metadata, [:resource_id]))
+    create_if_not_exists(index(:resource, [:dataset_id]))
+  end
+end

--- a/apps/transport/test/transport/jobs/dataset_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_history_job_test.exs
@@ -29,8 +29,15 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
     insert(:multi_validation, resource_id: r2.id)
     %{id: rmv_id_latest} = insert(:multi_validation, resource_id: r2.id)
 
-    # just a resource
+    # another resource with multiple resource metadata and validations
     r3 = insert(:resource, dataset_id: dataset.id, url: "url3")
+    insert(:resource_metadata, resource_id: r3.id)
+    %{id: rm_id_latest_3} = insert(:resource_metadata, resource_id: r3.id)
+    insert(:multi_validation, resource_id: r3.id)
+    %{id: rmv_id_latest_3} = insert(:multi_validation, resource_id: r3.id)
+
+    # just a resource
+    r4 = insert(:resource, dataset_id: dataset.id, url: "url4")
 
     :ok = perform_job(Transport.Jobs.DatasetHistoryJob, %{"dataset_id" => dataset.id})
 
@@ -46,7 +53,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
 
     dataset_history_resources = dataset_history.dataset_history_resources
 
-    assert Enum.count(dataset_history_resources) == 3
+    assert Enum.count(dataset_history_resources) == 4
 
     dhr1 = dataset_history_resources |> Enum.find(&(&1.resource_id == r1.id))
 
@@ -68,8 +75,17 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
 
     dhr3 = dataset_history_resources |> Enum.find(&(&1.resource_id == r3.id))
 
-    assert %{resource_history_id: nil, resource_metadata_id: nil, validation_id: nil, payload: %{"url" => "url3"}} =
-             dhr3
+    assert %{
+             resource_history_id: nil,
+             resource_metadata_id: ^rm_id_latest_3,
+             validation_id: ^rmv_id_latest_3,
+             payload: %{"url" => "url3"}
+           } = dhr3
+
+    dhr4 = dataset_history_resources |> Enum.find(&(&1.resource_id == r4.id))
+
+    assert %{resource_history_id: nil, resource_metadata_id: nil, validation_id: nil, payload: %{"url" => "url4"}} =
+             dhr4
   end
 
   test "enqueue all dataset history jobs" do


### PR DESCRIPTION
J'ai mis du temps à comprendre le problème. Ce n'était pas tant une question d'indexation que de left joins à répétition.
Je faisais 4 LEFT joins : 
- dataset <> resources
- resources <> resources_history
- resources <> multi_validation
- resources <> resource_metadata

On se retrouve donc avec un résultat qui a nb_resources * nb_resources_history * nb_validations * nb_metadata
Par exemple pour le dataset 612, on a 3 ressources, 37 resources history, 1458 metadata, 323 multi validations.
Ca commence à faire beaucoup de lignes, puis on fait un distinct final la dessus, mais à ce moment l'indexation des tables ne sert plus à rien. D'ou un gros tri qui prend du temps.
L'idée est donc de preloader une query pour les metadata qui se charge de n'attraper que les metadata les plus récentes. On évite ainsi les joins à répétition, et ça va beaucoup plus vite, même si ça fait plusieurs queries au lieu d'une.

J'ai appris au passage qu'on pouvait mettre une query dans le preload directement.