### PR TITLE
Fix : schema_type n'est pas renseigné dans la multi-validation

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_schema.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_schema.html.heex
@@ -12,8 +12,9 @@
     <%= if nb_errors > 0 do %>
       <%= render("_on_demand_validation_hint.html", conn: @conn, resource: @resource) %>
       <p><%= dgettext("validations", "Errors:") %></p>
-      <% is_jsonschema = @multi_validation.result["schema_type"] == "jsonschema" %>
-      <ul lang={if is_jsonschema, do: "en"}>
+      <% validation_schema_name = @multi_validation.resource_history.payload["schema_name"] %>
+      <% schema_type = schema_type(validation_schema_name) %>
+      <ul lang={if schema_type == "jsonschema", do: "en"}>
         <%= for error <- errors_sample(@multi_validation) do %>
           <li><%= error %></li>
         <% end %>
@@ -21,12 +22,12 @@
       <%= if nb_errors > max_display_errors() do %>
         <p class="notification">
           <%= dgettext("validations", "Showing only the first %{nb} errors.", nb: max_display_errors()) %>
-          <%= if @multi_validation.result["schema_type"] == "tableschema" do %>
+          <%= if schema_type == "tableschema" do %>
             <%= raw(
               dgettext(
                 "validations",
                 ~s(See all your errors <a href="%{url}" target="_blank">using the web interface</a>.),
-                url: validata_web_url(@resource.schema_name)
+                url: validata_web_url(validation_schema_name)
               )
             ) %>
           <% end %>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -13,6 +13,7 @@ defmodule TransportWeb.ResourceView do
   import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
   import Shared.Validation.TableSchemaValidator, only: [validata_web_url: 1]
   import Transport.GBFSUtils, only: [gbfs_validation_link: 1]
+  import Transport.Shared.Schemas.Wrapper, only: [schema_type: 1]
   alias Shared.DateTimeDisplay
   def format_related_objects(nil), do: ""
 


### PR DESCRIPTION
Fixes #3063

`schema_type` n'est pas renseigné directement dans la multi-validation, j'adapte donc le code et les tests à la réalité. `schema_type` est déterminé à partir du `schema_name`.

## Cohérence des données

En production.

```sql
select validator, rh.payload->>'schema_name', count(1)
from multi_validation mv
join resource_history rh on rh.id = mv.resource_history_id
where mv.inserted_at >= '2023-03-01'
group by 1, 2
```
|Validator|schema_name|count|
|--- | --- | ---|
|GTFS transport-validator |  | 1992|
|validata-api | etalab/schema-stationnement-cyclable | 624|
|EXJSONSchema | etalab/schema-zfe | 41|
|Validata JSON | etalab/schema-zfe | 39|
|Validata JSON | etalab/schema-amenagements-cyclables | 33|
|EXJSONSchema | etalab/schema-amenagements-cyclables | 32|
|validata-api | etalab/schema-irve-dynamique | 30|
|validata-api | etalab/schema-irve-statique | 25|
|validata-api | etalab/schema-lieux-covoiturage | 4|