### PR TITLE
API data.gouv.fr : retry en cas de timeout

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -33,9 +33,15 @@ defmodule Transport.DataChecker do
 
     # Some datasets marked as active in our database may have disappeared
     # on the data gouv side, mark them as inactive.
+    current_nb_active_datasets = Repo.aggregate(Dataset.base_query(), :count, :id)
     inactive_datasets = for {%Dataset{is_active: true} = dataset, :inactive} <- datasets_statuses, do: dataset
 
     inactive_ids = Enum.map(inactive_datasets, & &1.id)
+    desactivates_over_10_percent_datasets = Enum.count(inactive_datasets) > current_nb_active_datasets * 10 / 100
+
+    if desactivates_over_10_percent_datasets do
+      raise "Would desactivate over 10% of active datasets, stopping"
+    end
 
     Dataset
     |> where([d], d.id in ^inactive_ids)


### PR DESCRIPTION
Fixes #2887

Cette issue avait été fermée mais le problème est de retour, mais avec des logs cette fois https://github.com/etalab/transport-site/issues/2887#issuecomment-1378364617

Cette PR :
- permet de réessayer jusqu'à 3 fois les requêtes vers l'API data.gouv.fr en cas de timeout
- ajoute un mécanisme de sécurité empêchant de désactiver plus de 10% des JDD d'un coup (en cas de grosse panique côté API datagouv)

J'ai partagé ce problème récent [avec l'équipe datagouv](https://mattermost.incubateur.net/betagouv/pl/jkshojrwnjya7y8exampdj5aiy)