### PR TITLE
Possibilité d'utiliser du Markdown pour les breaking news

### DIFF
--- a/apps/transport/client/stylesheets/components/_notification.scss
+++ b/apps/transport/client/stylesheets/components/_notification.scss
@@ -1,0 +1,4 @@
+.notification > p {
+  padding: 0;
+  margin: 0;
+}

--- a/apps/transport/lib/db/breaking_news.ex
+++ b/apps/transport/lib/db/breaking_news.ex
@@ -7,7 +7,7 @@ defmodule DB.BreakingNews do
   import Ecto.{Changeset, Query}
 
   typed_schema "breaking_news" do
-    field(:level, :string)
+    field(:level, Ecto.Enum, values: [:info, :error])
     field(:msg, :string)
   end
 
@@ -31,6 +31,6 @@ defmodule DB.BreakingNews do
   def set_breaking_news(%{level: level, msg: msg}) do
     DB.BreakingNews |> DB.Repo.delete_all()
 
-    %DB.BreakingNews{} |> change(%{level: level, msg: msg}) |> DB.Repo.insert()
+    %DB.BreakingNews{} |> change(%{level: String.to_existing_atom(level), msg: msg}) |> DB.Repo.insert()
   end
 end

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -19,7 +19,9 @@ defmodule TransportWeb.PageController do
     Transport.Cache.API.fetch("home-index-stats", fn -> compute_home_index_stats() end)
   end
 
-  defp put_breaking_news(conn, %{level: level, msg: msg}), do: conn |> put_flash(String.to_atom(level), msg)
+  defp put_breaking_news(conn, %{level: level, msg: msg}),
+    do: conn |> put_flash(String.to_existing_atom("breaking_news_" <> level), msg)
+
   defp put_breaking_news(conn, %{}), do: conn
 
   def not_found(conn, _params) do

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -19,8 +19,10 @@ defmodule TransportWeb.PageController do
     Transport.Cache.API.fetch("home-index-stats", fn -> compute_home_index_stats() end)
   end
 
-  defp put_breaking_news(conn, %{level: level, msg: msg}),
-    do: conn |> put_flash(String.to_existing_atom("breaking_news_" <> level), msg)
+  defp put_breaking_news(conn, %{level: level, msg: msg}) do
+    # The flash reason should match the view _breaking_news.html.heex
+    conn |> put_flash(String.to_existing_atom("breaking_news_#{level}"), msg)
+  end
 
   defp put_breaking_news(conn, %{}), do: conn
 

--- a/apps/transport/lib/transport_web/templates/backoffice/breaking_news/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/breaking_news/index.html.heex
@@ -11,7 +11,9 @@
     <% end %>
 
     <%= label class: "pt-12" do %>
-      Type de message <%= select(f, :level, ["info", "error"], selected: Map.get(@current_breaking_news, :level, "info")) %>
+      Type de message <%= select(f, :level, Ecto.Enum.mappings(DB.BreakingNews, :level),
+        selected: Map.get(@current_breaking_news, :level, :info)
+      ) %>
     <% end %>
     <%= submit("Envoyer !") %>
   <% end %>

--- a/apps/transport/lib/transport_web/templates/backoffice/breaking_news/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/breaking_news/index.html.heex
@@ -1,7 +1,7 @@
 <div class="container">
-  <h1>Breaking News sur la home</h1>
+  <h1>Breaking News sur la page d'accueil</h1>
   <div class="pb-48">
-    Cette page permet de faire apparaître instantanément un message d'information sur la page home du site. <br />
+    Cette page permet de faire apparaitre instantanément un message d'information sur la page d'accueil du site. Il est possible d'utiliser <a href="https://www.markdownguide.org/basic-syntax/">du Markdown</a>.<br />
     Pour supprimer le bandeau, il suffit de supprimer le contenu du message.
   </div>
 

--- a/apps/transport/lib/transport_web/templates/layout/_breaking_news.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_breaking_news.html.heex
@@ -1,0 +1,7 @@
+<div :if={get_flash(@conn, :breaking_news_info)} class="notification">
+  <%= @conn |> get_flash(:breaking_news_info) |> markdown_to_safe_html!() %>
+</div>
+
+<div :if={get_flash(@conn, :breaking_news_error)} class="notification message--error">
+  <%= @conn |> get_flash(:breaking_news_error) |> markdown_to_safe_html!() %>
+</div>

--- a/apps/transport/lib/transport_web/templates/layout/app.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.heex
@@ -60,6 +60,7 @@
 
     <main class="layout-main">
       <%= if has_flash(@conn) do %>
+        <%= render(LayoutView, "_breaking_news.html", assigns) %>
         <%= if get_flash(@conn, :info) do %>
           <p class="notification"><%= get_flash(@conn, :info) %></p>
         <% end %>

--- a/apps/transport/lib/transport_web/views/layout_view.ex
+++ b/apps/transport/lib/transport_web/views/layout_view.ex
@@ -2,6 +2,7 @@ defmodule TransportWeb.LayoutView do
   use TransportWeb, :view
   alias __MODULE__
   alias Phoenix.Controller
