### PR TITLE
Capacité à se connecter à l'instance Elixir en cours d'exécution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,37 @@ RUN mix phx.digest
 
 EXPOSE 8080
 
-ENTRYPOINT ["mix", "phx.migrate_phx.server"]
+# See https://github.com/etalab/transport-site/issues/1384
+#
+# Here I discovered that a default cookie is generated automatically by Erlang,
+# and that its value will be the same when running Phoenix vs. running an iex
+# on the same node (but it will be different on e.g. site vs worker).
+#
+# So as long as a `-sname` has been set at Phoenix startup, this is good enough to
+# allow iex connection with the following command (after SSH):
+#
+# `iex --sname console --remsh node`
+#
+# I was also able to define a custom cookie, and I'm saving the notes in case we
+# decide the default cookie is not good enough, or detect a situation where it could
+# be guessable in a way or another.
+# 
+# Add this right above the `ENTRYPOINT`:
+#
+# `ENV ERL_FLAGS="-cookie $ELIXIR_NODE_SECRET_COOKIE"`
+#
+# (`-cookie` is not a typo, this is different from `elixir --cookie`)
+#
+# You will need to make sure to define the variable, otherwise it will fallback
+# to the automatically generated cookie value.
+#
+# Setting `ERL_FLAGS` via `ENV` makes it possible not to introduce a subshell
+# to evaluate the variable in `ENTRYPOINT`, something that would introduce other
+# problems such as the behaviour of kill on the container (subprocesses).
+# 
+# If you use `ERL_FLAGS` with a custom cookie, the command to connect to the node
+# will be slightly different:
+# `iex --sname console --cookie $ELIXIR_NODE_SECRET_COOKIE --remsh node`
+#
+
+ENTRYPOINT ["elixir", "--sname", "node", "-S", "mix", "phx.migrate_phx.server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ EXPOSE 8080
 # and that its value will be the same when running Phoenix vs. running an iex
 # on the same node (but it will be different on e.g. site vs worker).
 #
+# This cookie is stored in `~/.erlang_cookie` and can be read programmatically
+# via `:erlang.get_cookie()`.
+#
 # So as long as a `-sname` has been set at Phoenix startup, this is good enough to
 # allow iex connection with the following command (after SSH):
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ENV PORT 8080
 ENV MIX_ENV prod
 # Equivalent to `elixir --sname ... --cookie -S mix ...`, but without needing
 # a subprocess in ENTRYPOINT, which would introduce kill-time subtleties.
-ENV ERL_FLAGS="-sname node@$(hostname) -setcookie $ELIXIR_NODE_SECRET_COOKIE"
+# NOTE: complete name for access will be name@hostname
+ENV ERL_FLAGS="-sname node -setcookie $ELIXIR_NODE_SECRET_COOKIE"
 RUN mix deps.compile
 RUN cd apps/transport/client && yarn install && npm run build
 # assets digest must happen after the npm build step

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,4 @@ RUN mix phx.digest
 
 EXPOSE 8080
 
-# Equivalent to `elixir --sname ... --cookie -S mix ...`, but without needing
-# a subprocess in ENTRYPOINT, which would introduce kill-time subtleties.
-# NOTE: complete name for access will be name@hostname
-ENV ERL_FLAGS="-sname node -setcookie $ELIXIR_NODE_SECRET_COOKIE"
-
 ENTRYPOINT ["mix", "phx.migrate_phx.server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN node --version
 
 ENV PORT 8080
 ENV MIX_ENV prod
+# Equivalent to `elixir --sname ... --cookie -S mix ...`, but without needing
+# a subprocess in ENTRYPOINT, which would introduce kill-time subtleties.
+ENV ERL_FLAGS="-sname node@$(hostname) -setcookie $ELIXIR_NODE_SECRET_COOKIE"
 RUN mix deps.compile
 RUN cd apps/transport/client && yarn install && npm run build
 # assets digest must happen after the npm build step

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,16 @@ RUN node --version
 
 ENV PORT 8080
 ENV MIX_ENV prod
-# Equivalent to `elixir --sname ... --cookie -S mix ...`, but without needing
-# a subprocess in ENTRYPOINT, which would introduce kill-time subtleties.
-# NOTE: complete name for access will be name@hostname
-ENV ERL_FLAGS="-sname node -setcookie $ELIXIR_NODE_SECRET_COOKIE"
 RUN mix deps.compile
 RUN cd apps/transport/client && yarn install && npm run build
 # assets digest must happen after the npm build step
 RUN mix phx.digest
 
 EXPOSE 8080
+
+# Equivalent to `elixir --sname ... --cookie -S mix ...`, but without needing
+# a subprocess in ENTRYPOINT, which would introduce kill-time subtleties.
+# NOTE: complete name for access will be name@hostname
+ENV ERL_FLAGS="-sname node -setcookie $ELIXIR_NODE_SECRET_COOKIE"
 
 ENTRYPOINT ["mix", "phx.migrate_phx.server"]


### PR DESCRIPTION
En cherchant à aller vérifier un point pour:
- #2028 

j'ai eu besoin d'aller vérifier l'état en direct (en tout cas je me suis posé la question), ce que je ne pouvais pas faire tant que :
- #1384 

n'était pas traité.

J'ai pas mal fouillé et simplifié le problème, et noté tout ce que j'ai appris.

Au final: l'ironie est que la capacité était déjà là (via un cookie par défaut, cohérent entre iex et phoenix), mais qu'on n'avait pas compris que c'était le cas.

Je peux aujourd'hui lire les clés Cachex en direct sur prochainement:

```
❯ clever ssh --alias staging-site
# SNIP
# iex --sname console --remsh node
Erlang/OTP 24 [erts-12.3.2.6] [source] [64-bit] [smp:2:2] [ds:2:2:10] [async-threads:1] [jit]
# SNIP
iex(node@XYZ)2> Cachex.keys(:transport)
{:ok, ["home-index-stats"]}
```

À discuter avec @fchabouis demain avant un déploiement en production pour mieux enquêter sur #2028.

