### PR TITLE
Migration on delete pour notifications.dataset_id

### DIFF
--- a/apps/transport/lib/db/notification.ex
+++ b/apps/transport/lib/db/notification.ex
@@ -12,6 +12,8 @@ defmodule DB.Notification do
     )
 
     belongs_to(:dataset, DB.Dataset)
+    # `dataset_datagouv_id` may be useful if the linked dataset gets deleted
+    field(:dataset_datagouv_id, :string)
     field(:email, DB.Encrypted.Binary)
     # Should be used to search rows matching an email address
     # https://hexdocs.pm/cloak_ecto/install.html#usage
@@ -20,16 +22,16 @@ defmodule DB.Notification do
     timestamps(type: :utc_datetime_usec)
   end
 
-  def insert!(reason, %DB.Dataset{id: dataset_id}, email) do
+  def insert!(reason, %DB.Dataset{id: dataset_id, datagouv_id: datagouv_id}, email) do
     %__MODULE__{}
-    |> changeset(%{reason: reason, dataset_id: dataset_id, email: email})
+    |> changeset(%{reason: reason, dataset_id: dataset_id, dataset_datagouv_id: datagouv_id, email: email})
     |> DB.Repo.insert!()
   end
 
   def changeset(struct, attrs \\ %{}) do
     struct
-    |> cast(attrs, [:reason, :dataset_id, :email])
-    |> validate_required([:reason, :dataset_id, :email])
+    |> cast(attrs, [:reason, :dataset_id, :dataset_datagouv_id, :email])
+    |> validate_required([:reason, :dataset_id, :dataset_datagouv_id, :email])
     |> validate_format(:email, ~r/@/)
     |> put_hashed_fields()
   end

--- a/apps/transport/priv/repo/migrations/20230124110826_notification_change_dataset_on_delete_behavior.exs
+++ b/apps/transport/priv/repo/migrations/20230124110826_notification_change_dataset_on_delete_behavior.exs
@@ -1,0 +1,19 @@
+defmodule DB.Repo.Migrations.NotificationChangeDatasetOnDeleteBehavior do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:notifications, "notifications_dataset_id_fkey"))
+
+    alter table(:notifications) do
+      modify(:dataset_id, references(:dataset, on_delete: :nilify_all))
+    end
+  end
+
+  def down do
+    drop(constraint(:notifications, "notifications_dataset_id_fkey"))
+
+    alter table(:notifications) do
+      modify(:dataset_id, references(:dataset))
+    end
+  end
+end

--- a/apps/transport/priv/repo/migrations/20230124110826_notifications_change_dataset_on_delete_behavior.exs
+++ b/apps/transport/priv/repo/migrations/20230124110826_notifications_change_dataset_on_delete_behavior.exs
@@ -1,4 +1,4 @@
-defmodule DB.Repo.Migrations.NotificationChangeDatasetOnDeleteBehavior do
+defmodule DB.Repo.Migrations.NotificationsChangeDatasetOnDeleteBehavior do
   use Ecto.Migration
 
   def up do

--- a/apps/transport/priv/repo/migrations/20230125145703_notifications_add_dataset_datagouv_id.exs
+++ b/apps/transport/priv/repo/migrations/20230125145703_notifications_add_dataset_datagouv_id.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.NotificationsAddDatasetDatagouvId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      add :dataset_datagouv_id, :string
+    end
+  end
+end

--- a/apps/transport/test/db/notification_test.exs
+++ b/apps/transport/test/db/notification_test.exs
@@ -12,9 +12,9 @@ defmodule DB.NotificationTest do
 
     email = "foo@example.fr"
     other_email = Ecto.UUID.generate() <> "@example.com"
-    insert_notification(%{dataset_id: dataset.id, reason: :dataset_with_error, email: email})
-    insert_notification(%{dataset_id: dataset.id, reason: :dataset_with_error, email: email})
-    insert_notification(%{dataset_id: dataset.id, reason: :dataset_with_error, email: other_email})
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: email})
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: email})
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: other_email})
 
     # Can query using the hash column dedicated to search
     rows = DB.Notification |> where([n], n.email_hash == ^email) |> DB.Repo.all()

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -217,6 +217,13 @@ defmodule DB.Factory do
     insert_resource_and_friends(Date.utc_today() |> Date.add(-5), opts)
   end
 
