### PR TITLE
Améliorations d'UI pour contacts et abonnements

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -39,7 +39,7 @@ defmodule DB.Contact do
     struct
     |> cast(attrs, [:first_name, :last_name, :organization, :job_title, :email, :phone_number])
     |> trim_fields([:first_name, :last_name, :organization, :job_title])
-    |> capitalize_fields([:first_name, :last_name, :job_title])
+    |> capitalize_fields([:first_name, :last_name])
     |> validate_required([:first_name, :last_name, :organization, :email])
     |> validate_format(:email, ~r/@/)
     |> cast_phone_number()

--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -45,6 +45,12 @@ defmodule DB.NotificationSubscription do
   @spec reasons_related_to_datasets :: [atom()]
   def reasons_related_to_datasets, do: @reasons_related_to_datasets
 
+  @spec other_reasons :: [atom()]
+  def other_reasons, do: @other_reasons
+
+  @spec possible_reasons :: [atom()]
+  def possible_reasons, do: reasons_related_to_datasets() ++ other_reasons()
+
   @spec subscriptions_for_reason(atom()) :: [__MODULE__.t()]
   def subscriptions_for_reason(reason) do
     base_query()

--- a/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/notification_subscription_controller.ex
@@ -7,12 +7,7 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
         %Plug.Conn{} = conn,
         %{"contact_id" => contact_id, "dataset_id" => dataset_id, "redirect_location" => _} = params
       ) do
-    existing_reasons =
-      DB.NotificationSubscription.base_query()
-      |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
-      |> select([notification_subscription: ns], ns.reason)
-      |> DB.Repo.all()
-      |> Enum.map(&to_string/1)
+    existing_reasons = existing_reasons(params)
 
     params
     |> picked_reasons()
@@ -24,6 +19,31 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
 
     conn
     |> put_flash(:info, "L'abonnement a été créé")
+    |> redirect(to: redirect_location(conn, params))
+  end
+
+  def create(%Plug.Conn{} = conn, %{"contact_id" => contact_id, "redirect_location" => "contact"} = params) do
+    possible_reasons = DB.NotificationSubscription.other_reasons()
+    picked_reasons = params |> picked_reasons()
+
+    DB.NotificationSubscription.base_query()
+    |> where(
+      [notification_subscription: ns],
+      ns.reason not in ^picked_reasons and ns.contact_id == ^contact_id and ns.reason in ^possible_reasons
+    )
+    |> DB.Repo.delete_all()
+
+    existing_reasons = existing_reasons(params)
+
+    picked_reasons
+    |> Enum.reject(&(&1 in existing_reasons))
+    |> Enum.each(fn reason ->
+      %{contact_id: contact_id, reason: reason, dataset_id: nil, source: :admin}
+      |> DB.NotificationSubscription.insert!()
+    end)
+
+    conn
+    |> put_flash(:info, "Abonnements mis à jour")
     |> redirect(to: redirect_location(conn, params))
   end
 
@@ -49,30 +69,44 @@ defmodule TransportWeb.Backoffice.NotificationSubscriptionController do
   end
 
   defp picked_reasons(%{} = params) do
-    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
+    possible_reasons = DB.NotificationSubscription.possible_reasons() |> Enum.map(&to_string/1)
 
     params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
   end
 
-  defp redirect_location(
-         %Plug.Conn{} = conn,
-         %{"redirect_location" => redirect_location},
-         %DB.NotificationSubscription{} = notification_subscription
-       ) do
-    case redirect_location do
-      "contact" -> backoffice_contact_path(conn, :edit, notification_subscription.contact_id)
-      "dataset" -> backoffice_page_path(conn, :edit, notification_subscription.dataset_id)
-    end <> @target_html_anchor
+  defp existing_reasons(%{"contact_id" => contact_id, "dataset_id" => dataset_id}) do
+    DB.NotificationSubscription.base_query()
+    |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id == ^contact_id)
+    |> existing_reasons()
   end
 
