### PR TITLE
Réduit le nombre de DB.Metrics après 3 mois

### DIFF
--- a/apps/transport/lib/jobs/archive_metrics_job.ex
+++ b/apps/transport/lib/jobs/archive_metrics_job.ex
@@ -74,8 +74,7 @@ defmodule Transport.Jobs.ArchiveMetricsJob do
   ~U[2022-12-29 00:00:00Z]
   """
   def to_midnight_datetime(%Date{} = date) do
-    {:ok, datetime, 0} = DateTime.from_iso8601("#{Date.to_iso8601(date)} 00:00:00Z")
-    datetime
+    DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
   end
 
   def days_to_archive do

--- a/apps/transport/lib/jobs/archive_metrics_job.ex
+++ b/apps/transport/lib/jobs/archive_metrics_job.ex
@@ -1,0 +1,86 @@
+defmodule Transport.Jobs.ArchiveMetricsJob do
+  @moduledoc """
+  This job is in charge of archiving `DB.Metrics` after a given period.
+
+  For rows older than `@days_before_archiving` days, we keep a single row
+  per day, target and event.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+
+  @days_before_archiving 90
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) when is_nil(args) or args == %{} do
+    days_to_archive()
+    |> Enum.with_index()
+    |> Enum.map(fn {date, index} ->
+      %{date: date} |> new(schedule_in: index * 60)
+    end)
+    |> Oban.insert_all()
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"date" => date}}) do
+    date = Date.from_iso8601!(date)
+    {date_start, date_end} = {to_midnight_datetime(date), date |> Date.add(1) |> to_midnight_datetime()}
+
+    metrics =
+      DB.Metrics
+      |> where([m], m.period >= ^date_start and m.period < ^date_end)
+      |> group_by([m], [m.target, m.event, fragment("date")])
+      |> select([m], %{
+        target: m.target,
+        event: m.event,
+        date: fragment("date(?) as date", m.period),
+        total: sum(m.count)
+      })
+      |> DB.Repo.all()
+
+    DB.Repo.transaction(fn ->
+      DB.Metrics
+      |> where([m], m.period >= ^date_start and m.period < ^date_end)
+      |> DB.Repo.delete_all()
+
+      records =
+        Enum.map(metrics, fn record ->
+          now = DateTime.utc_now()
+
+          %{
+            target: record.target,
+            event: record.event,
+            period: to_midnight_datetime(record.date),
+            count: record.total,
+            inserted_at: now,
+            updated_at: now
+          }
+        end)
+
+      DB.Repo.insert_all(DB.Metrics, records)
+    end)
+
+    :ok
+  end
+
+  @doc """
+  iex> to_midnight_datetime(~D[2022-12-29])
+  ~U[2022-12-29 00:00:00Z]
+  """
+  def to_midnight_datetime(%Date{} = date) do
+    {:ok, datetime, 0} = DateTime.from_iso8601("#{Date.to_iso8601(date)} 00:00:00Z")
+    datetime
+  end
+
+  def days_to_archive do
+    limit_date = DateTime.utc_now() |> DateTime.add(-@days_before_archiving, :day)
+
+    DB.Metrics
+    |> where([m], m.period <= ^limit_date)
+    |> select([m], fragment("date(?) as date", m.period))
+    |> order_by([m], fragment("date"))
+    |> distinct(true)
+    |> DB.Repo.all()
+  end
+end

--- a/apps/transport/test/transport/jobs/archive_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/archive_metrics_job_test.exs
@@ -1,0 +1,71 @@
+defmodule Transport.Test.Transport.Jobs.ArchiveMetricsJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Ecto.Query
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.ArchiveMetricsJob
+
+  doctest ArchiveMetricsJob, import: true
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "enqueues jobs" do
+    today = %{DateTime.utc_now() | hour: 0}
+    last_month = today |> DateTime.add(-10, :day)
+    three_months_ago = today |> DateTime.add(-91, :day)
+    four_months_ago = today |> DateTime.add(-30 * 4, :day)
+
+    insert(:metrics, period: last_month, target: "foo", event: "bar")
+    insert(:metrics, period: three_months_ago, target: "foo", event: "bar")
+    insert(:metrics, period: three_months_ago |> DateTime.add(5, :hour), target: "foo", event: "bar")
+    insert(:metrics, period: four_months_ago, target: "foo", event: "bar")
+    insert(:metrics, period: four_months_ago, target: "foo", event: "baz")
+
+    assert :ok == perform_job(ArchiveMetricsJob, %{})
+
+    three_months_ago_date = three_months_ago |> DateTime.to_date() |> Date.to_iso8601()
+    four_months_ago_date = four_months_ago |> DateTime.to_date() |> Date.to_iso8601()
+
+    assert [
+             %Oban.Job{
+               state: "scheduled",
+               worker: "Transport.Jobs.ArchiveMetricsJob",
+               args: %{"date" => ^three_months_ago_date}
+             },
+             %Oban.Job{
+               state: "scheduled",
+               worker: "Transport.Jobs.ArchiveMetricsJob",
+               args: %{"date" => ^four_months_ago_date}
+             }
+           ] = all_enqueued()
+  end
+
+  test "archives rows for a given day" do
+    today = %{(DateTime.utc_now() |> DateTime.truncate(:second)) | hour: 0, minute: 0, second: 0}
+    yesterday = today |> DateTime.add(-1, :day)
+    tomorrow = today |> DateTime.add(1, :day)
+
+    insert(:metrics, period: yesterday, target: "foo", event: "baz", count: 10)
+    insert(:metrics, period: tomorrow, target: "foo", event: "baz", count: 5)
+    insert(:metrics, period: today, target: "foo", event: "baz", count: 1)
+    insert(:metrics, period: today |> DateTime.add(4, :hour), target: "foo", event: "baz", count: 2)
+    insert(:metrics, period: today |> DateTime.add(6, :hour), target: "foo", event: "bar", count: 4)
+
+    assert :ok == perform_job(ArchiveMetricsJob, %{"date" => today |> DateTime.to_date() |> Date.to_iso8601()})
+
+    metrics =
+      DB.Metrics
+      |> select([m], [:target, :event, :count, :period])
+      |> order_by([m], m.period)
+      |> DB.Repo.all()
+
+    assert [
+             %DB.Metrics{target: "foo", event: "baz", period: ^yesterday, count: 10},
+             %DB.Metrics{target: "foo", event: "bar", period: ^today, count: 4},
+             %DB.Metrics{target: "foo", event: "baz", period: ^today, count: 3},
+             %DB.Metrics{target: "foo", event: "baz", period: ^tomorrow, count: 5}
+           ] = metrics
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,7 +116,8 @@ oban_crontab_all_envs =
         {"15 */3 * * *", Transport.Jobs.ResourceHistoryTableSchemaValidationJob},
         {"5 6 * * *", Transport.Jobs.NewDatagouvDatasetsJob},
         {"0 6 * * *", Transport.Jobs.NewDatasetNotificationsJob},
-        {"0 21 * * *", Transport.Jobs.DatasetHistoryDispatcherJob}
+        {"0 21 * * *", Transport.Jobs.DatasetHistoryDispatcherJob},
+        {"0 22 * * *", Transport.Jobs.ArchiveMetricsJob}
       ]
 
     :dev ->


### PR DESCRIPTION
Fixes #2877

Ajoute un job quotidien en charge d'archiver les `DB.Metrics` après 90 jours.

On garde une seule ligne par jour, event et target en faisant la somme des événements.