### PR TITLE
Stats : corrige calcul nb_datasets

### DIFF
--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -58,7 +58,7 @@ defmodule Transport.StatsHandler do
       |> Enum.sum()
 
     %{
-      nb_datasets: Repo.aggregate(Dataset, :count, :id),
+      nb_datasets: Repo.aggregate(Dataset.base_query(), :count, :id),
       nb_pt_datasets: Dataset.count_by_type("public-transit"),
       nb_aoms: Enum.count(aoms),
       nb_aoms_with_data: Enum.count(aoms_with_datasets),


### PR DESCRIPTION
Le calcul n'est pas bon car il compte tous les JDD dans la table, pas uniquement les actifs. À moins que ce soit souhaitable ?!?