### PR TITLE
Notification : abonnements au récap des commentaires postés

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -9,7 +9,7 @@ defmodule DB.NotificationSubscription do
   # These notification reasons are required to have a `dataset_id` set
   @reasons_related_to_datasets [:expiration, :dataset_with_error, :resource_unavailable]
   # These notification reasons are *not* linked to a specific dataset, `dataset_id` should be nil
-  @platform_wide_reasons [:new_dataset, :dataset_now_licence_ouverte]
+  @platform_wide_reasons [:new_dataset, :dataset_now_licence_ouverte, :daily_new_comments]
 
   typed_schema "notification_subscription" do
     field(:reason, Ecto.Enum, values: @reasons_related_to_datasets ++ @platform_wide_reasons)

--- a/apps/transport/test/db/notification_subscription_test.exs
+++ b/apps/transport/test/db/notification_subscription_test.exs
@@ -8,7 +8,7 @@ defmodule DB.NotificationSubscriptionTest do
   end
 
   test "changeset" do
-    contact = DB.Contact.insert!(sample_contact_args())
+    contact = insert_contact()
     dataset = insert(:dataset)
     changeset = fn args -> NotificationSubscription.changeset(%NotificationSubscription{}, args) end
 
@@ -71,16 +71,5 @@ defmodule DB.NotificationSubscriptionTest do
                reason: :dataset_now_licence_ouverte,
                contact_id: contact.id
              })
-  end
-
-  defp sample_contact_args do
-    %{
-      first_name: "John",
-      last_name: "Doe",
-      email: "john#{Ecto.UUID.generate()}@example.fr",
-      job_title: "Boss",
-      organization: "Big Corp Inc",
-      phone_number: "06 92 22 88 03"
-    }
   end
 end

--- a/apps/transport/test/transport/comments_checker_test.exs
+++ b/apps/transport/test/transport/comments_checker_test.exs
@@ -22,6 +22,8 @@ defmodule Transport.CommentsCheckerTest do
 
   test "check for new comments on data.gouv.fr" do
     %{id: dataset_id} = insert(:dataset, datagouv_title: "dataset 1")
+    %DB.Contact{id: contact_id, email: email} = insert_contact()
+    insert(:notification_subscription, %{reason: :daily_new_comments, source: :admin, contact_id: contact_id})
 
     # when the dataset is created, no comment timestamp is stored
     assert_dataset_ts(dataset_id, nil)
@@ -51,7 +53,7 @@ defmodule Transport.CommentsCheckerTest do
       assert_dataset_ts(dataset_id, ~U[2020-01-01T12:00:00.000100Z])
     end
 
-    # second run : we shouldn't find new comment
+    # second run: we shouldn't find new comment
     with_mock Datagouvfr.Client.API, get: get_mock do
       Transport.EmailSender.Mock
       |> expect(:send_mail, 0, fn _, _, _, _, _, _, _ -> {:ok, "envoyé !"} end)
@@ -89,6 +91,12 @@ defmodule Transport.CommentsCheckerTest do
       verify!(Transport.EmailSender.Mock)
       assert_dataset_ts(dataset_id, ~U[2021-01-01T12:00:00.000200Z])
     end
+
+    # Logs have been saved
+    assert [
+             %DB.Notification{email: ^email, reason: :daily_new_comments, dataset_id: ^dataset_id},
+             %DB.Notification{email: ^email, reason: :daily_new_comments, dataset_id: ^dataset_id}
+           ] = DB.Notification |> DB.Repo.all()
   end
 
   test "get latest comment timestamp" do


### PR DESCRIPTION
Fixes #3070

- Ajout d'un motif de notification `:daily_new_comments`
- Adapte `Transport.CommentsChecker` pour utiliser ce nouveau motif
- Adapte les tests

:warning: Il faudra inscrire notre équipe + l'ART à ce nouveau motif une fois que ce sera déployé en production.