### PR TITLE
Rendu de tables en Markdown

### DIFF
--- a/apps/transport/lib/transport_web/views/markdown_handler.ex
+++ b/apps/transport/lib/transport_web/views/markdown_handler.ex
@@ -12,9 +12,12 @@ defmodule TransportWeb.MarkdownHandler do
   def markdown_to_safe_html!(nil), do: HTML.raw(nil)
 
   def markdown_to_safe_html!(md) do
-    md
-    |> Earmark.as_html!()
-    |> HtmlSanitizeEx.basic_html()
-    |> HTML.raw()
+    {:safe, txt} =
+      md
+      |> Earmark.as_html!(gfm_tables: true)
+      |> HtmlSanitizeEx.basic_html()
+      |> HTML.raw()
+
+    {:safe, String.replace(txt, "<table>", ~s(<table class="table">), global: true)}
   end
 end

--- a/apps/transport/test/transport_web/views/markdown_handler_test.exs
+++ b/apps/transport/test/transport_web/views/markdown_handler_test.exs
@@ -6,4 +6,17 @@ defmodule TransportWeb.MarkdownHandlerTest do
     content = "# Bonjour\n<script>alert(\"xxx\")</script>"
     assert content |> MarkdownHandler.markdown_to_safe_html!() == {:safe, "<h1>\nBonjour</h1>\n\n  alert(\"xxx\")\n"}
   end
+
+  test "renders tables" do
+    content = """
+    State | Abbrev
+    ------|-------
+    Texas | TX
+    """
+
+    assert content |> MarkdownHandler.markdown_to_safe_html!() == {
+             :safe,
+             ~s(<table class="table">\n  <thead>\n    <tr>\n      <th>\nState      </th>\n      <th>\nAbbrev      </th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>\nTexas      </td>\n      <td>\nTX      </td>\n    </tr>\n  </tbody>\n</table>\n)
+           }
+  end
 end


### PR DESCRIPTION
Fixes #3005

Earmark ne supporte pas les tableaux avec la syntaxe "GitHub Flavored Markdown" https://github.com/pragdave/earmark/issues/278, qui était la syntaxe pour ce jeu de données. C'est [le format qui est retourné par l'API de data.gouv.fr](https://www.data.gouv.fr/api/1/datasets/liste-des-passages-a-niveau/).

J'ajoute donc l'option qui permet de gérer cette syntaxe ainsi que l'ajout de la classe `.table` qui permet d'avoir un rendu convaincant.

![image](https://user-images.githubusercontent.com/295709/223402242-e100b4f3-0f5a-402a-9df9-76d274d0a6f7.png)

