### PR TITLE
GTFS-RT : affiche le détail des erreurs au cours des 30 derniers jours

### DIFF
--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -79,7 +79,7 @@ defmodule DB.MultiValidation do
     |> DB.Repo.exists?()
   end
 
-  @spec resource_latest_validation(integer(), atom | nil) :: __MODULE__.t() | nil
+  @spec resource_latest_validation(DB.Resource.t(), atom | nil) :: __MODULE__.t() | nil
   def resource_latest_validation(_, nil), do: nil
 
   def resource_latest_validation(resource_id, validator) when is_atom(validator) do
@@ -95,6 +95,16 @@ defmodule DB.MultiValidation do
     |> preload([:metadata, :resource_history])
     |> limit(1)
     |> DB.Repo.one()
+  end
+
+  @spec resource_latest_validations(integer(), atom, DateTime.t()) :: [__MODULE__.t()]
+  def resource_latest_validations(resource_id, validator, %DateTime{} = date_from) do
+    validator_name = validator.validator_name()
+
+    DB.MultiValidation
+    |> where([mv], mv.validator == ^validator_name and mv.resource_id == ^resource_id and mv.inserted_at >= ^date_from)
+    |> order_by([mv], asc: mv.validation_timestamp)
+    |> DB.Repo.all()
   end
 
   @spec resource_history_latest_validation(integer(), atom | nil) :: __MODULE__.t() | nil

--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -79,7 +79,7 @@ defmodule DB.MultiValidation do
     |> DB.Repo.exists?()
   end
 
-  @spec resource_latest_validation(DB.Resource.t(), atom | nil) :: __MODULE__.t() | nil
+  @spec resource_latest_validation(integer(), atom | nil) :: __MODULE__.t() | nil
   def resource_latest_validation(_, nil), do: nil
 
   def resource_latest_validation(resource_id, validator) when is_atom(validator) do

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -30,7 +30,7 @@ defmodule TransportWeb.ResourceController do
       |> assign(:resource_history_infos, DB.ResourceHistory.latest_resource_history_infos(id))
       |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
       |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
-      |> assign(:gtfs_rt_latest_validations_details, gtfs_rt_latest_validations_details(resource))
+      |> assign(:latest_validations_details, latest_validations_details(resource))
       |> assign(:multi_validation, latest_validation(resource))
       |> put_resource_flash(resource.dataset.is_active)
 
@@ -53,7 +53,7 @@ defmodule TransportWeb.ResourceController do
 
   def gtfs_rt_entities(%Resource{}), do: nil
 
-  def gtfs_rt_latest_validations_details(%Resource{format: "gtfs-rt", id: id}) do
+  def latest_validations_details(%Resource{format: "gtfs-rt", id: id}) do
     validations =
       DB.MultiValidation.resource_latest_validations(
         id,
@@ -100,7 +100,7 @@ defmodule TransportWeb.ResourceController do
     |> elem(1)
   end
 
-  def gtfs_rt_latest_validations_details(%Resource{}), do: nil
+  def latest_validations_details(%Resource{}), do: nil
 
   defp gtfs_rt_feed(conn, %Resource{format: "gtfs-rt", url: url, id: id}) do
     lang = get_session(conn, :locale)

--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_rt_previous_validations_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_rt_previous_validations_details.html.heex
@@ -1,0 +1,30 @@
+<%= unless Enum.empty?(@latest_validations_details) do %>
+  <h3><%= dgettext("validations", "Previous validations") %></h3>
+  <p>
+    <%= dgettext("validations", "Here is a recap of all the error types encountered over the last %{nb} days.",
+      nb: latest_validations_nb_days()
+    ) %>
+  </p>
+  <table class="table">
+    <tr>
+      <th><%= dgettext("validations", "Error ID") %></th>
+      <th><%= dgettext("validations", "Description") %></th>
+      <th><%= dgettext("validations", "Errors count") %></th>
+      <th><%= dgettext("validations", "Number of occurences") %></th>
+    </tr>
+
+    <%= for {error_id, details} <- @latest_validations_details |> Enum.sort_by(fn {_, v} -> v["occurence"] end, &>=/2) do %>
+      <tr>
+        <td><a href={gtfs_rt_validator_rule_url(error_id)} target="_blank"><%= error_id %></a></td>
+        <td lang="en"><%= details["description"] %></td>
+        <td><%= format_number(details["errors_count"]) %></td>
+        <td>
+          <%= dgettext("validations", "%{count} times (%{percentage} % of validations)",
+            count: format_number(details["occurence"]),
+            percentage: details["percentage"]
+          ) %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
@@ -9,7 +9,12 @@
 <% end %>
 
 <%= if show_gtfs_rt_validation do %>
-  <%= render("_validation_report_gtfs_rt.html", resource: @resource, conn: @conn, multi_validation: @multi_validation) %>
+  <%= render("_validation_report_gtfs_rt.html",
+    resource: @resource,
+    conn: @conn,
+    multi_validation: @multi_validation,
+    latest_validations_details: @gtfs_rt_latest_validations_details
+  ) %>
 <% end %>
 
 <%= if show_gbfs_validation do %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
@@ -13,7 +13,7 @@
     resource: @resource,
     conn: @conn,
     multi_validation: @multi_validation,
-    latest_validations_details: @gtfs_rt_latest_validations_details
+    latest_validations_details: @latest_validations_details
   ) %>
 <% end %>
 

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
@@ -26,4 +26,5 @@
     <%= render("_gtfs_rt_errors_for_severity.html", errors_for_severity: errors_warning_level) %>
   <% end %>
   <%= render("_validate_gtfs_rt_now.html", conn: @conn, resource: @resource) %>
