### PR TITLE
Ajout d'abonnements à des notifications

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -5,5 +5,5 @@
   # EctoInterval raises an unknown_type error
   ~r/gtfs_stop_times.ex/,
   # Cloak.Ecto.SHA256 and DB.Encrypted.Binary raise an unknown_type error
-  ~r/contact.ex/
+  {"lib/db/contact.ex", :unknown_type, 0}
 ]

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -3,5 +3,7 @@
   ~r/deps\/postgrex\/lib\/postgrex\/type_module.ex/,
   ~r/lib\/postgrex\/type_module.ex/,
   # EctoInterval raises an unknown_type error
-  ~r/gtfs_stop_times.ex/
+  ~r/gtfs_stop_times.ex/,
+  # Cloak.Ecto.SHA256 and DB.Encrypted.Binary raise an unknown_type error
+  ~r/contact.ex/
 ]

--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -82,7 +82,7 @@ nav.navigation input {
   text-align: center;
 }
 
-.button-outline.no-border{
+.button-outline.no-border {
   border: none;
 }
 

--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -82,6 +82,14 @@ nav.navigation input {
   text-align: center;
 }
 
+.button-outline.no-border{
+  border: none;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
 #close-menu {
   display: none;
 }

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -20,6 +20,8 @@ defmodule DB.Contact do
     field(:phone_number, DB.Encrypted.Binary)
 
     timestamps(type: :utc_datetime_usec)
+
+    has_many(:notification_subscriptions, DB.NotificationSubscription, on_delete: :delete_all)
   end
 
   def base_query, do: from(c in __MODULE__, as: :contact)

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -3,12 +3,12 @@ defmodule DB.Contact do
   Represents a contact/user
   """
   use Ecto.Schema
-  import Ecto.Changeset
-  import Ecto.Query
+  use TypedEctoSchema
+  import Ecto.{Changeset, Query}
 
   @default_phone_number_region "FR"
 
-  schema "contact" do
+  typed_schema "contact" do
     field(:first_name, :string)
     field(:last_name, :string)
     field(:organization, :string)

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -57,6 +57,7 @@ defmodule DB.Dataset do
 
     has_many(:resources, Resource, on_replace: :delete, on_delete: :delete_all)
     has_many(:logs_import, LogsImport, on_replace: :delete, on_delete: :delete_all)
+    has_many(:notification_subscriptions, DB.NotificationSubscription, on_delete: :delete_all)
     # A dataset can be "parent dataset" of many AOMs
     has_many(:child_aom, AOM, foreign_key: :parent_dataset_id)
   end

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -6,7 +6,7 @@ defmodule DB.Dataset do
   There are also trigger on update on aom and region that will force an update on this model
   so the search vector is up-to-date.
   """
-  alias DB.{AOM, Commune, DatasetGeographicView, LogsImport, Region, Repo, Resource}
+  alias DB.{AOM, Commune, DatasetGeographicView, LogsImport, NotificationSubscription, Region, Repo, Resource}
   alias Phoenix.HTML.Link
   import Ecto.{Changeset, Query}
   import TransportWeb.Gettext
@@ -57,7 +57,7 @@ defmodule DB.Dataset do
 
     has_many(:resources, Resource, on_replace: :delete, on_delete: :delete_all)
     has_many(:logs_import, LogsImport, on_replace: :delete, on_delete: :delete_all)
-    has_many(:notification_subscriptions, DB.NotificationSubscription, on_delete: :delete_all)
+    has_many(:notification_subscriptions, NotificationSubscription, on_delete: :delete_all)
     # A dataset can be "parent dataset" of many AOMs
     has_many(:child_aom, AOM, foreign_key: :parent_dataset_id)
   end

--- a/apps/transport/lib/db/notification.ex
+++ b/apps/transport/lib/db/notification.ex
@@ -7,9 +7,7 @@ defmodule DB.Notification do
   import Ecto.Changeset
 
   schema "notifications" do
-    field(:reason, Ecto.Enum,
-      values: [:dataset_with_error, :resource_unavailable, :expiration, :new_dataset, :dataset_now_licence_ouverte]
-    )
+    field(:reason, Ecto.Enum, values: Ecto.Enum.mappings(DB.NotificationSubscription, :reason))
 
     belongs_to(:dataset, DB.Dataset)
     # `dataset_datagouv_id` may be useful if the linked dataset gets deleted

--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -38,9 +38,10 @@ defmodule DB.NotificationSubscription do
     if get_field(changeset, :reason) in reasons_related_to_datasets() do
       changeset |> assoc_constraint(:dataset)
     else
-      changeset
+      changeset |> validate_inclusion(:dataset_id, [nil])
     end
   end
 
+  @spec reasons_related_to_datasets :: [atom()]
   def reasons_related_to_datasets, do: @reasons_related_to_datasets
 end

--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -1,0 +1,46 @@
+defmodule DB.NotificationSubscription do
+  @moduledoc """
+  Represents a subscription to a notification type for a `DB.Contact`
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  @reasons_related_to_datasets [:expiration, :dataset_with_error, :resource_unavailable]
+  @other_reasons [:new_dataset, :dataset_now_licence_ouverte]
+
+  schema "notification_subscription" do
+    field(:reason, Ecto.Enum, values: @reasons_related_to_datasets ++ @other_reasons)
+    field(:source, Ecto.Enum, values: [:admin, :user])
+
+    belongs_to(:contact, DB.Contact)
+    belongs_to(:dataset, DB.Dataset)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def base_query, do: from(ns in __MODULE__, as: :notification_subscription)
+
+  def insert!(%{} = fields), do: %__MODULE__{} |> changeset(fields) |> DB.Repo.insert!()
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, [:contact_id, :dataset_id, :reason, :source])
+    |> validate_required([:contact_id, :dataset_id, :reason, :source])
+    |> assoc_constraint(:contact)
+    |> maybe_assoc_constraint_dataset()
+    |> unique_constraint([:contact_id, :dataset_id, :reason],
+      name: :notification_subscription_contact_id_dataset_id_reason_index
+    )
+  end
+
+  defp maybe_assoc_constraint_dataset(%Ecto.Changeset{} = changeset) do
+    if get_field(changeset, :reason) in reasons_related_to_datasets() do
+      changeset |> assoc_constraint(:dataset)
+    else
+      changeset
+    end
+  end
+
+  def reasons_related_to_datasets, do: @reasons_related_to_datasets
+end

--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -3,13 +3,13 @@ defmodule DB.NotificationSubscription do
   Represents a subscription to a notification type for a `DB.Contact`
   """
   use Ecto.Schema
-  import Ecto.Changeset
-  import Ecto.Query
+  use TypedEctoSchema
+  import Ecto.{Changeset, Query}
 
   @reasons_related_to_datasets [:expiration, :dataset_with_error, :resource_unavailable]
   @other_reasons [:new_dataset, :dataset_now_licence_ouverte]
 
-  schema "notification_subscription" do
+  typed_schema "notification_subscription" do
     field(:reason, Ecto.Enum, values: @reasons_related_to_datasets ++ @other_reasons)
     field(:source, Ecto.Enum, values: [:admin, :user])
 

--- a/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
@@ -24,12 +24,6 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
     |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
   end
 
-  defp picked_reasons(%{} = params) do
-    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
-
-    params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
-  end
-
   def delete(%Plug.Conn{} = conn, %{"id" => id}) do
     notification_subscription = DB.Repo.get!(DB.NotificationSubscription, id)
     notification_subscription |> DB.Repo.delete!()
@@ -47,5 +41,11 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
     conn
     |> put_flash(:info, "Les abonnements ont été supprimés")
     |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
+  end
+
+  defp picked_reasons(%{} = params) do
+    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
+
+    params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
   end
 end

--- a/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
@@ -1,14 +1,9 @@
 defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
   use TransportWeb, :controller
   import Ecto.Query
+  @target_html_anchor "#notification_subscriptions"
 
-  def create(
-        %Plug.Conn{} = conn,
-        %{"contact_id" => contact_id, "dataset_id" => dataset_id, "reasons" => reasons} = params
-      ) do
-    dataset_id = String.to_integer(dataset_id)
-    contact_id = String.to_integer(contact_id)
-
+  def create(%Plug.Conn{} = conn, %{"contact_id" => contact_id, "dataset_id" => dataset_id} = params) do
     existing_reasons =
       DB.NotificationSubscription.base_query()
       |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
@@ -16,7 +11,8 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
       |> DB.Repo.all()
       |> Enum.map(&to_string/1)
 
-    reasons
+    params
+    |> picked_reasons()
     |> Enum.reject(&(&1 in existing_reasons))
     |> Enum.each(fn reason ->
       %{contact_id: contact_id, dataset_id: dataset_id, reason: reason, source: :admin}
@@ -25,7 +21,13 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
 
     conn
     |> put_flash(:info, "L'abonnement a été créé")
-    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id))
+    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
+  end
+
+  defp picked_reasons(%{} = params) do
+    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
+
+    params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
   end
 
   def delete(%Plug.Conn{} = conn, %{"id" => id}) do
