### PR TITLE
Helpers : corrige fonction last_updated

### DIFF
--- a/apps/shared/lib/helpers.ex
+++ b/apps/shared/lib/helpers.ex
@@ -51,9 +51,11 @@ defmodule Helpers do
   @spec last_updated([DB.Resource.t()]) :: binary()
   def last_updated(resources) do
     resources
-    |> Enum.max_by(& &1.last_update, DateTime)
-    |> Map.fetch!(:last_update)
-    |> DateTime.to_iso8601()
+    |> Enum.map(& &1.last_update)
+    |> case do
+      [] -> nil
+      dates -> dates |> Enum.max(DateTime) |> DateTime.to_iso8601()
+    end
   end
 
   @spec admin?(map | nil) :: boolean

--- a/apps/shared/test/helpers/helpers_test.exs
+++ b/apps/shared/test/helpers/helpers_test.exs
@@ -1,5 +1,14 @@
 defmodule Helpers.HelpersTest do
   use ExUnit.Case
-
   doctest Helpers, import: true
+
+  test "last_updated" do
+    assert nil == Helpers.last_updated([])
+
+    assert "2023-01-15T05:33:47Z" ==
+             Helpers.last_updated([
+               %DB.Resource{last_update: ~U[2023-01-15 05:33:47Z]},
+               %DB.Resource{last_update: ~U[2022-03-30 05:33:47Z]}
+             ])
+  end
 end


### PR DESCRIPTION
Corrige un bug introduit dans #3059, qui ne gère pas le cas d'une liste vide. Voir [sur Sentry](https://transport-data-gouv-fr.sentry.io/issues/4046454967/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)