### PR TITLE
Améliore la visibilité des conversions automatiques

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -791,6 +791,7 @@ defmodule DB.Dataset do
           %{
             url: fragment("? ->> 'permanent_url'", dc.payload),
             filesize: fragment("? ->> 'filesize'", dc.payload),
+            format: dc.convert_to,
             resource_history_last_up_to_date_at: rh.last_up_to_date_at
           }}}
       )

--- a/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
@@ -1,24 +1,15 @@
-<div class="panel resource">
-  <h4><%= @resource.title %></h4>
-  <p>
-    <%= dgettext("page-dataset-details", "Automatic conversions for this %{format} resource", format: @resource.format) %>
-  </p>
-  <div class="resource-panel-bottom">
-    <%= for {format, %{url: url}} <- @conversions_details |> Enum.sort_by(fn {k, _v} -> k end, :asc) do %>
-      <div class="resource-actions">
-        <div>
-          <div class="resource-format" title={dgettext("page-dataset-details", "resource format")}>
-            <span class="label"><%= conversion_cleaned_format(format) %></span>
-          </div>
-        </div>
-        <div>
-          <a class="download-button" href={url}>
-            <button class="button-outline primary small">
-              <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %>
-            </button>
-          </a>
-        </div>
-      </div>
+<hr class="mb-0 mt-24" />
+<p><%= dgettext("page-dataset-details", "Automatic conversions") %></p>
+<div class="resource-actions">
+  <div>
+    <%= for {format, %{url: url}} <- Enum.sort_by(@conversions_details, fn {format, _v} -> format end, :asc) do %>
+      <a class="download-button" href={url}>
+        <button class="button-outline primary small">
+          <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %> <%= conversion_cleaned_format(
+            format
+          ) %>
+        </button>
+      </a>
     <% end %>
   </div>
 </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
@@ -2,12 +2,10 @@
 <p><%= dgettext("page-dataset-details", "Automatic conversions") %></p>
 <div class="resource-actions">
   <div>
-    <%= for {format, %{url: url}} <- Enum.sort_by(@conversions_details, fn {format, _v} -> format end, :asc) do %>
+    <%= for {_, %{url: url, format: format}} <- Enum.sort_by(@conversions_details, fn {_, %{format: format}} -> format end, :asc) do %>
       <a class="download-button" href={url}>
         <button class="button-outline primary small">
-          <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %> <%= conversion_cleaned_format(
-            format
-          ) %>
+          <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %> <%= format %>
         </button>
       </a>
     <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
@@ -1,0 +1,24 @@
+<div class="panel resource">
+  <h4><%= @resource.title %></h4>
+  <p>
+    <%= dgettext("page-dataset-details", "Automatic conversions for this %{format} resource", format: @resource.format) %>
+  </p>
+  <div class="resource-panel-bottom">
+    <%= for {format, %{url: url}} <- @conversions_details |> Enum.sort_by(fn {k, _v} -> k end, :asc) do %>
+      <div class="resource-actions">
+        <div>
+          <div class="resource-format" title={dgettext("page-dataset-details", "resource format")}>
+            <span class="label"><%= conversion_cleaned_format(format) %></span>
+          </div>
+        </div>
+        <div>
+          <a class="download-button" href={url}>
+            <button class="button-outline primary small">
+              <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %>
+            </button>
+          </a>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -167,10 +167,7 @@
           <span class="label"><%= @resource.format %></span>
           <%= if has_associated_geojson or has_associated_netex do %>
             <div>
-              <a
-                class="other-formats-link light-grey-link"
-                href={resource_path(@conn, :details, @resource.id) <> "#other-formats"}
-              >
+              <a class="other-formats-link light-grey-link" href="#conversions">
                 <%= dgettext("page-dataset-details", "see other formats") %>
               </a>
             </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -1,6 +1,6 @@
 <% locale = get_session(@conn, :locale) %>
+<% has_conversions = ResourceView.has_associated_files(@resources_related_files, @resource.id) %>
 <% has_associated_geojson = ResourceView.has_associated_geojson(@resources_related_files, @resource.id) %>
-<% has_associated_netex = ResourceView.has_associated_netex(@resources_related_files, @resource.id) %>
 <% geojson_with_viz? =
   ResourceView.geojson_with_viz?(@resource, Map.get(@latest_resources_history_infos || %{}, @resource.id)) %>
 <% unavailabilities = @resources_infos.unavailabilities %>
