### PR TITLE
ArchiveMetricsJob : ne pas recalculer ce qui n'est pas nécessaire

### DIFF
--- a/apps/transport/lib/jobs/archive_metrics_job.ex
+++ b/apps/transport/lib/jobs/archive_metrics_job.ex
@@ -89,6 +89,6 @@ defmodule Transport.Jobs.ArchiveMetricsJob do
 
     base = from(d in subquery(dates_query))
 
-    base |> select([d], fragment("date")) |> order_by([m], fragment("date")) |> distinct(true) |> DB.Repo.all()
+    base |> select([d], d.date) |> order_by([d], d.date) |> distinct(true) |> DB.Repo.all()
   end
 end

--- a/apps/transport/test/transport/jobs/archive_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/archive_metrics_job_test.exs
@@ -16,12 +16,17 @@ defmodule Transport.Test.Transport.Jobs.ArchiveMetricsJobTest do
     last_month = today |> DateTime.add(-10, :day)
     three_months_ago = today |> DateTime.add(-91, :day)
     four_months_ago = today |> DateTime.add(-30 * 4, :day)
+    five_months_ago = today |> DateTime.add(-30 * 5, :day)
 
     insert(:metrics, period: last_month, target: "foo", event: "bar")
     insert(:metrics, period: three_months_ago, target: "foo", event: "bar")
     insert(:metrics, period: three_months_ago |> DateTime.add(5, :hour), target: "foo", event: "bar")
-    insert(:metrics, period: four_months_ago, target: "foo", event: "bar")
     insert(:metrics, period: four_months_ago, target: "foo", event: "baz")
+    insert(:metrics, period: four_months_ago |> DateTime.add(2, :hour), target: "foo", event: "baz")
+    # Don't need to process as we have a single line per (period, target, event)
+    insert(:metrics, period: five_months_ago, target: "foo", event: "baz")
+    insert(:metrics, period: five_months_ago, target: "foo", event: "bar")
+    insert(:metrics, period: five_months_ago, target: "baz", event: "bar")
 
     assert :ok == perform_job(ArchiveMetricsJob, %{})
 


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2879

Le job de dispatch renvoyait toutes les dates < 3 mois, même si ces enregistrements avaient déjà été passés à la journée au lieu de l'heure.

Cette PR retourne uniquement les dates pertinentes pour éviter de recalculer des choses qui sont déjà archivées (c'était très rapide, mais ça fait quand même [300 jobs par jour](https://transport.data.gouv.fr/backoffice/jobs?worker=ArchiveMetricsJob) inutiles dès à présent)