### PR TITLE
Plus de CSP pour la page swagger

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -8,14 +8,13 @@ defmodule TransportWeb.Router do
     def actions(e), do: [%{label: "Not found", handler: {IO, :puts, ["Template not found: #{inspect(e)}"]}}]
   end
 
-  pipeline :browser do
+  pipeline :browser_no_csp do
     plug(:canonical_host)
 
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_live_flash)
     plug(:protect_from_forgery)
-    plug(TransportWeb.Plugs.CustomSecureBrowserHeaders)
     plug(TransportWeb.Plugs.PutLocale)
     plug(:assign_current_user)
     plug(:assign_contact_email)
@@ -23,6 +22,11 @@ defmodule TransportWeb.Router do
     plug(:maybe_login_again)
     plug(:assign_mix_env)
     plug(Sentry.PlugContext)
+  end
+
+  pipeline :browser do
+    plug(:browser_no_csp)
+    plug(TransportWeb.Plugs.CustomSecureBrowserHeaders)
   end
 
   pipeline :accept_json do
@@ -40,7 +44,7 @@ defmodule TransportWeb.Router do
   end
 
   scope "/", OpenApiSpex.Plug do
-    pipe_through(:browser)
+    pipe_through(:browser_no_csp)
     get("/swaggerui", SwaggerUI, path: "/api/openapi")
   end
 


### PR DESCRIPTION
Notre page swagger est actuellement blanche car une bonne partie de son contenu est bloqué par nos headers CSP.

Malheureusement, cela semble concerner directement la lib [swagger-ui](https://github.com/swagger-api/swagger-ui) et le problème a déjà été remonté.

https://github.com/swagger-api/swagger-ui/issues/7540
https://github.com/swagger-api/swagger-ui/issues/5817

On dirait qu'il n'y a pas de possibilité d'injecter des nonce.

Plutôt que d'autoriser le CSS inline partout à cause de swagger, je préfère ne pas appliquer de CSP à cette page là uniquement.

In english: I now serve the swagger page without CSP headers, because I don't want to weaken the CSP policy on the whole website just for this page.