### PR TITLE
Bouton validation GTFS-RT : conserve uniquement les GTFS disponibles

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -1,4 +1,4 @@
-<% gtfs_resources = Enum.filter(@resource.dataset.resources, &DB.Resource.is_gtfs?/1) %>
+<% gtfs_resources = Enum.filter(@resource.dataset.resources, &(DB.Resource.is_gtfs?(&1) and &1.is_available)) %>
 <%= if Enum.empty?(gtfs_resources) do %>
   <div class="notification error full-width">
     <p>


### PR DESCRIPTION
Vu sur le JDD de Lille : 1 GTFS disponible, 1 GTFS indisponible, le bandeau disant qu'on ne peut pas déterminer le GTFS à utiliser est affiché alors que le validateur ne regarde que les ressources disponibles et à jour.