### PR TITLE
Contacts : ajout colonne pour titre

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -179,7 +179,7 @@ defmodule TransportWeb.Backoffice.PageController do
   end
 
   defp contacts_datalist do
-    DB.Contact.base_query() |> select([contact: c], [:first_name, :last_name, :id]) |> DB.Repo.all()
+    DB.Contact.base_query() |> select([contact: c], [:first_name, :last_name, :title, :id]) |> DB.Repo.all()
   end
 
   defp notifications_last_nb_days, do: 30

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -179,7 +179,9 @@ defmodule TransportWeb.Backoffice.PageController do
   end
 
   defp contacts_datalist do
-    DB.Contact.base_query() |> select([contact: c], [:first_name, :last_name, :title, :id]) |> DB.Repo.all()
+    DB.Contact.base_query()
+    |> select([contact: c], [:first_name, :last_name, :mailing_list_title, :id])
+    |> DB.Repo.all()
   end
 
   defp notifications_last_nb_days, do: 30

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -29,8 +29,8 @@
         <p class="separator pt-6 pb-6">
           - <%= dgettext("backoffice", "or") %> -
         </p>
-        <%= label f, :title do %>
-          Titre <%= text_input(f, :title, []) %>
+        <%= label f, :mailing_list_title do %>
+          Titre <%= text_input(f, :mailing_list_title, []) %>
           <div class="small">À utiliser quand un contact n'est pas une personne</div>
         <% end %>
       </div>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -27,7 +27,7 @@
           Nom <%= text_input(f, :last_name, []) %>
         <% end %>
         <p class="separator pt-6 pb-6">
-          - <%= dgettext("resource", "or") %> -
+          - <%= dgettext("backoffice", "or") %> -
         </p>
         <%= label f, :title do %>
           Titre <%= text_input(f, :title, []) %>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -19,12 +19,21 @@
     <% end %>
     <%= form_for @contact, backoffice_contact_path(@conn, :create), [class: "no-margin", method: "post"], fn f -> %>
       <%= hidden_input(f, :id, value: contact_id) %>
-      <%= label f, :first_name do %>
-        Prénom <%= text_input(f, :first_name, required: true) %>
-      <% end %>
-      <%= label f, :last_name, class: "pt-12" do %>
-        Nom <%= text_input(f, :last_name, required: true) %>
-      <% end %>
+      <div class="panel">
+        <%= label f, :first_name do %>
+          Prénom <%= text_input(f, :first_name, []) %>
+        <% end %>
+        <%= label f, :last_name, class: "pt-12" do %>
+          Nom <%= text_input(f, :last_name, []) %>
+        <% end %>
+        <p class="separator pt-6 pb-6">
+          - <%= dgettext("resource", "or") %> -
+        </p>
+        <%= label f, :title do %>
+          Titre <%= text_input(f, :title, []) %>
+          <div class="small">À utiliser quand un contact n'est pas une personne</div>
+        <% end %>
+      </div>
       <%= label f, :job_title, class: "pt-12" do %>
         Fonction <%= text_input(f, :job_title,
           placeholder: "Responsable numérique",

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
@@ -14,7 +14,7 @@
       <% end %>
     </datalist>
     <button type="submit" class="button backoffice_search_button"><i class="fa fa-search"></i></button>
-    <div class="small">Recherchez par nom de famille ou organisation</div>
+    <div class="small">Recherchez par nom de famille, titre ou organisation</div>
   <% end %>
 
   <a class="button" href={backoffice_contact_path(@conn, :new)}>
@@ -27,7 +27,6 @@
 
   <table class="backoffice-results">
     <tr>
-      <th>Prénom</th>
       <th>Nom</th>
       <th>E-mail</th>
       <th>Fonction</th>
@@ -35,8 +34,7 @@
     </tr>
     <%= for contact <- @contacts do %>
       <tr>
-        <td><%= contact.first_name %></td>
-        <td><%= contact.last_name %></td>
+        <td><%= DB.Contact.display_name(contact) %></td>
         <td><%= contact.email %></td>
         <td><%= contact_fonction(contact) %></td>
         <td class="bo_action_button">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -84,7 +84,7 @@
         <% end %>
         <datalist id="contacts_datalist">
           <%= for contact <- @contacts_datalist do %>
-            <option value={contact.id}><%= "#{contact.first_name} #{contact.last_name}" %></option>
+            <option value={contact.id}><%= DB.Contact.display_name(contact) %></option>
           <% end %>
         </datalist>
         <%= label f, :reasons, class: "pt-12" do %>

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -65,6 +65,6 @@ defmodule TransportWeb.Backoffice.PageView do
   end
 
   def notification_subscription_contact(%DB.NotificationSubscription{contact: %DB.Contact{} = contact}) do
-    "#{contact.first_name} #{contact.last_name} — #{contact.job_title} (#{contact.organization})"
+    "#{DB.Contact.display_name(contact)} — #{contact.job_title} (#{contact.organization})"
   end
 end

--- a/apps/transport/priv/repo/migrations/20230309102424_add_mailing_list_title_contact.exs
+++ b/apps/transport/priv/repo/migrations/20230309102424_add_mailing_list_title_contact.exs
@@ -1,4 +1,4 @@
-defmodule DB.Repo.Migrations.AddTitleContact do
+defmodule DB.Repo.Migrations.AddMailingListTitleContact do
   use Ecto.Migration
 
   def change do
@@ -7,7 +7,7 @@ defmodule DB.Repo.Migrations.AddTitleContact do
       modify :first_name, :string, null: true, from: {:string, null: false}
       modify :last_name, :string, null: true, from: {:string, null: false}
       # add new `column` for contacts that are not "real humans", for example mailing lists
-      add :title, :string, null: true
+      add :mailing_list_title, :string, null: true
     end
   end
 end

--- a/apps/transport/priv/repo/migrations/20230309102424_add_title_contact.exs
+++ b/apps/transport/priv/repo/migrations/20230309102424_add_title_contact.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.AddTitleContact do
+  use Ecto.Migration
+
+  def change do
+    alter table(:contact) do
+      # `first_name` and `last_name` can now be `null`
+      modify :first_name, :string, null: true, from: {:string, null: false}
+      modify :last_name, :string, null: true, from: {:string, null: false}
+      # add new `column` for contacts that are not "real humans", for example mailing lists
+      add :title, :string, null: true
+    end
+  end
+end

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -36,7 +36,7 @@ defmodule DB.ContactTest do
     assert DB.Contact |> where([n], n.email == ^"+33692228803") |> DB.Repo.all() |> Enum.empty?()
 
     # Can save a contact with a `title`
-    %{sample_contact_args() | first_name: nil, last_name: nil, title: "title"}
+    %{sample_contact_args() | first_name: nil, last_name: nil, mailing_list_title: "title"}
     |> DB.Contact.insert!()
 
     assert 2 == DB.Contact |> DB.Repo.aggregate(:count, :id)
@@ -67,36 +67,66 @@ defmodule DB.ContactTest do
              DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | phone_number: "+1 (438) 389 8482"})
   end
 