+  def insert_notification(%{dataset: %DB.Dataset{id: dataset_id, datagouv_id: datagouv_id}} = args) do
+    args
+    |> Map.delete(:dataset)
+    |> Map.merge(%{dataset_id: dataset_id, dataset_datagouv_id: datagouv_id})
+    |> insert_notification()
+  end
+
   def insert_notification(args) do
     %DB.Notification{}
     |> DB.Notification.changeset(args)

--- a/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
@@ -78,13 +78,13 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
     })
 
     already_sent_email = "alreadysent@example.fr"
-    insert_notification(%{dataset_id: dataset_id, reason: :dataset_with_error, email: already_sent_email})
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: already_sent_email})
     # Should be ignored because this is for another reason
-    insert_notification(%{dataset_id: dataset_id, reason: :expiration, email: "foo@example.com"})
+    insert_notification(%{dataset: dataset, reason: :expiration, email: "foo@example.com"})
     # Should be ignored because it's for another dataset
-    insert_notification(%{dataset_id: gtfs_dataset_id, reason: :dataset_with_error, email: "foo@example.com"})
+    insert_notification(%{dataset: gtfs_dataset, reason: :dataset_with_error, email: "foo@example.com"})
     # Should be ignored because it's too old
-    %{dataset_id: dataset_id, reason: :dataset_with_error, email: "foo@example.com"}
+    %{dataset: dataset, reason: :dataset_with_error, email: "foo@example.com"}
     |> insert_notification()
     |> Ecto.Changeset.change(%{inserted_at: DateTime.utc_now() |> DateTime.add(-20, :day)})
     |> DB.Repo.update!()

--- a/apps/transport/test/transport/jobs/resource_unavailable_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_notification_job_test.exs
@@ -72,13 +72,13 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableNotificationJobTest d
     )
 
     already_sent_email = "alreadysent@example.fr"
-    insert_notification(%{dataset_id: dataset_id, reason: :resource_unavailable, email: already_sent_email})
+    insert_notification(%{dataset: dataset, reason: :resource_unavailable, email: already_sent_email})
     # Should be ignored because this is for another reason
-    insert_notification(%{dataset_id: dataset_id, reason: :expiration, email: "foo@example.com"})
+    insert_notification(%{dataset: dataset, reason: :expiration, email: "foo@example.com"})
     # Should be ignored because it's for another dataset
-    insert_notification(%{dataset_id: gtfs_dataset_id, reason: :resource_unavailable, email: "foo@example.com"})
+    insert_notification(%{dataset: gtfs_dataset, reason: :resource_unavailable, email: "foo@example.com"})
     # Should be ignored because it's too old
-    %{dataset_id: dataset_id, reason: :resource_unavailable, email: "foo@example.com"}
+    %{dataset: dataset, reason: :resource_unavailable, email: "foo@example.com"}
     |> insert_notification()
     |> Ecto.Changeset.change(%{inserted_at: DateTime.utc_now() |> DateTime.add(-20, :day)})
     |> DB.Repo.update!()

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -84,8 +84,8 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
   test "notifications config and notifications sent are displayed", %{conn: conn} do
     dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate(), slug: Ecto.UUID.generate())
 
-    insert_notification(%{dataset_id: dataset.id, email: "foo@example.fr", reason: :expiration})
-    insert_notification(%{dataset_id: dataset.id, email: "bar@example.fr", reason: :expiration})
+    insert_notification(%{dataset: dataset, email: "foo@example.fr", reason: :expiration})
+    insert_notification(%{dataset: dataset, email: "bar@example.fr", reason: :expiration})
 
     Transport.Notifications.FetcherMock
     |> expect(:fetch_config!, fn ->


### PR DESCRIPTION
Voir [sur Sentry](https://sentry.io/organizations/transport-data-gouv-fr/issues/3893732231/?environment=prod&project=6197733&referrer=issue-stream), fixes #2950 

Avec la structure de base de données actuelle, il n'est pas possible de supprimer un jeu de données si des notifications sont liées à celui-ci.

Cette PR fait en sorte que la ligne soit conservée (pour des besoins statistiques), mais le `dataset_id` passera à `null`.

Comme suggéré par @fchabouis, j'ajoute une colonne supplémentaire dans les notifications `dataset_datagouv_id` pour garder une trace en cas de suppression du dataset