### PR TITLE
Uniformise les messages d'infos sur la page de JDD

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -78,7 +78,7 @@
   padding-top: 1vh;
 }
 
-.dataset__resources .reuser-message {
+.dataset__resources .information-message {
   color: var(--theme-label-text);
 }
 

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -559,3 +559,7 @@
 .panel > :first-child {
   margin-top: 0;
 }
+
+hr {
+  border-bottom: 1px solid var(--theme-border-lighter);
+}

--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
@@ -1,7 +1,7 @@
 <section class="dataset__resources white" id="community-resources">
   <h2><%= dgettext("page-dataset-details", "Community resources") %></h2>
   <section class="dataset__resources">
-    <div class="reuser-message">
+    <div class="information-message">
       <% odbl_text =
         if @dataset.licence == "odc-odbl" do
           dgettext(

--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
@@ -1,5 +1,5 @@
 <section class="dataset__resources white" id="community-resources">
-  <h3><%= dgettext("page-dataset-details", "Community resources") %></h3>
+  <h2><%= dgettext("page-dataset-details", "Community resources") %></h2>
   <section class="dataset__resources">
     <div class="reuser-message">
       <% odbl_text =

--- a/apps/transport/lib/transport_web/templates/dataset/_history_message.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_history_message.html.heex
@@ -2,7 +2,7 @@
   <% link_history =
     safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
   <section class="dataset__resources">
-    <p class="reuser-message">
+    <p class="information-message">
       <%= raw(
         dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.",
           link: link_history

--- a/apps/transport/lib/transport_web/templates/dataset/_history_message.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_history_message.html.heex
@@ -2,7 +2,7 @@
   <% link_history =
     safe_to_string(link(dgettext("page-dataset-details", "Backed up resources"), to: "#backed-up-resources")) %>
   <section class="dataset__resources">
-    <p>
+    <p class="reuser-message">
       <%= raw(
         dgettext("page-dataset-details", "Past versions of the dataset resources are available in the %{link} section.",
           link: link_history

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
@@ -4,7 +4,7 @@
   <section class="dataset__resources white" id={assigns[:section_id]}>
     <h2><%= @title %></h2>
     <%= if has_reuser_message do %>
-      <div class="reuser-message"><%= assigns[:reuser_message] %></div>
+      <div class="information-message"><%= assigns[:reuser_message] %></div>
     <% end %>
     <%= unless is_nil(assigns[:message]) do %>
       <div class="resources-message">

--- a/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.heex
@@ -1,6 +1,6 @@
 <hr />
 <section class="dataset__resources">
-  <div class="reuser-message pb-48">
+  <div class="reuser-message pb-24">
     <i class="fas fa-info-circle"></i>
     <%= dgettext(
       "page-dataset-details",

--- a/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_reuser_message.html.heex
@@ -1,6 +1,6 @@
 <hr />
 <section class="dataset__resources">
-  <div class="reuser-message pb-24">
+  <div class="information-message pb-24">
     <i class="fas fa-info-circle"></i>
     <%= dgettext(
       "page-dataset-details",


### PR DESCRIPTION
Fixes #2585

- Passe le texte "Des versions précédentes des ressources de ce jeu de données sont disponibles dans la section Ressources historisées." de noir à gris
- Sépare les ressources et la partie "inviter à déclarer une réutilisation"/"Ressources communautaires" par une fine bordure (il y avait déjà un tag `hr` mais invisible)
- Passe le titre "Ressources communautaires" en `h2` comme les autres titres

![image](https://user-images.githubusercontent.com/295709/207090878-b37032f9-361b-44ed-9966-76151f6e4b5b.png)
