### PR TITLE
Import de Dataset : mise à jour is_active

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -150,6 +150,7 @@ defmodule Transport.ImportData do
       |> Map.put("licence", licence(data_gouv_resp))
       |> Map.put("archived_at", archived(data_gouv_resp["archived"]))
       |> Map.put("zones", get_associated_zones_insee(data_gouv_resp))
+      |> Map.put("is_active", true)
 
     case Map.get(data_gouv_resp, "resources") do
       nil -> {:error, "dataset #{data_gouv_resp["id"]} has no resource"}


### PR DESCRIPTION
Fixes #2923

Cette PR s'assure que lors de l'import d'un JDD depuis data.gouv.fr, si on a bien eu une réponse 200 avec les attributs pertinents, on mette à jour `is_active = true` si nécessaire.

Ceci est particulièrement utile si :
- le JDD côté PAN était supprimé, on a changé son URL afin pointer vers un nouveau `datagouv_id` et il faut donc le "réactiver"
- le JDD a été supprimé, puis "désupprimé" et on veut le réactiver dès à présent en cliquant sur "Importer" depuis le backoffice

On ne touche pas à la logique présente dans `DataChecker` qui est charge d'activer/désactiver des JDD et d'envoyer un e-mail récapitulatif.