### PR TITLE
Ajout d'une page décrivant les missions du PAN

### DIFF
--- a/apps/transport/client/stylesheets/home.scss
+++ b/apps/transport/client/stylesheets/home.scss
@@ -79,7 +79,6 @@ html {
   flex-wrap: wrap;
   justify-content: space-around;
   align-items: stretch;
-  padding-bottom: 48px;
   .pan-offer {
     text-align: center;
     display: flex;

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -72,6 +72,10 @@ defmodule TransportWeb.PageController do
     single_page(conn, %{"page" => "accessibility"})
   end
 
+  def missions(conn, _params) do
+    single_page(conn, %{"page" => "missions"})
+  end
+
   def infos_producteurs(conn, _params) do
     conn
     |> assign(:mailchimp_newsletter_url, Application.get_env(:transport, :mailchimp_newsletter_url))

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -48,6 +48,7 @@ defmodule TransportWeb.Router do
     pipe_through(:browser)
     get("/", PageController, :index)
     get("/real_time", PageController, :real_time)
+    get("/missions", PageController, :missions)
     get("/accessibilite", PageController, :accessibility)
     get("/infos_producteurs", PageController, :infos_producteurs)
     get("/robots.txt", PageController, :robots_txt)

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -50,6 +50,14 @@
             </div>
           </li>
           <li class="nav__item">
+            <div class="dropdown">
+              <%= gettext("About") %>
+              <div class="dropdown-content">
+                <%= link(gettext("Our missions"), to: page_path(@conn, :missions)) %>
+              </div>
+            </div>
+          </li>
+          <li class="nav__item">
             <%= link(gettext("Blog"), to: "https://blog.transport.data.gouv.fr") %>
           </li>
           <%= if assigns[:current_user] do %>

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -78,6 +78,9 @@
         <%= dgettext("page-index", "Online tools to ease data reuses") %>
       </div>
     </div>
+    <p class="text-center">
+      <a href={page_path(@conn, :missions)}><%= dgettext("page-index", "Learn more about our missions") %></a>
+    </p>
 
     <div class="existing pt-48" id="datasets">
       <h1><%= dgettext("page-index", "Available data by theme") %></h1>

--- a/apps/transport/lib/transport_web/templates/page/missions.html.md
+++ b/apps/transport/lib/transport_web/templates/page/missions.html.md
@@ -1,0 +1,25 @@
+<%= raw ~s(<div lang=fr>) %>
+
+# Missions menées par le Point d'Accès National
+
+## Contexte
+
+Au carrefour d’enjeux environnementaux, sociaux et économiques, les solutions de déplacement sont en constante évolution, se caractérisant en particulier par une diversification des modes et services de mobilités. Cette multitude de solutions appelle, non seulement à être porté à la connaissance des usagers, mais surtout à faire l’objet d’une réelle articulation, notamment pour les rendre complémentaires, et ainsi s’inscrire dans une optique globale de report modal de l’usage individuel du véhicule vers des modes alternatifs plus vertueux.
+
+## Le problème de politique publique
+
+Au cœur de ce bouquet fleurissant de solutions de déplacements, les voyageurs sont susceptibles de ne pas trouver les informations nécessaires pour réaliser leurs déplacements, voire même de ne pas avoir connaissance de l’existence de service de transport. Ceci conduit en particulier à constituer un réel frein à la mobilité, ou du moins favoriser l’usage de la voiture, au détriment donc des modes alternatifs.
+
+## La solution transport.data.gouv.fr
+
+transport.data.gouv.fr est un produit numérique, qui se positionne en tant que plateforme de données entre des producteurs (autorités organisatrices de la mobilité, opérateurs de transport, système d’aide à l’exploitation, gestionnaires d’infrastructures) et des réutilisateurs (services numériques d’information voyageurs). La proposition de valeur consiste à rendre disponible facilement sur un point d’accès unique l’ensemble des données utiles à l’information des voyageurs, notamment sur des modes et services de mobilités durables, dans des conditions techniques et juridiques les plus adéquates à la réutilisation.
+
+## Nos missions
+
+transport.data.gouv.fr c’est également une équipe au service de l’écosystème dans lequel s’inscrit le produit, qui s’attache en particulier à (i) accompagner les producteurs de données dans le processus d’ouverture, et (ii) inciter les services numériques d’information voyageurs à intégrer les données ainsi ouvertes.
+
+D’une manière plus générale, transport.data.gouv.fr est le Point d’accès national officiel pour les données de mobilités en France, ce qui conduit également à jouer un rôle d’animateur au sein de l’écosystème, à agir en tiers de confiance, à apporter du liant entre les acteurs, et à dessiner les perspectives de référence en matière de données de transport.
+
+Enfin, nous veillons à proposer une plateforme parfaitement opérationnelle pour répondre à la demande de l’écosystème. Dans une logique de développement continu, notre infrastructure numérique évolue en effet selon les besoins exprimés par les producteurs, réutilisateurs ou l’équipe projet, avec le déploiement de nouvelles fonctionnalités, ou de nouveaux outils, pour faciliter l’ouverture de données, améliorer leur qualité, leur découvrabilité, et ainsi inciter à leur réutilisation.
+
+<%= raw ~s(</div>) %>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -30,6 +30,9 @@
           <div>Réutilisations déclarées</div>
         </div>
       </div>
+      <p>
+        <a href={page_path(@conn, :missions)}>Découvrez la politique publique mise en œuvre et nos missions</a>.
+      </p>
     </div>
     <div class="domain theorical">
       <h2>Transports en commun - horaires théoriques</h2>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -126,3 +126,11 @@ msgstr ""
 #, elixir-autogen
 msgid "Budget"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "About"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Our missions"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -126,3 +126,11 @@ msgstr ""
 #, elixir-autogen
 msgid "Budget"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "About"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Our missions"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -201,3 +201,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "They help us achieve our mission"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about our missions"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -126,3 +126,11 @@ msgstr "Générateur de requêtes SIRI"
 #, elixir-autogen
 msgid "Budget"
 msgstr "Budget"
+
+#, elixir-autogen, elixir-format
+msgid "About"
+msgstr "À propos"
+
+#, elixir-autogen, elixir-format
+msgid "Our missions"
+msgstr "Nos missions"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -204,4 +204,4 @@ msgstr "Ils nous aident dans notre mission"
 
 #, elixir-autogen, elixir-format
 msgid "Learn more about our missions"
-msgstr ""
+msgstr "Découvrez les missions que nous menons"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -201,3 +201,7 @@ msgstr "liste complète"
 #, elixir-autogen, elixir-format
 msgid "They help us achieve our mission"
 msgstr "Ils nous aident dans notre mission"
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about our missions"
+msgstr ""

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -201,3 +201,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "They help us achieve our mission"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about our missions"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -160,6 +160,10 @@ defmodule TransportWeb.PageControllerTest do
     conn |> get(page_path(conn, :accessibility)) |> html_response(200)
   end
 
+  test "missions page", %{conn: conn} do
+    conn |> get(page_path(conn, :missions)) |> html_response(200)
+  end
+
   test "budget page", %{conn: conn} do
     conn |> get("/budget") |> redirected_to(302) =~ "https://doc.transport.data.gouv.fr"
   end


### PR DESCRIPTION
Reprise de la [Fiche produit du PAN](https://docs.google.com/document/d/1Iw1HsnVBjbQmYOvifnL63ydy4nK5nBF9khh7HvWwb_o/edit) écrite par @Benoit-MINT pour valoriser les missions menées par le PAN.

La page est en Markdown dans le code, elle reste donc facilement modifiable.

## Page /missions
![image](https://user-images.githubusercontent.com/295709/221815227-60b7108f-dfd1-4893-96cc-33dd6534bc64.png)

## Liens vers cette page depuis l'accueil et la page stats

![image](https://user-images.githubusercontent.com/295709/221815569-7592a950-1119-432c-b607-0341393d8912.png)

![image](https://user-images.githubusercontent.com/295709/221815314-14a75191-d589-43f4-9f4f-32b171a69740.png)