-  defp redirect_location(%Plug.Conn{} = conn, %{
-         "contact_id" => contact_id,
-         "dataset_id" => dataset_id,
-         "redirect_location" => redirect_location
-       }) do
-    case redirect_location do
-      "contact" -> backoffice_contact_path(conn, :edit, contact_id)
-      "dataset" -> backoffice_page_path(conn, :edit, dataset_id)
-    end <> @target_html_anchor
+  defp existing_reasons(%{"contact_id" => contact_id}) do
+    DB.NotificationSubscription.base_query()
+    |> where([notification_subscription: ns], is_nil(ns.dataset_id) and ns.contact_id == ^contact_id)
+    |> existing_reasons()
+  end
+
+  defp existing_reasons(%Ecto.Query{} = query) do
+    query
+    |> select([notification_subscription: ns], ns.reason)
+    |> DB.Repo.all()
+    |> Enum.map(&to_string/1)
+  end
+
+  defp redirect_location(
+         %Plug.Conn{} = conn,
+         %{"redirect_location" => redirect_location} = params,
+         %DB.NotificationSubscription{} = notification_subscription
+       ) do
+    key = redirect_location <> "_id"
+    redirect_location(conn, Map.put(params, key, Map.fetch!(notification_subscription, String.to_existing_atom(key))))
+  end
+
+  defp redirect_location(%Plug.Conn{} = conn, %{"redirect_location" => "contact", "contact_id" => contact_id}) do
+    backoffice_contact_path(conn, :edit, contact_id) <> @target_html_anchor
+  end
+
+  defp redirect_location(%Plug.Conn{} = conn, %{"redirect_location" => "dataset", "dataset_id" => dataset_id}) do
+    backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
   end
 end

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -1,10 +1,13 @@
 <% subscriptions_with_dataset = notification_subscriptions_with_dataset(@notification_subscriptions) %>
 <% subscriptions_without_dataset = notification_subscriptions_without_dataset(@notification_subscriptions) %>
+<% reasons_subscribed_without_dataset = subscriptions_without_dataset |> Enum.map(& &1.reason) |> Enum.uniq() %>
 
 <div :if={!@creating_contact} class="panel" id="notification_subscriptions">
   <h2>Abonnements à des notifications</h2>
 
   <h3>Créer un abonnement</h3>
+
+  <h4>Lié à un jeu de données</h4>
 
   <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
     <%= hidden_input(f, :redirect_location, value: "contact") %>
@@ -28,6 +31,24 @@
     <% end %>
 
     <%= submit("Créer un abonnement") %>
+  <% end %>
+
+  <h4>Autres motifs</h4>
+
+  <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
+    <%= hidden_input(f, :redirect_location, value: "contact") %>
+    <%= hidden_input(f, :contact_id, value: @contact_id) %>
+    <%= label f, :reasons, class: "pt-12" do %>
+      <%= dgettext("backoffice", "Notification reason") %>
+      <%= for reason <- DB.NotificationSubscription.other_reasons() do %>
+        <%= label f, reason do %>
+          <%= checkbox(f, reason, hidden_input: false, value: reason in reasons_subscribed_without_dataset) %>
+          <%= reason %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= submit("Mettre à jour les abonnements") %>
   <% end %>
 
   <h3>Abonnements existants</h3>
@@ -79,7 +100,7 @@
       <th><%= dgettext("backoffice", "Notification reason") %></th>
       <th>Actions</th>
     </tr>
-    <%= for notification_subscription <- subscriptions_without_dataset do %>
+    <%= for notification_subscription <- Enum.sort_by(subscriptions_without_dataset, & &1.reason, :asc) do %>
       <tr>
         <td><%= notification_subscription.reason %></td>
         <td>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -1,6 +1,9 @@
 <% contact_id = Ecto.Changeset.get_field(@contact, :id) %>
 <% creating_contact = is_nil(contact_id) %>
-<div class="container mt-48 mb-24">
+<div class="container pb-24">
+  <div class="pb-24">
+    <%= breadcrumbs([@conn, :contacts_edit]) %>
+  </div>
   <div class="panel">
     <h2 :if={creating_contact}>Créer un contact</h2>
     <h2 :if={!creating_contact}>Éditer un contact</h2>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
@@ -1,4 +1,4 @@
-<section class="container pt-48 pb-48">
+<section class="container pt-24 pb-24">
   <h1>Contacts</h1>
 
   <%= form_for @conn, backoffice_contact_path(@conn, :index), [id: "backoffice_search_container", method: "get"], fn f -> %>
@@ -38,7 +38,7 @@
         <td><%= contact.first_name %></td>
         <td><%= contact.last_name %></td>
         <td><%= contact.email %></td>
