### PR TITLE
Se débarasser du end_date dans le backoffice

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -300,6 +300,13 @@ defmodule DB.Dataset do
 
   @spec list_datasets(map()) :: Ecto.Query.t()
   def list_datasets(%{} = params) do
+    params
+    |> list_datasets_no_order()
+    |> order_datasets(params)
+  end
+
+  @spec list_datasets_no_order(map()) :: Ecto.Query.t()
+  def list_datasets_no_order(%{} = params) do
     q =
       base_query()
       |> distinct([dataset: d], d.id)
@@ -318,7 +325,6 @@ defmodule DB.Dataset do
     base_query()
     |> where([dataset: d], d.id in subquery(q))
     |> preload_without_validations()
-    |> order_datasets(params)
   end
 
   @spec order_datasets(Ecto.Query.t(), map()) :: Ecto.Query.t()

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -5,7 +5,7 @@ defmodule TransportWeb.Backoffice.PageController do
   import Ecto.Query
   require Logger
 
-  def end_dates_query() do
+  def end_dates_query do
     DB.Dataset.base_query()
     |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
     |> where([metadata: m], fragment("?->>'end_date' IS NOT NULL", m.metadata))

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -115,22 +115,6 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render_index(conn, params)
   end
 
-  def index(%Plug.Conn{} = conn, %{"dataset_id" => dataset_id} = params) do
-    conn =
-      Dataset
-      |> preload([:aom, :logs_import])
-      |> Repo.get(dataset_id)
-      |> case do
-        nil ->
-          put_flash(conn, :error, dgettext("backoffice", "Unable to find dataset"))
-
-        dataset ->
-          assign(conn, :dataset, dataset)
-      end
-
-    render_index(Dataset, conn, params)
-  end
-
   def index(%Plug.Conn{} = conn, params) do
     Dataset.base_query()
     |> join(:left, [d], end_date in subquery(end_dates_query()), on: d.id == end_date.dataset_id, as: :end_dates)

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -5,13 +5,12 @@ defmodule TransportWeb.Backoffice.PageController do
   import Ecto.Query
   require Logger
 
-
   def end_dates_query() do
-      DB.Dataset.base_query()
-      |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
-      |> where([metadata: m], fragment("?->>'end_date' IS NOT NULL", m.metadata))
-      |> group_by([dataset: d], d.id)
-      |> select([dataset: d, metadata: m], %{dataset_id: d.id, end_date: fragment("max(?->>'end_date')", m.metadata)})
+    DB.Dataset.base_query()
+    |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
+    |> where([metadata: m], fragment("?->>'end_date' IS NOT NULL", m.metadata))
+    |> group_by([dataset: d], d.id)
+    |> select([dataset: d, metadata: m], %{dataset_id: d.id, end_date: fragment("max(?->>'end_date')", m.metadata)})
   end
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -29,37 +28,28 @@ defmodule TransportWeb.Backoffice.PageController do
   def index(%Plug.Conn{} = conn, %{"filter" => "outdated"} = params) do
     dt = Date.utc_today() |> Date.to_iso8601()
 
-    sub =
-      DB.Dataset.base_query()
-      |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
-      |> where([metadata: m], fragment("?->>'end_date' IS NOT NULL", m.metadata))
-      |> group_by([dataset: d], d.id)
-      |> having([metadata: m], fragment("max(?->>'end_date') <= ?", m.metadata, ^dt))
-      |> select([dataset: d, metadata: m], %{dataset_id: d.id, end_date: fragment("max(?->>'end_date')", m.metadata)})
+    sub = end_dates_query() |> having([metadata: m], fragment("max(?->>'end_date') <= ?", m.metadata, ^dt))
 
-    Dataset
-    |> join(:right, [d], r in subquery(sub), on: d.id == r.dataset_id)
+    Dataset.base_query()
+    |> join(:right, [d], end_date in subquery(sub), on: d.id == end_date.dataset_id, as: :end_dates)
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end
 
   def index(%Plug.Conn{} = conn, %{"filter" => "not_compliant"} = params) do
     sub =
-      DB.Dataset.base_query()
-      |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
-      |> where([metadata: m], fragment("?->>'end_date' IS NOT NULL", m.metadata))
-      |> group_by([dataset: d], d.id)
+      end_dates_query()
       |> having([metadata: m], fragment("MAX(CAST(?->'issues_count'->>'UnloadableModel' as INT)) > 0", m.metadata))
-      |> select([dataset: d, metadata: m], %{dataset_id: d.id, end_date: fragment("max(?->>'end_date')", m.metadata)})
 
