### PR TITLE
API : ajout de 2 champs pour les ressources

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -297,9 +297,11 @@ defmodule TransportWeb.API.DatasetController do
       end
 
     %{
+      "id" => resource.id,
       "datagouv_id" => resource.datagouv_id,
       "title" => resource.title,
       "updated" => Shared.DateTimeDisplay.format_naive_datetime_to_paris_tz(resource.last_update),
+      "is_available" => resource.is_available,
       "url" => resource.latest_url,
       "original_url" => resource.url,
       "end_calendar_validity" => metadata_content && Map.get(metadata, "end_date"),

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -56,13 +56,16 @@ defmodule TransportWeb.API.DatasetControllerTest do
         filesize: 43
       )
 
-    _gbfs_resource =
+    gbfs_resource =
       insert(:resource,
         dataset_id: dataset.id,
         url: "https://link.to/gbfs.json",
-        datagouv_id: "2",
+        latest_url: "https://link.to/latest",
+        datagouv_id: "3",
+        title: "GBFS",
         type: "main",
-        format: "gbfs"
+        format: "gbfs",
+        is_available: false
       )
 
     insert(:resource_metadata,
@@ -106,6 +109,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
       "resources" => [
         %{
           "content_hash" => "hash",
+          "id" => resource_1.id,
           "datagouv_id" => "1",
           "features" => ["couleurs des lignes"],
           "filesize" => 42,
@@ -116,10 +120,12 @@ defmodule TransportWeb.API.DatasetControllerTest do
           "title" => "GTFS.zip",
           "type" => "main",
           "updated" => "",
-          "url" => "https://static.data.gouv.fr/foo"
+          "url" => "https://static.data.gouv.fr/foo",
+          "is_available" => true
         },
         %{
           "content_hash" => "hash2",
+          "id" => resource_2.id,
           "datagouv_id" => "2",
           "features" => ["clim"],
           "filesize" => 43,
@@ -130,16 +136,19 @@ defmodule TransportWeb.API.DatasetControllerTest do
           "title" => "GTFS.zip",
           "type" => "main",
           "updated" => "",
-          "url" => "https://static.data.gouv.fr/foo2"
+          "url" => "https://static.data.gouv.fr/foo2",
+          "is_available" => true
         },
         %{
-          "datagouv_id" => "2",
-          "format" => "gbfs",
-          "original_url" => "https://link.to/gbfs.json",
-          "title" => "GTFS.zip",
+          "id" => gbfs_resource.id,
+          "datagouv_id" => gbfs_resource.datagouv_id,
+          "format" => gbfs_resource.format,
+          "original_url" => gbfs_resource.url,
+          "title" => gbfs_resource.title,
           "type" => "main",
           "updated" => "",
-          "url" => "url"
+          "url" => gbfs_resource.latest_url,
+          "is_available" => gbfs_resource.is_available
         }
       ],
       "slug" => "slug-1",
@@ -158,22 +167,23 @@ defmodule TransportWeb.API.DatasetControllerTest do
   end
 
   test "GET /api/datasets *without* history, multi_validation and resource_metadata", %{conn: conn} do
-    insert(:resource,
-      dataset:
-        insert(:dataset,
-          custom_title: "title",
-          type: "public-transit",
-          licence: "lov2",
-          datagouv_id: "datagouv",
-          slug: "slug-1",
-          is_active: true,
-          aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
-        ),
-      url: "https://link.to/gbfs.json",
-      datagouv_id: "2",
-      type: "main",
-      format: "gbfs"
-    )
+    resource =
+      insert(:resource,
+        dataset:
+          insert(:dataset,
+            custom_title: "title",
+            type: "public-transit",
+            licence: "lov2",
+            datagouv_id: "datagouv",
+            slug: "slug-1",
+            is_active: true,
+            aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
+          ),
+        url: "https://link.to/gbfs.json",
+        datagouv_id: "2",
+        type: "main",
+        format: "gbfs"
+      )
 
     path = Helpers.dataset_path(conn, :datasets)
 
@@ -194,6 +204,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
                "publisher" => %{"name" => nil, "type" => "organization"},
                "resources" => [
                  %{
+                   "id" => resource.id,
+                   "is_available" => true,
                    "datagouv_id" => "2",
                    "format" => "gbfs",
                    "original_url" => "https://link.to/gbfs.json",
@@ -241,6 +253,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
         aom: %DB.AOM{id: 4242, nom: "Angers Métropole", siren: "siren"}
       }
       |> DB.Repo.insert!()
+      |> DB.Repo.preload(:resources)
 
     Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _ -> [] end)
 
@@ -263,6 +276,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "resources" => [
                %{
                  "content_hash" => "hash",
+                 "is_available" => true,
+                 "id" => Enum.find(dataset.resources, &(&1.format == "GTFS")).id,
                  "datagouv_id" => "1",
                  "filesize" => 42,
                  "type" => "main",
@@ -272,6 +287,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
                  "url" => "https://static.data.gouv.fr/foo"
                },
                %{
+                 "is_available" => true,
+                 "id" => Enum.find(dataset.resources, &(&1.format == "geojson")).id,
                  "datagouv_id" => "2",
                  "type" => "main",
                  "format" => "geojson",
@@ -312,7 +329,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
         filesize: 42
       )
 
-    _gbfs_resource =
+    gbfs_resource =
       insert(:resource,
         dataset_id: dataset.id,
         url: "https://link.to/gbfs.json",
@@ -354,6 +371,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "resources" => [
                %{
                  "content_hash" => "hash",
+                 "id" => resource.id,
+                 "is_available" => true,
                  "datagouv_id" => "1",
                  "features" => ["couleurs des lignes"],
                  "filesize" => 42,
@@ -367,6 +386,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
                  "url" => "https://static.data.gouv.fr/foo"
                },
                %{
+                 "id" => gbfs_resource.id,
+                 "is_available" => true,
                  "datagouv_id" => "2",
                  "format" => "gbfs",
                  "original_url" => "https://link.to/gbfs.json",


### PR DESCRIPTION
Fixes #2852 #2303

Pour les ressources dans l'API, ajoute les champs suivants :
- Ajoute `id`
- Ajoute `is_available`