### PR TITLE
Backoffice : Ajout du champ "type d'organisation"

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
@@ -90,7 +90,7 @@ defmodule Datagouvfr.Client.Datasets do
   def get_infos_from_url(url) do
     with filename when not is_nil(filename) <- Helpers.filename_from_url(url),
          {:ok, dataset} <- [@endpoint, filename] |> API.get() do
-      %{id: dataset["id"], title: dataset["title"]}
+      %{id: dataset["id"], title: dataset["title"], organization: get_in(dataset, ["organization", "name"])}
     else
       _ -> nil
     end

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -172,7 +172,7 @@
   right: 0;
   text-align: right;
   &+h4 {
-    margin-top: 0;
+    margin-top: -1em;
   }
 }
 

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -171,7 +171,7 @@
   top: -1em;
   right: 0;
   text-align: right;
-  &+h4 {
+  & + h4 {
     margin-top: -1em;
   }
 }

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -165,6 +165,17 @@
   }
 }
 
+.panel-explanation {
+  color: var(--grey);
+  position: relative;
+  top: -1em;
+  right: 0;
+  text-align: right;
+  &+h4 {
+    margin-top: 0;
+  }
+}
+
 .custom-tag {
   animation: fade-in 0.5s;
   .delete-tag {

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -405,6 +405,7 @@ defmodule DB.Dataset do
       :description,
       :frequency,
       :organization,
+      :organization_type,
       :last_update,
       :licence,
       :logo,
@@ -432,6 +433,7 @@ defmodule DB.Dataset do
     |> maybe_dataset_now_licence_ouverte(dataset)
     |> maybe_overwrite_licence()
     |> has_real_time()
+    |> validate_organization_type()
     |> case do
       %{valid?: false, changes: changes} = changeset when changes == %{} ->
         {:ok, %{changeset | action: :ignore}}
@@ -779,6 +781,17 @@ defmodule DB.Dataset do
           :region,
           dgettext("db-dataset", "You need to fill either aom, region or use datagouv's zone")
         )
+    end
+  end
+
+  @spec validate_organization_type(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp validate_organization_type(changeset) do
+    changeset
+    |> get_field(:organization_type)
+    |> Kernel.in(TransportWeb.EditDatasetLive.organization_types())
+    |> case do
+      true -> changeset
+      false -> changeset |> add_error(:organization_type, dgettext("db-dataset", "Organization type is invalid"))
     end
   end
 

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -788,7 +788,8 @@ defmodule DB.Dataset do
   defp validate_organization_type(changeset) do
     changeset
     |> get_field(:organization_type)
-    |> Kernel.in(TransportWeb.EditDatasetLive.organization_types())
+    # allow a nil value for the moment
+    |> Kernel.in(TransportWeb.EditDatasetLive.organization_types() ++ [nil])
     |> case do
       true -> changeset
       false -> changeset |> add_error(:organization_type, dgettext("db-dataset", "Organization type is invalid"))

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -32,6 +32,7 @@ defmodule DB.Dataset do
     field(:datagouv_title, :string)
     field(:type, :string)
     field(:organization, :string)
+    field(:organization_type, :string)
     field(:has_realtime, :boolean)
     field(:is_active, :boolean)
     field(:population, :integer)

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -91,23 +91,21 @@ defmodule TransportWeb.EditDatasetLive do
         session: %{"dataset" => @dataset, "form" => f}
       ) %>
 
-      <%= if @dataset_organization do %>
-        <div class="panel mt-48">
-          <div class="panel-explanation">
-            <%= dgettext("backoffice", "published by") %>
-          </div>
-          <h4><%= @dataset_organization %></h4>
-          <%= select(f, :organization_type, @organization_types,
-            selected:
-              if not is_nil(@dataset) do
-                @dataset.organization_type
-              else
-                ""
-              end,
-            prompt: dgettext("backoffice", "Publisher type")
-          ) %>
+      <div class="panel mt-48" :if={@dataset_organization}>
+        <div class="panel-explanation">
+          <%= dgettext("backoffice", "published by") %>
         </div>
-      <% end %>
+        <h4><%= @dataset_organization %></h4>
+        <%= select(f, :organization_type, @organization_types,
+          selected:
+            if not is_nil(@dataset) do
+              @dataset.organization_type
+            else
+              ""
+            end,
+          prompt: dgettext("backoffice", "Publisher type")
+        ) %>
+      </div>
 
       <div class="panel mt-48">
         <div class="panel__header">

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -91,6 +91,24 @@ defmodule TransportWeb.EditDatasetLive do
         session: %{"dataset" => @dataset, "form" => f}
       ) %>
 
