### PR TITLE
Suppression du champ content_hash de la ressource

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -113,7 +113,6 @@ defmodule DB.Dataset do
         datagouv_id: r.datagouv_id,
         last_update: r.last_update,
         latest_url: r.latest_url,
-        content_hash: r.content_hash,
         is_community_resource: r.is_community_resource,
         is_available: r.is_available,
         description: r.description,

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -19,7 +19,6 @@ defmodule DB.Resource do
     # stable data.gouv.fr url if exists, else (for ODS gtfs as csv) it's the real url
     field(:latest_url, :string)
     field(:is_available, :boolean, default: true)
-    field(:content_hash, :string)
 
     field(:is_community_resource, :boolean)
 
@@ -101,7 +100,6 @@ defmodule DB.Resource do
         :schema_version,
         :community_resource_publisher,
         :original_resource_url,
-        :content_hash,
         :description,
         :filesize,
         :filetype,

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -49,7 +49,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   require Logger
   import Ecto.Query
   alias Transport.Shared.Schemas.Wrapper, as: Schemas
-  alias DB.{Repo, Resource, ResourceHistory}
+  alias DB.{Resource, ResourceHistory}
   import Transport.Jobs.Workflow.Notifier, only: [notify_workflow: 2]
 
   @impl Oban.Worker
@@ -101,10 +101,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
     case should_store_resource?(resource, hash) do
       true ->
-        # to be deleted later when validation v1 is unplugged
-        # https://github.com/etalab/transport-site/issues/2390
-        resource = validate_resource(resource, hash)
-
         filename = upload_filename(resource, download_datetime)
 
         base = %{
@@ -201,9 +197,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   def set_of_sha256(items) do
     items |> Enum.map(&{map_get(&1, :file_name), map_get(&1, :sha256)}) |> MapSet.new()
   end
-
-  defp to_content_hash(hash) when is_list(hash), do: Hasher.zip_hash(hash)
-  defp to_content_hash(hash) when is_binary(hash), do: hash
 
   defp resource_hash(%Resource{} = resource, resource_path) do
     case is_zip?(resource) do
@@ -312,12 +305,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     ]
 
     headers |> Enum.into(%{}, fn {h, v} -> {String.downcase(h), v} end) |> Map.take(headers_to_keep)
-  end
-
-  defp validate_resource(%Resource{} = resource, new_hash) do
-    # resource is not validated anymore here, but we temporarily keep the content hash updated
-    resource = resource |> Ecto.Changeset.change(%{content_hash: to_content_hash(new_hash)}) |> Repo.update!()
-    Repo.reload(resource)
   end
 
   defp latest_schema_version_to_date(%Resource{schema_name: nil}), do: nil

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -12,7 +12,6 @@ defmodule Transport.ImportData do
   import Ecto.Query
 
   defp availability_checker, do: Transport.AvailabilityChecker.Wrapper.impl()
-  defp hasher, do: Hasher.Wrapper.impl()
 
   def max_import_concurrent_jobs do
     Application.fetch_env!(:transport, :max_import_concurrent_jobs)
@@ -359,7 +358,6 @@ defmodule Transport.ImportData do
          "community_resource_publisher" => get_publisher(resource),
          "description" => resource["description"],
          "filesize" => resource["filesize"],
-         "content_hash" => hasher().get_content_hash(resource["url"]),
          "original_resource_url" => get_original_resource_url(resource),
          "schema_name" => ResourceSchema.guess_name(resource, type),
          "schema_version" => ResourceSchema.guess_version(resource),

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -308,8 +308,6 @@ defmodule TransportWeb.API.DatasetController do
       "start_calendar_validity" => metadata_content && Map.get(metadata, "start_date"),
       "type" => resource.type,
       "format" => resource.format,
-      # hash should come from the resource history instead
-      "content_hash" => resource.content_hash,
       "community_resource_publisher" => resource.community_resource_publisher,
       "metadata" => metadata_content,
       "original_resource_url" => resource.original_resource_url,

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -262,11 +262,6 @@ defmodule TransportWeb.API.Schemas do
             "The first day of the validity period of the file (read from the calendars for the GTFS). null if the file couldn’t be read"
         },
         format: %Schema{type: :string, description: "The format of the resource (GTFS, NeTEx, ...)"},
