### PR TITLE
DataChecker - état d'un JDD : ajout de logging Sentry

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -67,6 +67,13 @@ defmodule Transport.DataChecker do
         {:ok, datetime, 0} = DateTime.from_iso8601(String.replace_suffix(archived, "Z", "") <> "Z")
         {:archived, datetime}
 
+      {:error, %HTTPoison.Error{} = error} ->
+        Sentry.capture_message(
+          "Unable to get Dataset status from data.gouv.fr",
+          extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
+        )
+        :inactive
+
       {:error, _} ->
         :inactive
     end

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -72,6 +72,7 @@ defmodule Transport.DataChecker do
           "Unable to get Dataset status from data.gouv.fr",
           extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
         )
+
         :inactive
 
       {:error, _} ->

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -44,11 +44,13 @@ defmodule Transport.DataCheckerTest do
       :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
 
       # we create a dataset which is considered active on our side
-      dataset = insert(:dataset, is_active: true)
+      dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate())
 
       # but which is not found found (= inactive?) on data gouv side
+      api_url = "https://demo.data.gouv.fr/api/1/datasets/#{dataset.datagouv_id}/"
+
       Transport.HTTPoison.Mock
-      |> expect(:request, fn :get, "https://demo.data.gouv.fr/api/1/datasets/123/", "", [], [follow_redirect: true] ->
+      |> expect(:request, fn :get, ^api_url, "", [], [follow_redirect: true] ->
         # the dataset is not found on datagouv
         {:ok, %HTTPoison.Response{status_code: 404, body: ""}}
       end)


### PR DESCRIPTION
Lié à #2887

Ajout de logging pour essayer de déterminer la cause du problème. Je n'ai rien trouvé en lisant le code ou en l'exécutant en local plusieurs fois, mon hypothèse est donc un problème temporaire de l'API data.gouv.fr.