### PR TITLE
Backoffice : affichage des notifications envoyées

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -155,7 +155,7 @@
         </p>
       </div>
     <% end %>
-    <div :if={@dataset.type == "public-transit"} class="dashboard-description mt-48">
+    <div class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Expiration notifications") %></h3>
       <%= if Enum.empty?(@expiration_emails) do %>
         <p class="notification">
@@ -191,6 +191,29 @@
           <% end %>
         </table>
       <% end %>
+    </div>
+    <div :if={Enum.count(@notifications_sent) > 0} class="dashboard-description mt-48">
+      <h3><%= dgettext("backoffice", "Notifications sent") %></h3>
+
+      <p>
+        <%= dgettext("backoffice", "Notifications sent in the last %{nb_days} days.",
+          nb_days: @notifications_last_nb_days
+        ) %>
+      </p>
+      <table class="table">
+        <tr>
+          <th><%= dgettext("backoffice", "Notification reason") %></th>
+          <th><%= dgettext("backoffice", "Datetime") %></th>
+          <th><%= dgettext("backoffice", "Emails") %></th>
+        </tr>
+        <%= for {{reason, datetime}, emails} <- @notifications_sent do %>
+          <tr>
+            <td lang="en"><%= reason %></td>
+            <td><%= Shared.DateTimeDisplay.format_datetime_to_paris(datetime, "fr") %></td>
+            <td><%= emails |> Enum.sort() |> Enum.join(", ") %></td>
+          </tr>
+        <% end %>
+      </table>
     </div>
     <div class="dataset_import_validations_logs" id="imports_history">
       <h3><%= dgettext("backoffice", "Imports history") %></h3>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -240,3 +240,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Phoenix LiveDashboard"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Datetime"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Emails"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent in the last %{nb_days} days."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -240,3 +240,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Phoenix LiveDashboard"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Datetime"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Emails"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent in the last %{nb_days} days."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -259,4 +259,4 @@ msgstr "Notifications envoyées"
 
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
-msgstr "Notifications envoyées au cours des %{nb_days} jours."
+msgstr "Notifications envoyées au cours des %{nb_days} derniers jours."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -240,3 +240,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Phoenix LiveDashboard"
 msgstr "Phoenix LiveDashboard"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Datetime"
+msgstr "Date / heure"
+
+#, elixir-autogen, elixir-format
+msgid "Emails"
+msgstr "E-mails"
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr "Motif de notification"
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr "Notifications envoyées"
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent in the last %{nb_days} days."
+msgstr "Notifications envoyées au cours des %{nb_days} jours."


### PR DESCRIPTION
Suite au travail récent d'enregistrement des notifications envoyées en base de données, affiche cette information dans le backoffice, lors de l'édition d'un jeu de données.

![image](https://user-images.githubusercontent.com/295709/213136545-38f0a1e6-34af-4fa1-8d15-204dd062038f.png)

J'ai corrigé la mauvaise traduction visible dans https://github.com/etalab/transport-site/pull/2936/commits/439b154964ef2e766b42acab6ea900deba6d2741