+      <%= if @dataset_organization do %>
+        <div class="panel mt-48">
+          <div class="panel-explanation">
+            publié par
+          </div>
+          <h4><%= @dataset_organization %></h4>
+          <%= select(f, :organization_type, @organization_types,
+            selected:
+              if not is_nil(@dataset) do
+                @dataset.organization_type
+              else
+                ""
+              end,
+            prompt: "Type de publicateur"
+          ) %>
+        </div>
+      <% end %>
+
       <div class="panel mt-48">
         <div class="panel__header">
           <h4>
@@ -189,16 +207,34 @@ defmodule TransportWeb.EditDatasetLive do
         %{id: dataset_id} -> backoffice_dataset_path(socket, :post, dataset_id)
       end
 
+    dataset_organization =
+      case dataset do
+        nil -> nil
+        %{organization: organization} -> organization
+      end
+
     socket =
       socket
       |> assign(:dataset, dataset)
       |> assign(:dataset_types, dataset_types)
       |> assign(:regions, regions)
       |> assign(:form_url, form_url)
+      |> assign(:dataset_organization, dataset_organization)
+      |> assign(:organization_types, organization_types())
       |> assign(:trigger_submit, false)
 
     {:ok, socket}
   end
+
+  def organization_types,
+    do: [
+      "AOM",
+      "Réseau",
+      "Fournisseur de système",
+      "Opérateur de transport",
+      "Syndicat Mixte",
+      "Autre"
+    ]
 
   def handle_event(
         "change_dataset",
@@ -212,7 +248,7 @@ defmodule TransportWeb.EditDatasetLive do
       Task.async(fn -> get_datagouv_infos(datagouv_url) end)
       {:noreply, socket}
     else
-      {:noreply, assign(socket, datagouv_infos: nil)}
+      {:noreply, assign(socket, datagouv_infos: nil, dataset_organization: nil)}
     end
   end
 
@@ -229,7 +265,13 @@ defmodule TransportWeb.EditDatasetLive do
   def handle_info({ref, datagouv_infos}, socket) do
     # we stop monitoring the process after receiving the result
     Process.demonitor(ref, [:flush])
-    {:noreply, assign(socket, datagouv_infos: datagouv_infos)}
+
+    socket =
+      socket
+      |> assign(datagouv_infos: datagouv_infos)
+      |> assign(dataset_organization: Map.get(datagouv_infos, :organization))
+
+    {:noreply, socket}
   end
 
   def handle_info(_, socket) do
@@ -237,11 +279,14 @@ defmodule TransportWeb.EditDatasetLive do
   end
 
   def get_datagouv_infos(datagouv_url) do
-    case Datagouvfr.Client.Datasets.get_infos_from_url(datagouv_url) do
+    infos = Datagouvfr.Client.Datasets.get_infos_from_url(datagouv_url)
+    IO.inspect(infos)
+
+    case infos do
       nil ->
         %{dataset_datagouv_id: nil}
 
-      %{id: dataset_datagouv_id, title: title} ->
+      %{id: dataset_datagouv_id, title: title, organization: organization} ->
         # does the dataset already exists?
         dataset_id =
           case DB.Dataset |> DB.Repo.get_by(datagouv_id: dataset_datagouv_id) do
@@ -249,7 +294,12 @@ defmodule TransportWeb.EditDatasetLive do
             _ -> nil
           end
 
-        %{dataset_datagouv_id: dataset_datagouv_id, datagouv_title: title, dataset_id: dataset_id}
+        %{
+          dataset_datagouv_id: dataset_datagouv_id,
+          datagouv_title: title,
+          dataset_id: dataset_id,
+          organization: organization
+        }
     end
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -94,7 +94,7 @@ defmodule TransportWeb.EditDatasetLive do
       <%= if @dataset_organization do %>
         <div class="panel mt-48">
           <div class="panel-explanation">
-            publié par
+          <%= dgettext("backoffice", "published by") %>
           </div>
           <h4><%= @dataset_organization %></h4>
           <%= select(f, :organization_type, @organization_types,
@@ -104,7 +104,7 @@ defmodule TransportWeb.EditDatasetLive do
               else
                 ""
               end,
-            prompt: "Type de publicateur"
+            prompt: dgettext("backoffice", "Publisher type")
           ) %>
         </div>
       <% end %>

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -94,7 +94,7 @@ defmodule TransportWeb.EditDatasetLive do
       <%= if @dataset_organization do %>
         <div class="panel mt-48">
           <div class="panel-explanation">
-          <%= dgettext("backoffice", "published by") %>
+            <%= dgettext("backoffice", "published by") %>
           </div>
           <h4><%= @dataset_organization %></h4>
           <%= select(f, :organization_type, @organization_types,
@@ -280,7 +280,6 @@ defmodule TransportWeb.EditDatasetLive do
 
   def get_datagouv_infos(datagouv_url) do
     infos = Datagouvfr.Client.Datasets.get_infos_from_url(datagouv_url)
-    IO.inspect(infos)
 
     case infos do
       nil ->

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -91,7 +91,7 @@ defmodule TransportWeb.EditDatasetLive do
         session: %{"dataset" => @dataset, "form" => f}
       ) %>
 
-      <div class="panel mt-48" :if={@dataset_organization}>
+      <div :if={@dataset_organization} class="panel mt-48">
         <div class="panel-explanation">
           <%= dgettext("backoffice", "published by") %>
         </div>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -260,3 +260,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Publisher type"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "published by"
+msgstr ""

--- a/apps/transport/priv/gettext/db-dataset.pot
+++ b/apps/transport/priv/gettext/db-dataset.pot
@@ -85,3 +85,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Transport traffic"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Organization type is invalid"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -260,3 +260,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Publisher type"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "published by"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
@@ -86,3 +86,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Transport traffic"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Organization type is invalid"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -30,7 +30,7 @@ msgstr "id data.gouv.fr"
 
 #, elixir-autogen
 msgid "name"
-msgstr "Nom du réseau"
+msgstr "Nom du jeu de données sur le PAN"
 
 msgid "Dataset added with success"
 msgstr "Jeux de données ajouté avec succès"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -260,3 +260,11 @@ msgstr "Notifications envoyées"
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr "Notifications envoyées au cours des %{nb_days} derniers jours."
+
+#, elixir-autogen, elixir-format
+msgid "Publisher type"
+msgstr "Type de publicateur"
+
+#, elixir-autogen, elixir-format
+msgid "published by"
+msgstr "publié par"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
@@ -86,3 +86,7 @@ msgstr "Données routières"
 #, elixir-autogen, elixir-format
 msgid "Transport traffic"
 msgstr "Comptage des mobilités"
+
+#, elixir-autogen, elixir-format
+msgid "Organization type is invalid"
+msgstr "Le type d'organisation (publicateur) est invalide"

--- a/apps/transport/priv/repo/migrations/20230202090645_add_dataset_organization_type.exs
+++ b/apps/transport/priv/repo/migrations/20230202090645_add_dataset_organization_type.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddDatasetOrganizationType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataset) do
+      add :organization_type, :string
+    end
+  end
+end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -482,7 +482,6 @@ defmodule DB.DatasetDBTest do
              Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "lov2"})
   end
 