-    Dataset
-    |> join(:inner, [d], r in subquery(sub), on: d.id == r.dataset_id)
+    Dataset.base_query()
+    |> join(:inner, [d], end_date in subquery(sub), on: d.id == end_date.dataset_id, as: :end_dates)
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end
 
   def index(%Plug.Conn{} = conn, %{"filter" => "licence_not_specified"} = params) do
-    Dataset
+    Dataset.base_query()
+    |> join(:left, [d], end_date in subquery(end_dates_query()), on: d.id == end_date.dataset_id, as: :end_dates)
     |> where([d], d.licence == "notspecified")
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
@@ -74,8 +64,12 @@ defmodule TransportWeb.Backoffice.PageController do
         having: count(r.dataset_id) > 1
       )
 
-    Dataset
-    |> join(:inner, [d], r in subquery(resources), on: d.id == r.dataset_id)
+    Dataset.base_query()
+    |> join(:left, [dataset: d], end_date in subquery(end_dates_query()),
+      on: d.id == end_date.dataset_id,
+      as: :end_dates
+    )
+    |> join(:inner, [dataset: d], r in subquery(resources), on: d.id == r.dataset_id)
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end
@@ -88,8 +82,12 @@ defmodule TransportWeb.Backoffice.PageController do
         select: %{dataset_id: r.dataset_id}
       )
 
-    Dataset
-    |> join(:inner, [d], r in subquery(resources), on: d.id == r.dataset_id)
+    Dataset.base_query()
+    |> join(:left, [dataset: d], end_date in subquery(end_dates_query()),
+      on: d.id == end_date.dataset_id,
+      as: :end_dates
+    )
+    |> join(:inner, [dataset: d], r in subquery(resources), on: d.id == r.dataset_id)
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end
@@ -97,14 +95,22 @@ defmodule TransportWeb.Backoffice.PageController do
   def index(%Plug.Conn{} = conn, %{"filter" => "resource_under_90_availability"} = params) do
     datasets_id = dataset_with_resource_under_90_availability()
 
-    Dataset
-    |> where([d], d.id in ^datasets_id)
+    Dataset.base_query()
+    |> join(:left, [dataset: d], end_date in subquery(end_dates_query()),
+      on: d.id == end_date.dataset_id,
+      as: :end_dates
+    )
+    |> where([dataset: d], d.id in ^datasets_id)
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end
 
   def index(%Plug.Conn{} = conn, %{"filter" => "archived"} = params) do
     Dataset.archived()
+    |> join(:left, [dataset: d], end_date in subquery(end_dates_query()),
+      on: d.id == end_date.dataset_id,
+      as: :end_dates
+    )
     |> query_order_by_from_params(params)
     |> render_index(conn, params)
   end

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
@@ -29,7 +29,7 @@
     end %>
   </td>
   <td>
-    <%= end_date(@dataset) %>
+    <%= @end_date %>
   </td>
   <td class="bo_dataset_button">
     <%= form_for @conn, backoffice_dataset_path(@conn, :import_from_data_gouv_fr, @dataset.id, @conn.params), [nodiv: true], fn _ -> %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -132,7 +132,11 @@
       <th class="bo_dataset_button"></th>
     </tr>
     <%= for dataset <- @datasets do %>
-      <%= render(TransportWeb.Backoffice.PageView, "_dataset.html", dataset: dataset, conn: @conn) %>
+      <%= render(TransportWeb.Backoffice.PageView, "_dataset.html",
+        dataset: dataset,
+        end_date: Map.get(@end_dates, dataset.id),
+        conn: @conn
+      ) %>
     <% end %>
   </table>
   <div class="pt-48">

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -1,8 +1,8 @@
 defmodule TransportWeb.Backoffice.PageView do
   use TransportWeb, :view
+  alias DB.Dataset
   alias Plug.Conn.Query
   alias TransportWeb.PaginationHelpers
-  alias DB.Dataset
 
   def pagination_links(conn, datasets) do
     kwargs = [path: &backoffice_page_path/3] |> add_filter(conn.params)

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -2,7 +2,6 @@ defmodule TransportWeb.Backoffice.PageView do
   use TransportWeb, :view
   alias Plug.Conn.Query
   alias TransportWeb.PaginationHelpers
-  import TransportWeb.DatasetView, only: [end_date: 1]
   alias DB.Dataset
 
   def pagination_links(conn, datasets) do

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -36,23 +36,6 @@ defmodule TransportWeb.DatasetView do
   def count_discussions(nil), do: '-'
   def count_discussions(discussions), do: Enum.count(discussions)
 
