### PR TITLE
Permettre de mettre le slug d'un dataset à jour

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -350,6 +350,16 @@ defmodule DB.Dataset do
   end
 
   @spec changeset(map()) :: {:error, binary()} | {:ok, Ecto.Changeset.t()}
+  def changeset(%{"dataset_id" => dataset_id} = params) do
+    dataset =
+      case Repo.get(__MODULE__, dataset_id) do
+        nil -> %__MODULE__{}
+        dataset -> dataset
+      end
+
+    apply_changeset(dataset, params)
+  end
+
   def changeset(%{"datagouv_id" => datagouv_id} = params) when is_binary(datagouv_id) do
     dataset =
       case Repo.get_by(__MODULE__, datagouv_id: datagouv_id) do
@@ -357,6 +367,10 @@ defmodule DB.Dataset do
         dataset -> dataset
       end
 
+    apply_changeset(dataset, params)
+  end
+
+  def apply_changeset(%__MODULE__{} = dataset, params) do
     territory_name = Map.get(params, "associated_territory_name") || dataset.associated_territory_name
 
     dataset

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -350,6 +350,8 @@ defmodule DB.Dataset do
   end
 
   @spec changeset(map()) :: {:error, binary()} | {:ok, Ecto.Changeset.t()}
+  # used to update a dataset slug from backoffice without changing the dataset_id
+  # useful when the dataset has been deleted / recreated on data.gouv.fr but we want to keep the resources history
   def changeset(%{"dataset_id" => dataset_id} = params) do
     dataset =
       case Repo.get(__MODULE__, dataset_id) do

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -19,9 +19,10 @@ defmodule TransportWeb.Backoffice.DatasetController do
       }
     }
 
-    dataset_id = Datasets.get_id_from_url(params["url"])
+    dataset_datagouv_id = Datasets.get_id_from_url(params["url"])
+    params = Map.put(params, "dataset_id", params["id"])
 
-    with datagouv_id when not is_nil(datagouv_id) <- dataset_id,
+    with datagouv_id when not is_nil(datagouv_id) <- dataset_datagouv_id,
          {:ok, dg_dataset} <- ImportData.import_from_data_gouv(datagouv_id, params["type"]),
          params <- Map.merge(params, dg_dataset),
          {:ok, changeset} <- Dataset.changeset(params),
@@ -35,7 +36,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
           ". ",
           Phoenix.HTML.Link.link(
             dgettext("backoffice_dataset", "Check the dataset page"),
-            to: dataset_path(conn, :details, dataset_id)
+            to: dataset_path(conn, :details, dataset_datagouv_id)
           )
         ],
         msgs.error[params["action"]]

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -134,7 +134,7 @@ defmodule TransportWeb.Router do
       scope "/datasets" do
         get("/new", PageController, :new)
         get("/:id/edit", PageController, :edit)
-        post("/", DatasetController, :post)
+        post("/:id", DatasetController, :post)
         post("/:id/_import", DatasetController, :import_from_data_gouv_fr)
         post("/:id/_delete", DatasetController, :delete)
         post("/_all_/_import_validate", DatasetController, :import_validate_all)

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -1,6 +1,6 @@
 <% expiration_configuration_edit_url = "https://github.com/etalab/transport-notifications/edit/master/config.yml" %>
 <div class="pt-48">
-  <%= form_for @conn, backoffice_dataset_path(@conn, :post), fn f -> %>
+  <%= form_for @conn, backoffice_dataset_path(@conn, :post, @dataset_id), fn f -> %>
     <h1>
       <%= if is_nil(@dataset) do %>
         <%= dgettext("backoffice", "Add a dataset") %>

