### PR TITLE
MultiValidationWithErrorNotificationJob : utilise resource_history

### DIFF
--- a/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
+++ b/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
@@ -88,9 +88,9 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
       [mv],
       not is_nil(mv.resource_history_id) and mv.validator in ^validator_names and mv.inserted_at >= ^datetime_limit
     )
-    |> preload([:resource, resource: [:dataset]])
+    |> preload(resource_history: [resource: [:dataset]])
     |> DB.Repo.all()
-    |> Enum.group_by(& &1.resource.dataset)
+    |> Enum.group_by(& &1.resource_history.resource.dataset)
   end
 
   defp emails_list(%DB.Dataset{} = dataset) do
@@ -105,7 +105,9 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     "#{custom_title} — #{url}"
   end
 
-  defp resource_link(%DB.MultiValidation{resource: %DB.Resource{id: id, title: title}}) do
+  defp resource_link(%DB.MultiValidation{
+         resource_history: %DB.ResourceHistory{resource: %DB.Resource{id: id, title: title}}
+       }) do
     url = TransportWeb.Router.Helpers.resource_url(TransportWeb.Endpoint, :details, id) <> "#validation-report"
 
     "* #{title} — #{url}"

--- a/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
@@ -27,7 +27,6 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
     insert(:multi_validation, %{
       resource_history: rh_geojson_resource,
       validator: Transport.Validators.EXJSONSchema.validator_name(),
-      resource_id: rh_geojson_resource.resource_id,
       result: %{"has_errors" => true},
       inserted_at: DateTime.utc_now() |> DateTime.add(-45, :minute)
     })
@@ -63,21 +62,18 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
     insert(:multi_validation, %{
       resource_history: rh_resource_1,
       validator: Transport.Validators.EXJSONSchema.validator_name(),
-      resource_id: rh_resource_1.resource_id,
       result: %{"has_errors" => true}
     })
 
     insert(:multi_validation, %{
       resource_history: rh_resource_2,
       validator: Transport.Validators.EXJSONSchema.validator_name(),
-      resource_id: rh_resource_2.resource_id,
       result: %{"has_errors" => true}
     })
 
     insert(:multi_validation, %{
       resource_history: rh_resource_gtfs,
       validator: Transport.Validators.GTFSTransport.validator_name(),
-      resource_id: rh_resource_gtfs.resource_id,
       max_error: "Fatal"
     })
 


### PR DESCRIPTION
Corrige le travail effectué dans https://github.com/etalab/transport-site/pull/2909, lié à https://github.com/etalab/transport-site/issues/2903

En réalité dans `multi_validation` seule la colonne `resource_history_id` est renseignée quand une validation est effectuée sur une historisation, et non la colonne `resource_id` (utilisée elle pour une validation temps réel).

Mon code et mes tests ne représentaient pas la réalité, ce qui a causé des erreurs [en prod](https://transport.data.gouv.fr/backoffice/jobs?worker=notifi) (voir jobs `discarded`).

```
(KeyError) key :dataset not found in: nil. If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
(transport 0.0.1) lib/jobs/multi_validation_with_error_notification_job.ex:93: anonymous fn/1 in Transport.Jobs.MultiValidationWithErrorNotificationJob.relevant_validations/1
(elixir 1.14.1) lib/enum.ex:1375: anonymous fn/4 in Enum.group_by/3
(elixir 1.14.1) lib/enum.ex:2468: Enum.\"-group_by/3-lists^foldl/2-0-\"/3
(transport 0.0.1) lib/jobs/multi_validation_with_error_notification_job.ex:27: Transport.Jobs.MultiValidationWithErrorNotificationJob.perform/1
(oban 2.13.6) lib/oban/queue/executor.ex:129: Oban.Queue.Executor.perform/1
(oban 2.13.6) lib/oban/queue/executor.ex:74: Oban.Queue.Executor.call/1
(elixir 1.14.1) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
(elixir 1.14.1) lib/task/supervised.ex:34: Task.Supervised.reply/4\n
```

Confirmé par la requête suivante, montrant quelques cas où on aurait pu envoyer une notification aujourd'hui, mais que le code a crash.

```sql
select mv.resource_history_id, mv.resource_id
from multi_validation mv
join resource_history rh on rh.id = mv.resource_history_id
where
	((mv.max_error in ('Fatal', 'Error') and mv.validator = 'GTFS transport-validator') or mv.result->>'has_errors' = 'true')
	and mv.validator != 'gtfs-realtime-validator'
	and mv.resource_history_id is not null
	and mv.inserted_at >= '2023-01-17'
```

Je suis navré pour cette erreur.