### PR TITLE
Affichage des aires des ZFE sur la carte d'exploration

### DIFF
--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -52,11 +52,7 @@ function prepareLayer (layerId, layerData) {
 }
 
 const deckGLLayer = new LeafletLayer({
-    views: [
-        new MapView({
-            repeat: true
-        })
-    ],
+    views: [new MapView({repeat: true})],
     layers: [],
     getTooltip
 })
@@ -68,18 +64,21 @@ function getTooltip ({ object, layer }) {
             return { html: `<strong>Aire de covoiturage</strong><br>${object.properties.nom_lieu}` }
         } else if (layer.id === 'parkings_relais-layer') {
             return { html: `<strong>Parking relai</strong><br>${object.properties.nom}<br>Capacité : ${object.properties.nb_pr} places` }
+        } else if (layer.id === 'zfe-layer') {
+            return { html: `<strong>Zone à Faible Émission</strong>` }
         } else {
             return { html: `<strong>Position temps-réel</strong><br>transport_resource: ${object.transport.resource_id}<br>id: ${object.vehicle.id}` }
         }
     }
 }
 // internal dictionary were all layers are stored
-const layers = { gtfsrt: {}, bnlc: undefined, parkings_relais: undefined }
+const layers = { gtfsrt: {}, bnlc: undefined, parkings_relais: undefined, zfe: undefined }
 
 function getLayers (layers) {
     const layersArray = Object.values(layers.gtfsrt)
     layersArray.push(layers.bnlc)
     layersArray.push(layers.parkings_relais)
+    layersArray.push(layers.zfe)
     return layersArray
 }
 
@@ -126,6 +125,16 @@ document.getElementById('parkings_relais-check').addEventListener('change', (eve
     }
 })
 
