### PR TITLE
Ajout scripts pour insérer contacts et abonnements

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -26,7 +26,7 @@ defmodule DB.NotificationSubscription do
   def changeset(struct, attrs \\ %{}) do
     struct
     |> cast(attrs, [:contact_id, :dataset_id, :reason, :source])
-    |> validate_required([:contact_id, :dataset_id, :reason, :source])
+    |> validate_required([:contact_id, :reason, :source])
     |> assoc_constraint(:contact)
     |> maybe_assoc_constraint_dataset()
     |> unique_constraint([:contact_id, :dataset_id, :reason],
@@ -36,7 +36,7 @@ defmodule DB.NotificationSubscription do
 
   defp maybe_assoc_constraint_dataset(%Ecto.Changeset{} = changeset) do
     if get_field(changeset, :reason) in reasons_related_to_datasets() do
-      changeset |> assoc_constraint(:dataset)
+      changeset |> validate_required(:dataset_id) |> assoc_constraint(:dataset)
     else
       changeset |> validate_inclusion(:dataset_id, [nil])
     end

--- a/apps/transport/test/db/notification_subscription_test.exs
+++ b/apps/transport/test/db/notification_subscription_test.exs
@@ -1,0 +1,86 @@
+defmodule DB.NotificationSubscriptionTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  alias DB.NotificationSubscription
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "changeset" do
+    contact = DB.Contact.insert!(sample_contact_args())
+    dataset = insert(:dataset)
+    changeset = fn args -> NotificationSubscription.changeset(%NotificationSubscription{}, args) end
+
+    # valid cases
+    assert %Ecto.Changeset{valid?: true} =
+             changeset.(%{
+               source: :admin,
+               reason: :dataset_now_licence_ouverte,
+               contact_id: contact.id
+             })
+
+    assert %Ecto.Changeset{valid?: true} =
+             changeset.(%{
+               source: :admin,
+               reason: :expiration,
+               contact_id: contact.id,
+               dataset_id: dataset.id
+             })
+
+    # `dataset_id` can't be blank and should exist if the `reason` is related to a dataset
+    assert %Ecto.Changeset{valid?: false, errors: [dataset_id: {"can't be blank", [validation: :required]}]} =
+             changeset.(%{
+               source: :admin,
+               reason: :expiration,
+               contact_id: contact.id,
+               dataset_id: nil
+             })
+
+    assert {:error, %Ecto.Changeset{valid?: false, errors: [dataset: {"does not exist", _}]}} =
+             %{
+               source: :admin,
+               reason: :expiration,
+               contact_id: contact.id,
+               dataset_id: -1
+             }
+             |> changeset.()
+             |> DB.Repo.insert()
+
+    # `contact_id` can never be blank and should exist
+    assert %Ecto.Changeset{valid?: false, errors: [contact_id: {"can't be blank", [validation: :required]}]} =
+             changeset.(%{
+               source: :admin,
+               reason: :dataset_now_licence_ouverte,
+               contact_id: nil
+             })
+
+    assert {:error, %Ecto.Changeset{valid?: false, errors: [contact: {"does not exist", _}]}} =
+             %{
+               source: :admin,
+               reason: :dataset_now_licence_ouverte,
+               contact_id: -1
+             }
+             |> changeset.()
+             |> DB.Repo.insert()
+
+    # `source` is an enum
+    assert %Ecto.Changeset{valid?: false, errors: [source: {"is invalid", _}]} =
+             changeset.(%{
+               source: :foo,
+               reason: :dataset_now_licence_ouverte,
+               contact_id: contact.id
+             })
+  end
+
+  defp sample_contact_args do
+    %{
+      first_name: "John",
+      last_name: "Doe",
+      email: "john#{Ecto.UUID.generate()}@example.fr",
+      job_title: "Boss",
+      organization: "Big Corp Inc",
+      phone_number: "06 92 22 88 03"
+    }
+  end
+end

--- a/scripts/contacts/insert_contacts.exs
+++ b/scripts/contacts/insert_contacts.exs
@@ -1,0 +1,28 @@
+# Insert `DB.Contact` rows from a CSV file created by our team.
+# Sample content:
+# ```
+# email,first_name,last_name,job_title,organization,phone_number
+# foo.bar@example.fr,Foo,Bar,Boss,Loire Atlantique,
+# ```
+# See https://mattermost.incubateur.net/betagouv/pl/io33ern89traxkhmac5x1ue1ho
+# Run with `mix run scripts/contacts/insert_contacts.exs`
+csv_config_filepath = "/tmp/contacts.csv"
+
+csv_config_filepath
+|> File.stream!()
+|> CSV.decode!(headers: true)
+|> Enum.to_list()
+|> Enum.each(fn %{} = data ->
+  {_, data} =
+    Map.get_and_update(data, "organization", fn current_value ->
+      new_value =
+        case current_value do
+          "" -> "?"
+          other -> other
+        end
+
+      {current_value, new_value}
+    end)
+
+  DB.Contact.insert!(data)
+end)

--- a/scripts/contacts/insert_notification_subscriptions.exs
+++ b/scripts/contacts/insert_notification_subscriptions.exs
@@ -1,0 +1,38 @@
+# Insert `DB.NotificationSubscription` rows in the database using a notifications' config in YAML.
+# It looks up for the associated dataset and contact, which must exist.
+# Run with `mix run scripts/contacts/insert_notification_subscriptions.exs`
+
+yaml_config_filepath = "/tmp/config.yml"
+
+defmodule Converter do
+  def convert({"expiration", data}) do
+    Enum.flat_map(data, fn {slug, %{"emails" => emails}} ->
+      Enum.map(emails, fn email -> ["expiration", slug, String.downcase(email)] end)
+    end)
+  end
+
+  def convert({reason, emails}) do
+    Enum.map(emails, fn email -> [reason, nil, String.downcase(email)] end)
+  end
+end
+
+yaml_config_filepath
+|> File.read!()
+|> YamlElixir.read_from_string!()
+|> Enum.flat_map(&Converter.convert/1)
+|> Enum.map(fn [reason, dataset_slug, email] ->
+  dataset_id =
+    case dataset_slug do
+      nil -> nil
+      slug when is_binary(slug) -> DB.Repo.get_by!(DB.Dataset, slug: slug).id
+    end
+
+  contact_id = DB.Repo.get_by!(DB.Contact, email_hash: email).id
+
+  DB.NotificationSubscription.insert!(%{
+    contact_id: contact_id,
+    dataset_id: dataset_id,
+    source: :admin,
+    reason: reason
+  })
+end)


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/2981

Cette PR ajoute :
- un script d'import de contacts à partir d'un fichier CSV, pour alimenter notre base de données pour ~130 contacts
- un script d'import d'abonnements à des notifications, pour les contacts précédemment importés

C'est une étape de migration de la [configuration YAML](https://github.com/etalab/transport-notifications) vers l'import en base de données