### PR TITLE
Forcer la validation depuis le Backoffice

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -315,10 +315,14 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
   def historize_and_validate_job(%{resource_id: resource_id}, options \\ []) do
     history_options = options |> Keyword.get(:history_options, []) |> Transport.Jobs.Workflow.kw_to_map()
+    validation_custom_args = options |> Keyword.get(:validation_custom_args, %{})
 
     # jobs is a list of jobs that will be enqueued as a workflow.
     # if ResourceHistoryJob is a success, ResourceHistoryValidationJob will be enqueued.
-    jobs = [[Transport.Jobs.ResourceHistoryJob, %{}, history_options], Transport.Jobs.ResourceHistoryValidationJob]
+    jobs = [
+      [Transport.Jobs.ResourceHistoryJob, %{}, history_options],
+      [Transport.Jobs.ResourceHistoryValidationJob, validation_custom_args, %{}]
+    ]
 
     Transport.Jobs.Workflow.new(%{jobs: jobs, first_job_args: %{resource_id: resource_id}})
   end

--- a/apps/transport/lib/transport_web/live/validate_dataset_view.ex
+++ b/apps/transport/lib/transport_web/live/validate_dataset_view.ex
@@ -33,7 +33,7 @@ defmodule TransportWeb.Live.ValidateDatasetView do
 
   def handle_info({:validate, dataset_id}, socket) do
     new_socket =
-      case Dataset.validate(dataset_id) do
+      case Dataset.validate(dataset_id, force_validation: true) do
         {:ok, _} ->
           assign_step(socket, :validated)
       end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -333,7 +333,7 @@ defmodule DB.DatasetDBTest do
                  "first_job_args" => %{"resource_id" => ^gtfs_resource_id},
                  "jobs" => [
                    ["Elixir.Transport.Jobs.ResourceHistoryJob", %{}, %{}],
-                   "Elixir.Transport.Jobs.ResourceHistoryValidationJob"
+                   ["Elixir.Transport.Jobs.ResourceHistoryValidationJob", %{"force_validation" => false}, %{}]
                  ]
                },
                worker: "Transport.Jobs.Workflow",
@@ -355,7 +355,7 @@ defmodule DB.DatasetDBTest do
                  "first_job_args" => %{"resource_id" => gtfs_resource_id},
                  "jobs" => [
                    ["Elixir.Transport.Jobs.ResourceHistoryJob", %{}, %{}],
-                   "Elixir.Transport.Jobs.ResourceHistoryValidationJob"
+                   ["Elixir.Transport.Jobs.ResourceHistoryValidationJob", %{"force_validation" => false}, %{}]
                  ]
                },
                worker: "Transport.Jobs.Workflow",
@@ -371,7 +371,7 @@ defmodule DB.DatasetDBTest do
                  "first_job_args" => %{"resource_id" => gtfs_resource_id},
                  "jobs" => [
                    ["Elixir.Transport.Jobs.ResourceHistoryJob", %{}, %{}],
-                   "Elixir.Transport.Jobs.ResourceHistoryValidationJob"
+                   ["Elixir.Transport.Jobs.ResourceHistoryValidationJob", %{"force_validation" => false}, %{}]
                  ]
                },
                worker: "Transport.Jobs.Workflow",

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -479,6 +479,15 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
     end
   end
 
+  test "historize and validate job workflow, with options" do
+    job = Transport.Jobs.ResourceHistoryJob.historize_and_validate_job(%{resource_id: resource_id = 123},
+      history_options: [unique: nil], validation_custom_args: %{"force_validation" => true}
+    )
+
+    assert %{changes: %{args: %{jobs: jobs, first_job_args: %{resource_id: ^resource_id}}}} = job
+    assert [[Transport.Jobs.ResourceHistoryJob, %{}, %{unique: nil}], [Transport.Jobs.ResourceHistoryValidationJob, %{"force_validation" => true}, %{}]] = jobs
+  end
+
   defp create_resources_for_history do
     %{id: active_dataset_id} = insert(:dataset, is_active: true, type: "public-transit")
     %{id: inactive_dataset_id} = insert(:dataset, is_active: false, type: "public-transit")

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -480,12 +480,18 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   end
 
   test "historize and validate job workflow, with options" do
-    job = Transport.Jobs.ResourceHistoryJob.historize_and_validate_job(%{resource_id: resource_id = 123},
-      history_options: [unique: nil], validation_custom_args: %{"force_validation" => true}
-    )
+    job =
+      Transport.Jobs.ResourceHistoryJob.historize_and_validate_job(%{resource_id: resource_id = 123},
+        history_options: [unique: nil],
+        validation_custom_args: %{"force_validation" => true}
+      )
 
     assert %{changes: %{args: %{jobs: jobs, first_job_args: %{resource_id: ^resource_id}}}} = job
-    assert [[Transport.Jobs.ResourceHistoryJob, %{}, %{unique: nil}], [Transport.Jobs.ResourceHistoryValidationJob, %{"force_validation" => true}, %{}]] = jobs
+
+    assert [
+             [Transport.Jobs.ResourceHistoryJob, %{}, %{unique: nil}],
+             [Transport.Jobs.ResourceHistoryValidationJob, %{"force_validation" => true}, %{}]
+           ] = jobs
   end
 
   defp create_resources_for_history do

--- a/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
@@ -161,7 +161,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
                    "first_job_args" => %{"resource_id" => ^resource_id},
                    "jobs" => [
                      ["Elixir.Transport.Jobs.ResourceHistoryJob", _, _],
-                     "Elixir.Transport.Jobs.ResourceHistoryValidationJob"
+                     ["Elixir.Transport.Jobs.ResourceHistoryValidationJob", %{}, %{}]
                    ]
                  }
                }

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -294,7 +294,7 @@ defmodule TransportWeb.BackofficeControllerTest do
                  "first_job_args" => %{"resource_id" => ^resource_id},
                  "jobs" => [
                    ["Elixir.Transport.Jobs.ResourceHistoryJob", %{}, %{}],
-                   "Elixir.Transport.Jobs.ResourceHistoryValidationJob"
+                   ["Elixir.Transport.Jobs.ResourceHistoryValidationJob", %{"force_validation" => false}, %{}]
                  ]
                },
                worker: "Transport.Jobs.Workflow"


### PR DESCRIPTION
Quand on clique sur "valider" sur un dataset dans le Backoffice, on force maintenant la validation.

Sinon, quand on a besoin de mettre à jour une validation, elle se fait skipper tant qu'il n'y a pas de nouvelle resource_history.

J'en ai besoin pour mettre à jour la validation de cette [ressource](https://github.com/etalab/transport-site/issues/2958).