### PR TITLE
Recherche JDD : ajout guard pour modes

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -208,14 +208,14 @@ defmodule DB.Dataset do
   defp filter_by_feature(query, _), do: query
 
   @spec filter_by_mode(Ecto.Query.t(), map()) :: Ecto.Query.t()
-  defp filter_by_mode(query, %{"modes" => mode}) do
+  defp filter_by_mode(query, %{"modes" => modes}) when is_list(modes) do
     query
     |> DB.ResourceHistory.join_dataset_with_latest_resource_history()
     |> DB.MultiValidation.join_resource_history_with_latest_validation(
       Transport.Validators.GTFSTransport.validator_name()
     )
     |> DB.ResourceMetadata.join_validation_with_metadata()
-    |> where([metadata: rm], fragment("? @> ?::varchar[]", rm.modes, ^mode))
+    |> where([metadata: rm], fragment("? @> ?::varchar[]", rm.modes, ^modes))
   end
 
   defp filter_by_mode(query, _), do: query


### PR DESCRIPTION
Répare [cette erreur Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3017325701/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream) où il y a surement des personnes qui mettent le query param `modes=` ce qui n'est pas accepté.

Je n'ai pas trouvé comment une utilisation classique arrivait à ces URLs.