+// Handle ZFE toggle
+document.getElementById('zfe-check').addEventListener('change', (event) => {
+    if (event.currentTarget.checked) {
+        fetch('/api/geo-query?data=zfe')
+            .then(data => updateZFELayer(data.json()))
+    } else {
+        updateZFELayer(null)
+    }
+})
+
 function updateBNLCLayer (geojson) {
     layers.bnlc = createPointsLayer(geojson, 'bnlc-layer')
     deckGLLayer.setProps({ layers: getLayers(layers) })
@@ -134,11 +143,16 @@ function updateParkingsRelaisLayer (geojson) {
     layers.parkings_relais = createPointsLayer(geojson, 'parkings_relais-layer')
     deckGLLayer.setProps({ layers: getLayers(layers) })
 }
+function updateZFELayer (geojson) {
+    layers.zfe = createPointsLayer(geojson, 'zfe-layer')
+    deckGLLayer.setProps({ layers: getLayers(layers) })
+}
 
 function createPointsLayer (geojson, id) {
     const fillColor = {
         'bnlc-layer': [255, 174, 0, 100],
-        'parkings_relais-layer': [0, 33, 70, 100]
+        'parkings_relais-layer': [0, 33, 70, 100],
+        'zfe-layer': [155, 89, 182, 100],
     }[id]
 
     return new GeoJsonLayer({
@@ -147,7 +161,7 @@ function createPointsLayer (geojson, id) {
         pickable: true,
         stroked: false,
         filled: true,
-        extruded: true,
+        extruded: false,
         pointType: 'circle',
         getFillColor: fillColor,
         getPointRadius: 1000,

--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -52,7 +52,7 @@ function prepareLayer (layerId, layerData) {
 }
 
 const deckGLLayer = new LeafletLayer({
-    views: [new MapView({repeat: true})],
+    views: [new MapView({ repeat: true })],
     layers: [],
     getTooltip
 })
@@ -65,7 +65,7 @@ function getTooltip ({ object, layer }) {
         } else if (layer.id === 'parkings_relais-layer') {
             return { html: `<strong>Parking relai</strong><br>${object.properties.nom}<br>Capacité : ${object.properties.nb_pr} places` }
         } else if (layer.id === 'zfe-layer') {
-            return { html: `<strong>Zone à Faible Émission</strong>` }
+            return { html: '<strong>Zone à Faible Émission</strong>' }
         } else {
             return { html: `<strong>Position temps-réel</strong><br>transport_resource: ${object.transport.resource_id}<br>id: ${object.vehicle.id}` }
         }
@@ -152,7 +152,7 @@ function createPointsLayer (geojson, id) {
     const fillColor = {
         'bnlc-layer': [255, 174, 0, 100],
         'parkings_relais-layer': [0, 33, 70, 100],
-        'zfe-layer': [155, 89, 182, 100],
+        'zfe-layer': [155, 89, 182, 100]
     }[id]
 
     return new GeoJsonLayer({

--- a/apps/transport/client/stylesheets/components/_explore.scss
+++ b/apps/transport/client/stylesheets/components/_explore.scss
@@ -16,4 +16,7 @@
   #parkings_relais-check:checked {
     background-color: rgb(0, 33, 70);
   }
+  #zfe-check:checked {
+    background-color: rgb(155, 89, 182);
+  }
 }

--- a/apps/transport/lib/transport_web/api/controllers/geo_query_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/geo_query_controller.ex
@@ -30,6 +30,10 @@ defmodule TransportWeb.API.GeoQueryController do
       "parkings-relais" => %{
         dataset: Transport.Jobs.ParkingsRelaisToGeoData.relevant_dataset(),
         transform_fn: &parkings_relais_geojson/1
+      },
+      "zfe" => %{
+        dataset: Transport.Jobs.LowEmissionZonesToGeoData.relevant_dataset(),
+        transform_fn: &zfe_geojson/1
       }
     }
   end
@@ -45,6 +49,12 @@ defmodule TransportWeb.API.GeoQueryController do
         select_merge: %{nom: fragment("payload->>'nom'"), nb_pr: fragment("(payload->>'nb_pr')::int")}
       )
     end
+
+    DB.GeoData.geo_data_as_geojson(geo_data_import, add_fields)
+  end
+
+  def zfe_geojson(%DB.GeoDataImport{} = geo_data_import) do
+    add_fields = fn query -> query end
 
     DB.GeoData.geo_data_as_geojson(geo_data_import, add_fields)
   end

--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -5,6 +5,7 @@ defmodule TransportWeb.ExploreController do
     conn
     |> assign(:bnlc_dataset, Transport.Jobs.BNLCToGeoData.relevant_dataset())
     |> assign(:parcs_relais_dataset, Transport.Jobs.ParkingsRelaisToGeoData.relevant_dataset())
+    |> assign(:zfe_dataset, Transport.Jobs.LowEmissionZonesToGeoData.relevant_dataset())
     |> render("explore.html")
   end
 

--- a/apps/transport/lib/transport_web/templates/explore/explore.html.heex
+++ b/apps/transport/lib/transport_web/templates/explore/explore.html.heex
@@ -1,6 +1,7 @@
 <% real_time_datasets = dataset_path(@conn, :index, type: "public-transit", filter: "has_realtime") %>
 <% bnlc_link = dataset_path(@conn, :details, @bnlc_dataset.slug) %>
 <% parcs_relais_link = dataset_path(@conn, :details, @parcs_relais_dataset.slug) %>
+<% zfe_link = dataset_path(@conn, :details, @zfe_dataset.slug) %>
 <div class="container dataset-page-top">
   <h2><%= dgettext("explore", "Transport Explore") %></h2>
 
@@ -42,6 +43,17 @@
         dgettext("explore", "park-and-ride-explanation",
           link: safe_to_string(link(dgettext("explore", "dataset"), to: parcs_relais_link))
         )
+      ) %>
+    </details>
+  </div>
+  <div class="checkbox-explore pb-24">
+    <input id="zfe-check" name="zfe" type="checkbox" value="true" />
+    <details>
+      <summary>
+        <%= dgettext("explore", "Low emission zones database") %>
+      </summary>
+      <%= raw(
+        dgettext("explore", "lez-explanation", link: safe_to_string(link(dgettext("explore", "dataset"), to: zfe_link)))
       ) %>
     </details>
   </div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/explore.po
@@ -94,3 +94,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Stop Reference (only one)"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Low emission zones database"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "lez-explanation"
+msgstr "Latest data from the Low Emission Zones %{link}. Traffic restrictions details are included in the database."

--- a/apps/transport/priv/gettext/explore.pot
+++ b/apps/transport/priv/gettext/explore.pot
@@ -93,3 +93,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Stop Reference (only one)"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Low emission zones database"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "lez-explanation"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
@@ -94,3 +94,11 @@ msgstr "Références de Lignes (séparées par des virgules)"
 #, elixir-autogen, elixir-format
 msgid "Stop Reference (only one)"
 msgstr "Référence d'Arrêt (un seul)"
+
+#, elixir-autogen, elixir-format
+msgid "Low emission zones database"
+msgstr "Base nationale des Zones à Faibles Émissions"
+
+#, elixir-autogen, elixir-format
+msgid "lez-explanation"
+msgstr "Données issues du %{link} de la Base nationale des Zones à Faibles Émissions. Les restrictions de circulation sont inclues dans la base."

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -5,15 +5,16 @@ defmodule TransportWeb.ExploreControllerTest do
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
 
-    insert(:dataset, %{
-      type: "carpooling-areas",
-      organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
-    })
+    pan_org = Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+
+    insert(:dataset, %{type: "carpooling-areas", organization: pan_org})
+
+    insert(:dataset, %{type: "private-parking", custom_title: "Base nationale des parcs relais", organization: pan_org})
 
     insert(:dataset, %{
-      type: "private-parking",
-      custom_title: "Base nationale des parcs relais",
-      organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+      type: "low-emission-zones",
+      custom_title: "Base Nationale des Zones à Faibles Émissions (BNZFE)",
+      organization: pan_org
     })
 
     :ok
@@ -26,10 +27,11 @@ defmodule TransportWeb.ExploreControllerTest do
   end
 
   test "GET /explore/vehicle-positions", %{conn: conn} do
-    conn =
+    redirect_path =
       conn
       |> get("/explore/vehicle-positions")
+      |> redirected_to(302)
 
-    assert redirected_to(conn, 302) == "/explore"
+    assert redirect_path == "/explore"
   end
 end


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2943

Je récupère les données dans `geo_query` et j'affiche ceci sur la carte d'exploration.

![image](https://user-images.githubusercontent.com/295709/214049246-7e33136c-fa16-43df-aef9-8982975e854d.png)