-        content_hash: %Schema{
-          type: :string,
-          description:
-            "A hash on the content of the file. Can be either a sha256 or an etag. Can be stored and used to check if the resource has changed."
-        },
         metadata: %Schema{
           type: :object,
           description: "Some metadata about the resource"

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -231,18 +231,15 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
         id: resource_id,
         datagouv_id: datagouv_id,
         dataset_id: dataset_id,
-        title: title,
-        content_hash: first_content_hash
+        title: title
       } =
-        resource =
         insert(:resource,
           url: resource_url,
           dataset: insert(:dataset, is_active: true),
           format: "GTFS",
           title: "title",
           datagouv_id: "1",
-          is_community_resource: false,
-          content_hash: "first_hash"
+          is_community_resource: false
         )
 
       Transport.HTTPoison.Mock
@@ -314,8 +311,6 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       assert permanent_url == Transport.S3.permanent_url(:history, filename)
       refute is_nil(last_up_to_date_at)
-      %DB.Resource{content_hash: content_hash} = DB.Repo.reload(resource)
-      refute content_hash == first_content_hash
     end
 
     test "a simple successful case for a CSV" do
@@ -323,7 +318,6 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       latest_schema_version = "0.4.2"
 
       %DB.Resource{id: resource_id, dataset_id: dataset_id} =
-        resource =
         insert(:resource,
           url: resource_url = "https://example.com/file.csv",
           latest_url: resource_latest_url = "https://example.com/#{Ecto.UUID.generate()}",
@@ -404,10 +398,6 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert schema_version != latest_schema_version
       assert permanent_url == Transport.S3.permanent_url(:history, filename)
       refute is_nil(last_up_to_date_at)
-
-      # No validation but content hash should be set to the file hash
-      %DB.Resource{content_hash: content_hash} = DB.Repo.reload(resource)
-      assert content_hash == "580fb39789859f7dc29aebe6bdec9666fc8311739a8705fda0916e2907449e17"
     end
 
     test "discards the job when the resource should not be historicised" do

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -37,7 +37,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
         dataset_id: dataset.id,
         url: "https://link.to/file.zip",
         latest_url: "https://static.data.gouv.fr/foo",
-        content_hash: "hash",
         datagouv_id: "1",
         type: "main",
         format: "GTFS",
@@ -49,7 +48,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
         dataset_id: dataset.id,
         url: "https://link.to/file2.zip",
         latest_url: "https://static.data.gouv.fr/foo2",
-        content_hash: "hash2",
         datagouv_id: "2",
         type: "main",
         format: "GTFS",
@@ -108,7 +106,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
       "publisher" => %{"name" => nil, "type" => "organization"},
       "resources" => [
         %{
-          "content_hash" => "hash",
           "page_url" => resource_page_url(resource_1),
           "datagouv_id" => "1",
           "features" => ["couleurs des lignes"],
@@ -124,7 +121,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
           "is_available" => true
         },
         %{
-          "content_hash" => "hash2",
           "page_url" => resource_page_url(resource_2),
           "datagouv_id" => "2",
           "features" => ["clim"],
@@ -236,7 +232,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
           %DB.Resource{
             url: "https://link.to/file.zip",
             latest_url: "https://static.data.gouv.fr/foo",
-            content_hash: "hash",
             datagouv_id: "1",
             type: "main",
             format: "GTFS",
@@ -275,7 +270,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "publisher" => %{"name" => nil, "type" => "organization"},
              "resources" => [
                %{
-                 "content_hash" => "hash",
                  "is_available" => true,
                  "page_url" => dataset.resources |> Enum.find(&(&1.format == "GTFS")) |> resource_page_url(),
                  "datagouv_id" => "1",
@@ -322,7 +316,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
         dataset_id: dataset.id,
         url: "https://link.to/file.zip",
         latest_url: "https://static.data.gouv.fr/foo",
-        content_hash: "hash",
         datagouv_id: "1",
         type: "main",
         format: "GTFS",
@@ -370,7 +363,6 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "publisher" => %{"name" => nil, "type" => "organization"},
              "resources" => [
                %{
-                 "content_hash" => "hash",
                  "page_url" => resource_page_url(resource),
                  "is_available" => true,
                  "datagouv_id" => "1",


### PR DESCRIPTION
Cette information est maintenant stockée au niveau des ressources history. Historiquement on se servait de ce champ pour décider si on validait (V1) une ressource lors de l'import.

La bonne nouvelle, c'est que ça va grandement accélérer les imports, car on téléchargeait systématiquement la ressource lors de l'import pour calculer son hash. Ce n'est plus nécessaire.