### PR TITLE
GTFS-RT : met à jour le fichier Protobuf

### DIFF
--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
@@ -1,6 +1,6 @@
 defmodule TransitRealtime.FeedHeader.Incrementality do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:FULL_DATASET, 0)
   field(:DIFFERENTIAL, 1)
@@ -8,16 +8,17 @@ end
 
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:SKIPPED, 1)
   field(:NO_DATA, 2)
+  field(:UNSCHEDULED, 3)
 end
 
 defmodule TransitRealtime.VehiclePosition.VehicleStopStatus do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:INCOMING_AT, 0)
   field(:STOPPED_AT, 1)
@@ -26,7 +27,7 @@ end
 
 defmodule TransitRealtime.VehiclePosition.CongestionLevel do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:UNKNOWN_CONGESTION_LEVEL, 0)
   field(:RUNNING_SMOOTHLY, 1)
@@ -37,7 +38,7 @@ end
 
 defmodule TransitRealtime.VehiclePosition.OccupancyStatus do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:EMPTY, 0)
   field(:MANY_SEATS_AVAILABLE, 1)
@@ -46,11 +47,13 @@ defmodule TransitRealtime.VehiclePosition.OccupancyStatus do
   field(:CRUSHED_STANDING_ROOM_ONLY, 4)
   field(:FULL, 5)
   field(:NOT_ACCEPTING_PASSENGERS, 6)
+  field(:NO_DATA_AVAILABLE, 7)
+  field(:NOT_BOARDABLE, 8)
 end
 
 defmodule TransitRealtime.Alert.Cause do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:UNKNOWN_CAUSE, 1)
   field(:OTHER_CAUSE, 2)
@@ -68,7 +71,7 @@ end
 
 defmodule TransitRealtime.Alert.Effect do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:NO_SERVICE, 1)
   field(:REDUCED_SERVICE, 2)
@@ -79,31 +82,56 @@ defmodule TransitRealtime.Alert.Effect do
   field(:OTHER_EFFECT, 7)
   field(:UNKNOWN_EFFECT, 8)
   field(:STOP_MOVED, 9)
+  field(:NO_EFFECT, 10)
+  field(:ACCESSIBILITY_ISSUE, 11)
+end
+
+defmodule TransitRealtime.Alert.SeverityLevel do
+  @moduledoc false
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:UNKNOWN_SEVERITY, 1)
+  field(:INFO, 2)
+  field(:WARNING, 3)
+  field(:SEVERE, 4)
 end
 
 defmodule TransitRealtime.TripDescriptor.ScheduleRelationship do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:ADDED, 1)
   field(:UNSCHEDULED, 2)
   field(:CANCELED, 3)
+  field(:REPLACEMENT, 5)
+  field(:DUPLICATED, 6)
+  field(:DELETED, 7)
+end
+
+defmodule TransitRealtime.VehicleDescriptor.WheelchairAccessible do
+  @moduledoc false
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:NO_VALUE, 0)
+  field(:UNKNOWN, 1)
+  field(:WHEELCHAIR_ACCESSIBLE, 2)
+  field(:WHEELCHAIR_INACCESSIBLE, 3)
 end
 
 defmodule TransitRealtime.FeedMessage do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:header, 1, required: true, type: TransitRealtime.FeedHeader)
   field(:entity, 2, repeated: true, type: TransitRealtime.FeedEntity)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.FeedHeader do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:gtfs_realtime_version, 1, required: true, type: :string)
 
@@ -116,41 +144,57 @@ defmodule TransitRealtime.FeedHeader do
 
   field(:timestamp, 3, optional: true, type: :uint64)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.FeedEntity do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:id, 1, required: true, type: :string)
   field(:is_deleted, 2, optional: true, type: :bool, default: false)
   field(:trip_update, 3, optional: true, type: TransitRealtime.TripUpdate)
   field(:vehicle, 4, optional: true, type: TransitRealtime.VehiclePosition)
   field(:alert, 5, optional: true, type: TransitRealtime.Alert)
+  field(:shape, 6, optional: true, type: TransitRealtime.Shape)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TripUpdate.StopTimeEvent do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:delay, 1, optional: true, type: :int32)
   field(:time, 2, optional: true, type: :int64)
   field(:uncertainty, 3, optional: true, type: :int32)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:assigned_stop_id, 1, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32)
   field(:stop_id, 4, optional: true, type: :string)
   field(:arrival, 2, optional: true, type: TransitRealtime.TripUpdate.StopTimeEvent)
   field(:departure, 3, optional: true, type: TransitRealtime.TripUpdate.StopTimeEvent)
