### PR TITLE
Correctif test fragile bien embêtant

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -59,7 +59,10 @@ defmodule Transport.DataChecker do
   end
 
   def datasets_datagouv_statuses do
-    Dataset |> Repo.all() |> Enum.map(&{&1, dataset_status(&1)})
+    Dataset
+    |> order_by(:id)
+    |> Repo.all()
+    |> Enum.map(&{&1, dataset_status(&1)})
   end
 
   @spec dataset_status(Dataset.t()) :: :active | :inactive | {:archived, DateTime.t()}


### PR DESCRIPTION
Voir:
- #2947 

Ce test échouait sur toutes les PR ce matin, alors j'ai été voir. 

Il s'agissait au final d'une question d'ordre des requêtes HTTP reçues par les mocks.

Je stabilise l'ordre avec un tri, à voir si ça ne pose pas de problème "métier" ? 