### PR TITLE
Oban : ajout du plugin Lifeline

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -143,7 +143,7 @@ extra_oban_conf =
       queues: [default: 2, heavy: 1, on_demand_validation: 1, resource_validation: 1, workflow: 2],
       plugins: [
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
-        {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
+        {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(60)},
         {Oban.Plugins.Cron, crontab: List.flatten(oban_crontab_all_envs, production_server_crontab)}
       ]
     ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -143,6 +143,7 @@ extra_oban_conf =
       queues: [default: 2, heavy: 1, on_demand_validation: 1, resource_validation: 1, workflow: 2],
       plugins: [
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24},
+        {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
         {Oban.Plugins.Cron, crontab: List.flatten(oban_crontab_all_envs, production_server_crontab)}
       ]
     ]


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2075

Ajoute le plugin [Lifeline](https://hexdocs.pm/oban/Oban.Plugins.Lifeline.html) qui permet de remettre des jobs en `available` alors qu'ils sont en `executing` depuis un certain temps.

> The Lifeline plugin periodically rescues orphaned jobs, i.e. jobs that are stuck in the executing state because the node was shut down before the job could finish. Rescuing is purely based on time, rather than any heuristic about the job's expected execution time or whether the node is still alive.