### PR TITLE
Backoffice : ajout organisation d'un contact dans datalist

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -180,7 +180,7 @@ defmodule TransportWeb.Backoffice.PageController do
 
   defp contacts_datalist do
     DB.Contact.base_query()
-    |> select([contact: c], [:first_name, :last_name, :mailing_list_title, :id])
+    |> select([contact: c], [:first_name, :last_name, :mailing_list_title, :organization, :id])
     |> DB.Repo.all()
   end
 

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -84,7 +84,7 @@
         <% end %>
         <datalist id="contacts_datalist">
           <%= for contact <- @contacts_datalist do %>
-            <option value={contact.id}><%= DB.Contact.display_name(contact) %></option>
+            <option value={contact.id}><%= DB.Contact.display_name(contact) %> (<%= contact.organization %>)</option>
           <% end %>
         </datalist>
         <%= label f, :reasons, class: "pt-12" do %>


### PR DESCRIPTION
On n'affichait pas l'organisation d'un contact dans la `datalist` ce qui ne facilite pas vraiment la recherche, voire est source de confusiant pour les listes de diffusion (découvert quand je cherchais notre contact "Équipe déploiement").