@@ -165,13 +165,6 @@
       <div>
         <div class="resource-format" title={dgettext("page-dataset-details", "resource format")}>
           <span class="label"><%= @resource.format %></span>
-          <%= if has_associated_geojson or has_associated_netex do %>
-            <div>
-              <a class="other-formats-link light-grey-link" href="#conversions">
-                <%= dgettext("page-dataset-details", "see other formats") %>
-              </a>
-            </div>
-          <% end %>
         </div>
       </div>
       <div>
@@ -202,5 +195,11 @@
         <% end %>
       </div>
     </div>
+    <%= if has_conversions do %>
+      <%= render(TransportWeb.DatasetView, "_conversions.html",
+        resource: @resource,
+        conversions_details: Map.fetch!(@resources_related_files, @resource.id)
+      ) %>
+    <% end %>
   </div>
 </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
@@ -1,19 +1,27 @@
 <% has_resources = not Enum.empty?(@resources || []) %>
 <% has_reuser_message = not is_nil(assigns[:reuser_message]) %>
-<%= if has_resources or has_reuser_message  do %>
+<%= if has_resources or (has_reuser_message and assigns[:section_id] != "conversions") do %>
   <section class="dataset__resources white" id={assigns[:section_id]}>
     <h2><%= @title %></h2>
-    <%= if has_reuser_message do %>
-      <div class="information-message"><%= assigns[:reuser_message] %></div>
-    <% end %>
-    <%= unless is_nil(assigns[:message]) do %>
-      <div class="resources-message">
-        <i class="fa fa-exclamation-triangle warning-red"></i>
-        <%= assigns[:message] %>
-      </div>
-    <% end %>
+    <p :if={has_reuser_message} class="information-message">
+      <%= assigns[:reuser_message] %>
+    </p>
+
+    <div :if={!is_nil(assigns[:warning_message])} class="resources-message">
+      <i class="fa fa-exclamation-triangle warning-red"></i>
+      <%= assigns[:warning_message] %>
+    </div>
     <div>
-      <div class="ressources-list">
+      <div :if={!is_nil(assigns[:conversions])} class="ressources-list">
+        <%= for resource <- @resources |> Enum.sort_by(fn %DB.Resource{title: title} -> title end) do %>
+          <%= render(TransportWeb.DatasetView, "_conversions.html",
+            resource: resource,
+            conversions_details: Map.fetch!(@conversions, resource.id)
+          ) %>
+        <% end %>
+      </div>
+
+      <div :if={is_nil(assigns[:conversions])} class="ressources-list">
         <%= for resource <- @resources |> order_resources_by_validity(assigns[:resources_infos]) |> order_resources_by_format() do %>
           <%= render(TransportWeb.DatasetView, "_resource.html",
             conn: @conn,

--- a/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resources_container.html.heex
@@ -1,6 +1,6 @@
 <% has_resources = not Enum.empty?(@resources || []) %>
 <% has_reuser_message = not is_nil(assigns[:reuser_message]) %>
-<%= if has_resources or (has_reuser_message and assigns[:section_id] != "conversions") do %>
+<%= if has_resources or has_reuser_message do %>
   <section class="dataset__resources white" id={assigns[:section_id]}>
     <h2><%= @title %></h2>
     <p :if={has_reuser_message} class="information-message">
@@ -12,16 +12,7 @@
       <%= assigns[:warning_message] %>
     </div>
     <div>
-      <div :if={!is_nil(assigns[:conversions])} class="ressources-list">
-        <%= for resource <- @resources |> Enum.sort_by(fn %DB.Resource{title: title} -> title end) do %>
-          <%= render(TransportWeb.DatasetView, "_conversions.html",
-            resource: resource,
-            conversions_details: Map.fetch!(@conversions, resource.id)
-          ) %>
-        <% end %>
-      </div>
-
-      <div :if={is_nil(assigns[:conversions])} class="ressources-list">
+      <div class="ressources-list">
         <%= for resource <- @resources |> order_resources_by_validity(assigns[:resources_infos]) |> order_resources_by_format() do %>
           <%= render(TransportWeb.DatasetView, "_resource.html",
             conn: @conn,

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -149,18 +149,6 @@
           dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"),
         latest_resources_history_infos: @latest_resources_history_infos
       ) %>
-      <%= render(TransportWeb.DatasetView, "_resources_container.html",
-        conn: @conn,
-        resources: resources_with_conversions(@dataset, @resources_related_files),
-        resources_infos: @resources_infos,
-        conversions: @resources_related_files,
-        dataset: @dataset,
-        title: dgettext("page-dataset-details", "Conversions"),
-        reuser_message:
-          dgettext("page-dataset-details", "These resources are created automatically by transport.data.gouv.fr"),
-        section_id: "conversions"
-      ) %>
-
       <%= render("_reuser_message.html") %>
       <%= render("_community_resources.html", dataset: @dataset) %>
     </section>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -145,9 +145,20 @@
         resources: unavailable_resources(@dataset),
         dataset: @dataset,
         title: dgettext("page-dataset-details", "unavailable resources"),
-        message:
+        warning_message:
           dgettext("page-dataset-details", "Those resources are listed by the provider but are unreachable for now"),
         latest_resources_history_infos: @latest_resources_history_infos
+      ) %>
+      <%= render(TransportWeb.DatasetView, "_resources_container.html",
+        conn: @conn,
+        resources: resources_with_conversions(@dataset, @resources_related_files),
+        resources_infos: @resources_infos,
+        conversions: @resources_related_files,
+        dataset: @dataset,
+        title: dgettext("page-dataset-details", "Conversions"),
+        reuser_message:
+          dgettext("page-dataset-details", "These resources are created automatically by transport.data.gouv.fr"),
+        section_id: "conversions"
       ) %>
 
       <%= render("_reuser_message.html") %>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -1,6 +1,5 @@
 <section>
   <% associated_geojson = get_associated_geojson(@related_files) %>