@@ -34,6 +36,16 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
 
     conn
     |> put_flash(:info, "L'abonnement a été supprimé")
-    |> redirect(to: backoffice_page_path(conn, :edit, notification_subscription.dataset_id))
+    |> redirect(to: backoffice_page_path(conn, :edit, notification_subscription.dataset_id) <> @target_html_anchor)
+  end
+
+  def delete_for_contact_and_dataset(%Plug.Conn{} = conn, %{"contact_id" => contact_id, "dataset_id" => dataset_id}) do
+    DB.NotificationSubscription.base_query()
+    |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
+    |> DB.Repo.delete_all()
+
+    conn
+    |> put_flash(:info, "Les abonnements ont été supprimés")
+    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
   end
 end

--- a/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
@@ -3,7 +3,10 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
   import Ecto.Query
   @target_html_anchor "#notification_subscriptions"
 
-  def create(%Plug.Conn{} = conn, %{"contact_id" => contact_id, "dataset_id" => dataset_id} = params) do
+  def create(
+        %Plug.Conn{} = conn,
+        %{"contact_id" => contact_id, "dataset_id" => dataset_id, "redirect_location" => _} = params
+      ) do
     existing_reasons =
       DB.NotificationSubscription.base_query()
       |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
@@ -21,31 +24,56 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
 
     conn
     |> put_flash(:info, "L'abonnement a été créé")
-    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
+    |> redirect(to: redirect_location(conn, params))
   end
 
-  def delete(%Plug.Conn{} = conn, %{"id" => id}) do
+  def delete(%Plug.Conn{} = conn, %{"id" => id, "redirect_location" => _} = params) do
     notification_subscription = DB.Repo.get!(DB.NotificationSubscription, id)
     notification_subscription |> DB.Repo.delete!()
 
     conn
     |> put_flash(:info, "L'abonnement a été supprimé")
-    |> redirect(to: backoffice_page_path(conn, :edit, notification_subscription.dataset_id) <> @target_html_anchor)
+    |> redirect(to: redirect_location(conn, params, notification_subscription))
   end
 
-  def delete_for_contact_and_dataset(%Plug.Conn{} = conn, %{"contact_id" => contact_id, "dataset_id" => dataset_id}) do
+  def delete_for_contact_and_dataset(
+        %Plug.Conn{} = conn,
+        %{"contact_id" => contact_id, "dataset_id" => dataset_id, "redirect_location" => _} = params
+      ) do
     DB.NotificationSubscription.base_query()
     |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
     |> DB.Repo.delete_all()
 
     conn
     |> put_flash(:info, "Les abonnements ont été supprimés")
-    |> redirect(to: backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor)
+    |> redirect(to: redirect_location(conn, params))
   end
 
   defp picked_reasons(%{} = params) do
     possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
 
     params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