+
+  field(:departure_occupancy_status, 7,
+    optional: true,
+    type: TransitRealtime.VehiclePosition.OccupancyStatus,
+    enum: true
+  )
 
   field(:schedule_relationship, 5,
     optional: true,
@@ -159,25 +203,63 @@ defmodule TransitRealtime.TripUpdate.StopTimeUpdate do
     enum: true
   )
 
-  extensions([{1000, 2000}])
+  field(:stop_time_properties, 6,
+    optional: true,
+    type: TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties
+  )
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TripUpdate.TripProperties do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:trip_id, 1, optional: true, type: :string)
+  field(:start_date, 2, optional: true, type: :string)
+  field(:start_time, 3, optional: true, type: :string)
+  field(:shape_id, 4, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TripUpdate do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:trip, 1, required: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 3, optional: true, type: TransitRealtime.VehicleDescriptor)
   field(:stop_time_update, 2, repeated: true, type: TransitRealtime.TripUpdate.StopTimeUpdate)
   field(:timestamp, 4, optional: true, type: :uint64)
   field(:delay, 5, optional: true, type: :int32)
+  field(:trip_properties, 6, optional: true, type: TransitRealtime.TripUpdate.TripProperties)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.VehiclePosition.CarriageDetails do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:id, 1, optional: true, type: :string)
+  field(:label, 2, optional: true, type: :string)
+
+  field(:occupancy_status, 3,
+    optional: true,
+    type: TransitRealtime.VehiclePosition.OccupancyStatus,
+    default: :NO_DATA_AVAILABLE,
+    enum: true
+  )
+
+  field(:occupancy_percentage, 4, optional: true, type: :int32, default: -1)
+  field(:carriage_sequence, 5, optional: true, type: :uint32)
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.VehiclePosition do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:trip, 1, optional: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 8, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -206,12 +288,19 @@ defmodule TransitRealtime.VehiclePosition do
     enum: true
   )
 
-  extensions([{1000, 2000}])
+  field(:occupancy_percentage, 10, optional: true, type: :uint32)
+
+  field(:multi_carriage_details, 11,
+    repeated: true,
+    type: TransitRealtime.VehiclePosition.CarriageDetails
+  )
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.Alert do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:active_period, 1, repeated: true, type: TransitRealtime.TimeRange)
   field(:informed_entity, 5, repeated: true, type: TransitRealtime.EntitySelector)
@@ -233,23 +322,37 @@ defmodule TransitRealtime.Alert do
   field(:url, 8, optional: true, type: TransitRealtime.TranslatedString)
   field(:header_text, 10, optional: true, type: TransitRealtime.TranslatedString)
   field(:description_text, 11, optional: true, type: TransitRealtime.TranslatedString)
+  field(:tts_header_text, 12, optional: true, type: TransitRealtime.TranslatedString)
+  field(:tts_description_text, 13, optional: true, type: TransitRealtime.TranslatedString)
 
-  extensions([{1000, 2000}])
+  field(:severity_level, 14,
+    optional: true,
+    type: TransitRealtime.Alert.SeverityLevel,
+    default: :UNKNOWN_SEVERITY,
+    enum: true
+  )
+
+  field(:image, 15, optional: true, type: TransitRealtime.TranslatedImage)
+  field(:image_alternative_text, 16, optional: true, type: TransitRealtime.TranslatedString)
+  field(:cause_detail, 17, optional: true, type: TransitRealtime.TranslatedString)
+  field(:effect_detail, 18, optional: true, type: TransitRealtime.TranslatedString)
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TimeRange do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:start, 1, optional: true, type: :uint64)
   field(:end, 2, optional: true, type: :uint64)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.Position do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:latitude, 1, required: true, type: :float)
   field(:longitude, 2, required: true, type: :float)
@@ -257,12 +360,12 @@ defmodule TransitRealtime.Position do
   field(:odometer, 4, optional: true, type: :double)
   field(:speed, 5, optional: true, type: :float)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TripDescriptor do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string)
   field(:route_id, 5, optional: true, type: :string)
@@ -276,48 +379,86 @@ defmodule TransitRealtime.TripDescriptor do
     enum: true
   )
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.VehicleDescriptor do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
   field(:license_plate, 3, optional: true, type: :string)
 
-  extensions([{1000, 2000}])
+  field(:wheelchair_accessible, 4,
+    optional: true,
+    type: TransitRealtime.VehicleDescriptor.WheelchairAccessible,
+    default: :NO_VALUE,
+    enum: true
+  )
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.EntitySelector do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:agency_id, 1, optional: true, type: :string)
   field(:route_id, 2, optional: true, type: :string)
   field(:route_type, 3, optional: true, type: :int32)
   field(:trip, 4, optional: true, type: TransitRealtime.TripDescriptor)
   field(:stop_id, 5, optional: true, type: :string)
