### PR TITLE
DataConversion : adapte casting pour accélérer les requêtes

### DIFF
--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -20,7 +20,7 @@ defmodule DB.DataConversion do
   def join_resource_history_with_data_conversion(query, list_of_convert_to) do
     query
     |> join(:left, [resource_history: rh], dc in DB.DataConversion,
-      on: fragment("?->>'uuid' = ?.resource_history_uuid::text", rh.payload, dc),
+      on: fragment("(?->>'uuid')::uuid = ?", rh.payload, dc.resource_history_uuid),
       as: :data_conversion
     )
     |> where([data_conversion: dc], dc.convert_to in ^list_of_convert_to)

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -494,7 +494,7 @@ defmodule DB.Resource do
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
       as: :dc,
-      on: fragment("?::text = ? ->> 'uuid'", dc.resource_history_uuid, rh.payload)
+      on: fragment("? = (?->>'uuid')::uuid", dc.resource_history_uuid, rh.payload)
     )
     |> select([rh, dc], %{
       url: fragment("? ->> 'permanent_url'", dc.payload),


### PR DESCRIPTION
Un problème de performance étonnant étant donné que `data_conversion` fait moins de 45 000 lignes.

On passe de

```
Limit  (cost=3248.79..3265.49 rows=1 width=80)
  ->  Nested Loop  (cost=3248.79..744650.90 rows=44399 width=80)
        Join Filter: ((r0.payload ->> 'uuid'::text) = (d1.resource_history_uuid)::text)
        ->  Gather Merge  (cost=3248.79..3297.91 rows=431 width=421)
              Workers Planned: 1
              ->  Sort  (cost=2248.78..2249.41 rows=254 width=421)
                    Sort Key: r0.inserted_at DESC
                    ->  Parallel Seq Scan on resource_history r0  (cost=0.00..2238.63 rows=254 width=421)
                          Filter: (resource_id = 79011)
        ->  Materialize  (cost=0.00..4744.91 rows=20603 width=472)
              ->  Seq Scan on data_conversion d1  (cost=0.00..3393.89 rows=20603 width=472)
                    Filter: (((convert_from)::text = 'GTFS'::text) AND ((convert_to)::text = 'GeoJSON'::text))
```

à

```
Limit  (cost=3249.21..3669.64 rows=1 width=80)
  ->  Nested Loop  (cost=3249.21..182774.59 rows=427 width=80)
        ->  Gather Merge  (cost=3248.79..3297.91 rows=431 width=421)
              Workers Planned: 1
              ->  Sort  (cost=2248.78..2249.41 rows=254 width=421)
                    Sort Key: r0.inserted_at DESC
                    ->  Parallel Seq Scan on resource_history r0  (cost=0.00..2238.63 rows=254 width=421)
                          Filter: (resource_id = 79011)
        ->  Index Scan using data_conversion_convert_from_convert_to_resource_history_uuid_i on data_conversion d1  (cost=0.42..416.40 rows=1 width=472)
              Index Cond: (((convert_to)::text = 'GeoJSON'::text) AND (resource_history_uuid = ((r0.payload ->> 'uuid'::text))::uuid))
```

pour 1.3s ce que je trouve beaucoup encore (mais il y a 430 lignes d'historisation pour la ressource 79011).