+  end
+
+  defp redirect_location(
+         %Plug.Conn{} = conn,
+         %{"redirect_location" => redirect_location},
+         %DB.NotificationSubscription{} = notification_subscription
+       ) do
+    case redirect_location do
+      "contact" -> backoffice_contact_path(conn, :edit, notification_subscription.contact_id)
+      "dataset" -> backoffice_page_path(conn, :edit, notification_subscription.dataset_id)
+    end <> @target_html_anchor
+  end
+
+  defp redirect_location(%Plug.Conn{} = conn, %{
+         "contact_id" => contact_id,
+         "dataset_id" => dataset_id,
+         "redirect_location" => redirect_location
+       }) do
+    case redirect_location do
+      "contact" -> backoffice_contact_path(conn, :edit, contact_id)
+      "dataset" -> backoffice_page_path(conn, :edit, dataset_id)
+    end <> @target_html_anchor
   end
 end

--- a/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
@@ -28,8 +28,7 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
   end
 
   def delete(%Plug.Conn{} = conn, %{"id" => id, "redirect_location" => _} = params) do
-    notification_subscription = DB.Repo.get!(DB.NotificationSubscription, id)
-    notification_subscription |> DB.Repo.delete!()
+    notification_subscription = DB.NotificationSubscription |> DB.Repo.get!(id) |> DB.Repo.delete!()
 
     conn
     |> put_flash(:info, "L'abonnement a été supprimé")

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -147,7 +147,7 @@ defmodule TransportWeb.Backoffice.PageController do
   def edit(%Plug.Conn{} = conn, %{"id" => dataset_id}) do
     conn =
       Dataset
-      |> preload(:aom)
+      |> preload([:aom, :notification_subscriptions, [notification_subscriptions: :contact]])
       |> Repo.get(dataset_id)
       |> case do
         nil -> put_flash(conn, :error, dgettext("backoffice", "Unable to find dataset"))
@@ -162,6 +162,7 @@ defmodule TransportWeb.Backoffice.PageController do
     |> assign(:notifications_sent, notifications_sent(conn.assigns[:dataset]))
     |> assign(:notifications_last_nb_days, notifications_last_nb_days())
     |> assign(:resources_with_history, DB.Dataset.last_resource_history(dataset_id))
+    |> assign(:contacts_datalist, contacts_datalist())
     |> assign(
       :import_logs,
       LogsImport
@@ -170,6 +171,10 @@ defmodule TransportWeb.Backoffice.PageController do
       |> Repo.all()
     )
     |> render("form_dataset.html")
+  end
+
+  defp contacts_datalist do
+    DB.Contact.base_query() |> select([contact: c], [:first_name, :last_name, :id]) |> DB.Repo.all()
   end
 
   defp notification_expiration_emails(nil), do: []

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -124,6 +124,7 @@ defmodule TransportWeb.Router do
       scope "/notification_subscription" do
         post("/", NotificationSubscriptionController, :create)
         delete("/:id", NotificationSubscriptionController, :delete)
+        delete("/contact/:contact_id/:dataset_id", NotificationSubscriptionController, :delete_for_contact_and_dataset)
       end
 
       get("/broken-urls", BrokenUrlsController, :index)

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -112,11 +112,20 @@ defmodule TransportWeb.Router do
       pipe_through([:admin_rights])
       get("/", PageController, :index)
       get("/dashboard", DashboardController, :index)
-      get("/contacts", ContactController, :index)
-      get("/contacts/new", ContactController, :new)
-      post("/contacts/create", ContactController, :create)
-      get("/contacts/:id/edit", ContactController, :edit)
-      post("/contacts/:id/delete", ContactController, :delete)
+
+      scope "/contacts" do
+        get("/", ContactController, :index)
+        get("/new", ContactController, :new)
+        post("/create", ContactController, :create)
+        get("/:id/edit", ContactController, :edit)
+        post("/:id/delete", ContactController, :delete)
+      end
+
+      scope "/notification_subscription" do
+        post("/", NotificationSubscriptionController, :create)
+        delete("/:id", NotificationSubscriptionController, :delete)
+      end
+
       get("/broken-urls", BrokenUrlsController, :index)
       get("/gtfs-export", GTFSExportController, :export)
 

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -1,0 +1,94 @@
+<% subscriptions_with_dataset = notification_subscriptions_with_dataset(@notification_subscriptions) %>
+<% subscriptions_without_dataset = notification_subscriptions_without_dataset(@notification_subscriptions) %>
+
+<div :if={!@creating_contact} class="panel" id="notification_subscriptions">
+  <h2>Abonnements à des notifications</h2>
+
+  <h3>Créer un abonnement</h3>
+
+  <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
+    <%= hidden_input(f, :redirect_location, value: "contact") %>
+    <%= hidden_input(f, :contact_id, value: @contact_id) %>
+    <%= label f, :dataset_id do %>
+      Jeu de données <%= text_input(f, :dataset_id, required: true, list: "datasets_datalist") %>
+    <% end %>
+    <datalist id="datasets_datalist">
+      <%= for dataset <- @datasets_datalist do %>
+        <option value={dataset.id}><%= "#{dataset.custom_title} (#{dataset.type})" %></option>
+      <% end %>
+    </datalist>
+    <%= label f, :reasons, class: "pt-12" do %>
+      <%= dgettext("backoffice", "Notification reason") %>
+      <%= for reason <- DB.NotificationSubscription.reasons_related_to_datasets() do %>
+        <%= label f, reason do %>
+          <%= checkbox(f, reason, hidden_input: false, value: true) %>
+          <%= reason %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= submit("Créer un abonnement") %>
+  <% end %>
+
+  <h3>Abonnements existants</h3>
+
+  <p :if={Enum.empty?(@notification_subscriptions)} class="notification">
+    Il n'y a pas d'abonnements à des notifications pour ce contact.
+  </p>
+
+  <table :if={Enum.count(subscriptions_with_dataset) > 0} class="table mt-48 dashboard-description">
+    <tr>
+      <th>Jeu de données</th>
+      <th><%= dgettext("backoffice", "Notification reason") %></th>
+      <th>Actions</th>
+    </tr>
+    <%= for {dataset, notification_subscriptions} <- subscriptions_with_dataset do %>
+      <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
+        <tr>
+          <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
+            <strong><%= dataset.custom_title %></strong> <span class="small"><%= dataset.type %></span>
+            <br />
+            <a href={backoffice_page_path(@conn, :edit, dataset.id)}>
+              <i class="fas fa-edit"></i> Éditer le JDD
+            </a>
+            <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, @contact_id, dataset.id), [method: "delete"], fn f -> %>
+              <%= hidden_input(f, :redirect_location, value: "contact") %>
+              <button class="small button-outline warning">
+                <i class="fas fa-trash"></i> Supprimer les abonnements
+              </button>
+            <% end %>
+          </td>
+          <td><%= notification_subscription.reason %></td>
+          <td>
+            <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
+              <%= hidden_input(f, :redirect_location, value: "contact") %>
+              <button class="small button-outline warning">
+                <i class="fas fa-trash"></i> Supprimer
+              </button>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </table>
+
+  <table :if={Enum.count(subscriptions_without_dataset) > 0} class="table mt-48 dashboard-description">
+    <tr>
+      <th><%= dgettext("backoffice", "Notification reason") %></th>
+      <th>Actions</th>
+    </tr>
+    <%= for notification_subscription <- subscriptions_without_dataset do %>
+      <tr>
+        <td><%= notification_subscription.reason %></td>
+        <td>
+          <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
+            <%= hidden_input(f, :redirect_location, value: "contact") %>
+            <button class="small button-outline warning">
+              <i class="fas fa-trash"></i> Supprimer
+            </button>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -10,7 +10,7 @@
     <%= hidden_input(f, :redirect_location, value: "contact") %>
     <%= hidden_input(f, :contact_id, value: @contact_id) %>
     <%= label f, :dataset_id do %>
