### PR TITLE
BaseGeoData : amélioration du parsing de floats

### DIFF
--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -56,5 +56,5 @@ defmodule Transport.Jobs.BaseGeoData do
   end
 
   # remove spaces (U+0020) and non-break spaces (U+00A0) from the string
-  defp string_to_float(s), do: s |> String.replace([" ", " "], "") |> String.to_float()
+  defp string_to_float(s), do: s |> String.trim() |> String.replace([" ", " "], "") |> String.to_float()
 end


### PR DESCRIPTION
Vu en production sur la BNLC.

```
(ArgumentError) errors were found at the given arguments:
  * 1st argument: not a textual representation of a float
  :erlang.binary_to_float(\"50.6062355590429\\r\\n\")
```

alors que le fichier est considéré valide par Validata.