### PR TITLE
Ajout d'informations sur l'historisation dans le BO

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -80,6 +80,27 @@ defmodule DB.Dataset do
     |> DB.ResourceMetadata.join_validation_with_metadata()
   end
 
+  @doc """
+  Returns a list of resources, with their last resource_history preloaded
+  """
+  def last_resource_history(dataset_id) do
+    DB.Dataset.base_query()
+    |> where([dataset: d], d.id == ^dataset_id)
+    |> join(:left, [dataset: d], r in DB.Resource, on: d.id == r.dataset_id, as: :resource)
+    |> join(:left, [resource: r], rh in DB.ResourceHistory,
+      on: rh.resource_id == r.id,
+      as: :resource_history
+    )
+    |> distinct([resource: r], r.id)
+    |> order_by([resource: r, resource_history: rh],
+      asc: r.id,
+      desc: rh.inserted_at
+    )
+    |> preload([resource: r, resource_history: rh], resources: {r, resource_history: rh})
+    |> DB.Repo.one!()
+    |> Map.get(:resources, [])
+  end
+
   @spec type_to_str_map() :: %{binary() => binary()}
   def type_to_str_map,
     do: %{

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -161,6 +161,7 @@ defmodule TransportWeb.Backoffice.PageController do
     |> assign(:expiration_emails, notification_expiration_emails(conn.assigns[:dataset]))
     |> assign(:notifications_sent, notifications_sent(conn.assigns[:dataset]))
     |> assign(:notifications_last_nb_days, notifications_last_nb_days())
+    |> assign(:resources_with_history, DB.Dataset.last_resource_history(dataset_id))
     |> assign(
       :import_logs,
       LogsImport

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -27,13 +27,47 @@
         <% end %>
       </div>
     </div>
-    <%= if Dataset.should_skip_history?(@dataset) do %>
-      <div class="dashboard-description mt-48">
+
+    <div class="dashboard-description mt-48">
+      <h3><%= dgettext("backoffice", "Resource historization") %></h3>
+
+      <%= if Dataset.should_skip_history?(@dataset) do %>
         <p class="notification">
           <%= dgettext("backoffice", "This dataset is not historicized on purpose.") %>
         </p>
-      </div>
-    <% end %>
+      <% else %>
+        <% nb_resources = length(@resources_with_history) %>
+        <%= dngettext(
+          "backoffice",
+          "There is % {n} resource in this dataset",
+          "There are %{n} resources in this dataset",
+          nb_resources,
+          n: nb_resources
+        ) %>
+
+        <%= if nb_resources > 0 do %>
+          <table class="table">
+            <tr>
+              <th><%= dgettext("backoffice", "Resource") %></th>
+              <th><%= dgettext("backoffice", "Last historization") %></th>
+            </tr>
+            <%= for r <- @resources_with_history do %>
+              <tr>
+                <td><%= link(r.title, to: resource_path(@conn, :details, r.id)) %></td>
+                <td>
+                  <%= if r.resource_history == [] do %>
+                    🚫
+                  <% else %>
+                    <%= r.resource_history |> Enum.at(0) |> Map.get(:inserted_at) %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        <% end %>
+      <% end %>
+    </div>
+
     <div class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Expiration notifications") %></h3>
       <%= if Enum.empty?(@expiration_emails) do %>
@@ -113,4 +147,5 @@
     </div>
   <% end %>
 </div>
+<div class="pt-48"></div>
 <script src={static_path(@conn, "/js/app.js")} />

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -260,3 +260,21 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "There is % {n} resource in this dataset"
+msgid_plural "There are %{n} resources in this dataset"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Last historization"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resource"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resource historization"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -260,3 +260,21 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "There is % {n} resource in this dataset"
+msgid_plural "There are %{n} resources in this dataset"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Last historization"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resource"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Resource historization"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -260,3 +260,21 @@ msgstr "Notifications envoyées"
 #, elixir-autogen, elixir-format
 msgid "Notifications sent in the last %{nb_days} days."
 msgstr "Notifications envoyées au cours des %{nb_days} derniers jours."
+
+#, elixir-autogen, elixir-format
+msgid "There is % {n} resource in this dataset"
+msgid_plural "There are %{n} resources in this dataset"
+msgstr[0] "Il y a %{n} ressource dans ce jeu de données"
+msgstr[1] "Il y a %{n} ressources dans ce jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "Last historization"
+msgstr "Dernière historisation"
+
+#, elixir-autogen, elixir-format
+msgid "Resource"
+msgstr "Ressource"
+
+#, elixir-autogen, elixir-format
+msgid "Resource historization"
+msgstr "Historisation des ressources"

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -466,4 +466,22 @@ defmodule DB.DatasetDBTest do
     # this counts national datasets (region id = 14) with bus resources
     assert DB.Dataset.count_coach() == 1
   end
+
+  test "dataset last resource history" do
+    dataset = insert(:dataset)
+
+    r1 = insert(:resource, dataset_id: dataset.id)
+    insert(:resource_history, resource_id: r1.id, inserted_at: DateTime.utc_now() |> DateTime.add(-3, :day))
+    rh = insert(:resource_history, resource_id: r1.id, inserted_at: DateTime.utc_now())
+
+    r2 = insert(:resource, dataset_id: dataset.id)
+
+    insert(:resource)
+
+    last_resource_history = DB.Dataset.last_resource_history(dataset.id)
+
+    assert length(last_resource_history) == 2
+    assert last_resource_history |> Enum.find(&(&1.id == r1.id)) |> Map.get(:resource_history) == [rh]
+    assert last_resource_history |> Enum.find(&(&1.id == r2.id)) |> Map.get(:resource_history) == []
+  end
 end


### PR DESCRIPTION
closes https://github.com/etalab/transport-site/issues/2912

Permet de se rendre compte si une ressource n'est pas historisée depuis longtemps, ou si elle n'a jamais été historisée.

![image](https://user-images.githubusercontent.com/15341118/216581374-b6496cac-077f-4789-9153-2ed14822a313.png)
