### PR TITLE
latest_data_gouv_comment_timestamp: pas besoin de usec

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -37,7 +37,7 @@ defmodule DB.Dataset do
     field(:is_active, :boolean)
     field(:population, :integer)
     field(:nb_reuses, :integer)
-    field(:latest_data_gouv_comment_timestamp, :utc_datetime_usec)
+    field(:latest_data_gouv_comment_timestamp, :utc_datetime)
     field(:archived_at, :utc_datetime_usec)
     field(:custom_tags, {:array, :string})
 

--- a/apps/transport/lib/transport/comments_checker.ex
+++ b/apps/transport/lib/transport/comments_checker.ex
@@ -112,7 +112,7 @@ defmodule Transport.CommentsChecker do
     |> Map.get("posted_on")
     |> DateTime.from_iso8601()
     |> case do
-      {:ok, %DateTime{} = datetime, 0} -> datetime
+      {:ok, %DateTime{} = datetime, 0} -> datetime |> DateTime.truncate(:second)
       _ -> nil
     end
   end

--- a/apps/transport/test/transport/comments_checker_test.exs
+++ b/apps/transport/test/transport/comments_checker_test.exs
@@ -100,7 +100,7 @@ defmodule Transport.CommentsCheckerTest do
     ]
 
     assert CommentsChecker.comments_latest_timestamp(discussions) ==
-             ~U[2021-05-12 15:07:04.547000Z]
+             ~U[2021-05-12 15:07:04Z]
   end
 
   test "timestamp of empty list is nil" do


### PR DESCRIPTION
Fixes #3051

Il semblerait que l'API de data.gouv.fr puisse renvoyer un datetime sans microsecondes, ce fait hurler Ecto quand le type indiqué est `:utc_datetime_usec`, [voir doc](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types).

> For calendar types with and without microseconds, the precision is enforced when persisting to the DB. For example, casting ~T[09:00:00] as :time_usec will succeed and result in ~T[09:00:00.000000], but persisting a type without microseconds as :time_usec will fail. Similarly, casting ~T[09:00:00.000000] as :time will succeed, but persisting will not. This is the same behaviour as seen in other types, where casting has to be done explicitly and is never performed implicitly when loading from or dumping to the database.

En attendant que l'équipe de data.gouv.fr clarifie la situation, il me parait tout à fait acceptable d'indiquer qu'on n'a pas besoin d'une précision avec des microsecondes.