-
   test "incorrect organization type" do
     insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
 

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -490,7 +490,7 @@ defmodule DB.DatasetDBTest do
         Dataset.changeset(%{"datagouv_id" => datagouv_id, "organization_type" => "US Gvt"})
       end)
 
-    assert logs =~ "Organization type is invalid"
-    assert {:error, "%{organization_type: [\"Organization type is invalid\"]}"} == res
+    assert logs =~ "Le type d'organisation (publicateur) est invalide"
+    assert {:error, "%{organization_type: [\"Le type d'organisation (publicateur) est invalide\"]}"} == res
   end
 end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -466,4 +466,32 @@ defmodule DB.DatasetDBTest do
     # this counts national datasets (region id = 14) with bus resources
     assert DB.Dataset.count_coach() == 1
   end
+
+  test "correct organization type" do
+    insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+    assert {:ok, %Ecto.Changeset{changes: %{organization_type: "AOM"}}} =
+             Dataset.changeset(%{"datagouv_id" => datagouv_id, "organization_type" => "AOM"})
+  end
+
+  test "empty organization type" do
+    insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+    # we test a random change to check if the changeset is valid without an organization type specified
+    assert {:ok, %Ecto.Changeset{changes: %{licence: "lov2"}}} =
+             Dataset.changeset(%{"datagouv_id" => datagouv_id, "licence" => "lov2"})
+  end
+
+
+  test "incorrect organization type" do
+    insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+    {res, logs} =
+      with_log(fn ->
+        Dataset.changeset(%{"datagouv_id" => datagouv_id, "organization_type" => "US Gvt"})
+      end)
+
+    assert logs =~ "Organization type is invalid"
+    assert {:error, "%{organization_type: [\"Organization type is invalid\"]}"} == res
+  end
 end

