### PR TITLE
Dataset#details : utilise DatasetHistory pour rediriger depuis un ancien slug

### DIFF
--- a/apps/transport/lib/db/dataset_history.ex
+++ b/apps/transport/lib/db/dataset_history.ex
@@ -19,6 +19,8 @@ defmodule DB.DatasetHistory do
     __MODULE__
     |> join(:inner, [dh], d in DB.Dataset, on: d.id == dh.dataset_id and d.slug != ^slug)
     |> where([dh], fragment("?->>'slug'", dh.payload) == ^slug)
+    |> select([dh, _d], [:dataset_id])
+    |> distinct(true)
     |> DB.Repo.one()
   end
 end

--- a/apps/transport/lib/db/dataset_history.ex
+++ b/apps/transport/lib/db/dataset_history.ex
@@ -17,7 +17,7 @@ defmodule DB.DatasetHistory do
 
   def from_old_dataset_slug(slug) do
     __MODULE__
-    |> join(:inner, [dh], d in DB.Dataset, on: d.id == dh.dataset_id and d.is_active and d.slug != ^slug)
+    |> join(:inner, [dh], d in DB.Dataset, on: d.id == dh.dataset_id and d.slug != ^slug)
     |> where([dh], fragment("?->>'slug'", dh.payload) == ^slug)
     |> DB.Repo.one()
   end

