### PR TITLE
Ajout méthode insert! pour DB.Notification

### DIFF
--- a/apps/transport/lib/db/notification.ex
+++ b/apps/transport/lib/db/notification.ex
@@ -21,8 +21,8 @@ defmodule DB.Notification do
   end
 
   def insert!(reason, %DB.Dataset{id: dataset_id}, email) do
-    __MODULE__
-    |> changeset(%{email: email, dataset_id: dataset_id, reason: @notification_reason})
+    %__MODULE__{}
+    |> changeset(%{reason: reason, dataset_id: dataset_id, email: email})
     |> DB.Repo.insert!()
   end
 

--- a/apps/transport/lib/db/notification.ex
+++ b/apps/transport/lib/db/notification.ex
@@ -20,6 +20,12 @@ defmodule DB.Notification do
     timestamps(type: :utc_datetime_usec)
   end
 
+  def insert!(reason, %DB.Dataset{id: dataset_id}, email) do
+    __MODULE__
+    |> changeset(%{email: email, dataset_id: dataset_id, reason: @notification_reason})
+    |> DB.Repo.insert!()
+  end
+
   def changeset(struct, attrs \\ %{}) do
     struct
     |> cast(attrs, [:reason, :dataset_id, :email])

--- a/apps/transport/lib/jobs/dataset_now_licence_ouverte_job.ex
+++ b/apps/transport/lib/jobs/dataset_now_licence_ouverte_job.ex
@@ -44,10 +44,8 @@ defmodule Transport.Jobs.DatasetNowLicenceOuverteJob do
     :ok
   end
 
-  def save_notification(%DB.Dataset{id: dataset_id}, email) do
-    %DB.Notification{}
-    |> DB.Notification.changeset(%{email: email, dataset_id: dataset_id, reason: @notification_reason})
-    |> DB.Repo.insert!()
+  def save_notification(%DB.Dataset{} = dataset, email) do
+    DB.Notification.insert!(@notification_reason, dataset, email)
   end
 
   defp link(%DB.Dataset{slug: slug}), do: TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)

--- a/apps/transport/lib/jobs/new_dataset_notifications_job.ex
+++ b/apps/transport/lib/jobs/new_dataset_notifications_job.ex
@@ -2,7 +2,7 @@ defmodule Transport.Jobs.NewDatasetNotificationsJob do
   @moduledoc """
   Job in charge of sending notifications about datasets that have been added recently.
   """
-  use Oban.Worker, max_attempts: 3
+  use Oban.Worker, max_attempts: 3, tags: ["notifications"]
   import Ecto.Query
 
   @impl Oban.Worker

--- a/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
@@ -79,10 +79,8 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     |> Enum.group_by(& &1.resource.dataset)
   end
 
-  defp save_notification(%DB.Dataset{id: dataset_id}, email) do
-    %DB.Notification{}
-    |> DB.Notification.changeset(%{email: email, dataset_id: dataset_id, reason: @notification_reason})
-    |> DB.Repo.insert!()
+  defp save_notification(%DB.Dataset{} = dataset, email) do
+    DB.Notification.insert!(@notification_reason, dataset, email)
   end
 
   defp emails_list(%DB.Dataset{} = dataset) do

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -201,10 +201,8 @@ defmodule Transport.DataChecker do
     payload
   end
 
-  defp save_notification(reason, %Dataset{id: dataset_id}, email) do
-    %DB.Notification{}
-    |> DB.Notification.changeset(%{email: email, dataset_id: dataset_id, reason: reason})
-    |> DB.Repo.insert!()
+  defp save_notification(reason, %Dataset{} = dataset, email) do
+    DB.Notification.insert!(reason, dataset, email)
   end
 
   def has_expiration_notifications?(%Dataset{} = dataset) do


### PR DESCRIPTION
Un peu de refactor pour éviter d'avoir du `DB.Notification.changeset` partout.