### PR TITLE
Permalink record stats conversions

### DIFF
--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -7,7 +7,7 @@ defmodule DB.DataConversion do
   import Ecto.Query
 
   typed_schema "data_conversion" do
-    field(:convert_from, :string)
+    field(:convert_from, Ecto.Enum, values: [:GTFS])
     field(:convert_to, Ecto.Enum, values: [:GeoJSON, :NeTEx])
     field(:resource_history_uuid, Ecto.UUID)
     field(:payload, :map)

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -8,7 +8,7 @@ defmodule DB.DataConversion do
 
   typed_schema "data_conversion" do
     field(:convert_from, :string)
-    field(:convert_to, :string)
+    field(:convert_to, Ecto.Enum, values: [:GeoJSON, :NeTEx])
     field(:resource_history_uuid, Ecto.UUID)
     field(:payload, :map)
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -220,7 +220,7 @@ defmodule DB.Resource do
   @spec get_related_conversion_info(integer() | nil, binary()) :: %{url: binary(), filesize: binary()} | nil
   def get_related_conversion_info(nil, _), do: nil
 
-  def get_related_conversion_info(resource_id, format) when format in ["GeoJSON", "NeTEx"] do
+  def get_related_conversion_info(resource_id, format) do
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
       as: :dc,

--- a/apps/transport/lib/jobs/backfill/backfill_data_conversion_netex_filesize.ex
+++ b/apps/transport/lib/jobs/backfill/backfill_data_conversion_netex_filesize.ex
@@ -30,7 +30,7 @@ defmodule Transport.Jobs.Backfill.DataConversionNeTExFilesize do
 
   defp fetch_next(data_conversion_id) do
     DataConversion
-    |> where([dc], dc.id > ^data_conversion_id and dc.convert_to == "NeTEx")
+    |> where([dc], dc.id > ^data_conversion_id and dc.convert_to == :NeTEx)
     |> order_by(asc: :id)
     |> limit(1)
     |> select([dc], dc.id)
@@ -42,7 +42,7 @@ defmodule Transport.Jobs.Backfill.DataConversionNeTExFilesize do
   end
 
   defp do_update(
-         %DataConversion{convert_from: "GTFS", convert_to: "NeTEx", payload: %{"permanent_url" => url} = payload} = dc
+         %DataConversion{convert_from: :GTFS, convert_to: :NeTEx, payload: %{"permanent_url" => url} = payload} = dc
        ) do
     http_client = Transport.Shared.Wrapper.HTTPoison.impl()
 