-      Jeu de données <%= text_input(f, :dataset_id, required: true, list: "datasets_datalist") %>
+      Jeu de données <%= text_input(f, :dataset_id, required: true, list: "datasets_datalist", pattern: "[0-9]+") %>
     <% end %>
     <datalist id="datasets_datalist">
       <%= for dataset <- @datasets_datalist do %>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -46,24 +46,26 @@
       <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
         <tr>
           <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
-            <strong><%= dataset.custom_title %></strong> <span class="small"><%= dataset.type %></span>
-            <br />
             <a href={backoffice_page_path(@conn, :edit, dataset.id)}>
-              <i class="fas fa-edit"></i> Éditer le JDD
+              <%= dataset.custom_title %>
             </a>
-            <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, @contact_id, dataset.id), [method: "delete"], fn f -> %>
-              <%= hidden_input(f, :redirect_location, value: "contact") %>
-              <button class="small button-outline warning">
-                <i class="fas fa-trash"></i> Supprimer les abonnements
-              </button>
-            <% end %>
+
+            <div class="inline-block">
+              <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, @contact_id, dataset.id), [method: "delete"], fn f -> %>
+                <%= hidden_input(f, :redirect_location, value: "contact") %>
+                <button class="small button-outline no-border warning" title="désabonner entièrement">
+                  <i class="fa-solid fa-xmark"></i>
+                </button>
+              <% end %>
+            </div>
+            <div class="small"><%= dataset.type %></div>
           </td>
           <td><%= notification_subscription.reason %></td>
           <td>
             <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
               <%= hidden_input(f, :redirect_location, value: "contact") %>
-              <button class="small button-outline warning">
-                <i class="fas fa-trash"></i> Supprimer
+              <button class="small button-outline no-border warning">
+                <i class="fas fa-trash"></i>
               </button>
             <% end %>
           </td>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -1,4 +1,5 @@
-<% creating_contact = is_nil(Ecto.Changeset.get_field(@contact, :id)) %>
+<% contact_id = Ecto.Changeset.get_field(@contact, :id) %>
+<% creating_contact = is_nil(contact_id) %>
 <div class="container mt-48 mb-24">
   <div class="panel">
     <h2 :if={creating_contact}>Créer un contact</h2>
@@ -14,7 +15,7 @@
       </div>
     <% end %>
     <%= form_for @contact, backoffice_contact_path(@conn, :create), [class: "no-margin", method: "post"], fn f -> %>
-      <%= hidden_input(f, :id, value: Ecto.Changeset.get_field(@contact, :id)) %>
+      <%= hidden_input(f, :id, value: contact_id) %>
       <%= label f, :first_name do %>
         Prénom <%= text_input(f, :first_name, required: true) %>
       <% end %>
@@ -59,8 +60,78 @@
 
   <div :if={!creating_contact} class="panel">
     <h2>Actions</h2>
-    <%= form_for @contact, backoffice_contact_path(@conn, :delete, Ecto.Changeset.get_field(@contact, :id)), [class: "no-margin", method: "post"], fn _ -> %>
+    <%= form_for @contact, backoffice_contact_path(@conn, :delete, contact_id), [class: "no-margin", method: "post"], fn _ -> %>
       <%= submit("Supprimer", class: "button warning") %>
     <% end %>
