### PR TITLE
Ajout de headers de sécurité pour Swagger

### DIFF
--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -19,6 +19,7 @@ defmodule TransportWeb.API.Router do
 
   scope "/api/" do
     pipe_through([:accept_json, :api])
+    get("/", TransportWeb.Redirect, to: "/swaggerui")
 
     scope "/aoms" do
       get("/", TransportWeb.API.AomController, :by_coordinates)

--- a/apps/transport/lib/transport_web/redirect.ex
+++ b/apps/transport/lib/transport_web/redirect.ex
@@ -1,17 +1,17 @@
 defmodule TransportWeb.Redirect do
   @moduledoc """
-  Redirect utility to be able to add routes like
+  Redirect utility to be able to add routes like:
   get("/example", Redirect, external: "https://example.com")
+  get("/example", Redirect, to: "/foo")
   """
   import Phoenix.Controller
   import Plug.Conn
 
   def init([external: _] = opts), do: opts
-  def init(_default), do: raise("Missing required external: option in redirect")
+  def init([to: _] = opts), do: opts
+  def init(_default), do: raise("Missing required option. Specify `external` or `to`")
 
   def call(conn, opts) do
-    conn
-    |> redirect(opts)
-    |> halt()
+    conn |> redirect(opts) |> halt()
   end
 end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -38,11 +38,13 @@ defmodule TransportWeb.Router do
     plug(:transport_data_gouv_member)
   end
 
-  get("/swaggerui", OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi")
+  scope "/" do
+    pipe_through(:browser)
+    get("/swaggerui", OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi")
+  end
 
   scope "/", TransportWeb do
     pipe_through(:browser)
-
     get("/", PageController, :index)
     get("/real_time", PageController, :real_time)
     get("/accessibilite", PageController, :accessibility)


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/1814

Répare ["Missing Anti-clickjacking Header"](https://dashlord.mte.incubateur.net/dashlord/report/aHR0cHM6Ly90cmFuc3BvcnQuZGF0YS5nb3V2LmZy/zap.html#10020). Ce header était présent sur la quasi exclusivité des pages, le Swagger avait un traitement particulier.

Répare au passage https://github.com/etalab/transport-site/issues/1851 en introduisant une redirection sur `/api`.