### PR TITLE
Ajout client HTTP pour API Recherche d'Entreprises

### DIFF
--- a/apps/transport/lib/transport/companies.ex
+++ b/apps/transport/lib/transport/companies.ex
@@ -15,14 +15,10 @@ defmodule Transport.Companies do
   """
   @spec by_siren_or_siret(binary()) :: {:ok, map()} | {:error, atom()}
   def by_siren_or_siret(siren_or_siret) do
-    if is_valid_siren?(siren_or_siret) do
-      by_siren(siren_or_siret)
-    else
-      if is_valid_siret?(siren_or_siret) do
-        siren_or_siret |> siret_to_siren() |> by_siren()
-      else
-        {:error, :invalid_siren_siret_format}
-      end
+    cond do
+      is_valid_siren?(siren_or_siret) -> by_siren(siren_or_siret)
+      is_valid_siret?(siren_or_siret) -> siren_or_siret |> siret_to_siren() |> by_siren()
+      true -> {:error, :invalid_siren_siret_format}
     end
   end
 

--- a/apps/transport/lib/transport/companies.ex
+++ b/apps/transport/lib/transport/companies.ex
@@ -1,0 +1,127 @@
+defmodule Transport.Companies do
+  @moduledoc """
+  An HTTP client for the "Recherche d'entreprises API"
+  See the documentation: https://api.gouv.fr/documentation/api-recherche-entreprises
+  ⚠️ rate limit is 7 requests per second, watch out if you're using this in a batch job.
+  See a sample response:
+  https://recherche-entreprises.api.gouv.fr/search?q=420495178
+  """
+  @endpoint URI.new!("https://recherche-entreprises.api.gouv.fr/search")
+
+  @doc """
+  Find a company registered in France using its SIREN or one of its SIRET number.
+  If you provide a SIRET number, it will search using its SIREN number
+  and **will not** check that the establishment is currently active.
+  """
+  @spec by_siren_or_siret(binary()) :: {:ok, map()} | {:error, atom()}
+  def by_siren_or_siret(siren_or_siret) do
+    if is_valid_siren?(siren_or_siret) do
+      by_siren(siren_or_siret)
+    else
+      if is_valid_siret?(siren_or_siret) do
+        siren_or_siret |> siret_to_siren() |> by_siren()
+      else
+        {:error, :invalid_siren_siret_format}
+      end
+    end
+  end
+
+  @doc """
+  Find a company registered in France using its SIREN number.
+  """
+  @spec by_siren(binary()) :: {:ok, map()} | {:error, atom()}
+  def by_siren(siren) do
+    if is_valid_siren?(siren) do
+      case search(%{"q" => siren}) do
+        {:ok, json} ->
+          json
+          |> Map.get("results", [])
+          |> Enum.find({:error, :result_not_found}, fn result -> result["siren"] == siren end)
+          |> case do
+            {:error, _} = error_details -> error_details
+            %{} = result -> {:ok, result}
+          end
+
+        {:error, _} = error_details ->
+          error_details
+      end
+    else
+      {:error, :invalid_siren_format}
+    end
+  end
+
+  @doc """
+  Call the "Recherche d'entreprises API" with the specified params.
+  See the documentation for available params: https://api.gouv.fr/documentation/api-recherche-entreprises
+  """
+  @spec search(map()) :: {:ok, map()} | {:error, atom()}
+  def search(%{} = params) do
+    case params |> build_url() |> http_client().get() do
+      {:ok, %HTTPoison.Response{status_code: 404}} ->
+        {:error, :not_found}
+
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, body |> Jason.decode!()}
+
+      {:ok, %HTTPoison.Response{}} ->
+        {:error, :invalid_http_response}
+
+      {:error, %HTTPoison.Error{}} ->
+        {:error, :http_error}
+    end
+  end
+
+  @doc """
+  iex> build_url(%{"q" => "420495178"})
+  %URI{
+    host: "recherche-entreprises.api.gouv.fr",
+    path: "/search",
+    port: 443,
+    query: "q=420495178",
+    scheme: "https"
+  }
+  """
+  def build_url(%{} = uri_params) do
+    @endpoint |> URI.append_query(URI.encode_query(uri_params))
+  end
+
+  @doc """
+  Check if a SIREN appears to be valid: expected length and valid Luhn checksum.
+
+  iex> is_valid_siren?("420495178")
+  true
+  iex> is_valid_siren?("420495179")
+  false
+  iex> is_valid_siren?("foo")
+  false
+  iex> is_valid_siren?("42049517800014")
+  false
+  """
+  def is_valid_siren?(siren) when is_binary(siren) do
+    String.match?(siren, ~r/^\d{9}$/) and Luhn.valid?(siren)
+  end
+
+  @doc """
+  Check if a SIRET appears to be valid: expected length and valid Luhn checksum.
+
+  iex> is_valid_siret?("420495178")
+  false
+  iex> is_valid_siret?("foo")
+  false
+  iex> is_valid_siret?("42049517800014")
+  true
+  iex> is_valid_siret?("42049517800015")
+  false
+  """
+  def is_valid_siret?(siret) when is_binary(siret) do
+    String.match?(siret, ~r/^\d{14}$/) and Luhn.valid?(siret)
+  end
+
+  @doc """
+  iex> siret_to_siren("42049517800015")
+  "420495178"
+  """
+  def siret_to_siren(siret), do: String.slice(siret, 0..8)
+
+  defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
+end

--- a/apps/transport/mix.exs
+++ b/apps/transport/mix.exs
@@ -125,7 +125,8 @@ defmodule Transport.Mixfile do
       {:phoenix_live_dashboard, "~> 0.7"},
       {:ecto_psql_extras, "~> 0.6"},
       {:telemetry_poller, "~> 0.4"},
-      {:telemetry_metrics, "~> 0.4"}
+      {:telemetry_metrics, "~> 0.4"},
+      {:luhn, "~> 0.3.0"}
     ]
   end
 end

--- a/apps/transport/test/transport/companies_test.exs
+++ b/apps/transport/test/transport/companies_test.exs
@@ -1,0 +1,62 @@
+defmodule Transport.CompaniesTest do
+  use ExUnit.Case, async: true
+  alias Transport.Companies
+  import Mox
+  doctest Companies, import: true
+
+  @siren "420495178"
+  setup :verify_on_exit!
+
+  describe "by_siren_or_siret" do
+    test "validates formats" do
+      assert {:error, :invalid_siren_siret_format} == Companies.by_siren_or_siret("420495179")
+      assert {:error, :invalid_siren_siret_format} == Companies.by_siren_or_siret("42049517800016")
+      assert {:error, :invalid_siren_siret_format} == Companies.by_siren_or_siret("foo")
+    end
+
+    test "result is found" do
+      payload = %{
+        "results" => [result = %{"siren" => @siren, "nom_complet" => "air france"}, %{"siren" => Ecto.UUID.generate()}]
+      }
+
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(payload)}}
+      setup_response_by_siren(@siren, response)
+
+      assert {:ok, result} == Companies.by_siren_or_siret(@siren)
+    end
+
+    test "500 from server" do
+      response = {:ok, %HTTPoison.Response{status_code: 500}}
+      setup_response_by_siren(@siren, response)
+
+      assert {:error, :invalid_http_response} == Companies.by_siren_or_siret(@siren)
+    end
+
+    test "200 from server but siren is not found in the results" do
+      payload = %{"results" => [%{"siren" => Ecto.UUID.generate(), "nom_complet" => "air france"}]}
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(payload)}}
+      setup_response_by_siren(@siren, response)
+
+      assert {:error, :result_not_found} == Companies.by_siren_or_siret(@siren)
+    end
+
+    test "timeout from server" do
+      response = {:error, %HTTPoison.Error{reason: :timeout}}
+      setup_response_by_siren(@siren, response)
+
+      assert {:error, :http_error} == Companies.by_siren_or_siret(@siren)
+    end
+  end
+
+  defp setup_response_by_siren(siren, response) do
+    uri = %URI{
+      scheme: "https",
+      host: "recherche-entreprises.api.gouv.fr",
+      port: 443,
+      path: "/search",
+      query: "q=#{siren}"
+    }
+
+    Transport.HTTPoison.Mock |> expect(:get, fn ^uri -> response end)
+  end
+end

--- a/apps/transport/test/transport/companies_test.exs
+++ b/apps/transport/test/transport/companies_test.exs
@@ -25,6 +25,20 @@ defmodule Transport.CompaniesTest do
       assert {:ok, result} == Companies.by_siren_or_siret(@siren)
     end
 
+    test "providing a valid SIRET searches for the associated SIREN" do
+      siret = "42049517800014"
+      assert String.starts_with?(siret, @siren)
+
+      payload = %{
+        "results" => [result = %{"siren" => @siren, "nom_complet" => "air france"}, %{"siren" => Ecto.UUID.generate()}]
+      }
+
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(payload)}}
+      setup_response_by_siren(@siren, response)
+
+      assert {:ok, result} == Companies.by_siren_or_siret(siret)
+    end
+
     test "500 from server" do
       response = {:ok, %HTTPoison.Response{status_code: 500}}
       setup_response_by_siren(@siren, response)

--- a/mix.lock
+++ b/mix.lock
@@ -57,6 +57,7 @@
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm", "fc3499fed7a726995aa659143a248534adc754ebd16ccd437cd93b649a95091f"},
   "jumper": {:hex, :jumper, "1.0.1", "3c00542ef1a83532b72269fab9f0f0c82bf23a35e27d278bfd9ed0865cecabff", [:mix], [], "hexpm", "318c59078ac220e966d27af3646026db9b5a5e6703cb2aa3e26bcfaba65b7433"},
   "kino": {:hex, :kino, "0.7.0", "98d2623bebf8d1c4d761c5ed9741c6aae2f1909706baec501f2fdad347cb9d92", [:mix], [{:table, "~> 0.1.2", [hex: :table, repo: "hexpm", optional: false]}], "hexpm", "3dd1ee761c241caa30364333e3102a954d68188414a46e867f95c858d745f3fd"},
+  "luhn": {:hex, :luhn, "0.3.3", "5aa0c6a32c2db4b9db9f9b883ba8301c1ae169d57199b9e6cb1ba2707bc51d96", [:mix], [], "hexpm", "3e823a913a25aab51352c727f135278d22954874d5f0835be81ed4fec3daf78d"},
   "meck": {:hex, :meck, "0.9.2", "85ccbab053f1db86c7ca240e9fc718170ee5bda03810a6292b5306bf31bae5f5", [:rebar3], [], "hexpm", "81344f561357dc40a8344afa53767c32669153355b626ea9fcbc8da6b3045826"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.3", "3676436d3d1f7b81b5a2d2bd8405f412c677558c81b1c92be58c00562bb59095", [:mix], [], "hexpm", "27a30bf0db44d25eecba73755acf4068cbfe26a4372f9eb3e4ea3a45956bff6b"},


### PR DESCRIPTION
Je prépare un client HTTP pour rechercher des entreprises en utilisant SIREN ou SIRET, utile plus tard pour les changements à venir sur le backoffice.