-        <td><%= "#{contact.job_title} (#{contact.organization})" %></td>
+        <td><%= contact_fonction(contact) %></td>
         <td class="bo_action_button">
           <%= form_for @conn, backoffice_contact_path(@conn, :edit, contact.id), [nodiv: true, method: "get"], fn _ -> %>
             <%= submit("Éditer", class: "button", nodiv: true) %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -76,6 +76,11 @@
         <%= hidden_input(f, :dataset_id, value: @dataset.id) %>
         <%= label f, :contact_id do %>
           Contact <%= text_input(f, :contact_id, required: true, list: "contacts_datalist", pattern: "[0-9]+") %>
+          <div class="small">
+            <a href={backoffice_contact_path(@conn, :new)} target="_blank">
+              <i class="fas fa-external-link"></i> Créer un contact
+            </a>
+          </div>
         <% end %>
         <datalist id="contacts_datalist">
           <%= for contact <- @contacts_datalist do %>

--- a/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
@@ -1,11 +1,20 @@
 defmodule TransportWeb.Backoffice.ContactView do
   use TransportWeb, :view
+  import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   alias TransportWeb.PaginationHelpers
 
   def pagination_links(conn, contacts) do
     kwargs = [path: &backoffice_contact_path/3] |> add_filter(conn.params)
 
     PaginationHelpers.pagination_links(conn, contacts, kwargs)
+  end
+
+  defp contact_fonction(%DB.Contact{job_title: nil, organization: organization}) do
+    organization
+  end
+
+  defp contact_fonction(%DB.Contact{job_title: job_title, organization: organization}) do
+    "#{job_title} (#{organization})"
   end
 
   defp notification_subscriptions_with_dataset(records) do

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -21,6 +21,14 @@ defmodule TransportWeb.BreadCrumbs do
       ]
   end
 
+  def crumbs(conn, :contacts) do
+    [{"Contacts", backoffice_contact_path(conn, :index)}]
+  end
+
+  def crumbs(conn, :contacts_edit) do
+    crumbs(conn, :contacts) ++ [{"Créer/éditer un contact", nil}]
+  end
+
   def crumbs(conn, :proxy_statistics) do
     crumbs(conn, :espace_producteur) ++
       [

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -11,7 +11,7 @@ defmodule DB.ContactTest do
       first_name: "john ",
       last_name: " doe",
       email: email = "john@example.fr",
-      job_title: "boss",
+      job_title: "Chef SIG",
       organization: "Big Corp Inc",
       phone_number: "06 92 22 88 03"
     }
@@ -20,7 +20,7 @@ defmodule DB.ContactTest do
     assert %DB.Contact{
              email: ^email,
              first_name: "John",
-             job_title: "Boss",
+             job_title: "Chef SIG",
              last_name: "Doe",
              organization: "Big Corp Inc",
              phone_number: "+33692228803"

--- a/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/notification_subscription_controller_test.exs
@@ -8,59 +8,130 @@ defmodule TransportWeb.NotificationSubscriptionControllerTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "create", %{conn: conn} do
-    %DB.Dataset{id: dataset_id} = insert(:dataset)
-    %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
+  describe "create" do
+    test "for reasons related to a dataset", %{conn: conn} do
+      %DB.Dataset{id: dataset_id} = insert(:dataset)
+      %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
 
-    args = %{
-      "redirect_location" => "dataset",
-      "dataset_id" => dataset_id,
-      "contact_id" => contact_id,
-      "expiration" => "true",
-      "resource_unavailable" => "true",
-      # Should be ignored because this is not a valid reason
-      "ignored_notification_reason" => "true",
-      # Ignored because it's set to false (happens only when manipulating requests)
-      "dataset_with_error" => "false"
-    }
+      args = %{
+        "redirect_location" => "dataset",
+        "dataset_id" => dataset_id,
+        "contact_id" => contact_id,
+        "expiration" => "true",
+        "resource_unavailable" => "true",
+        # Should be ignored because this is not a valid reason
+        "ignored_notification_reason" => "true",
+        # Ignored because it's set to false (happens only when manipulating requests)
+        "dataset_with_error" => "false"
+      }
 
-    conn_response =
-      conn
-      |> setup_admin_in_session()
-      |> post(backoffice_notification_subscription_path(conn, :create, args))
+      conn_response =
+        conn
+        |> setup_admin_in_session()
+        |> post(backoffice_notification_subscription_path(conn, :create, args))
 
-    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
-    assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
+      assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+      assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
 
-    assert [
-             %DB.NotificationSubscription{
-               contact_id: ^contact_id,
-               dataset_id: ^dataset_id,
-               source: :admin,
-               reason: :expiration
-             },
-             %DB.NotificationSubscription{
-               contact_id: ^contact_id,
-               dataset_id: ^dataset_id,
-               source: :admin,
-               reason: :resource_unavailable
-             }
-           ] = DB.NotificationSubscription |> DB.Repo.all() |> Enum.sort_by(& &1.reason)
+      assert [
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: ^dataset_id,
+                 source: :admin,
+                 reason: :expiration
+               },
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: ^dataset_id,
+                 source: :admin,
+                 reason: :resource_unavailable
+               }
+             ] = DB.NotificationSubscription |> DB.Repo.all() |> Enum.sort_by(& &1.reason)
 