-  test "validates that you can fill first_name/last_name OR title" do
+  test "validates that you can fill first_name/last_name OR mailing_list_title" do
     assert %Ecto.Changeset{
              valid?: false,
-             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+             errors: [first_name: {"You need to fill either first_name and last_name OR mailing_list_title", []}]
            } =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: "B", title: "C"})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: "A",
+                 last_name: "B",
+                 mailing_list_title: "C"
+             })
 
     assert %Ecto.Changeset{
              valid?: false,
-             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+             errors: [first_name: {"You need to fill either first_name and last_name OR mailing_list_title", []}]
            } =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: nil, title: "C"})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: "A",
+                 last_name: nil,
+                 mailing_list_title: "C"
+             })
 
     assert %Ecto.Changeset{
              valid?: false,
-             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+             errors: [first_name: {"You need to fill either first_name and last_name OR mailing_list_title", []}]
            } =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: "B", title: "C"})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: nil,
+                 last_name: "B",
+                 mailing_list_title: "C"
+             })
 
     assert %Ecto.Changeset{
              valid?: false,
-             errors: [first_name: {"You need to fill first_name and last_name OR title", []}]
+             errors: [first_name: {"You need to fill first_name and last_name OR mailing_list_title", []}]
            } =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: nil, title: nil})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: nil,
+                 last_name: nil,
+                 mailing_list_title: nil
+             })
 
     assert %Ecto.Changeset{valid?: true} =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: "B", title: nil})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: "A",
+                 last_name: "B",
+                 mailing_list_title: nil
+             })
 
     assert %Ecto.Changeset{valid?: true} =
-             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: nil, title: "C"})
+             DB.Contact.changeset(%DB.Contact{}, %{
+               sample_contact_args()
+               | first_name: nil,
+                 last_name: nil,
+                 mailing_list_title: "C"
+             })
   end
 
   test "cannot have duplicates based on email" do
@@ -128,7 +158,7 @@ defmodule DB.ContactTest do
       sample_contact_args()
       | first_name: nil,
         last_name: nil,
-        title: "Service SIG",
+        mailing_list_title: "Service SIG",
         organization: "Geo Inc"
     })
 
@@ -136,14 +166,14 @@ defmodule DB.ContactTest do
     assert [%DB.Contact{last_name: "Doe"}] = search_fn.(%{"q" => "doe"})
     assert [%DB.Contact{last_name: "Bar"}] = search_fn.(%{"q" => "bar"})
     assert [%DB.Contact{organization: "Foo Bar"}] = search_fn.(%{"q" => "Foo Bar"})
