### PR TITLE
Fix Gtfs Diff

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -70,6 +70,7 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
           socket |> assign(:error_msg, "Job aborted, the diff is taking too long (>120sec).")
       end
 
+    Oban.Notifier.unlisten([:gossip])
     {:noreply, socket |> assign(:job_running, false)}
   end
 
@@ -81,6 +82,11 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
     diff_summary = diff |> diff_summary()
 
     {:noreply, socket |> assign(:diff_summary, diff_summary)}
+  end
+
+  # catch-all
+  def handle_info(_, socket) do
+    {:noreply, socket}
   end
 
   def diff_summary(diff) do

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -7,6 +7,7 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
   import TransportWeb.Router.Helpers
   import TransportWeb.Gettext
 
+  @max_file_size_mb 4
   def mount(_params, %{"locale" => locale} = _session, socket) do
     Gettext.put_locale(locale)
 
@@ -16,7 +17,7 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
      |> allow_upload(:gtfs,
        accept: ~w(.zip),
        max_entries: 2,
-       max_file_size: 4_000_000,
+       max_file_size: @max_file_size_mb * 1_000_000,
        auto_upload: true
      )}
   end
@@ -101,7 +102,7 @@ defmodule TransportWeb.Live.GtfsDiffSelectLive do
     gtfs |> Enum.count() == 2 and gtfs |> Enum.all?(& &1.valid?)
   end
 
-  defp error_to_string(:too_large), do: "File is too large, must be <2MB"
+  defp error_to_string(:too_large), do: "File is too large, must be <#{@max_file_size_mb}MB"
   defp error_to_string(:too_many_files), do: "You must select 2 files"
   defp error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
 end


### PR DESCRIPTION
Bug remonté par Tu-Tho Thai lors de l'utilisation du GTFS Diff.

Assez marrant l'erreur arrivait parce que la liveview attrapait un message venant d'un autre process (d'historisation des ressources) et que cela faisait planter la liveview. Tu-Tho a dû faire son test quand des taches d'historisations étaient en train d'être traitées par le worker !

L'erreur [Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3850504329/?project=6197733&query=is%3Aunresolved+gtfs_diff&referrer=issue-stream&statsPeriod=14d)