+  </div>
+
+  <div :if={!creating_contact} class="panel" id="notification_subscriptions">
+    <h2>Abonnements à des notifications</h2>
+
+    <h3>Créer un abonnement</h3>
+
+    <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
+      <%= hidden_input(f, :redirect_location, value: "contact") %>
+      <%= hidden_input(f, :contact_id, value: @contact_id) %>
+      <%= label f, :dataset_id do %>
+        Jeu de données <%= text_input(f, :dataset_id, required: true, list: "datasets_datalist") %>
+      <% end %>
+      <datalist id="datasets_datalist">
+        <%= for dataset <- @datasets_datalist do %>
+          <option value={dataset.id}><%= "#{dataset.custom_title} (#{dataset.type})" %></option>
+        <% end %>
+      </datalist>
+      <%= label f, :reasons, class: "pt-12" do %>
+        <%= dgettext("backoffice", "Notification reason") %>
+        <%= for reason <- DB.NotificationSubscription.reasons_related_to_datasets() do %>
+          <%= label f, reason do %>
+            <%= checkbox(f, reason, hidden_input: false, value: true) %>
+            <%= reason %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= submit("Créer un abonnement") %>
+    <% end %>
+
+    <h3>Abonnements existants</h3>
+    <p :if={Enum.empty?(@notification_subscriptions)} class="notification">
+      Il n'y a pas d'abonnements à des notifications pour ce contact.
+    </p>
+    <table :if={Enum.count(@notification_subscriptions) > 0} class="table dashboard-description">
+      <tr>
+        <th>Jeu de données</th>
+        <th><%= dgettext("backoffice", "Notification reason") %></th>
+        <th>Actions</th>
+      </tr>
+      <%= for {dataset, notification_subscriptions} <- @notification_subscriptions |> Enum.sort_by(&{&1.dataset.custom_title, &1.reason}) |> Enum.group_by(& &1.dataset) do %>
+        <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
+          <tr>
+            <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
+              <strong><%= dataset.custom_title %></strong> <span class="small"><%= dataset.type %></span>
+              <br />
+              <a href={backoffice_page_path(@conn, :edit, dataset.id)}>
+                <i class="fas fa-edit"></i> Éditer le JDD
+              </a>
+              <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact_id, dataset.id), [method: "delete"], fn f -> %>
+                <%= hidden_input(f, :redirect_location, value: "contact") %>
+                <button class="small button-outline warning">
+                  <i class="fas fa-trash"></i> Supprimer les abonnements
+                </button>
+              <% end %>
+            </td>
+            <td><%= notification_subscription.reason %></td>
+            <td>
+              <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
+                <%= hidden_input(f, :redirect_location, value: "contact") %>
+                <button class="small button-outline warning">
+                  <i class="fas fa-trash"></i> Supprimer
+                </button>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </table>
   </div>
 </div>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -65,73 +65,11 @@
     <% end %>
   </div>
 
-  <div :if={!creating_contact} class="panel" id="notification_subscriptions">
-    <h2>Abonnements à des notifications</h2>
-
-    <h3>Créer un abonnement</h3>
-
-    <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
-      <%= hidden_input(f, :redirect_location, value: "contact") %>
-      <%= hidden_input(f, :contact_id, value: @contact_id) %>
-      <%= label f, :dataset_id do %>
-        Jeu de données <%= text_input(f, :dataset_id, required: true, list: "datasets_datalist") %>
-      <% end %>
-      <datalist id="datasets_datalist">
-        <%= for dataset <- @datasets_datalist do %>
-          <option value={dataset.id}><%= "#{dataset.custom_title} (#{dataset.type})" %></option>
-        <% end %>
-      </datalist>
-      <%= label f, :reasons, class: "pt-12" do %>
-        <%= dgettext("backoffice", "Notification reason") %>
-        <%= for reason <- DB.NotificationSubscription.reasons_related_to_datasets() do %>
-          <%= label f, reason do %>
-            <%= checkbox(f, reason, hidden_input: false, value: true) %>
-            <%= reason %>
-          <% end %>
-        <% end %>
-      <% end %>
-
-      <%= submit("Créer un abonnement") %>
-    <% end %>
-
-    <h3>Abonnements existants</h3>
-    <p :if={Enum.empty?(@notification_subscriptions)} class="notification">
-      Il n'y a pas d'abonnements à des notifications pour ce contact.
-    </p>
-    <table :if={Enum.count(@notification_subscriptions) > 0} class="table dashboard-description">
-      <tr>
-        <th>Jeu de données</th>
-        <th><%= dgettext("backoffice", "Notification reason") %></th>
-        <th>Actions</th>
-      </tr>
-      <%= for {dataset, notification_subscriptions} <- @notification_subscriptions |> Enum.sort_by(&{&1.dataset.custom_title, &1.reason}) |> Enum.group_by(& &1.dataset) do %>
-        <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
-          <tr>
-            <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
-              <strong><%= dataset.custom_title %></strong> <span class="small"><%= dataset.type %></span>
-              <br />
-              <a href={backoffice_page_path(@conn, :edit, dataset.id)}>
-                <i class="fas fa-edit"></i> Éditer le JDD
-              </a>
-              <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact_id, dataset.id), [method: "delete"], fn f -> %>
-                <%= hidden_input(f, :redirect_location, value: "contact") %>
-                <button class="small button-outline warning">
-                  <i class="fas fa-trash"></i> Supprimer les abonnements
-                </button>
-              <% end %>
-            </td>
-            <td><%= notification_subscription.reason %></td>
-            <td>
-              <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
-                <%= hidden_input(f, :redirect_location, value: "contact") %>
-                <button class="small button-outline warning">
-                  <i class="fas fa-trash"></i> Supprimer
-                </button>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      <% end %>
-    </table>
-  </div>
+  <%= render("_notification_subscriptions.html",
+    creating_contact: creating_contact,
+    contact_id: contact_id,
+    datasets_datalist: @datasets_datalist,
+    notification_subscriptions: @notification_subscriptions,
+    conn: @conn
+  ) %>
 </div>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -147,7 +147,8 @@
                 <a href={backoffice_contact_path(@conn, :edit, contact.id)}>
                   <i class="fas fa-edit"></i> Éditer le contact
                 </a>
-                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact.id, @dataset.id), [method: "delete"], fn _f -> %>
+                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact.id, @dataset.id), [method: "delete"], fn f -> %>
+                  <%= hidden_input(f, :redirect_location, value: "dataset") %>
                   <button class="small button-outline warning">
                     <i class="fas fa-trash"></i> Supprimer les abonnements
                   </button>
@@ -155,7 +156,8 @@
               </td>
               <td><%= notification_subscription.reason %></td>
               <td>