-    assert [%DB.Contact{title: "Service SIG"}] = search_fn.(%{"q" => "SIG"})
+    assert [%DB.Contact{mailing_list_title: "Service SIG"}] = search_fn.(%{"q" => "SIG"})
   end
 
   defp sample_contact_args do
     %{
       first_name: "John",
       last_name: "Doe",
-      title: nil,
+      mailing_list_title: nil,
       email: "john#{Ecto.UUID.generate()}@example.fr",
       job_title: "Boss",
       organization: "Big Corp Inc",

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -6,6 +6,8 @@ defmodule DB.ContactTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
+  doctest DB.Contact, import: true
+
   test "can save objects in the database with relevant casts" do
     %{
       first_name: "john ",
@@ -32,6 +34,12 @@ defmodule DB.ContactTest do
     # Cannot get rows by using the email/phone_number values, because values are encrypted
     assert DB.Contact |> where([n], n.email == ^email) |> DB.Repo.all() |> Enum.empty?()
     assert DB.Contact |> where([n], n.email == ^"+33692228803") |> DB.Repo.all() |> Enum.empty?()
+
+    # Can save a contact with a `title`
+    %{sample_contact_args() | first_name: nil, last_name: nil, title: "title"}
+    |> DB.Contact.insert!()
+
+    assert 2 == DB.Contact |> DB.Repo.aggregate(:count, :id)
   end
 
   test "validates and formats phone numbers" do
@@ -59,6 +67,38 @@ defmodule DB.ContactTest do
              DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | phone_number: "+1 (438) 389 8482"})
   end
 
+  test "validates that you can fill first_name/last_name OR title" do
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+           } =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: "B", title: "C"})
+
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+           } =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: nil, title: "C"})
+
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [first_name: {"You need to fill either first_name and last_name OR title", []}]
+           } =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: "B", title: "C"})
+
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [first_name: {"You need to fill first_name and last_name OR title", []}]
+           } =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: nil, title: nil})
+
+    assert %Ecto.Changeset{valid?: true} =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: "A", last_name: "B", title: nil})
+
+    assert %Ecto.Changeset{valid?: true} =
+             DB.Contact.changeset(%DB.Contact{}, %{sample_contact_args() | first_name: nil, last_name: nil, title: "C"})
+  end
+
   test "cannot have duplicates based on email" do
     params = %{sample_contact_args() | email: "foo@example.fr"}
 
@@ -84,16 +124,26 @@ defmodule DB.ContactTest do
     DB.Contact.insert!(%{sample_contact_args() | last_name: "Bar", organization: "Big Corp Inc"})
     DB.Contact.insert!(%{sample_contact_args() | last_name: "Baz", organization: "Foo Bar"})
 
+    DB.Contact.insert!(%{
+      sample_contact_args()
+      | first_name: nil,
+        last_name: nil,
+        title: "Service SIG",
+        organization: "Geo Inc"
+    })
+
     assert [%DB.Contact{last_name: "Doe"}] = search_fn.(%{"q" => "DOE"})
     assert [%DB.Contact{last_name: "Doe"}] = search_fn.(%{"q" => "doe"})
     assert [%DB.Contact{last_name: "Bar"}] = search_fn.(%{"q" => "bar"})
     assert [%DB.Contact{organization: "Foo Bar"}] = search_fn.(%{"q" => "Foo Bar"})
+    assert [%DB.Contact{title: "Service SIG"}] = search_fn.(%{"q" => "SIG"})
   end
 
   defp sample_contact_args do
     %{
       first_name: "John",
       last_name: "Doe",
+      title: nil,
       email: "john#{Ecto.UUID.generate()}@example.fr",
       job_title: "Boss",
       organization: "Big Corp Inc",

--- a/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
@@ -62,7 +62,7 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
       doc = content |> Floki.parse_document!()
 
       assert [
-               {"li", [], ["first_name : You need to fill either first_name and last_name OR title"]},
+               {"li", [], ["first_name : You need to fill either first_name and last_name OR mailing_list_title"]},
                {"li", [], ["organization : can't be blank"]},
                {"li", [], ["email : can't be blank"]}
              ] == Floki.find(doc, ".notification.error ul li")

--- a/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
@@ -62,7 +62,7 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
       doc = content |> Floki.parse_document!()
 
       assert [
-               {"li", [], ["last_name : can't be blank"]},
+               {"li", [], ["first_name : You need to fill either first_name and last_name OR title"]},
                {"li", [], ["organization : can't be blank"]},
                {"li", [], ["email : can't be blank"]}
              ] == Floki.find(doc, ".notification.error ul li")


### PR DESCRIPTION
Ajout d'une colonne `mailing_list_title` pour les contacts qui ne sont pas des personnes mais plutôt des alias/listes de diffusion comme `service-sig@example.fr`.

Adapte les formulaires, tableaux et interfaces où prénom + nom étaient présents.

![image](https://user-images.githubusercontent.com/295709/224035678-d7a1f9a0-524b-4d1d-842d-0aecc543b6e8.png)

