### PR TITLE
Recherche par région : tri par population descendante

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -387,6 +387,7 @@ defmodule DB.Dataset do
       {region_id, ""} ->
         order_by(datasets,
           desc: fragment("case when region_id = ? then 1 else 0 end", ^region_id),
+          desc: fragment("coalesce(population, 0)"),
           asc: :custom_title
         )
 


### PR DESCRIPTION
je mets le coalesce car certaines populations ne sont pas remplies et le NULL fait un peu n'importe quoi dans le tri.

Je vais faire une autre PR pour régler le problème des populations non renseignées / fausses.

ça fait remonter IDFm en page 1 mais toujours derrière 2 autres jeux qui ont des populations fausses.
![image](https://user-images.githubusercontent.com/15341118/227959858-f8148f3e-adaa-4270-9b7e-5824cac4be9d.png)
