### PR TITLE
Validateur JSON schema validata : json output

### DIFF
--- a/apps/transport/lib/validators/jsonschema_validata_json_validator.ex
+++ b/apps/transport/lib/validators/jsonschema_validata_json_validator.ex
@@ -86,6 +86,8 @@ defmodule Transport.Validators.ValidataJson do
 
         base_url()
         |> Map.put(:path, location)
+        # get a json validation report
+        |> URI.append_query(URI.encode_query(text_or_json: "json"))
         |> URI.to_string()
         |> get_results()
 

--- a/apps/transport/test/transport/validators/jsonschema_validata_json_test.exs
+++ b/apps/transport/test/transport/validators/jsonschema_validata_json_test.exs
@@ -34,7 +34,7 @@ defmodule Transport.Validators.ValidataJsonTest do
     end)
 
     poll_url = "https://json.validator.validata.fr/job/#{job_id}"
-    output_url = poll_url <> "/output"
+    output_url = poll_url <> "/output?text_or_json=json"
 
     Transport.HTTPoison.Mock
     |> expect(:get, 1, fn ^poll_url ->


### PR DESCRIPTION
on stockait pour l'instant des rapports de validation en text (la sortie par défaut), je passe en json.