-  <% associated_netex = get_associated_netex(@related_files) %>
   <div class="grey-background">
     <div class="container">
       <h2 class="mt-48"><%= dgettext("validations", "Resource details") %></h2>
@@ -21,31 +20,6 @@
           ) %>.
         </p>
         <%= render("_resources_details.html", conn: @conn, metadata: @metadata, modes: @modes) %>
-        <%= if !is_nil(associated_geojson) or !is_nil(associated_netex) do %>
-          <div id="other-formats">
-            <%= dgettext("validations", "This resource is also available in the following formats:") %>
-            <ul>
-              <%= unless is_nil(associated_geojson) do %>
-                <li>
-                  <a href={associated_geojson.url}>GeoJSON</a>*
-                </li>
-              <% end %>
-              <%= unless is_nil(associated_netex) do %>
-                <li><a href={associated_netex.url}>NeTEx</a></li>
-              <% end %>
-            </ul>
-            * <%= dgettext(
-              "validations",
-              "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)
-              It corresponds to the data you can see on the map below."
-            ) %>
-            <%= unless is_nil(associated_geojson) or is_nil(associated_geojson.resource_history_last_up_to_date_at) do %>
-              <%= dgettext("validations", "This GeoJSON was up-to-date with the GTFS resource %{hours} ago.",
-                hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at)
-              ) %>
-            <% end %>
-          </div>
-        <% end %>
       </div>
 
       <h2 id="download-availability"><%= dgettext("page-dataset-details", "Download availability") %></h2>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -331,7 +331,8 @@ defmodule TransportWeb.DatasetView do
   def resources_with_conversions(%Dataset{} = dataset, resources_related_files) do
     resource_ids =
       # Don't keep records looking like `%{79088 => %{geojson: nil, netex: nil}}`
