### PR TITLE
Améliore ordre des datasets lors d'une recherche par région

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -338,6 +338,19 @@ defmodule DB.Dataset do
         asc: :custom_title
       )
 
+  def order_datasets(datasets, %{"region" => region_id}) do
+    case Integer.parse(region_id) do
+      {region_id, ""} ->
+        order_by(datasets,
+          desc: fragment("case when region_id = ? then 1 else 0 end", ^region_id),
+          asc: :custom_title
+        )
+
+      :error ->
+        datasets
+    end
+  end
+
   def order_datasets(datasets, _params) do
     pan_publisher = Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
 

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -189,4 +189,18 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
     assert first_dataset_id != base_nationale_dataset_id
   end
+
+  test "datasets associated to a region are displayed first when searching for a region" do
+    aom_dataset = insert(:dataset, is_active: true)
+    refute is_nil(aom_dataset.aom_id)
+    aom = DB.Repo.get!(DB.AOM, aom_dataset.aom_id)
+    region_dataset = insert(:dataset, region_id: aom.region_id, is_active: true)
+
+    list_datasets = fn %{} = args ->
+      args |> Dataset.list_datasets() |> Repo.all() |> Enum.map(& &1.id)
+    end
+
+    assert [region_dataset.id, aom_dataset.id] == list_datasets.(%{"region" => aom.region_id |> to_string()})
+    assert list_datasets.(%{}) != list_datasets.(%{"region" => aom.region_id |> to_string()})
+  end
 end


### PR DESCRIPTION
Fixes #2938

Si on cherche des jeux de données pour une région (`/datasets/region/:id`), mettre en premiers résultats les jeux de données associés à la région, puis les autres.

## Avant

![image](https://user-images.githubusercontent.com/295709/213494085-5a5cae61-d51f-438d-869e-0a00a4f2b96c.png)

## Après 

![image](https://user-images.githubusercontent.com/295709/213493897-b885aaa5-20a0-4437-8823-64b9d32a295e.png)
