### PR TITLE
S'adapter au changement d'API côté data.gouv.fr

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -84,8 +84,6 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
   end
 
   def after_datetime?(created_at, %DateTime{} = dt_limit) when is_binary(created_at) do
-    # data.gouv.fr does not include the timezone (trailing Z) but these are UTC datetimes
-    created_at = String.replace_trailing(created_at, "Z", "") <> "Z"
     {:ok, datetime, 0} = DateTime.from_iso8601(created_at)
     DateTime.compare(datetime, dt_limit) == :gt
   end

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -72,8 +72,7 @@ defmodule Transport.DataChecker do
         :active
 
       {:ok, %{"archived" => archived}} ->
-        # data.gouv.fr does not include the timezone
-        {:ok, datetime, 0} = DateTime.from_iso8601(String.replace_suffix(archived, "Z", "") <> "Z")
+        {:ok, datetime, 0} = DateTime.from_iso8601(archived)
         {:archived, datetime}
 
       {:error, %HTTPoison.Error{} = error} ->

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -164,7 +164,7 @@ defmodule Transport.ImportData do
 
   iex>archived(nil)
   nil
-  iex>archived("2022-09-28T03:08:59.782000")
+  iex>archived("2022-09-28T03:08:59.782000+00:00")
   ~U[2022-09-28 03:08:59.782000Z]
   iex>archived("2022-09-28T03:08:59.782000Z")
   ~U[2022-09-28 03:08:59.782000Z]
@@ -172,7 +172,7 @@ defmodule Transport.ImportData do
   def archived(nil), do: nil
 
   def archived(datetime_str) when is_binary(datetime_str) do
-    {:ok, datetime, 0} = DateTime.from_iso8601(String.replace_suffix(datetime_str, "Z", "") <> "Z")
+    {:ok, datetime, 0} = DateTime.from_iso8601(datetime_str)
     datetime
   end
 

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -89,8 +89,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
         "resources" => [],
         "tags" => [],
         "description" => "",
-        "created_at" =>
-          DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601(),
+        "created_at" => DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601(),
         "page" => "https://example.com/link",
         "id" => Ecto.UUID.generate()
       }

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -50,7 +50,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
       "resources" => [],
       "tags" => [],
       "description" => "",
-      "created_at" => "2022-11-01 00:01:00",
+      "created_at" => "2022-11-01 00:01:00+00:00",
       "id" => Ecto.UUID.generate()
     }
 
@@ -58,7 +58,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
     datasets = [
       base,
-      %{base | "created_at" => "2022-10-30 00:00:00", "title" => "GTFS de Dijon"},
+      %{base | "created_at" => "2022-10-30 00:00:00+00:00", "title" => "GTFS de Dijon"},
       dataset_to_keep = %{base | "title" => "GTFS de Dijon"},
       %{base | "tags" => ["gbfs"], "id" => datagouv_id}
     ]
@@ -90,7 +90,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
         "tags" => [],
         "description" => "",
         "created_at" =>
-          DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601() |> String.trim_trailing("Z"),
+          DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601(),
         "page" => "https://example.com/link",
         "id" => Ecto.UUID.generate()
       }


### PR DESCRIPTION
Data.gouv.fr vient de modifier le comportement de son API et ne renvoie plus de datetimes naives. Sauf que nous nous étions préparés à avoir des dates au format "2022-09-28T03:08:59.782000**Z**" et que c'est finalement des dates au format "2022-09-28T03:08:59.782000 **+00:00** " qui sont renvoyées.

J'ai pu reproduire en local et vérifier que le fix corrigeait bien le problème d'import.