### PR TITLE
Espace producteur : répare erreur 500 lors d'une exception

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -125,7 +125,7 @@ defmodule TransportWeb.PageController do
       |> Enum.split_with(&(elem(&1, 0) == :ok))
 
     datasets = datasets |> Enum.flat_map(&elem(&1, 1))
-    errors |> Enum.each(&Sentry.capture_exception(&1))
+    errors |> Enum.map(&inspect(elem(&1, 1))) |> Enum.each(&Sentry.capture_message(&1))
 
     # NOTE: this could be refactored in more functional style, but that will be good enough for today
     conn =

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -93,7 +93,7 @@ defmodule TransportWeb.PageControllerTest do
     end
 
     test "renders a degraded mode when data gouv returns error", %{conn: conn} do
-      with_mock Sentry, capture_exception: fn _ -> nil end do
+      with_mock Sentry, capture_message: fn _ -> nil end do
         with_mock Dataset,
           user_datasets: fn _ -> {:error, "BAD"} end,
           user_org_datasets: fn _ -> {:error, "SOMETHING"} end do
@@ -115,8 +115,8 @@ defmodule TransportWeb.PageControllerTest do
 
         # we want to be notified
         assert history == [
-                 {Sentry, :capture_exception, [error: "BAD"]},
-                 {Sentry, :capture_exception, [error: "SOMETHING"]}
+                 {Sentry, :capture_message, [~s("BAD")]},
+                 {Sentry, :capture_message, [~s("SOMETHING")]}
                ]
       end
     end


### PR DESCRIPTION
Fixes #2967

On avait une erreur 500 sur l'espace producteur quand une erreur survenait lors d'une tentative de récupération de jeux de données depuis data.gouv.fr.

```
FunctionClauseError Sentry.Event.transform_exception/2
```

on passait en fait un tuple `{:error, _}` ce qui ne correspond à ce qu'attend Sentry.


Cette PR répare ce bug, on pourra au moins savoir quel était le problème. Étant donné que le problème a été reporté par la métropole de Lyon, je dirais que l'erreur originale est un timeout de l'API qui ne retourne pas tous les nombreux jeux de données en moins de 5s. On verra !

Testé aussi en local en me mettant un mauvais token OAuth

![image](https://user-images.githubusercontent.com/295709/218997745-63aa7f35-903e-4ab1-9e06-3ed2bc12ae28.png)
