### PR TITLE
Validation GTFS : ajout nouveaux templates d'erreurs

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_missing_id_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_missing_id_issue.html.heex
@@ -1,0 +1,14 @@
+<p>
+  <%= dgettext("validations-explanations", "MissingId") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Object type") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_type"] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/templates/resource/_missing_name_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_missing_name_issue.html.heex
@@ -4,11 +4,13 @@
 <table class="table">
   <tr>
     <th><%= dgettext("validations-explanations", "Object type") %></th>
+    <th><%= dgettext("validations-explanations", "Object ID") %></th>
   </tr>
 
   <%= for issue <- @issues do %>
     <tr>
       <td><%= issue["object_type"] %></td>
+      <td><%= issue["object_id"] %></td>
     </tr>
   <% end %>
 </table>

--- a/apps/transport/lib/transport_web/templates/resource/_missing_name_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_missing_name_issue.html.heex
@@ -1,0 +1,14 @@
+<p>
+  <%= dgettext("validations-explanations", "MissingName") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Object type") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_type"] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -38,7 +38,9 @@ defmodule TransportWeb.ResourceView do
         "InvalidCoordinates" => "_coordinates_issue.html",
         "MissingCoordinates" => "_coordinates_issue.html",
         "UnusedShapeId" => "_unused_shape_issue.html",
-        "InvalidShapeId" => "_invalid_shape_id_issue.html"
+        "InvalidShapeId" => "_invalid_shape_id_issue.html",
+        "MissingId" => "_missing_id_issue.html",
+        "MissingName" => "_missing_name_issue.html"
       },
       issue_type(issues.entries),
       "_generic_issue.html"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -98,3 +98,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Trip ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "MissingId"
+msgstr "Some required IDs are missing"
+
+#, elixir-autogen, elixir-format
+msgid "MissingName"
+msgstr "Some required names are missing"
+
+#, elixir-autogen, elixir-format
+msgid "Object type"
+msgstr "Object type"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -110,3 +110,7 @@ msgstr "Some required names are missing"
 #, elixir-autogen, elixir-format
 msgid "Object type"
 msgstr "Object type"
+
+#, elixir-autogen, elixir-format
+msgid "Object ID"
+msgstr "Object ID"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -98,3 +98,15 @@ msgstr "Certaines shapes définies dans shapes.txt ne sont pas utilisées dans t
 #, elixir-autogen, elixir-format
 msgid "Trip ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "MissingId"
+msgstr "Certains identifiants obligatoires sont manquants"
+
+#, elixir-autogen, elixir-format
+msgid "MissingName"
+msgstr "Certains noms obligatoires sont manquants"
+
+#, elixir-autogen, elixir-format
+msgid "Object type"
+msgstr "Type d'objet"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -110,3 +110,7 @@ msgstr "Certains noms obligatoires sont manquants"
 #, elixir-autogen, elixir-format
 msgid "Object type"
 msgstr "Type d'objet"
+
+#, elixir-autogen, elixir-format
+msgid "Object ID"
+msgstr "Identifiant de l’objet"

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -109,3 +109,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Object type"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Object ID"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -97,3 +97,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Trip ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "MissingId"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "MissingName"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Object type"
+msgstr ""


### PR DESCRIPTION
Fixes #2905

Améliore le rendu de validation pour 2 types d'errreurs : `MissingId` et `MissingName`. Auparavant le template utilisé était le template générique, qui donne peu d'informations.

![image](https://user-images.githubusercontent.com/295709/210976594-44c44e14-80d8-4c3a-9ee0-8896bd32dece.png)



Le validateur donne assez peu de détails pour donner de meilleurs indications (pas de nom de fichier ou de ligne dans le fichier)
```json
{
   "severity":"Error",
   "object_id":"",
   "issue_type":"MissingId",
   "object_name":"",
   "object_type":"Agency",
   "related_objects":[]
}
```

On pourrait envisager l'ajout du numéro de ligne pour `MissingId`, une prochaine fois ? :wink: La structure n'existe pas dans le validateur.