-      Enum.reject(resources_related_files, fn {_resource_id, conversions} ->
+      resources_related_files
+      |> Enum.reject(fn {_resource_id, conversions} ->
         conversions |> Map.values() |> Enum.reject(&is_nil/1) |> Enum.empty?()
       end)
       |> Enum.map(fn {resource_id, _} -> resource_id end)

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -515,18 +515,4 @@ defmodule TransportWeb.DatasetView do
   end
 
   def displays_odbl_specific_usage_conditions?(%Dataset{}), do: false
-
-  @doc """
-  Gets the human-friendly version of a `DB.DataConversion.format`
-
-  iex> conversion_cleaned_format(:netex)
-  "NeTEx"
-  iex> conversion_cleaned_format(:geojson)
-  "geojson"
-  """
-  def conversion_cleaned_format(conversion_format) do
-    type = nil
-    is_community_resource = false
-    Transport.ImportData.formated_format(%{"format" => to_string(conversion_format)}, type, is_community_resource)
-  end
 end

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -328,20 +328,6 @@ defmodule TransportWeb.DatasetView do
     |> Enum.filter(&Resource.is_documentation?/1)
   end
 
-  def resources_with_conversions(%Dataset{} = dataset, resources_related_files) do
-    resource_ids =
-      # Don't keep records looking like `%{79088 => %{geojson: nil, netex: nil}}`
-      resources_related_files
-      |> Enum.reject(fn {_resource_id, conversions} ->
-        conversions |> Map.values() |> Enum.reject(&is_nil/1) |> Enum.empty?()
-      end)
-      |> Enum.map(fn {resource_id, _} -> resource_id end)
-
-    dataset
-    |> Dataset.official_resources()
-    |> Enum.filter(&(&1.id in resource_ids))
-  end
-
   def is_real_time_public_transit?(%Dataset{type: "public-transit"} = dataset) do
     not Enum.empty?(real_time_official_resources(dataset))
   end

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -80,6 +80,20 @@ defmodule TransportWeb.ResourceView do
       |> Application.fetch_env!(:datagouvfr_site)
       |> Path.join("/fr/admin/dataset/new/")
 
+  def has_associated_files(%{} = resources_related_files, resource_id) do
+    # Don't keep records looking like `%{79088 => %{geojson: nil, netex: nil}}`
+    resource_ids =
+      resources_related_files
+      |> Enum.reject(fn {_resource_id, conversions} ->
+        conversions |> Map.values() |> Enum.reject(&is_nil/1) |> Enum.empty?()
+      end)
+      |> Enum.map(fn {resource_id, _} -> resource_id end)
+
+    resource_id in resource_ids
+  end
+
+  def has_associated_files(_, _), do: false
+
   def has_associated_file(%{} = resources_related_files, resource_id, get_associated_file) do
     resources_related_files
     |> Map.get(resource_id)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -557,3 +557,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Static data"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Automatic conversions for this %{format} resource"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Conversions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "These resources are created automatically by transport.data.gouv.fr"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -291,10 +291,6 @@ msgid "resource format"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "see other formats"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "real-time"
 msgstr ""
 
@@ -558,14 +554,6 @@ msgstr ""
 msgid "Static data"
 msgstr ""
 
-#, elixir-autogen, elixir-format
-msgid "Automatic conversions for this %{format} resource"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Conversions"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "These resources are created automatically by transport.data.gouv.fr"
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Automatic conversions"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -99,14 +99,6 @@ msgstr ""
 msgid "Stops and routes visualization of the GTFS file"
 msgstr ""
 
-#, elixir-autogen, elixir-format
-msgid "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)\n              It corresponds to the data you can see on the map below."
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This resource is also available in the following formats:"
-msgstr ""
-
 #, elixir-format
 msgctxt "errors"
 msgid "error"
@@ -132,10 +124,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "No error detected"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This GeoJSON was up-to-date with the GTFS resource %{hours} ago."
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -291,10 +291,6 @@ msgid "resource format"
 msgstr "format de la ressource"
 
 #, elixir-autogen, elixir-format
-msgid "see other formats"
-msgstr "autres formats"
-
-#, elixir-autogen, elixir-format
 msgid "real-time"
 msgstr "temps réel"
 
@@ -559,13 +555,5 @@ msgid "Static data"
 msgstr "Données statiques"
 
 #, elixir-autogen, elixir-format
-msgid "Automatic conversions for this %{format} resource"
-msgstr "Conversions automatiques pour cette ressource %{format}"
-
-#, elixir-autogen, elixir-format
-msgid "Conversions"
-msgstr "Conversions"
-
-#, elixir-autogen, elixir-format
-msgid "These resources are created automatically by transport.data.gouv.fr"
-msgstr "Ces ressources ont été générées automatiquement par transport.data.gouv.fr"
+msgid "Automatic conversions"
+msgstr "Conversions automatiques"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -557,3 +557,15 @@ msgstr "Données temps réel"
 #, elixir-autogen, elixir-format
 msgid "Static data"
 msgstr "Données statiques"
+
+#, elixir-autogen, elixir-format
+msgid "Automatic conversions for this %{format} resource"
+msgstr "Conversions automatiques pour cette ressource %{format}"
+
+#, elixir-autogen, elixir-format
+msgid "Conversions"
+msgstr "Conversions"
+
+#, elixir-autogen, elixir-format
+msgid "These resources are created automatically by transport.data.gouv.fr"
+msgstr "Ces ressources ont été générées automatiquement par transport.data.gouv.fr"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -99,14 +99,6 @@ msgstr "La visualisation des arrêts est volumineuse"
 msgid "Stops and routes visualization of the GTFS file"
 msgstr "Aperçu des arrêts et lignes de la ressource GTFS"
 
-#, elixir-autogen, elixir-format
-msgid "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)\n              It corresponds to the data you can see on the map below."
-msgstr "Le format GeoJSON ne contient que les informations géographiques de la ressource (position des arrêts, éventuellement tracé des lignes), telles que vous les visualisez sur la carte ci-dessous."
-
-#, elixir-autogen, elixir-format
-msgid "This resource is also available in the following formats:"
-msgstr "Cette ressource est également disponible dans les formats suivants :"
-
 #, elixir-format
 msgctxt "errors"
 msgid "error"
@@ -133,10 +125,6 @@ msgstr "Rapport de validation"
 #, elixir-autogen, elixir-format
 msgid "No error detected"
 msgstr "Pas d'erreur"
-
-#, elixir-autogen, elixir-format
-msgid "This GeoJSON was up-to-date with the GTFS resource %{hours} ago."
-msgstr "Ce GeoJSON était bien à jour avec la ressource GTFS il y a %{hours}."
 
 #, elixir-autogen, elixir-format
 msgid "Visualization up-to-date %{hours} ago."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -557,3 +557,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Static data"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Automatic conversions for this %{format} resource"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Conversions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "These resources are created automatically by transport.data.gouv.fr"
+msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -291,10 +291,6 @@ msgid "resource format"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "see other formats"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "real-time"
 msgstr ""
 
@@ -559,13 +555,5 @@ msgid "Static data"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Automatic conversions for this %{format} resource"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Conversions"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "These resources are created automatically by transport.data.gouv.fr"
+msgid "Automatic conversions"
 msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -98,14 +98,6 @@ msgstr ""
 msgid "Stops and routes visualization of the GTFS file"
 msgstr ""
 
-#, elixir-autogen, elixir-format
-msgid "GeoJSON format contains only the spatial information of the resource (stops coordinates, eventually lines shapes)\n              It corresponds to the data you can see on the map below."
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This resource is also available in the following formats:"
-msgstr ""
-
 #, elixir-format
 msgctxt "errors"
 msgid "error"
@@ -131,10 +123,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "No error detected"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This GeoJSON was up-to-date with the GTFS resource %{hours} ago."
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -429,19 +429,22 @@ defmodule DB.DatasetDBTest do
                geojson: %{
                  url: "url1",
                  filesize: "size1",
-                 resource_history_last_up_to_date_at: dt1
+                 resource_history_last_up_to_date_at: dt1,
+                 format: "GeoJSON"
                },
                netex: %{
                  url: "url11",
                  filesize: "size11",
-                 resource_history_last_up_to_date_at: dt1
+                 resource_history_last_up_to_date_at: dt1,
+                 format: "NeTEx"
                }
              },
              r2.id => %{
                geojson: %{
                  url: "url2",
                  filesize: "size2",
-                 resource_history_last_up_to_date_at: dt2
+                 resource_history_last_up_to_date_at: dt2,
+                 format: "GeoJSON"
                },
                netex: nil
              },

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -75,22 +75,6 @@ defmodule TransportWeb.ResourceControllerTest do
     end
   end
 