-                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn _f -> %>
+                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
+                  <%= hidden_input(f, :redirect_location, value: "dataset") %>
                   <button class="small button-outline warning">
                     <i class="fas fa-trash"></i> Supprimer
                   </button>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -105,8 +105,10 @@
         </table>
       <% end %>
     </div>
-    <div class="dashboard-description mt-48">
+    <div id="notification_subscriptions" class="dashboard-description mt-48">
       <h3>Abonnements aux notifications</h3>
+
+      <h4>Créer un abonnement</h4>
       <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
         <%= hidden_input(f, :dataset_id, value: @dataset.id) %>
         <%= label f, :contact_id do %>
@@ -118,16 +120,19 @@
           <% end %>
         </datalist>
         <%= label f, :reasons, class: "pt-12" do %>
-          <%= dgettext("backoffice", "Notification reason") %><br />
-          <%= multiple_select(f, :reasons, DB.NotificationSubscription.reasons_related_to_datasets(),
-            selected: DB.NotificationSubscription.reasons_related_to_datasets()
-          ) %>
+          <%= dgettext("backoffice", "Notification reason") %>
+          <%= for reason <- DB.NotificationSubscription.reasons_related_to_datasets() do %>
+            <%= label f, reason do %>
+              <%= checkbox(f, reason, hidden_input: false, value: true) %>
+              <%= reason %>
+            <% end %>
+          <% end %>
         <% end %>
 
         <%= submit("Créer un abonnement") %>
       <% end %>
-
-      <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="mt-48 table">
+      <h4>Abonnements existants</h4>
+      <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="table">
         <tr>
           <th>Contact</th>
           <th><%= dgettext("backoffice", "Notification reason") %></th>
@@ -137,11 +142,16 @@
           <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
             <tr>
               <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
-                <%= notification_subscription_contact(notification_subscription) %>
+                <strong><%= notification_subscription_contact(notification_subscription) %></strong>
                 <br />
                 <a href={backoffice_contact_path(@conn, :edit, contact.id)}>
-                  <i class="fas fa-edit"></i> Éditer
+                  <i class="fas fa-edit"></i> Éditer le contact
                 </a>
+                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact.id, @dataset.id), [method: "delete"], fn _f -> %>
+                  <button class="small button-outline warning">
+                    <i class="fas fa-trash"></i> Supprimer les abonnements
+                  </button>
+                <% end %>
               </td>
               <td><%= notification_subscription.reason %></td>
               <td>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -143,24 +143,25 @@
           <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
             <tr>
               <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
-                <strong><%= notification_subscription_contact(notification_subscription) %></strong>
-                <br />
                 <a href={backoffice_contact_path(@conn, :edit, contact.id)}>
-                  <i class="fas fa-edit"></i> Éditer le contact
+                  <%= notification_subscription_contact(notification_subscription) %>
                 </a>
-                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact.id, @dataset.id), [method: "delete"], fn f -> %>
-                  <%= hidden_input(f, :redirect_location, value: "dataset") %>
-                  <button class="small button-outline warning">
-                    <i class="fas fa-trash"></i> Supprimer les abonnements
-                  </button>
-                <% end %>
+
+                <div class="inline-block">
+                  <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete_for_contact_and_dataset, contact.id, @dataset.id), [method: "delete"], fn f -> %>
+                    <%= hidden_input(f, :redirect_location, value: "dataset") %>
+                    <button class="small button-outline no-border warning" title="désabonner entièrement">
+                      <i class="fa-solid fa-xmark"></i>
+                    </button>
+                  <% end %>
+                </div>
               </td>
               <td><%= notification_subscription.reason %></td>
               <td>
                 <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn f -> %>
                   <%= hidden_input(f, :redirect_location, value: "dataset") %>
-                  <button class="small button-outline warning">
-                    <i class="fas fa-trash"></i> Supprimer
+                  <button class="small button-outline no-border warning">
+                    <i class="fas fa-trash"></i>
                   </button>
                 <% end %>
               </td>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -110,6 +110,7 @@
 
       <h4>Créer un abonnement</h4>
       <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
+        <%= hidden_input(f, :redirect_location, value: "dataset") %>
         <%= hidden_input(f, :dataset_id, value: @dataset.id) %>
         <%= label f, :contact_id do %>
           Contact <%= text_input(f, :contact_id, required: true, list: "contacts_datalist") %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -113,7 +113,7 @@
         <%= hidden_input(f, :redirect_location, value: "dataset") %>
         <%= hidden_input(f, :dataset_id, value: @dataset.id) %>
         <%= label f, :contact_id do %>
-          Contact <%= text_input(f, :contact_id, required: true, list: "contacts_datalist") %>
+          Contact <%= text_input(f, :contact_id, required: true, list: "contacts_datalist", pattern: "[0-9]+") %>
         <% end %>
         <datalist id="contacts_datalist">
           <%= for contact <- @contacts_datalist do %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -105,6 +105,60 @@
         </table>
       <% end %>
     </div>
