### PR TITLE
Scaleway : correction configuration bucket lifecycle

### DIFF
--- a/docs/scaleway/bucket_lifecycle_configuration_production.json
+++ b/docs/scaleway/bucket_lifecycle_configuration_production.json
@@ -6,10 +6,7 @@
          },
          "ID":"delete-after-90-days",
          "Filter":{
-            "Prefix":"",
-            "And":{
-               "Prefix":"*"
-            }
+            "Prefix":""
          },
          "Status":"Enabled"
       }

--- a/docs/scaleway/bucket_lifecycle_configuration_staging.json
+++ b/docs/scaleway/bucket_lifecycle_configuration_staging.json
@@ -6,10 +6,7 @@
          },
          "ID":"delete-after-30-days",
          "Filter":{
-            "Prefix":"",
-            "And":{
-               "Prefix":"*"
-            }
+            "Prefix":""
          },
          "Status":"Enabled"
       }


### PR DESCRIPTION
Corrige la configuration de bucket lifecycle pour les buckets chez Scaleway.

De manière étrange, seul le bucket de staging avait une mauvaise configuration appliquée, le bucket de prod avait bien la configuration sans préfixe. La conf avec `"prefix": "*"` ne fonctionne pas car elle ne prend en compte que les objets/dossiers qui commencent par `*` et non `*` en tant que glob.

J'ai remplacé la configuration avec

```
aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api put-bucket-lifecycle-configuration --lifecycle-configuration file://policy.json --bucket transport-staging-backups
```

et vérifié la bonne prise en compte en CLI + UI.

```
$ aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api get-bucket-lifecycle-configuration --bucket transport-prod-backups                

{
    "Rules": [
        {
            "Expiration": {
                "Days": 90
            },
            "ID": "delete-after-90-days",
            "Filter": {
                "Prefix": ""
            },
            "Status": "Enabled"
        }
    ]
}

$ aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api get-bucket-lifecycle-configuration --bucket transport-staging-backups

{
    "Rules": [
        {
            "Expiration": {
                "Days": 30
            },
            "ID": "delete-after-30-days",
            "Filter": {
                "Prefix": ""
            },
            "Status": "Enabled"
        }
    ]
}
```


J'irai vérifier sur [l'UI web](https://console.scaleway.com/object-storage/buckets/fr-par/transport-staging-backups/explorer) dans quelques heures/demain que c'est bien pris en compte et que les objets > 30 jours ont été supprimés.