--- a/apps/transport/lib/jobs/gtfs_generic_converter.ex
+++ b/apps/transport/lib/jobs/gtfs_generic_converter.ex
@@ -127,8 +127,8 @@ defmodule Transport.Jobs.GTFSGenericConverter do
           Transport.S3.upload_to_s3!(:history, file, conversion_file_name)
 
           %DataConversion{
-            convert_from: "GTFS",
-            convert_to: format,
+            convert_from: :GTFS,
+            convert_to: String.to_existing_atom(format),
             resource_history_uuid: resource_uuid,
             payload: %{
               filename: conversion_file_name,

--- a/apps/transport/lib/transport/telemetry.ex
+++ b/apps/transport/lib/transport/telemetry.ex
@@ -9,6 +9,12 @@ defmodule Transport.Telemetry do
   defdelegate proxy_request_event_name(request), to: Unlock.Telemetry
   defdelegate gbfs_request_event_name(request), to: Unlock.Telemetry
 
+  def conversions_get_event_names do
+    DB.DataConversion
+    |> Ecto.Enum.dump_values(:convert_to)
+    |> Enum.map(&[:conversions, :get, &1 |> String.downcase() |> String.to_existing_atom()])
+  end
+
   @moduledoc """
   This place groups various aspects of event handling (currently to get metrics for the proxy, later more):
   - events handler declaration
@@ -55,22 +61,52 @@ defmodule Transport.Telemetry do
     end)
   end
 
+  def handle_event(
+        [:conversions, :get, convert_to] = event,
+        _measurements,
+        %{target: target},
+        _config
+      ) do
+    # make it non-blocking, to ensure the traffic will be served quickly. this also means, though, we
+    # won't notice if a tracing of event fails
+    Task.start(fn ->
+      Logger.info("Telemetry event: processing #{convert_to} conversions request for #{target}")
+      count_event(target, event, DateTime.utc_now(), :day)
+    end)
+  end
+
   def database_event_name(event_name), do: Enum.join(event_name, ":")
 
   @doc """
   We embrace the fact that our current implementation's goal is not to replace
   a full-blown timeseries, by limiting the bucket timespan to 1 hour.
+
+  iex> truncate_datetime_to_hour(~U[2023-03-14 09:36:11.642695Z])
+  ~U[2023-03-14 09:00:00Z]
   """
   def truncate_datetime_to_hour(datetime) do
     %{DateTime.truncate(datetime, :second) | second: 0, minute: 0}
   end
 
   @doc """
+  iex> truncate_datetime_to_day(~U[2023-03-14 09:36:11.642695Z])
+  ~U[2023-03-14 00:00:00Z]
+  """
+  def truncate_datetime_to_day(datetime) do
+    %{DateTime.truncate(datetime, :second) | second: 0, minute: 0, hour: 0}
+  end
+
+  @doc """
   Atomically upsert a count record in the database.
   """
-  def count_event(target, event, period \\ DateTime.utc_now()) do
+  def count_event(target, event, period \\ DateTime.utc_now(), truncate_period \\ :hour) do
     event = database_event_name(event)
-    period = truncate_datetime_to_hour(period)
+
+    period =
+      case truncate_period do
+        :hour -> truncate_datetime_to_hour(period)
+        :day -> truncate_datetime_to_day(period)
+      end
 
     DB.Repo.insert!(
       %DB.Metrics{target: target, event: event, period: period, count: 1},
@@ -84,25 +120,24 @@ defmodule Transport.Telemetry do
   Attach the required handlers. To be called at application start.
   """
   def setup do
-    :ok =
-      :telemetry.attach_many(
-        # unique handler id
-        "proxy-logging-handler",
-        # here we list the "event names" (a name is actually a list of atoms, per
-        # https://hexdocs.pm/telemetry/telemetry.html#t:event_name/0)
-        # for which we want to be called in the handler
-        proxy_request_event_names(),
-        &Transport.Telemetry.handle_event/4,
-        nil
-      )
-
-    :ok =
-      :telemetry.attach_many(
-        "gbfs-logging-handler",
-        gbfs_request_event_names(),
-        &Transport.Telemetry.handle_event/4,
-        nil
-      )
+    [
+      {"proxy-logging-handler", proxy_request_event_names()},
+      {"gbfs-logging-handler", gbfs_request_event_names()},
+      {"conversions-logging-handler", conversions_get_event_names()}
+    ]
+    |> Enum.each(fn {name, events} ->
+      :ok =
+        :telemetry.attach_many(
+          # unique handler id
+          name,
+          # here we list the "event names" (a name is actually a list of atoms, per
+          # https://hexdocs.pm/telemetry/telemetry.html#t:event_name/0)
+          # for which we want to be called in the handler
+          events,
+          &Transport.Telemetry.handle_event/4,
+          nil
+        )
+    end)
 
     :ok =
       :telemetry.attach(

--- a/apps/transport/lib/transport_web/controllers/conversion_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/conversion_controller.ex
@@ -1,0 +1,37 @@
+defmodule TransportWeb.ConversionController do
+  use TransportWeb, :controller
+
+  def get(%Plug.Conn{} = conn, %{"resource_id" => resource_id, "convert_to" => convert_to}) do
+    if convert_to in Ecto.Enum.dump_values(DB.DataConversion, :convert_to) do
+      case DB.Resource.get_related_conversion_info(resource_id, convert_to) do
+        nil ->
+          conn |> conversion_not_found()
+
+        %{url: url} ->
+          trace_request(resource_id, convert_to)
+          conn |> put_status(302) |> redirect(external: url)
+      end
+    else
+      conn |> conversion_not_found("`convert_to` is not a possible value.")
+    end
+  end
+
+  def get(%Plug.Conn{} = conn, _) do
+    conn |> conversion_not_found("Unrecognized parameters.")
+  end
+
+  defp trace_request(resource_id, convert_to) do
+    convert_to_atom = convert_to |> String.downcase() |> String.to_existing_atom()
+    :telemetry.execute([:conversions, :get, convert_to_atom], %{}, %{target: "resource_id:#{resource_id}"})
+  end
+
+  defp conversion_not_found(%Plug.Conn{} = conn, explanation \\ "") do
+    message =
+      case explanation do
+        "" -> "Conversion not found."
+        explanation -> "Conversion not found. " <> explanation
+      end
+
+    conn |> put_status(:not_found) |> text(message)
+  end
+end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -100,6 +100,10 @@ defmodule TransportWeb.Router do
       get("/:id", ResourceController, :details)
       get("/:id/download", ResourceController, :download)
 
+      scope "/conversions" do
+        get("/:resource_id/:convert_to", ConversionController, :get)
+      end
+
       scope "/show" do
         pipe_through([:authenticated])
         get("/proxy_statistics", ResourceController, :proxy_statistics)

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -9,16 +9,15 @@ defmodule DB.DataConversionTest do
   test "constraints on data_conversion table" do
     assert %{id: _data_conversion_id} =
              insert(:data_conversion,
-               convert_from: "GTFS",
-               convert_to: "GeoJSON",
+               convert_from: :GTFS,
+               convert_to: :GeoJSON,
                resource_history_uuid: Ecto.UUID.generate(),
                payload: %{}
              )
 
     # Enforce correct case for convert_from format
-    # Constraints are enforced by the DB, if we need to support new formats,
-    # we need to do via a new migration.
-    assert_raise(Ecto.ConstraintError, fn ->
+    # Constraints are enforced by the DB and by `Ecto.Enum`s
+    assert_raise(RuntimeError, fn ->
       insert(:data_conversion,
         convert_from: "gtfsqq",
         convert_to: "GeoJSON",
@@ -28,10 +27,10 @@ defmodule DB.DataConversionTest do
     end)
 
     # enforce correct case for convert_to format
-    assert_raise(Ecto.ConstraintError, fn ->
+    assert_raise(RuntimeError, fn ->
       insert(:data_conversion,
-        convert_from: "GTFS",
-        convert_to: "geojson",
+        convert_from: :GTFS,
+        convert_to: :geojson,
         resource_history_uuid: Ecto.UUID.generate(),
         payload: %{}
       )
@@ -41,8 +40,8 @@ defmodule DB.DataConversionTest do
   test "uniqueness of data_conversion" do
     assert %{id: _data_conversion_id} =
              insert(:data_conversion,
-               convert_from: "GTFS",
-               convert_to: "GeoJSON",
+               convert_from: :GTFS,
+               convert_to: :GeoJSON,
                resource_history_uuid: uuid = Ecto.UUID.generate(),
                payload: %{}
              )
@@ -50,8 +49,8 @@ defmodule DB.DataConversionTest do
     # you cannot have 2 rows with the same {convert_from, convert_to, resource_history_uuid}
     assert_raise(Ecto.ConstraintError, fn ->
       insert(:data_conversion,
-        convert_from: "GTFS",
-        convert_to: "GeoJSON",
+        convert_from: :GTFS,
+        convert_to: :GeoJSON,
         resource_history_uuid: uuid,
         payload: %{}
       )


### PR DESCRIPTION
Suite de #3018, lié à #2969

Cette PR crée des URLs stables pour les conversions des ressources GTFS (GeoJSON et NeTEx pour le moment) et enregistre des statistiques du nombre de téléchargements à la journée, en reprenant les `metrics` utilisées par le proxy GBFS et GTFS-RT au pas de temps de l'heure.