-    # Sending a request again, but with a new valid reason. Should not try to create duplicates.
-    conn_response =
-      conn
-      |> setup_admin_in_session()
-      |> post(backoffice_notification_subscription_path(conn, :create, Map.put(args, "dataset_with_error", "true")))
+      # Sending a request again, but with a new valid reason. Should not try to create duplicates.
+      conn_response =
+        conn
+        |> setup_admin_in_session()
+        |> post(backoffice_notification_subscription_path(conn, :create, Map.put(args, "dataset_with_error", "true")))
 
-    assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
-    assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
+      assert redirected_to(conn_response, 302) == backoffice_page_path(conn, :edit, dataset_id) <> @target_html_anchor
+      assert get_flash(conn_response, :info) =~ "L'abonnement a été créé"
 
-    assert MapSet.new([:dataset_with_error, :expiration, :resource_unavailable]) ==
-             DB.NotificationSubscription.base_query()
-             |> select([notification_subscription: ns], ns.reason)
-             |> DB.Repo.all()
-             |> MapSet.new()
+      assert MapSet.new([:dataset_with_error, :expiration, :resource_unavailable]) ==
+               DB.NotificationSubscription.base_query()
+               |> select([notification_subscription: ns], ns.reason)
+               |> DB.Repo.all()
+               |> MapSet.new()
+    end
+
+    test "for reasons not related to datasets", %{conn: conn} do
+      %DB.Dataset{id: dataset_id} = insert(:dataset)
+      %DB.Contact{id: contact_id} = DB.Contact.insert!(sample_contact_args())
+      # An existing subscription linked to a dataset
+      insert(:notification_subscription,
+        dataset_id: dataset_id,
+        source: :admin,
+        contact_id: contact_id,
+        reason: :expiration
+      )
+
+      # An existing subscription not linked to a dataset
+      insert(:notification_subscription,
+        dataset_id: nil,
+        source: :admin,
+        contact_id: contact_id,
+        reason: :dataset_now_licence_ouverte
+      )
+
+      assert [
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: ^dataset_id,
+                 source: :admin,
+                 reason: :expiration
+               },
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: nil,
+                 source: :admin,
+                 reason: :dataset_now_licence_ouverte
+               }
+             ] = DB.NotificationSubscription |> DB.Repo.all()
+
+      args = %{
+        "redirect_location" => "contact",
+        "contact_id" => contact_id,
+        "dataset_now_licence_ouverte" => "false",
+        "new_dataset" => "true",
+        # Not a valid reason, should be ignored
+        "foobar" => "true"
+      }
+
+      conn_response =
+        conn
+        |> setup_admin_in_session()
+        |> post(backoffice_notification_subscription_path(conn, :create, args))
+
+      assert redirected_to(conn_response, 302) ==
+               backoffice_contact_path(conn, :edit, contact_id) <> @target_html_anchor
+
+      assert get_flash(conn_response, :info) =~ "Abonnements mis à jour"
+
+      assert [
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: ^dataset_id,
+                 source: :admin,
+                 reason: :expiration
+               },
+               %DB.NotificationSubscription{
+                 contact_id: ^contact_id,
+                 dataset_id: nil,
+                 source: :admin,
+                 reason: :new_dataset
+               }
+             ] = DB.NotificationSubscription |> DB.Repo.all()
+    end
   end
 
   test "delete", %{conn: conn} do


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/issues/2993

Quelques améliorations :
- ajout d'un breadcrumb lors de l'édition d'un contact
- ajout d'un lien (ouvert dans un nouvel onglet) pour créer un contact quand on édite un dataset dans le backoffice
- possibilité d'abonner des contacts pour des raisons non liées à des jeux de données
- un peu de refactoring
- des tests