+  field(:direction_id, 6, optional: true, type: :uint32)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TranslatedString.Translation do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:text, 1, required: true, type: :string)
   field(:language, 2, optional: true, type: :string)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TranslatedString do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
   field(:translation, 1, repeated: true, type: TransitRealtime.TranslatedString.Translation)
 
-  extensions([{1000, 2000}])
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TranslatedImage.LocalizedImage do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:url, 1, required: true, type: :string)
+  field(:media_type, 2, required: true, type: :string)
+  field(:language, 3, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TranslatedImage do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:localized_image, 1, repeated: true, type: TransitRealtime.TranslatedImage.LocalizedImage)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.Shape do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  field(:shape_id, 1, optional: true, type: :string)
+  field(:encoded_polyline, 2, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
 end

--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
@@ -23,10 +23,8 @@
 // https://github.com/google/transit/tree/master/gtfs-realtime
 
 syntax = "proto2";
-
-package transit_realtime;
-
 option java_package = "com.google.transit.realtime";
+package transit_realtime;
 
 // The contents of a feed message.
 // A feed is a continuous stream of feed messages. Each message in the stream is
@@ -48,12 +46,15 @@ message FeedMessage {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Metadata about a feed, included in feed messages.
 message FeedHeader {
   // Version of the feed specification.
-  // The current version is 2.0.
+  // The current version is 2.0.  Valid versions are "2.0", "1.0".
   required string gtfs_realtime_version = 1;
 
   // Determines whether the current fetch is incremental.  Currently,
@@ -76,6 +77,9 @@ message FeedHeader {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A definition (or update) of an entity in the transit feed.
@@ -100,10 +104,16 @@ message FeedEntity {
   optional VehiclePosition vehicle = 4;
   optional Alert alert = 5;
 
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional Shape shape = 6;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -182,6 +192,9 @@ message TripUpdate {
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Realtime update for arrival and/or departure events for a given stop on a
@@ -200,33 +213,83 @@ message TripUpdate {
     optional StopTimeEvent arrival = 2;
     optional StopTimeEvent departure = 3;
 
-    // The relation between this StopTime and the static schedule.
+    // Expected occupancy after departure from the given stop.
+    // Should be provided only for future stops.
+    // In order to provide departure_occupancy_status without either arrival or
+    // departure StopTimeEvents, ScheduleRelationship should be set to NO_DATA.
+    optional VehiclePosition.OccupancyStatus departure_occupancy_status = 7;
+
+    // The relation between the StopTimeEvents and the static schedule.
     enum ScheduleRelationship {
       // The vehicle is proceeding in accordance with its static schedule of
       // stops, although not necessarily according to the times of the schedule.
       // At least one of arrival and departure must be provided. If the schedule
       // for this stop contains both arrival and departure times then so must
-      // this update.
+      // this update. Frequency-based trips (GTFS frequencies.txt with exact_times = 0)
+      // should not have a SCHEDULED value and should use UNSCHEDULED instead.
       SCHEDULED = 0;
 
       // The stop is skipped, i.e., the vehicle will not stop at this stop.
       // Arrival and departure are optional.
       SKIPPED = 1;
 
-      // No data is given for this stop. The main intention for this value is to
-      // give the predictions only for part of a trip, i.e., if the last update
-      // for a trip has a NO_DATA specifier, then StopTimes for the rest of the
-      // stops in the trip are considered to be unspecified as well.
+      // No StopTimeEvents are given for this stop.
+      // The main intention for this value is to give time predictions only for
+      // part of a trip, i.e., if the last update for a trip has a NO_DATA
+      // specifier, then StopTimeEvents for the rest of the stops in the trip
+      // are considered to be unspecified as well.
       // Neither arrival nor departure should be supplied.
       NO_DATA = 2;
+
+      // The vehicle is operating a trip defined in GTFS frequencies.txt with exact_times = 0.
+      // This value should not be used for trips that are not defined in GTFS frequencies.txt,
+      // or trips in GTFS frequencies.txt with exact_times = 1. Trips containing StopTimeUpdates
+      // with ScheduleRelationship=UNSCHEDULED must also set TripDescriptor.ScheduleRelationship=UNSCHEDULED.
+      // NOTE: This field is still experimental, and subject to change. It may be
+      // formally adopted in the future.
+      UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
+
+    // Provides the updated values for the stop time.
+    // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+    message StopTimeProperties {
+      // Supports real-time stop assignments. Refers to a stop_id defined in the GTFS stops.txt.
+      // The new assigned_stop_id should not result in a significantly different trip experience for the end user than
+      // the stop_id defined in GTFS stop_times.txt. In other words, the end user should not view this new stop_id as an
+      // "unusual change" if the new stop was presented within an app without any additional context.
+      // For example, this field is intended to be used for platform assignments by using a stop_id that belongs to the
+      // same station as the stop originally defined in GTFS stop_times.txt.
+      // To assign a stop without providing any real-time arrival or departure predictions, populate this field and set
+      // StopTimeUpdate.schedule_relationship = NO_DATA.
+      // If this field is populated, it is preferred to omit `StopTimeUpdate.stop_id` and use only `StopTimeUpdate.stop_sequence`. If
+      // `StopTimeProperties.assigned_stop_id` and `StopTimeUpdate.stop_id` are populated, `StopTimeUpdate.stop_id` must match `assigned_stop_id`.
+      // Platform assignments should be reflected in other GTFS-realtime fields as well
+      // (e.g., `VehiclePosition.stop_id`).
+      // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+      optional string assigned_stop_id = 1;
+
+      // The extensions namespace allows 3rd-party developers to extend the
+      // GTFS Realtime Specification in order to add and evaluate new features
+      // and modifications to the spec.
+      extensions 1000 to 1999;
+
+      // The following extension IDs are reserved for private use by any organization.
+      extensions 9000 to 9999;
+    }
+
+    // Realtime updates for certain properties defined within GTFS stop_times.txt
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional StopTimeProperties stop_time_properties = 6;
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Updates to StopTimes for the trip (both future, i.e., predictions, and in
@@ -250,7 +313,9 @@ message TripUpdate {
   // - stop_sequences 10,... have unknown delay.
   repeated StopTimeUpdate stop_time_update = 2;
 
-  // Moment at which the vehicle's real-time progress was measured. In POSIX
+  // The most recent moment at which the vehicle's real-time progress was measured
+  // to estimate StopTimes in the future. When StopTimes in the past are provided,
+  // arrival/departure times may be earlier than this value. In POSIX
   // time (i.e., the number of seconds since January 1st 1970 00:00:00 UTC).
   optional uint64 timestamp = 4;
 
@@ -274,10 +339,61 @@ message TripUpdate {
   // formally adopted in the future.
   optional int32 delay = 5;
 
+  // Defines updated properties of the trip, such as a new shape_id when there is a detour. Or defines the
+  // trip_id, start_date, and start_time of a DUPLICATED trip.
+  // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+  message TripProperties {
+    // Defines the identifier of a new trip that is a duplicate of an existing trip defined in (CSV) GTFS trips.txt
+    // but will start at a different service date and/or time (defined using the TripProperties.start_date and
+    // TripProperties.start_time fields). See definition of trips.trip_id in (CSV) GTFS. Its value must be different
+    // than the ones used in the (CSV) GTFS. Required if schedule_relationship=DUPLICATED, otherwise this field must not
+    // be populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string trip_id = 1;
+    // Service date on which the DUPLICATED trip will be run, in YYYYMMDD format. Required if
+    // schedule_relationship=DUPLICATED, otherwise this field must not be populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string start_date = 2;
+    // Defines the departure start time of the trip when it’s duplicated. See definition of stop_times.departure_time
+    // in (CSV) GTFS. Scheduled arrival and departure times for the duplicated trip are calculated based on the offset
+    // between the original trip departure_time and this field. For example, if a GTFS trip has stop A with a
+    // departure_time of 10:00:00 and stop B with departure_time of 10:01:00, and this field is populated with the value
+    // of 10:30:00, stop B on the duplicated trip will have a scheduled departure_time of 10:31:00. Real-time prediction
+    // delay values are applied to this calculated schedule time to determine the predicted time. For example, if a
+    // departure delay of 30 is provided for stop B, then the predicted departure time is 10:31:30. Real-time
+    // prediction time values do not have any offset applied to them and indicate the predicted time as provided.
+    // For example, if a departure time representing 10:31:30 is provided for stop B, then the predicted departure time
+    // is 10:31:30. This field is required if schedule_relationship is DUPLICATED, otherwise this field must not be
+    // populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string start_time = 3;
+    // Specifies the shape of the vehicle travel path when the trip shape differs from the shape specified in
+    // (CSV) GTFS or to specify it in real-time when it's not provided by (CSV) GTFS, such as a vehicle that takes differing
+    // paths based on rider demand. See definition of trips.shape_id in (CSV) GTFS. If a shape is neither defined in (CSV) GTFS
+    // nor in real-time, the shape is considered unknown. This field can refer to a shape defined in the (CSV) GTFS in shapes.txt
+    // or a Shape in the (protobuf) real-time feed. The order of stops (stop sequences) for this trip must remain the same as
+    // (CSV) GTFS. Stops that are a part of the original trip but will no longer be made, such as when a detour occurs, should
+    // be marked as schedule_relationship=SKIPPED.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string shape_id = 4;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features
+    // and modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+  optional TripProperties trip_properties = 6;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Realtime positioning information for a given vehicle.
@@ -331,46 +447,130 @@ message VehiclePosition {
   }
   optional CongestionLevel congestion_level = 6;
 
-  // The degree of passenger occupancy of the vehicle. This field is still
-  // experimental, and subject to change. It may be formally adopted in the
-  // future.
+  // The state of passenger occupancy for the vehicle or carriage.
+  // Individual producers may not publish all OccupancyStatus values. Therefore, consumers
+  // must not assume that the OccupancyStatus values follow a linear scale.
+  // Consumers should represent OccupancyStatus values as the state indicated
+  // and intended by the producer. Likewise, producers must use OccupancyStatus values that
+  // correspond to actual vehicle occupancy states.
+  // For describing passenger occupancy levels on a linear scale, see `occupancy_percentage`.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   enum OccupancyStatus {
-    // The vehicle is considered empty by most measures, and has few or no
+    // The vehicle or carriage is considered empty by most measures, and has few or no
     // passengers onboard, but is still accepting passengers.
     EMPTY = 0;
 
-    // The vehicle has a relatively large percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
+    // The vehicle or carriage has a large number of seats available.
+    // The amount of free seats out of the total seats available to be
     // considered large enough to fall into this category is determined at the
     // discretion of the producer.
     MANY_SEATS_AVAILABLE = 1;
 
-    // The vehicle has a relatively small percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
+    // The vehicle or carriage has a relatively small number of seats available.
+    // The amount of free seats out of the total seats available to be
     // considered small enough to fall into this category is determined at the
     // discretion of the feed producer.
     FEW_SEATS_AVAILABLE = 2;
 
-    // The vehicle can currently accommodate only standing passengers.
+    // The vehicle or carriage can currently accommodate only standing passengers.
     STANDING_ROOM_ONLY = 3;
 
-    // The vehicle can currently accommodate only standing passengers
+    // The vehicle or carriage can currently accommodate only standing passengers
     // and has limited space for them.
     CRUSHED_STANDING_ROOM_ONLY = 4;
 
-    // The vehicle is considered full by most measures, but may still be
+    // The vehicle or carriage is considered full by most measures, but may still be
     // allowing passengers to board.
     FULL = 5;
 
-    // The vehicle is not accepting additional passengers.
+    // The vehicle or carriage is not accepting passengers, but usually accepts passengers for boarding.
     NOT_ACCEPTING_PASSENGERS = 6;
+
+    // The vehicle or carriage doesn't have any occupancy data available at that time.
+    NO_DATA_AVAILABLE = 7;
+
+    // The vehicle or carriage is not boardable and never accepts passengers.
+    // Useful for special vehicles or carriages (engine, maintenance carriage, etc…).
+    NOT_BOARDABLE = 8;
+
   }
+  // If multi_carriage_status is populated with per-carriage OccupancyStatus,
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   optional OccupancyStatus occupancy_status = 9;
+
+  // A percentage value indicating the degree of passenger occupancy in the vehicle.
+  // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
+  // The value 100 should represent the total maximum occupancy the vehicle was designed for,
+  // including both seated and standing capacity, and current operating regulations allow.
+  // The value may exceed 100 if there are more passengers than the maximum designed capacity.
+  // The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle.
+  // If multi_carriage_status is populated with per-carriage occupancy_percentage,
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional uint32 occupancy_percentage = 10;
+
+  // Carriage specific details, used for vehicles composed of several carriages
+  // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+  message CarriageDetails {
+
+    // Identification of the carriage. Should be unique per vehicle.
+    optional string id = 1;
+
+    // User visible label that may be shown to the passenger to help identify
+    // the carriage. Example: "7712", "Car ABC-32", etc...
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string label = 2;
+
+    // Occupancy status for this given carriage, in this vehicle
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional OccupancyStatus occupancy_status = 3 [default = NO_DATA_AVAILABLE];
+
+    // Occupancy percentage for this given carriage, in this vehicle.
+    // Follows the same rules as "VehiclePosition.occupancy_percentage"
+    // -1 in case data is not available for this given carriage (as protobuf defaults to 0 otherwise)
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional int32 occupancy_percentage = 4 [default = -1];
+
+    // Identifies the order of this carriage with respect to the other
+    // carriages in the vehicle's list of CarriageDetails.
+    // The first carriage in the direction of travel must have a value of 1.
+    // The second value corresponds to the second carriage in the direction
+    // of travel and must have a value of 2, and so forth.
+    // For example, the first carriage in the direction of travel has a value of 1.
+    // If the second carriage in the direction of travel has a value of 3,
+    // consumers will discard data for all carriages (i.e., the multi_carriage_details field).
+    // Carriages without data must be represented with a valid carriage_sequence number and the fields
+    // without data should be omitted (alternately, those fields could also be included and set to the "no data" values).
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional uint32 carriage_sequence = 5;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+
+  // Details of the multiple carriages of this given vehicle.
+  // The first occurrence represents the first carriage of the vehicle,
+  // given the current direction of travel.
+  // The number of occurrences of the multi_carriage_details
+  // field represents the number of carriages of the vehicle.
+  // It also includes non boardable carriages,
+  // like engines, maintenance carriages, etc… as they provide valuable
+  // information to passengers about where to stand on a platform.
+  // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+  repeated CarriageDetails multi_carriage_details = 11;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An alert, indicating some sort of incident in the public transit network.
@@ -383,13 +583,13 @@ message Alert {
   // Entities whose users we should notify of this alert.
   repeated EntitySelector informed_entity = 5;
 
-  // Cause of this alert.
+  // Cause of this alert. If cause_detail is included, then Cause must also be included.
   enum Cause {
     UNKNOWN_CAUSE = 1;
-    OTHER_CAUSE = 2;  // Not machine-representable.
+    OTHER_CAUSE = 2;        // Not machine-representable.
     TECHNICAL_PROBLEM = 3;
-    STRIKE = 4;         // Public transit agency employees stopped working.
-    DEMONSTRATION = 5;  // People are blocking the streets.
+    STRIKE = 4;             // Public transit agency employees stopped working.
+    DEMONSTRATION = 5;      // People are blocking the streets.
     ACCIDENT = 6;
     HOLIDAY = 7;
     WEATHER = 8;
@@ -400,7 +600,7 @@ message Alert {
   }
   optional Cause cause = 6 [default = UNKNOWN_CAUSE];
 
-  // What is the effect of this problem on the affected entity.
+  // What is the effect of this problem on the affected entity. If effect_detail is included, then Effect must also be included.
   enum Effect {
     NO_SERVICE = 1;
     REDUCED_SERVICE = 2;
@@ -416,6 +616,8 @@ message Alert {
     OTHER_EFFECT = 7;
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
+    NO_EFFECT = 10;
+    ACCESSIBILITY_ISSUE = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 
@@ -429,10 +631,48 @@ message Alert {
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
 
+  // Text for alert header to be used in text-to-speech implementations. This field is the text-to-speech version of header_text.
+  optional TranslatedString tts_header_text = 12;
+
+  // Text for full description for the alert to be used in text-to-speech implementations. This field is the text-to-speech version of description_text.
+  optional TranslatedString tts_description_text = 13;
+
+  // Severity of this alert.
+  enum SeverityLevel {
+  UNKNOWN_SEVERITY = 1;
+  INFO = 2;
+  WARNING = 3;
+  SEVERE = 4;
+  }
+
+  optional SeverityLevel severity_level = 14 [default = UNKNOWN_SEVERITY];
+
+  // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
+  // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedImage image = 15;
+
+  // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
+  // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString image_alternative_text = 16;
+
+
+  // Description of the cause of the alert that allows for agency-specific language; more specific than the Cause. If cause_detail is included, then Cause must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString cause_detail = 17;
+
+  // Description of the effect of the alert that allows for agency-specific language; more specific than the Effect. If effect_detail is included, then Effect must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString effect_detail = 18;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features
   // and modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -456,6 +696,9 @@ message TimeRange {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A position.
@@ -482,6 +725,9 @@ message Position {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A descriptor that identifies an instance of a GTFS trip, or all instances of
@@ -497,22 +743,22 @@ message TripDescriptor {
   // The trip_id from the GTFS feed that this selector refers to.
   // For non frequency-based trips, this field is enough to uniquely identify
   // the trip. For frequency-based trip, start_time and start_date might also be
-  // necessary.
+  // necessary. When schedule_relationship is DUPLICATED within a TripUpdate, the trip_id identifies the trip from
+  // static GTFS to be duplicated. When schedule_relationship is DUPLICATED within a VehiclePosition, the trip_id
+  // identifies the new duplicate trip and must contain the value for the corresponding TripUpdate.TripProperties.trip_id.
   optional string trip_id = 1;
 
   // The route_id from the GTFS that this selector refers to.
   optional string route_id = 5;
 
   // The direction_id from the GTFS feed trips.txt file, indicating the
-  // direction of travel for trips this selector refers to. This field is
-  // still experimental, and subject to change. It may be formally adopted in
-  // the future.
+  // direction of travel for trips this selector refers to.
   optional uint32 direction_id = 6;
 
   // The initially scheduled start time of this trip instance.
   // When the trip_id corresponds to a non-frequency-based trip, this field
   // should either be omitted or be equal to the value in the GTFS feed. When
-  // the trip_id corresponds to a frequency-based trip, the start_time must be
+  // the trip_id correponds to a frequency-based trip, the start_time must be
   // specified for trip updates and vehicle positions. If the trip corresponds
   // to exact_times=1 GTFS record, then start_time must be some multiple
   // (including zero) of headway_secs later than frequencies.txt start_time for
@@ -548,14 +794,49 @@ message TripDescriptor {
     // An extra trip that was added in addition to a running schedule, for
     // example, to replace a broken vehicle or to respond to sudden passenger
     // load.
+    // NOTE: Currently, behavior is unspecified for feeds that use this mode. There are discussions on the GTFS GitHub
+    // [(1)](https://github.com/google/transit/issues/106) [(2)](https://github.com/google/transit/pull/221)
+    // [(3)](https://github.com/google/transit/pull/219) around fully specifying or deprecating ADDED trips and the
+    // documentation will be updated when those discussions are finalized.
     ADDED = 1;
 
-    // A trip that is running with no schedule associated to it, for example, if
-    // there is no schedule at all.
+    // A trip that is running with no schedule associated to it (GTFS frequencies.txt exact_times=0).
+    // Trips with ScheduleRelationship=UNSCHEDULED must also set all StopTimeUpdates.ScheduleRelationship=UNSCHEDULED.
     UNSCHEDULED = 2;
 
     // A trip that existed in the schedule but was removed.
     CANCELED = 3;
+
+    // Should not be used - for backwards-compatibility only.
+    REPLACEMENT = 5 [deprecated=true];
+
+    // An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to
+    // respond to sudden passenger load. Used with TripUpdate.TripProperties.trip_id, TripUpdate.TripProperties.start_date,
+    // and TripUpdate.TripProperties.start_time to copy an existing trip from static GTFS but start at a different service
+    // date and/or time. Duplicating a trip is allowed if the service related to the original trip in (CSV) GTFS
+    // (in calendar.txt or calendar_dates.txt) is operating within the next 30 days. The trip to be duplicated is
+    // identified via TripUpdate.TripDescriptor.trip_id. This enumeration does not modify the existing trip referenced by
+    // TripUpdate.TripDescriptor.trip_id - if a producer wants to cancel the original trip, it must publish a separate
+    // TripUpdate with the value of CANCELED or DELETED. Trips defined in GTFS frequencies.txt with exact_times that is
+    // empty or equal to 0 cannot be duplicated. The VehiclePosition.TripDescriptor.trip_id for the new trip must contain
+    // the matching value from TripUpdate.TripProperties.trip_id and VehiclePosition.TripDescriptor.ScheduleRelationship
+    // must also be set to DUPLICATED.
+    // Existing producers and consumers that were using the ADDED enumeration to represent duplicated trips must follow
+    // the migration guide (https://github.com/google/transit/tree/master/gtfs-realtime/spec/en/examples/migration-duplicated.md)
+    // to transition to the DUPLICATED enumeration.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    DUPLICATED = 6;
+
+
+    // A trip that existed in the schedule but was removed and must not be shown to users.
+    // DELETED should be used instead of CANCELED to indicate that a transit provider would like to entirely remove
+    // information about the corresponding trip from consuming applications, so the trip is not shown as cancelled to
+    // riders, e.g. a trip that is entirely being replaced by another trip.
+    // This designation becomes particularly important if several trips are cancelled and replaced with substitute service.
+    // If consumers were to show explicit information about the cancellations it would distract from the more important
+    // real-time predictions.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    DELETED = 7;
   }
   optional ScheduleRelationship schedule_relationship = 4;
 
@@ -563,6 +844,9 @@ message TripDescriptor {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Identification information for the vehicle performing the trip.
@@ -579,10 +863,33 @@ message VehicleDescriptor {
   // The license plate of the vehicle.
   optional string license_plate = 3;
 
+  enum WheelchairAccessible {
+    // The trip doesn't have information about wheelchair accessibility.
+    // This is the **default** behavior. If the static GTFS contains a
+    // _wheelchair_accessible_ value, it won't be overwritten.
+    NO_VALUE = 0;
+
+    // The trip has no accessibility value present.
+    // This value will overwrite the value from the GTFS.
+    UNKNOWN = 1;
+
+    // The trip is wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_ACCESSIBLE = 2;
+
+    // The trip is **not** wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_INACCESSIBLE = 3;
+  }
+  optional WheelchairAccessible wheelchair_accessible = 4 [default = NO_VALUE];
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A selector for an entity in a GTFS feed.
@@ -597,11 +904,17 @@ message EntitySelector {
   optional int32 route_type = 3;
   optional TripDescriptor trip = 4;
   optional string stop_id = 5;
+  // Corresponds to trip direction_id in GTFS trips.txt. If provided the
+  // route_id must also be provided.
+  optional uint32 direction_id = 6;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An internationalized message containing per-language versions of a snippet of
@@ -627,6 +940,9 @@ message TranslatedString {
     // GTFS Realtime Specification in order to add and evaluate new features and
     // modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
   // At least one translation must be provided.
   repeated Translation translation = 1;
@@ -635,4 +951,85 @@ message TranslatedString {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// An internationalized image containing per-language versions of a URL linking to an image
+// along with meta information
+// Only one of the images from a message will be retained by consumers. The resolution proceeds
+// as follows:
+// 1. If the UI language matches the language code of a translation,
+//    the first matching translation is picked.
+// 2. If a default UI language (e.g., English) matches the language code of a
+//    translation, the first matching translation is picked.
+// 3. If some translation has an unspecified language code, that translation is
+//    picked.
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+message TranslatedImage {
+  message LocalizedImage {
+    // String containing an URL linking to an image
+    // The image linked must be less than 2MB.
+    // If an image changes in a significant enough way that an update is required on the consumer side, the producer must update the URL to a new one.
+    // The URL should be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
+    required string url = 1;
+
+    // IANA media type as to specify the type of image to be displayed.
+    // The type must start with "image/"
+    required string media_type = 2;
+
+    // BCP-47 language code. Can be omitted if the language is unknown or if
+    // no i18n is done at all for the feed. At most one translation is
+    // allowed to have an unspecified language tag.
+    optional string language = 3;
+
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+  // At least one localized image must be provided.
+  repeated LocalizedImage localized_image = 1;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// Describes the physical path that a vehicle takes when it's not part of the (CSV) GTFS,
+// such as for a detour. Shapes belong to Trips, and consist of a sequence of shape points.
+// Tracing the points in order provides the path of the vehicle.  Shapes do not need to intercept
+// the location of Stops exactly, but all Stops on a trip should lie within a small distance of
+// the shape for that trip, i.e. close to straight line segments connecting the shape points
+// NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+message Shape {
+  // Identifier of the shape. Must be different than any shape_id defined in the (CSV) GTFS.
+  // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"
+  // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional string shape_id = 1;
+
+  // Encoded polyline representation of the shape. This polyline must contain at least two points.
+  // For more information about encoded polylines, see https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"
+  // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional string encoded_polyline = 2;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -229,6 +229,8 @@ defmodule TransportWeb.ResourceView do
       :OTHER_EFFECT -> dgettext("page-dataset-details", "Other effect")
       :UNKNOWN_EFFECT -> dgettext("page-dataset-details", "Unknown effect")
       :STOP_MOVED -> dgettext("page-dataset-details", "Stop moved")
+      :NO_EFFECT -> dgettext("page-dataset-details", "No effect")
+      :ACCESSIBILITY_ISSUE -> dgettext("page-dataset-details", "Accessibility issue")
     end
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -557,3 +557,11 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic conversions"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Accessibility issue"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No effect"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -557,3 +557,11 @@ msgstr "Données statiques"
 #, elixir-autogen, elixir-format
 msgid "Automatic conversions"
 msgstr "Conversions automatiques"
+
+#, elixir-autogen, elixir-format
+msgid "Accessibility issue"
+msgstr "Problème d'accessibilité"
+
+#, elixir-autogen, elixir-format
+msgid "No effect"
+msgstr "Pas d'impact"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -557,3 +557,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Automatic conversions"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Accessibility issue"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No effect"
+msgstr ""


### PR DESCRIPTION
Fixes #3053

Ajoute 2 nouveaux motifs d'effet pour un _service alert_. Notre fichier Protobuf n'était pas à jour, donc il manquait 2 valeurs dans un énuméré qu'on utilise.

Remonté à la source côté Google https://github.com/google/transit/issues/373