### PR TITLE
Ajout page budget dans footer

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -205,6 +205,8 @@ defmodule TransportWeb.Router do
         "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/conditions-dutilisation-des-donnees/licence-odbl"
     )
 
+    get("/budget", Redirect, external: "https://doc.transport.data.gouv.fr/guide-du-pan/budget")
+
     # old static pages that have been moved to blog.transport
     get("/blog/2019_04_26_interview_my_bus", Redirect,
       external:

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
@@ -40,17 +40,31 @@
         </li>
       <% end %>
       <li>
-        <a class="footer__link" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/">API</a>
+        <a class="footer__link" target="_blank" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/">API</a>
       </li>
       <li>
-        <a class="footer__link" href="https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites">FAQ</a>
+        <a
+          class="footer__link"
+          target="_blank"
+          href="https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites"
+        >
+          FAQ
+        </a>
       </li>
       <li>
-        <a class="footer__link" href="https://github.com/etalab/transport-site/"><%= gettext("Source code") %></a>
+        <a class="footer__link" target="_blank" href="https://github.com/etalab/transport-site/">
+          <%= gettext("Source code") %>
+        </a>
       </li>
       <li>
         <a class="footer__link" href="/legal">
           <%= gettext("Legal Information") %>
+        </a>
+      </li>
+      <li>
+        
+        <a class="footer__link" target="_blank" href="/budget">
+          <%= gettext("Budget") %>
         </a>
       </li>
       <li>

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
@@ -62,7 +62,6 @@
         </a>
       </li>
       <li>
-        
         <a class="footer__link" target="_blank" href="/budget">
           <%= gettext("Budget") %>
         </a>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -122,3 +122,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "SIRI query generator"
 msgstr ""
+
+#, elixir-autogen
+msgid "Budget"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -122,3 +122,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "SIRI query generator"
 msgstr ""
+
+#, elixir-autogen
+msgid "Budget"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -122,3 +122,7 @@ msgstr "Carte d'exploration"
 #, elixir-autogen, elixir-format
 msgid "SIRI query generator"
 msgstr "Générateur de requêtes SIRI"
+
+#, elixir-autogen
+msgid "Budget"
+msgstr "Budget"

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -159,4 +159,8 @@ defmodule TransportWeb.PageControllerTest do
   test "accessibility page", %{conn: conn} do
     conn |> get(page_path(conn, :accessibility)) |> html_response(200)
   end
+
+  test "budget page", %{conn: conn} do
+    conn |> get("/budget") |> redirected_to(302) =~ "https://doc.transport.data.gouv.fr"
+  end
 end


### PR DESCRIPTION
Lien vers la page de budget dans le footer.

La PR sur beta.gouv.fr a déjà été faites https://github.com/betagouv/beta.gouv.fr/pull/12885

Je fais une page `/budget`, commune à pas mal de produits beta.gouv.fr, qui redirige.

![image](https://user-images.githubusercontent.com/295709/212283982-eb7ba4f8-5ed2-409e-ae01-017c6c5e7271.png)