+  import TransportWeb.DatasetView, only: [markdown_to_safe_html!: 1]
 
   def current_path(conn) do
     Controller.current_path(conn)

--- a/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
@@ -22,7 +22,7 @@ defmodule TransportWeb.BreakingNewsControllerTest do
     end
 
     test "update a message, check it is displayed on home, delete it", %{conn: conn} do
-      message = "coucou message alerte"
+      message = "coucou message **alerte**"
 
       # set the message
       conn_admin =
@@ -35,20 +35,16 @@ defmodule TransportWeb.BreakingNewsControllerTest do
       # message has been set with sucess
       assert html_response(conn_admin, 200)
 
-      conn_client =
-        conn
-        |> get(page_path(conn, :index))
+      conn_client = conn |> get(page_path(conn, :index))
 
-      # message is displayed on home page
-      assert html_response(conn_client, 200) =~ message
+      # message is displayed on home page and Markdown is rendered
+      assert html_response(conn_client, 200) =~ "coucou message <strong>alerte</strong>"
 
       # set an empty message
       conn_admin
       |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: "info", msg: ""}))
 
-      conn_client =
-        conn
-        |> get(page_path(conn, :index))
+      conn_client = conn |> get(page_path(conn, :index))
 
       # no more message is displayed on home
       doc = conn_client |> html_response(200) |> Floki.parse_document!()

--- a/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
@@ -1,13 +1,10 @@
 defmodule TransportWeb.BreakingNewsControllerTest do
   use TransportWeb.ConnCase, async: true
   use TransportWeb.DatabaseCase, cleanup: []
-  import Plug.Test
 
   describe "breaking news home message" do
     test "no flash message by default", %{conn: conn} do
-      conn =
-        conn
-        |> get(page_path(conn, :index))
+      conn = conn |> get(page_path(conn, :index))
 
       doc = conn |> html_response(200) |> Floki.parse_document!()
       assert [] == Floki.find(doc, ".notification")
@@ -23,32 +20,35 @@ defmodule TransportWeb.BreakingNewsControllerTest do
 
     test "update a message, check it is displayed on home, delete it", %{conn: conn} do
       message = "coucou message **alerte**"
+      expected_message = "coucou message <strong>alerte</strong>"
 
-      # set the message
-      conn_admin =
+      ~w(info error)
+      |> Enum.each(fn level ->
+        # set the message
         conn
-        |> init_test_session(%{
-          current_user: %{"organizations" => [%{"slug" => "equipe-transport-data-gouv-fr"}]}
-        })
-        |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: "info", msg: message}))
+        |> setup_admin_in_session()
+        |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: level, msg: message}))
+        |> html_response(200)
 
-      # message has been set with sucess
-      assert html_response(conn_admin, 200)
+        response = conn |> get(page_path(conn, :index)) |> html_response(200)
 
-      conn_client = conn |> get(page_path(conn, :index))
-
-      # message is displayed on home page and Markdown is rendered
-      assert html_response(conn_client, 200) =~ "coucou message <strong>alerte</strong>"
+        # message is displayed on home page and Markdown is rendered
+        assert response =~ expected_message
+      end)
 
       # set an empty message
-      conn_admin
+      conn
+      |> setup_admin_in_session()
       |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: "info", msg: ""}))
+      |> html_response(200)
+
+      assert DB.BreakingNews |> DB.Repo.all() |> Enum.empty?()
 
       conn_client = conn |> get(page_path(conn, :index))
 
-      # no more message is displayed on home
+      # Message has been removed on the home page
       doc = conn_client |> html_response(200) |> Floki.parse_document!()
-      refute html_response(conn_client, 200) =~ message
+      refute html_response(conn_client, 200) =~ expected_message
       assert [] == Floki.find(doc, ".notification")
     end
   end

--- a/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/breaking_news_controller_test.exs
@@ -22,8 +22,9 @@ defmodule TransportWeb.BreakingNewsControllerTest do
       message = "coucou message **alerte**"
       expected_message = "coucou message <strong>alerte</strong>"
 
-      ~w(info error)
-      |> Enum.each(fn level ->
+      levels = Ecto.Enum.values(DB.BreakingNews, :level)
+
+      Enum.each(levels, fn level ->
         # set the message
         conn
         |> setup_admin_in_session()
@@ -39,7 +40,7 @@ defmodule TransportWeb.BreakingNewsControllerTest do
       # set an empty message
       conn
       |> setup_admin_in_session()
-      |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: "info", msg: ""}))
+      |> post(backoffice_breaking_news_path(conn, :update_breaking_news, %{level: hd(levels), msg: ""}))
       |> html_response(200)
 
       assert DB.BreakingNews |> DB.Repo.all() |> Enum.empty?()


### PR DESCRIPTION
Ajoute la possibilité d'utiliser du Markdown lors de la rédaction de breaking news, et uniquement pour ça.

Utile pour @etalab/transport-bizdev prochainement, avec la mise en ligne du sondage à destination des utilisateurs où indiquer un lien sera très utile.

![image](https://user-images.githubusercontent.com/295709/214085112-9c5c9c07-e381-4163-be50-e3d285eb0ef0.png)