-  def end_date(dataset) do
-    dataset.resources
-    |> Enum.filter(&Resource.is_gtfs?/1)
-    |> Enum.max_by(
-      fn
-        %{metadata: nil} -> ""
-        %{metadata: metadata} -> metadata["end_date"]
-        _ -> ""
-      end,
-      fn -> nil end
-    )
-    |> case do
-      nil -> ""
-      resource -> resource.metadata["end_date"]
-    end
-  end
-
   def pagination_links(%{path_info: ["datasets", "region", region]} = conn, datasets) do
     kwargs = [path: &Helpers.dataset_path/4, action: :by_region] |> add_query_params(conn.query_params)
 

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -157,7 +157,8 @@ defmodule DB.Factory do
       region_id: Keyword.get(opts, :region_id),
       has_realtime: Keyword.get(opts, :has_realtime),
       type: Keyword.get(opts, :type),
-      aom: Keyword.get(opts, :aom)
+      aom: Keyword.get(opts, :aom),
+      custom_title: Keyword.get(opts, :custom_title)
     ]
 
     dataset_opts =

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule TransportWeb.Backoffice.PageControllerTest do
-  use ExUnit.Case
+  use TransportWeb.ConnCase, async: true
+  import Plug.Test, only: [init_test_session: 2]
+  alias TransportWeb.Router.Helpers, as: Routes
   alias TransportWeb.Backoffice.PageController
   import DB.Factory
 
@@ -47,5 +49,30 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     insert(:resource_unavailability, %{resource_id: resource_id, start: hours_ago_73, end: minute_ago_1})
 
     assert [] == PageController.dataset_with_resource_under_90_availability()
+  end
+
+  test "outdated datasets filter", %{conn: conn} do
+    insert_outdated_resource_and_friends(custom_title: "un dataset outdated")
+    insert_up_to_date_resource_and_friends(custom_title: "un dataset bien à jour")
+
+    conn1 =
+      conn
+      |> init_test_session(%{
+        current_user: %{"organizations" => [%{"slug" => "blurp"}, %{"slug" => "equipe-transport-data-gouv-fr"}]}
+      })
+      |> get(Routes.backoffice_page_path(conn, :index))
+
+    assert html_response(conn1, 200) =~ "un dataset outdated"
+    assert html_response(conn1, 200) =~ "un dataset bien à jour"
+
+    conn2 =
+      conn
+      |> init_test_session(%{
+        current_user: %{"organizations" => [%{"slug" => "blurp"}, %{"slug" => "equipe-transport-data-gouv-fr"}]}
+      })
+      |> get(Routes.backoffice_page_path(conn, :index, %{"filter" => "outdated", "dir" => "asc", "order_by" => "end_date"}))
+
+    assert html_response(conn2, 200) =~ "un dataset outdated"
+    refute html_response(conn2, 200) =~ "un dataset bien à jour"
   end
 end

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule TransportWeb.Backoffice.PageControllerTest do
   use TransportWeb.ConnCase, async: true
   import Plug.Test, only: [init_test_session: 2]
-  alias TransportWeb.Router.Helpers, as: Routes
   alias TransportWeb.Backoffice.PageController
+  alias TransportWeb.Router.Helpers, as: Routes
   import DB.Factory
 
   setup do
@@ -70,7 +70,9 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
       |> init_test_session(%{
         current_user: %{"organizations" => [%{"slug" => "blurp"}, %{"slug" => "equipe-transport-data-gouv-fr"}]}
       })
-      |> get(Routes.backoffice_page_path(conn, :index, %{"filter" => "outdated", "dir" => "asc", "order_by" => "end_date"}))
+      |> get(
+        Routes.backoffice_page_path(conn, :index, %{"filter" => "outdated", "dir" => "asc", "order_by" => "end_date"})
+      )
 
     assert html_response(conn2, 200) =~ "un dataset outdated"
     refute html_response(conn2, 200) =~ "un dataset bien à jour"


### PR DESCRIPTION
Le coquin de `end_date` n'a pas dit son dernier mot, il en reste dans le backoffice dans la colonne "fin de validité" qui est en bonus utilisable pour trier les datasets...

J'en profite pour réparer un bug : certaines pages du backoffice faisaient des 500, par exemple : https://transport.data.gouv.fr/backoffice?dir=asc&order_by=end_date&q=gtfs#backoffice-datasets-table

je rajoute un test sur un des filtres du BO.