### PR TITLE
Schemas : ignore les datapackage

### DIFF
--- a/apps/shared/lib/schemas.ex
+++ b/apps/shared/lib/schemas.ex
@@ -100,7 +100,9 @@ defmodule Transport.Shared.Schemas do
       body
       |> Jason.decode!()
       |> Map.fetch!("schemas")
-      |> Enum.filter(&Enum.member?(&1["labels"], "transport.data.gouv.fr"))
+      |> Enum.filter(
+        &(Enum.member?(&1["labels"], "transport.data.gouv.fr") and Map.fetch!(&1, "schema_type") != "datapackage")
+      )
       |> Enum.into(%{}, fn schema -> {Map.fetch!(schema, "name"), schema} end)
     end
 

--- a/apps/shared/test/fixtures/schemas.json
+++ b/apps/shared/test/fixtures/schemas.json
@@ -158,6 +158,29 @@
          "external_doc":null,
          "external_tool":null,
          "homepage":"https://github.com/etalab/schema-lieux-covoiturage.git"
+      },
+      {
+         "name": "etalab/schema-irve",
+         "title": "Infrastructures de recharges pour véhicules électriques",
+         "description": "data package contenant 2 schémas : IRVE statique et IRVE dynamique",
+         "schema_url": "https://schema.data.gouv.fr/schemas/etalab/schema-irve/latest/datapackage.json",
+         "schema_type": "datapackage",
+         "contact": "contact@transport.beta.gouv.fr",
+         "examples": [],
+         "labels": [
+            "Socle Commun des Données Locales",
+            "transport.data.gouv.fr"
+         ],
+         "consolidation_dataset_id": "5448d3e0c751df01f85d0572",
+         "versions": [
+            {
+               "version_name": "2.2.0",
+               "schema_url": "https://schema.data.gouv.fr/schemas/etalab/schema-irve/2.2.0/datapackage.json"
+            }
+         ],
+         "external_doc": "https://doc.transport.data.gouv.fr/producteurs/infrastructures-de-recharge-de-vehicules-electriques-irve",
+         "external_tool": null,
+         "homepage": "https://github.com/etalab/schema-irve.git"
       }
    ]
 }


### PR DESCRIPTION
Fixes #2985

Ignore les datapackages qui sont présents sur [`schemas.json`](https://schema.data.gouv.fr/schemas.json). Ce ne sont pas de "vrais" schémas et en conséquence ils sont affichés sur des pages comme `/validation`, ce qui n'est pas un comportement souhaité.

Si on souhaite les utiliser directement plus tard on pourra voir pour ne pas les exclure aussi "haut" dans les traitements.