+    <div class="dashboard-description mt-48">
+      <h3>Abonnements aux notifications</h3>
+      <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
+        <%= hidden_input(f, :dataset_id, value: @dataset.id) %>
+        <%= label f, :contact_id do %>
+          Contact <%= text_input(f, :contact_id, required: true, list: "contacts_datalist") %>
+        <% end %>
+        <datalist id="contacts_datalist">
+          <%= for contact <- @contacts_datalist do %>
+            <option value={contact.id}><%= "#{contact.first_name} #{contact.last_name}" %></option>
+          <% end %>
+        </datalist>
+        <%= label f, :reasons, class: "pt-12" do %>
+          <%= dgettext("backoffice", "Notification reason") %><br />
+          <%= multiple_select(f, :reasons, DB.NotificationSubscription.reasons_related_to_datasets(),
+            selected: DB.NotificationSubscription.reasons_related_to_datasets()
+          ) %>
+        <% end %>
+
+        <%= submit("Créer un abonnement") %>
+      <% end %>
+
+      <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="mt-48 table">
+        <tr>
+          <th>Contact</th>
+          <th><%= dgettext("backoffice", "Notification reason") %></th>
+          <th>Actions</th>
+        </tr>
+        <%= for {contact, notification_subscriptions} <- @dataset.notification_subscriptions |> Enum.sort_by(&{&1.contact.last_name, &1.reason}) |> Enum.group_by(& &1.contact) do %>
+          <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
+            <tr>
+              <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
+                <%= notification_subscription_contact(notification_subscription) %>
+                <br />
+                <a href={backoffice_contact_path(@conn, :edit, contact.id)}>
+                  <i class="fas fa-edit"></i> Éditer
+                </a>
+              </td>
+              <td><%= notification_subscription.reason %></td>
+              <td>
+                <%= form_for @conn, backoffice_notification_subscription_path(@conn, :delete, notification_subscription.id), [method: "delete"], fn _f -> %>
+                  <button class="small button-outline warning">
+                    <i class="fas fa-trash"></i> Supprimer
+                  </button>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </table>
+      <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
+        Il n'y a pas d'abonnements à des notifications pour ce jeu de données.
+      </p>
+    </div>
     <div :if={Enum.count(@notifications_sent) > 0} class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Notifications sent") %></h3>
 

--- a/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
@@ -8,6 +8,19 @@ defmodule TransportWeb.Backoffice.ContactView do
     PaginationHelpers.pagination_links(conn, contacts, kwargs)
   end
 
+  defp notification_subscriptions_with_dataset(records) do
+    records
+    |> Enum.reject(&is_nil(&1.dataset_id))
+    |> Enum.sort_by(&{&1.dataset.custom_title, &1.reason})
+    |> Enum.group_by(& &1.dataset)
+  end
+
+  defp notification_subscriptions_without_dataset(records) do
+    records
+    |> Enum.filter(&is_nil(&1.dataset_id))
+    |> Enum.sort_by(& &1.reason)
+  end
+
   @spec add_filter(list, map) :: list
   defp add_filter(kwargs, params) do
     params

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -63,4 +63,8 @@ defmodule TransportWeb.Backoffice.PageView do
         "<i class=\"sort-icon fa fa-sort-up\"></i>"
     end
   end
+
+  def notification_subscription_contact(%DB.NotificationSubscription{contact: %DB.Contact{} = contact}) do
+    "#{contact.first_name} #{contact.last_name} — #{contact.job_title} (#{contact.organization})"
+  end
 end

--- a/apps/transport/priv/repo/migrations/20230220102200_add_notification_subscription.exs
+++ b/apps/transport/priv/repo/migrations/20230220102200_add_notification_subscription.exs
@@ -1,0 +1,22 @@
+defmodule DB.Repo.Migrations.AddNotificationSubscription do
+  use Ecto.Migration
+
+  def change do
+    create table(:notification_subscription) do
+      add :contact_id, references(:contact, on_delete: :delete_all)
+      add :dataset_id, references(:dataset, on_delete: :delete_all), null: true
+      add :reason, :string, null: false
+      add :source, :string, null: false
+
+      timestamps([type: :utc_datetime_usec])
+    end
+
+    create index(:notification_subscription, [:contact_id])
+    create index(:notification_subscription, [:dataset_id])
+    create unique_index(
+      :notification_subscription,
+      [:contact_id, :dataset_id, :reason],
+      name: :notification_subscription_contact_id_dataset_id_reason_index
+    )
+  end
+end

--- a/apps/transport/priv/repo/migrations/20230220102200_add_notification_subscription.exs
+++ b/apps/transport/priv/repo/migrations/20230220102200_add_notification_subscription.exs
@@ -3,7 +3,7 @@ defmodule DB.Repo.Migrations.AddNotificationSubscription do
 
   def change do
     create table(:notification_subscription) do
-      add :contact_id, references(:contact, on_delete: :delete_all)
+      add :contact_id, references(:contact, on_delete: :delete_all), null: false
       add :dataset_id, references(:dataset, on_delete: :delete_all), null: true
       add :reason, :string, null: false
       add :source, :string, null: false

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -229,4 +229,8 @@ defmodule DB.Factory do
     |> DB.Notification.changeset(args)
     |> DB.Repo.insert!()
   end
+
+  def notification_subscription_factory do
+    %DB.NotificationSubscription{}
+  end
 end

--- a/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule TransportWeb.BreakingNewsControllerTest do
+defmodule TransportWeb.NotificationSubscriptionControllerTest do
   use TransportWeb.ConnCase, async: true
   import Ecto.Query
   import DB.Factory