+  <%= render("_gtfs_rt_previous_validations_details.html", latest_validations_details: @latest_validations_details) %>
 </div>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -33,7 +33,12 @@
       <% end %>
 
       <%= unless DB.Resource.is_documentation?(@resource) do %>
-        <%= render("_validation_report.html", resource: @resource, multi_validation: @multi_validation, conn: @conn) %>
+        <%= render("_validation_report.html",
+          resource: @resource,
+          multi_validation: @multi_validation,
+          gtfs_rt_latest_validations_details: @gtfs_rt_latest_validations_details,
+          conn: @conn
+        ) %>
       <% end %>
 
       <%= if geojson_with_viz?(@resource, @resource_history_infos) do %>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -36,7 +36,7 @@
         <%= render("_validation_report.html",
           resource: @resource,
           multi_validation: @multi_validation,
-          gtfs_rt_latest_validations_details: @gtfs_rt_latest_validations_details,
+          latest_validations_details: @latest_validations_details,
           conn: @conn
         ) %>
       <% end %>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -153,6 +153,10 @@ defmodule TransportWeb.ResourceView do
   def gtfs_rt_validator_url, do: "https://github.com/MobilityData/gtfs-realtime-validator"
   def gtfs_validator_url, do: "https://github.com/etalab/transport-validator"
 
+  def gtfs_rt_validator_rule_url(error_id) when is_binary(error_id) do
+    gtfs_rt_validator_rule_url(%{"error_id" => error_id})
+  end
+
   def gtfs_rt_validator_rule_url(%{"error_id" => error_id}) do
     "https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md##{error_id}"
   end
@@ -285,4 +289,6 @@ defmodule TransportWeb.ResourceView do
     </div>
     """
   end
+
+  def latest_validations_nb_days, do: 30
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -324,3 +324,31 @@ msgstr "To access information related to European standards, you can browse <a h
 #, elixir-autogen, elixir-format
 msgid "netex-siri-validator"
 msgstr "The European program DATA4PT is in charge of deploying the NeTEx and SIRI standards. They publish a NeTEx validator <a href=\"%{link}\" target=\"_blank\">available online</a>."
+
+#, elixir-autogen, elixir-format
+msgid "%{count} times (%{percentage} % of validations)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Description"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Error ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Errors count"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Here is a recap of all the error types encountered over the last %{nb} days."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Number of occurences"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Previous validations"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -324,3 +324,31 @@ msgstr "Pour accéder aux ressources autour des normes européennes, vous pouvez
 #, elixir-autogen, elixir-format
 msgid "netex-siri-validator"
 msgstr "Le projet européen DATA4PT assure aujourd'hui l'accompagnement au déploiement des normes européennes NeTEx et SIRI. Dans ce cadre, il est mis à disposition un outil de validation NeTEx <a href=\"%{link}\" target=\"_blank\">accessible en ligne</a>."
+
+#, elixir-autogen, elixir-format
+msgid "%{count} times (%{percentage} % of validations)"
+msgstr "%{count} fois (%{percentage} % des validations)"
+
+#, elixir-autogen, elixir-format
+msgid "Description"
+msgstr "Description"
+
+#, elixir-autogen, elixir-format
+msgid "Error ID"
+msgstr "Identifiant d'erreur"
+
+#, elixir-autogen, elixir-format
+msgid "Errors count"
+msgstr "Nombre d'erreurs"
+
+#, elixir-autogen, elixir-format
+msgid "Here is a recap of all the error types encountered over the last %{nb} days."
+msgstr "Voici un récapitulatif des différents types d'erreurs constatés au cours des %{nb} derniers jours."
+
+#, elixir-autogen, elixir-format
+msgid "Number of occurences"
+msgstr "Nombre d'occurences"
+
+#, elixir-autogen, elixir-format
+msgid "Previous validations"
+msgstr "Validations précédentes"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -323,3 +323,31 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "netex-siri-validator"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "%{count} times (%{percentage} % of validations)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Error ID"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Errors count"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Here is a recap of all the error types encountered over the last %{nb} days."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Number of occurences"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Previous validations"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -638,7 +638,7 @@ defmodule TransportWeb.ResourceControllerTest do
     assert html =~ requestor_ref
   end
 
-  test "gtfs_rt_latest_validations_details" do
+  test "latest_validations_details" do
     resource = insert(:resource, format: "gtfs-rt")
 
     insert(:multi_validation,
@@ -712,7 +712,7 @@ defmodule TransportWeb.ResourceControllerTest do
                "occurence" => 1,
                "percentage" => 50
              }
-           } == TransportWeb.ResourceController.gtfs_rt_latest_validations_details(resource)
+           } == TransportWeb.ResourceController.latest_validations_details(resource)
   end
 
   defp test_remote_download_error(%Plug.Conn{} = conn, mock_status_code) do


### PR DESCRIPTION
Affiche, sur la page de détails d'une ressource GTFS-RT, un récapitulatif des rapports de validation au cours des 30 derniers jours.

![image](https://user-images.githubusercontent.com/295709/209563904-f9c74f0d-4515-4166-9963-bf7917ea9601.png)