--- a/apps/transport/lib/db/dataset_history.ex
+++ b/apps/transport/lib/db/dataset_history.ex
@@ -4,6 +4,7 @@ defmodule DB.DatasetHistory do
   """
   use Ecto.Schema
   use TypedEctoSchema
+  import Ecto.Query
 
   typed_schema "dataset_history" do
     belongs_to(:dataset, DB.Dataset)
@@ -12,5 +13,12 @@ defmodule DB.DatasetHistory do
     has_many(:dataset_history_resources, DB.DatasetHistoryResources)
 
     timestamps(type: :utc_datetime_usec)
+  end
+
+  def from_old_dataset_slug(slug) do
+    __MODULE__
+    |> join(:inner, [dh], d in DB.Dataset, on: d.id == dh.dataset_id and d.is_active and d.slug != ^slug)
+    |> where([dh], fragment("?->>'slug'", dh.payload) == ^slug)
+    |> DB.Repo.one()
   end
 end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -270,12 +270,16 @@ defmodule TransportWeb.DatasetController do
   end
 
   defp find_dataset_from_slug(%Plug.Conn{} = conn, slug) do
-    case DB.DatasetHistory.from_old_dataset_slug(slug) do
-      %DB.DatasetHistory{dataset_id: dataset_id} ->
-        redirect_to_dataset(conn, Repo.get_by(Dataset, id: dataset_id))
+    try do
+      case DB.DatasetHistory.from_old_dataset_slug(slug) do
+        %DB.DatasetHistory{dataset_id: dataset_id} ->
+          redirect_to_dataset(conn, Repo.get_by(Dataset, id: dataset_id))
 
-      nil ->
-        find_dataset_from_datagouv(conn, slug)
+        nil ->
+          find_dataset_from_datagouv(conn, slug)
+      end
+    rescue
+      Ecto.MultipleResultsError -> redirect_to_dataset(conn, nil)
     end
   end
 

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -270,17 +270,15 @@ defmodule TransportWeb.DatasetController do
   end
 
   defp find_dataset_from_slug(%Plug.Conn{} = conn, slug) do
-    try do
-      case DB.DatasetHistory.from_old_dataset_slug(slug) do
-        %DB.DatasetHistory{dataset_id: dataset_id} ->
-          redirect_to_dataset(conn, Repo.get_by(Dataset, id: dataset_id))
+    case DB.DatasetHistory.from_old_dataset_slug(slug) do
+      %DB.DatasetHistory{dataset_id: dataset_id} ->
+        redirect_to_dataset(conn, Repo.get_by(Dataset, id: dataset_id))
 
-        nil ->
-          find_dataset_from_datagouv(conn, slug)
-      end
-    rescue
-      Ecto.MultipleResultsError -> redirect_to_dataset(conn, nil)
+      nil ->
+        find_dataset_from_datagouv(conn, slug)
     end
+  rescue
+    Ecto.MultipleResultsError -> redirect_to_dataset(conn, nil)
   end
 
   defp find_dataset_from_datagouv(%Plug.Conn{} = conn, slug) do

--- a/apps/transport/priv/repo/migrations/20230111115335_add_index_dataset_history_slug.exs
+++ b/apps/transport/priv/repo/migrations/20230111115335_add_index_dataset_history_slug.exs
@@ -1,0 +1,16 @@
+defmodule DB.Repo.Migrations.AddIndexDatasetHistorySlug do
+  use Ecto.Migration
+
+  @index_name "dataset_history_payload_slug"
+
+  def up do
+    # ->> operator returns text, index it as an integer
+    # as slug is an integer and will be compared against
+    # integers
+    execute("CREATE INDEX #{@index_name} ON dataset_history((payload->>'slug'));")
+  end
+
+  def down do
+    execute("DROP INDEX #{@index_name};")
+  end
+end

--- a/apps/transport/priv/repo/migrations/20230111115335_add_index_dataset_history_slug.exs
+++ b/apps/transport/priv/repo/migrations/20230111115335_add_index_dataset_history_slug.exs
@@ -4,9 +4,6 @@ defmodule DB.Repo.Migrations.AddIndexDatasetHistorySlug do
   @index_name "dataset_history_payload_slug"
 
   def up do
-    # ->> operator returns text, index it as an integer
-    # as slug is an integer and will be compared against
-    # integers
     execute("CREATE INDEX #{@index_name} ON dataset_history((payload->>'slug'));")
   end
 

--- a/apps/transport/test/db/dataset_history_test.exs
+++ b/apps/transport/test/db/dataset_history_test.exs
@@ -40,5 +40,16 @@ defmodule DB.DatasetHistoryTest do
 
       assert %DB.DatasetHistory{dataset_id: ^dataset_id} = from_old_dataset_slug(old_slug)
     end
+
+    test "it works when the slug has been present for a few days" do
+      %{id: dataset_id} =
+        dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
+
+      old_slug = Ecto.UUID.generate()
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug})
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug})
+
+      assert %DB.DatasetHistory{dataset_id: ^dataset_id} = from_old_dataset_slug(old_slug)
+    end
   end
 end

--- a/apps/transport/test/db/dataset_history_test.exs
+++ b/apps/transport/test/db/dataset_history_test.exs
@@ -31,12 +31,14 @@ defmodule DB.DatasetHistoryTest do
       end
     end
 
-    test "ignores inactive datasets" do
-      dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: false, slug: Ecto.UUID.generate())
+    test "it works with inactive datasets" do
+      %{id: dataset_id} =
+        dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: false, slug: Ecto.UUID.generate())
+
       refute dataset.is_active
       insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug = Ecto.UUID.generate()})
 
-      assert nil == from_old_dataset_slug(old_slug)
+      assert %DB.DatasetHistory{dataset_id: ^dataset_id} = from_old_dataset_slug(old_slug)
     end
   end
 end

--- a/apps/transport/test/db/dataset_history_test.exs
+++ b/apps/transport/test/db/dataset_history_test.exs
@@ -8,7 +8,7 @@ defmodule DB.DatasetHistoryTest do
   end
 
   describe "from_old_dataset_slug" do
-    test "it finds the current dataset when given with an old slug" do
+    test "it finds the current dataset when given an old slug" do
       %{id: dataset_id} =
         dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
 
@@ -19,7 +19,7 @@ defmodule DB.DatasetHistoryTest do
       assert nil == from_old_dataset_slug(dataset.slug)
     end
 
-    test "it crashes when there are multiple results" do
+    test "it raises when there are multiple results" do
       dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
       dataset2 = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
       old_slug = Ecto.UUID.generate()
@@ -33,6 +33,7 @@ defmodule DB.DatasetHistoryTest do
 
     test "ignores inactive datasets" do
       dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: false, slug: Ecto.UUID.generate())
+      refute dataset.is_active
       insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug = Ecto.UUID.generate()})
 
       assert nil == from_old_dataset_slug(old_slug)

--- a/apps/transport/test/db/dataset_history_test.exs
+++ b/apps/transport/test/db/dataset_history_test.exs
@@ -1,0 +1,41 @@
+defmodule DB.DatasetHistoryTest do
+  use ExUnit.Case, async: true
+  import DB.DatasetHistory
+  import DB.Factory
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "from_old_dataset_slug" do
+    test "it finds the current dataset when given with an old slug" do
+      %{id: dataset_id} =
+        dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
+
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug = Ecto.UUID.generate()})
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: other_old_slug = Ecto.UUID.generate()})
+      assert %DB.DatasetHistory{dataset_id: ^dataset_id} = from_old_dataset_slug(old_slug)
+      assert %DB.DatasetHistory{dataset_id: ^dataset_id} = from_old_dataset_slug(other_old_slug)
+      assert nil == from_old_dataset_slug(dataset.slug)
+    end
+
+    test "it crashes when there are multiple results" do
+      dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
+      dataset2 = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: true, slug: Ecto.UUID.generate())
+      old_slug = Ecto.UUID.generate()
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug})
+      insert(:dataset_history, dataset_id: dataset2.id, payload: %{slug: old_slug})
+
+      assert_raise Ecto.MultipleResultsError, fn ->
+        from_old_dataset_slug(old_slug)
+      end
+    end
+
+    test "ignores inactive datasets" do
+      dataset = insert(:dataset, datagouv_id: Ecto.UUID.generate(), is_active: false, slug: Ecto.UUID.generate())
+      insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug = Ecto.UUID.generate()})
+
+      assert nil == from_old_dataset_slug(old_slug)
+    end
+  end
+end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -250,6 +250,15 @@ defmodule TransportWeb.DatasetControllerTest do
     end)
   end
 
+  test "dataset#details uses DatasetHistory when passed an old slug", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, slug: Ecto.UUID.generate(), datagouv_id: Ecto.UUID.generate())
+
+    insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug = Ecto.UUID.generate()})
+
+    {path, _} = with_log(fn -> conn |> get(dataset_path(conn, :details, old_slug)) |> redirected_to(302) end)
+    assert path == dataset_path(conn, :details, dataset.slug)
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -259,6 +259,17 @@ defmodule TransportWeb.DatasetControllerTest do
     assert path == dataset_path(conn, :details, dataset.slug)
   end
 
+  test "dataset#details with an old slug when DatasetHistory returns multiple possible datasets", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, slug: Ecto.UUID.generate(), datagouv_id: Ecto.UUID.generate())
+    dataset2 = insert(:dataset, is_active: true, slug: Ecto.UUID.generate(), datagouv_id: Ecto.UUID.generate())
+    old_slug = Ecto.UUID.generate()
+
+    insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug})
+    insert(:dataset_history, dataset_id: dataset2.id, payload: %{slug: old_slug})
+
+    conn |> get(dataset_path(conn, :details, old_slug)) |> html_response(404)
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -267,7 +267,7 @@ defmodule TransportWeb.DatasetControllerTest do
     insert(:dataset_history, dataset_id: dataset.id, payload: %{slug: old_slug})
     insert(:dataset_history, dataset_id: dataset2.id, payload: %{slug: old_slug})
 
-    conn |> get(dataset_path(conn, :details, old_slug)) |> html_response(404)
+    with_log(fn -> conn |> get(dataset_path(conn, :details, old_slug)) |> html_response(404) end)
   end
 
   test "gtfs-rt entities" do


### PR DESCRIPTION
En lien avec #2913 et suite de https://github.com/etalab/transport-site/pull/2826#pullrequestreview-1202574142, @fchabouis tu l'avais bien dit.

> Peut-être que prochainement on pourra aller chercher ce slug nous même pour éviter l'appel à data.gouv, mais c'est déjà beaucoup mieux comme ça 🙏

Utilise `DB.DatasetHistory` pour tenter de trouver le dataset actuel pour un ancien slug, si jamais on ne trouve pas un dataset immédiatement (par slug, datagouv_id ou id).

On garde le fallback à l'API de data.gouv.fr en dernier recours.