-  test "GTFS resource with associated NeTEx", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
-    insert(:resource_history, resource_id: resource.id, payload: %{"uuid" => uuid = Ecto.UUID.generate()})
-
-    insert(:data_conversion,
-      resource_history_uuid: uuid,
-      convert_from: "GTFS",
-      convert_to: "NeTEx",
-      payload: %{"permanent_url" => url = "https://super-cellar-url.com/netex"}
-    )
-
-    html_response = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
-    assert html_response =~ "NeTEx"
-    assert html_response =~ url
-  end
-
   test "GBFS resource with multi-validation sends back 200", %{conn: conn} do
     resource = Resource |> Repo.get_by(datagouv_id: "3")
     assert Resource.is_gbfs?(resource)


### PR DESCRIPTION
Fixes #2969

Affiche les conversions automatiques à partir de ressources publiées de manière plus visible qu'auparavant. Avant c'était sur la page "+ détails".

![image](https://user-images.githubusercontent.com/295709/224724796-5005b9cd-0594-4229-b38b-2b71b11bcbab.png)

Je supprime l'ancien affichage et j'ajoute des tests.

Améliorations possibles ultérieures :
- ajouts dans l'API
- stocker des statistiques pour connaitre le téléchargements de ces conversions automatiques
- création d'URLs stables `/conversions/:resource_id/:format` ?
