### PR TITLE
JDD : utilise la licence mobilités si tag licence-mobilités présent

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -177,37 +177,15 @@ defmodule Transport.ImportData do
   end
 
   @doc """
-  Set the licence according to the datagouv response with possible overrides.
-  Context: we're doing this directly on transport.data.gouv.fr because data.gouv.fr does
-  not handle licences that have not been homologated. Some custom licences will be
-  classified as `notspecified` on the datagouv API response as a result.
+  Set the licence according to the datagouv response.
 
-    ## Examples
+  ## Examples
 
-      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Lyon"}})
-      "mobility-licence"
-
-      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Île-de-France Mobilités"}})
-      "mobility-licence"
-
-      iex> licence(%{"license" => "odc-odbl", "organization" => %{"name" => "Île-de-France Mobilités"}})
-      "odc-odbl"
-
-      iex> licence(%{"license" => "notspecified", "organization" => %{"name" => "Métropole de Rouen"}})
-      "notspecified"
-
-      iex> licence(%{"license" => "odc-odbl"})
-      "odc-odbl"
-
+  iex> licence(%{"license" => "odc-odbl"})
+  "odc-odbl"
+  iex> licence("odc-odbl")
+  nil
   """
-  def licence(%{"license" => "notspecified", "organization" => %{"name" => org_name}}) do
-    if org_name in Application.fetch_env!(:transport, :orgs_with_mobility_licence) do
-      "mobility-licence"
-    else
-      "notspecified"
-    end
-  end
-
   def licence(%{"license" => datagouv_licence}), do: datagouv_licence
   def licence(_), do: nil
 

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -175,6 +175,32 @@ defmodule DB.DatasetDBTest do
     end
   end
 
+  describe "mobility-licence" do
+    test "does not change the licence if the magic custom tag is not set" do
+      insert(:dataset, licence: "lov2", datagouv_id: datagouv_id = Ecto.UUID.generate(), custom_tags: nil)
+
+      assert {:ok, %Ecto.Changeset{changes: %{licence: "fr-lo"}}} =
+               Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
+    end
+
+    test "if the magic tag is set, change the licence" do
+      insert(:dataset, custom_tags: ["licence-mobilités"], datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+      assert {:ok, %Ecto.Changeset{changes: %{licence: "mobility-licence"}}} =
+               Dataset.changeset(%{"datagouv_id" => datagouv_id})
+
+      assert {:ok, %Ecto.Changeset{changes: %{licence: "mobility-licence"}}} =
+               Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
+    end
+
+    test "ignores other tags in custom_tags" do
+      insert(:dataset, custom_tags: ["foo"], datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+      assert {:ok, %Ecto.Changeset{changes: %{licence: "fr-lo"}}} =
+               Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "fr-lo"})
+    end
+  end
+
   describe "resources last content update time" do
     test "for a dataset, get resources last update times" do
       %{id: dataset_id} = insert(:dataset, %{datagouv_id: "xxx", datagouv_title: "coucou"})

--- a/config/config.exs
+++ b/config/config.exs
@@ -140,7 +140,6 @@ config :transport,
 
 config :transport,
   datagouv_static_hosts: ["static.data.gouv.fr", "demo-static.data.gouv.fr"],
-  orgs_with_mobility_licence: ["Métropole de Lyon", "Île-de-France Mobilités"],
   bison_fute_host: "tipi.bison-fute.gouv.fr"
 
 # A list of publicly transmissible requestor refs for open data SIRI. Currently


### PR DESCRIPTION
Adapte le mécanisme mis en place précédemment dans https://github.com/etalab/transport-site/pull/2194, utilise désormais les `custom_tags` pour assigner la licence mobilités à certains jeux de données. On évite une configuration en dur et l'assignation automatique qui pouvait manquer de flexibilité.

PS : j'ai déjà mis le tag nécessaire aux JDD concernés en production.