--- a/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
@@ -13,6 +13,7 @@ defmodule TransportWeb.NotificationSubscriptionControllerTest do
     %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
 
     args = %{
+      "redirect_location" => "dataset",
       "dataset_id" => dataset_id,
       "contact_id" => contact_id,
       "expiration" => "true",
@@ -77,7 +78,9 @@ defmodule TransportWeb.NotificationSubscriptionControllerTest do
     conn_response =
       conn
       |> setup_admin_in_session()
-      |> delete(backoffice_notification_subscription_path(conn, :delete, subscription_id))
+      |> delete(backoffice_notification_subscription_path(conn, :delete, subscription_id), %{
+        "redirect_location" => "dataset"
+      })
 
     assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
     assert get_flash(conn_response, :info) =~ "L'abonnement a été supprimé"
@@ -116,7 +119,8 @@ defmodule TransportWeb.NotificationSubscriptionControllerTest do
       conn
       |> setup_admin_in_session()
       |> delete(
-        backoffice_notification_subscription_path(conn, :delete_for_contact_and_dataset, contact_id, dataset_id)
+        backoffice_notification_subscription_path(conn, :delete_for_contact_and_dataset, contact_id, dataset_id),
+        %{"redirect_location" => "dataset"}
       )
 
     assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor

--- a/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
@@ -1,0 +1,145 @@
+defmodule TransportWeb.BreakingNewsControllerTest do
+  use TransportWeb.ConnCase, async: true
+  import Ecto.Query
+  import DB.Factory
+  @target_html_anchor "#notification_subscriptions"
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "create", %{conn: conn} do
+    %DB.Dataset{id: dataset_id} = insert(:dataset)
+    %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
+
+    args = %{
+      "dataset_id" => dataset_id,
+      "contact_id" => contact_id,
+      "expiration" => "true",
+      "resource_unavailable" => "true",
+      # Should be ignored because this is not a valid reason
+      "ignored_notification_reason" => "true",
+      # Ignored because it's set to false (happens only when manipulating requests)
+      "dataset_with_error" => "false"
+    }
+
+    conn_response =
+      conn
+      |> setup_admin_in_session()
+      |> post(backoffice_notification_subscription_path(conn, :create, args))
+
+    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+    assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
+
+    assert [
+             %DB.NotificationSubscription{
+               contact_id: ^contact_id,
+               dataset_id: ^dataset_id,
+               source: :admin,
+               reason: :expiration
+             },
+             %DB.NotificationSubscription{
+               contact_id: ^contact_id,
+               dataset_id: ^dataset_id,
+               source: :admin,
+               reason: :resource_unavailable
+             }
+           ] = DB.NotificationSubscription |> DB.Repo.all() |> Enum.sort_by(& &1.reason)
+
+    # Sending a request again, but with a new valid reason. Should not try to create duplicates.
+    conn_response =
+      conn
+      |> setup_admin_in_session()
+      |> post(backoffice_notification_subscription_path(conn, :create, Map.put(args, "dataset_with_error", "true")))
+
+    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+    assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
+
+    assert MapSet.new([:dataset_with_error, :expiration, :resource_unavailable]) ==
+             DB.NotificationSubscription.base_query()
+             |> select([notification_subscription: ns], ns.reason)
+             |> DB.Repo.all()
+             |> MapSet.new()
+  end
+
+  test "delete", %{conn: conn} do
+    %DB.Dataset{id: dataset_id} = insert(:dataset)
+    %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
+
+    %DB.NotificationSubscription{id: subscription_id} =
+      insert(:notification_subscription,
+        contact_id: contact_id,
+        dataset_id: dataset_id,
+        reason: :expiration,
+        source: :admin
+      )
+
+    conn_response =
+      conn
+      |> setup_admin_in_session()
+      |> delete(backoffice_notification_subscription_path(conn, :delete, subscription_id))
+
+    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+    assert get_flash(conn_response, :info) =~ "L'abonnement a été supprimé"
+
+    assert DB.NotificationSubscription |> DB.Repo.all() |> Enum.empty?()
+  end
+
+  test "delete_for_contact_and_dataset", %{conn: conn} do
+    %DB.Dataset{id: dataset_id} = insert(:dataset)
+    %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
+    %DB.Contact{id: other_contact_id} = DB.Contact.insert!(sample_contact_args())
+
+    insert(:notification_subscription,
+      contact_id: contact_id,
+      dataset_id: dataset_id,
+      reason: :expiration,
+      source: :admin
+    )
+
+    insert(:notification_subscription,
+      contact_id: contact_id,
+      dataset_id: dataset_id,
+      reason: :dataset_with_error,
+      source: :admin
+    )
+
+    # A subscription, but for another contact.
+    insert(:notification_subscription,
+      contact_id: other_contact_id,
+      dataset_id: dataset_id,
+      reason: :dataset_with_error,
+      source: :admin
+    )
+
+    conn_response =
+      conn
+      |> setup_admin_in_session()
+      |> delete(
+        backoffice_notification_subscription_path(conn, :delete_for_contact_and_dataset, contact_id, dataset_id)
+      )
+
+    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+    assert get_flash(conn_response, :info) =~ "Les abonnements ont été supprimés"
+
+    assert [
+             %DB.NotificationSubscription{
+               contact_id: ^other_contact_id,
+               dataset_id: ^dataset_id,
+               reason: :dataset_with_error,
+               source: :admin
+             }
+           ] = DB.NotificationSubscription |> DB.Repo.all()
+  end
+
+  defp sample_contact_args do
+    %{
+      first_name: "John",
+      last_name: "Doe",
+      email: "john#{Ecto.UUID.generate()}@example.fr",
+      job_title: "Boss",
+      organization: "Big Corp Inc",
+      phone_number: "06 92 22 88 03"
+    }
+  end
+end


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2965

Cette PR (un peu grosse, désolé 🙈) ajoute la possibilité d'inscrire des contacts à des motifs de notifications depuis le backoffice.

Ce qui est inclut :
- ajout de la table et du modèle `notification_subscriptions`
- ajout de `TransportWeb.Backoffice.NotificationSubscriptionController` qui gère la création et la suppression d'abonnements à des notifications
- mise à jour de `dataset#edit` et `contact#edit` pour créer et supprimer des abonnements aux notifications en prenant comme référence un JDD ou un contact
- mise à jour du code existant pour charger les abonnements aux notifications dans les situations pertinentes

Le code HEEX est assez lourd car il y a des tableaux à générer, avec les bons boutons pour avoir des actions de création ou de suppression d'abonnements.

## Choses non traitées et à venir

- Migration de la configuration existante YAML vers la base de données
- Suppression et adaption du code qui gère l'envoi de notifications à partir de la conf YAML
- Suppression et adaption de quelques UIs de backoffice utilisées par la conf YAML
- Archive du dépôt [🔒 transport-notifications](https://github.com/etalab/transport-notifications)

## Interfaces

Il est préférable de tester ceci en local, néanmoins voici quelques captures d'écrans.

### Côté Contact
![image](https://user-images.githubusercontent.com/295709/220578004-cffc8b40-7008-4a53-9c13-45266644f94d.png)

### Côté Dataset
![image](https://user-images.githubusercontent.com/295709/220578102-902a0b76-48f6-49c4-8fce-1ccff693b858.png)