--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -1,0 +1,95 @@
+defmodule TransportWeb.Backoffice.DatasetControllerTest do
+  use TransportWeb.ConnCase, async: true
+  import Plug.Test
+  alias TransportWeb.Router.Helpers, as: Routes
+  import DB.Factory
+  import Mox
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  def setup_admin_in_session(conn) do
+    conn
+    |> init_test_session(%{
+      current_user: %{
+        "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr"}]
+      }
+    })
+  end
+
+  test "update a dataset custom title", %{conn: conn} do
+    dataset = insert(:dataset, custom_title: "title 1", slug: slug = "https://example.com/slug")
+
+    Transport.HTTPoison.Mock
+    |> expect(:request, fn :get, "https://demo.data.gouv.fr/api/1/datasets/slug/", _, _, _ ->
+      {:ok, %HTTPoison.Response{body: "{\"id\": \"datagouv_id\"}", status_code: 200}}
+    end)
+
+    Transport.HTTPoison.Mock
+    |> expect(:get!, fn "https://demo.data.gouv.fr/api/1/datasets/datagouv_id/", _, _ ->
+      %HTTPoison.Response{body: "{\"id\": \"datagouv_id\", \"resources\": []}", status_code: 200}
+    end)
+
+    Datagouvfr.Client.CommunityResources.Mock
+    |> expect(:get, fn _ -> {:ok, []} end)
+
+    conn
+    |> setup_admin_in_session()
+    |> post(Routes.backoffice_dataset_path(conn, :post, dataset.id), %{
+      "custom_title" => "new title",
+      "url" => slug,
+      "type" => "public-transit"
+    })
+
+    # the title has been updated, the dataset_id has not changed
+    assert %{custom_title: "new title"} = DB.Repo.reload!(dataset)
+  end
+
+  test "update a dataset slug", %{conn: conn} do
+    dataset =
+      %{id: dataset_id} =
+      insert(:dataset,
+        datagouv_id: "datagouv_id",
+        custom_title: "title",
+        slug: "https://example.com/slug"
+      )
+
+    datagouv_id_2 = "datagouv_id_2"
+
+    Transport.HTTPoison.Mock
+    |> expect(:request, fn :get, "https://demo.data.gouv.fr/api/1/datasets/slug_2/", _, _, _ ->
+      # the slug changes, the datagouv_id too
+      {:ok, %HTTPoison.Response{body: "{\"id\": \"#{datagouv_id_2}\"}", status_code: 200}}
+    end)
+
+    slug_2 = "slug_2"
+
+    Transport.HTTPoison.Mock
+    |> expect(:get!, fn url, _, _ ->
+      assert "https://demo.data.gouv.fr/api/1/datasets/#{datagouv_id_2}/" == url
+
+      %HTTPoison.Response{
+        body: "{\"id\": \"#{datagouv_id_2}\", \"resources\": [], \"slug\": \"#{slug_2}\"}",
+        status_code: 200
+      }
+    end)
+
+    Datagouvfr.Client.CommunityResources.Mock
+    |> expect(:get, fn _ -> {:ok, []} end)
+
+    conn
+    |> setup_admin_in_session()
+    |> post(Routes.backoffice_dataset_path(conn, :post, dataset.id), %{
+      "custom_title" => "title",
+      "url" => "https://example.com/#{slug_2}",
+      "type" => "public-transit"
+    })
+
+    # the slug and datagouv_id have been updated, but the dataset_id has not changed
+    assert %{id: ^dataset_id, datagouv_id: ^datagouv_id_2, custom_title: "title", slug: ^slug_2} =
+             DB.Repo.reload!(dataset)
+  end
+end


### PR DESCRIPTION
Sans que cela se traduise par une suppression / création de dataset chez nous.
Cela va nous permettre de gérer les cas où des datasets ont disparu de data.gouv et ont été recréés sans perdre l'historique des ressources, ou remettre à zéro un futur score de qualité.

On va pouvoir changer l'url ici :
![image](https://user-images.githubusercontent.com/15341118/211569822-cdf74e4b-c0e6-4a37-909f-631e267e5035.png)