--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -94,7 +94,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
            } = DB.Repo.reload!(dataset)
   end
 
-  test "update a dataset custom tags", %{conn: conn} do
+  test "update a dataset custom tags and organization type", %{conn: conn} do
     dataset = insert(:dataset, slug: slug = "slug")
 
     Transport.HTTPoison.Mock
@@ -118,11 +118,13 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
         "url" => slug,
         "type" => "public-transit",
         "custom_tags[0]" => tag1 = "top",
-        "custom_tags[1]" => tag2 = "super"
+        "custom_tags[1]" => tag2 = "super",
+        "organization_type" => organization_type = "AOM"
       }
     })
 
     # the custom tags have been saved
-    assert %DB.Dataset{custom_tags: [^tag1, ^tag2]} = DB.Repo.reload!(dataset)
+    assert %DB.Dataset{custom_tags: [^tag1, ^tag2], organization_type: ^organization_type} =
+             DB.Repo.reload!(dataset)
   end
 end

--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -124,7 +124,6 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
     })
 
     # the custom tags have been saved
-    assert %DB.Dataset{custom_tags: [^tag1, ^tag2], organization_type: ^organization_type} =
-             DB.Repo.reload!(dataset)
+    assert %DB.Dataset{custom_tags: [^tag1, ^tag2], organization_type: ^organization_type} = DB.Repo.reload!(dataset)
   end
 end

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -62,10 +62,13 @@ defmodule TransportWeb.EditDatasetLiveTest do
     |> expect(:request, 1, fn :get, "https://demo.data.gouv.fr/api/1/datasets/url_200/", _, _, _ ->
       {:ok,
        %HTTPoison.Response{
-         body: ~s({"id":"1234","title": "Horaires de Talence"}),
+         body: ~s({"id":"1234","title": "Horaires de Talence", "organization": {"name": "Mairie de Talence"}}),
          status_code: 200
        }}
     end)
+
+    # this is shown only when we know the organization name
+    refute render(view) =~ "publié par"
 
     datagouv_info = TransportWeb.EditDatasetLive.get_datagouv_infos(input_data_gouv_url)
 
@@ -75,6 +78,9 @@ defmodule TransportWeb.EditDatasetLiveTest do
     assert render(view) =~ "Horaires de Talence"
     assert render(view) =~ "1234"
     assert render(view) =~ "pas encore référencé chez nous"
+
+    assert render(view) =~ "publié par"
+    assert render(view) =~ "Mairie de Talence"
   end
 
   test "dataset form, input url is 200, existing dataset", %{conn: conn} do


### PR DESCRIPTION
Après discussion avec les bizdevs, ce champ va être rempli dataset par dataset, il n'y a pas de notion d'organisation qui aurait toujours le même type pour tout les datasets (on n'était pas sûr que cette hypothèse soit toujours vraie). Techniquement c'est donc plus simple, il suffit de rajouter un champ dans la table `dataset`.

Je n'ai pas mis de restrictions sur les valeurs du champ en base, juste de le changeset, car ça va forcément bouger.

![image](https://user-images.githubusercontent.com/15341118/216353074-234b4b46-9a6e-4a1c-b0c0-bca282acb829.png)
