### PR TITLE
Recherche de contacts par prénom

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -31,10 +31,9 @@ defmodule DB.Contact do
   def base_query, do: from(c in __MODULE__, as: :contact)
 
   def search(%{"q" => q}) do
-    ilike = "%#{q}%"
-
     base_query()
-    |> where([contact: c], ilike(c.last_name, ^ilike) or ilike(c.mailing_list_title, ^ilike) or c.organization == ^q)
+    |> where([contact: c], c.organization == ^q)
+    |> or_where([contact: c], fragment("to_tsvector('custom_french', concat(?, ' ', ?, ' ', ?)) @@  plainto_tsquery('custom_french', ?)", c.first_name, c.last_name, c.mailing_list_title, ^q))
   end
 
   def search(%{}), do: base_query()

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -33,7 +33,16 @@ defmodule DB.Contact do
   def search(%{"q" => q}) do
     base_query()
     |> where([contact: c], c.organization == ^q)
-    |> or_where([contact: c], fragment("to_tsvector('custom_french', concat(?, ' ', ?, ' ', ?)) @@  plainto_tsquery('custom_french', ?)", c.first_name, c.last_name, c.mailing_list_title, ^q))
+    |> or_where(
+      [contact: c],
+      fragment(
+        "to_tsvector('custom_french', concat(?, ' ', ?, ' ', ?)) @@  plainto_tsquery('custom_french', ?)",
+        c.first_name,
+        c.last_name,
+        c.mailing_list_title,
+        ^q
+      )
+    )
   end
 
   def search(%{}), do: base_query()

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/index.html.heex
@@ -14,7 +14,7 @@
       <% end %>
     </datalist>
     <button type="submit" class="button backoffice_search_button"><i class="fa fa-search"></i></button>
-    <div class="small">Recherchez par nom de famille, titre ou organisation</div>
+    <div class="small">Rechercher par prénom, nom, titre ou organisation</div>
   <% end %>
 
   <a class="button" href={backoffice_contact_path(@conn, :new)}>

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -153,6 +153,7 @@ defmodule DB.ContactTest do
     DB.Contact.insert!(%{sample_contact_args() | last_name: "Doe", organization: "Big Corp Inc"})
     DB.Contact.insert!(%{sample_contact_args() | last_name: "Bar", organization: "Big Corp Inc"})
     DB.Contact.insert!(%{sample_contact_args() | last_name: "Baz", organization: "Foo Bar"})
+    DB.Contact.insert!(%{sample_contact_args() | first_name: "Marina", last_name: "Loiseau", organization: "CNRS"})
 
     DB.Contact.insert!(%{
       sample_contact_args()
@@ -167,6 +168,7 @@ defmodule DB.ContactTest do
     assert [%DB.Contact{last_name: "Bar"}] = search_fn.(%{"q" => "bar"})
     assert [%DB.Contact{organization: "Foo Bar"}] = search_fn.(%{"q" => "Foo Bar"})
     assert [%DB.Contact{mailing_list_title: "Service SIG"}] = search_fn.(%{"q" => "SIG"})
+    assert [%DB.Contact{first_name: "Marina"}] = search_fn.(%{"q" => "marina"})
   end
 
   defp sample_contact_args do


### PR DESCRIPTION
Fixes #3031

Recherche par prénom, nom, titre (avec `ts_query`) ou organisation (stricte) de contacts.