### PR TITLE
Introduction Generic.HTTP pour le proxy

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -81,7 +81,7 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
     end)
   end
 
-  defp extract_config(proxy_base_url, %Unlock.Config.Item.GTFS.RT{} = resource) do
+  defp extract_config(proxy_base_url, %Unlock.Config.Item.Generic.HTTP{} = resource) do
     %{
       unique_slug: resource.identifier,
       proxy_url: Transport.Proxy.resource_url(proxy_base_url, resource.identifier),

--- a/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/broken_urls_controller_test.exs
@@ -64,7 +64,7 @@ defmodule TransportWeb.Backoffice.BrokenUrlsControllerTest do
              disappeared_urls: true,
              new_urls: true,
              dataset_custom_title: dataset_2.custom_title
-           } == broken_1
+           } == %{broken_1 | urls: broken_1.urls |> Enum.sort()}
 
     assert %{
              dataset_id: dataset.id,

--- a/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
@@ -18,7 +18,7 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
 
   def setup_proxy_config(slug, siri_slug) do
     config = %{
-      slug => %Unlock.Config.Item.GTFS.RT{
+      slug => %Unlock.Config.Item.Generic.HTTP{
         identifier: slug,
         target_url: "http://localhost/some-remote-resource",
         ttl: 10

--- a/apps/unlock/lib/config.ex
+++ b/apps/unlock/lib/config.ex
@@ -10,9 +10,11 @@ defmodule Unlock.Config do
     external YAML configuration, for generic HTTP and gtfs-rt items.
 
     It supports hardcoded request headers for e.g. simple authentication.
+
+    Default subtype is "gtfs-rt" for historical reasons, see `convert_yaml_item_to_struct` in the code.
     """
     @enforce_keys [:identifier, :target_url, :ttl]
-    defstruct [:identifier, :target_url, :ttl, request_headers: []]
+    defstruct [:identifier, :target_url, :ttl, subtype: "gtfs-rt", request_headers: []]
   end
 
   defmodule Item.SIRI do
@@ -41,22 +43,20 @@ defmodule Unlock.Config do
       }
     end
 
-    def convert_yaml_item_to_struct(%{"type" => "generic-http"} = item) do
+    @doc """
+    At the moment, GTFS-RT is just an alias for HTTP generic. This is done
+    to make it easier to achieve alternate processing later if needed.
+    """
+    def convert_yaml_item_to_struct(%{"type" => subtype} = item) when subtype in ["generic-http", "gtfs-rt"] do
       %Item.Generic.HTTP{
         identifier: Map.fetch!(item, "identifier"),
         target_url: Map.fetch!(item, "target_url"),
         # By default, no TTL
         ttl: Map.get(item, "ttl", 0),
+        # keep the subtype in case we need to do alternate processing later, without creating too many types too soon
+        subtype: subtype,
         request_headers: parse_config_request_headers(Map.get(item, "request_headers", []))
       }
-    end
-
-    @doc """
-    At the moment, GTFS-RT is just an alias for HTTP generic. This is done
-    to make it easier to achieve alternate processing later if needed.
-    """
-    def convert_yaml_item_to_struct(%{"type" => "gtfs-rt"} = item) do
-      convert_yaml_item_to_struct(item |> Map.put("type", "generic-http"))
     end
 
     # provide an automatic upgrade path for existing configuration, to be

--- a/apps/unlock/lib/config.ex
+++ b/apps/unlock/lib/config.ex
@@ -4,10 +4,10 @@ defmodule Unlock.Config do
   """
   require Logger
 
-  defmodule Item.GTFS.RT do
+  defmodule Item.Generic.HTTP do
     @moduledoc """
     An intermediate structure to add a bit of typing to the
-    external YAML configuration, specialized for GTFS-RT config.
+    external YAML configuration, for generic HTTP and gtfs-rt items.
 
     It supports hardcoded request headers for e.g. simple authentication.
     """
@@ -41,8 +41,8 @@ defmodule Unlock.Config do
       }
     end
 
-    def convert_yaml_item_to_struct(%{"type" => "gtfs-rt"} = item) do
-      %Item.GTFS.RT{
+    def convert_yaml_item_to_struct(%{"type" => "generic-http"} = item) do
+      %Item.Generic.HTTP{
         identifier: Map.fetch!(item, "identifier"),
         target_url: Map.fetch!(item, "target_url"),
         # By default, no TTL

--- a/apps/unlock/lib/config.ex
+++ b/apps/unlock/lib/config.ex
@@ -51,6 +51,14 @@ defmodule Unlock.Config do
       }
     end
 
+    @doc """
+    At the moment, GTFS-RT is just an alias for HTTP generic. This is done
+    to make it easier to achieve alternate processing later if needed.
+    """
+    def convert_yaml_item_to_struct(%{"type" => "gtfs-rt"} = item) do
+      convert_yaml_item_to_struct(item |> Map.put("type", "generic-http"))
+    end
+
     # provide an automatic upgrade path for existing configuration, to be
     # deprecated later
     def convert_yaml_item_to_struct(item) when not is_map_key(item, "type") do

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -164,7 +164,7 @@ defmodule Unlock.Controller do
     |> send_resp(response.status, body)
   end
 
-  defp fetch_remote(item) do
+  defp fetch_remote(%Unlock.Config.Item.Generic.HTTP{} = item) do
     comp_fn = fn _key ->
       Logger.info("Processing proxy request for identifier #{item.identifier}")
 

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -51,9 +51,9 @@ defmodule Unlock.Controller do
     text(conn, "Unlock Proxy")
   end
 
-  # for now we use a whitelist which we'll gradually expand.
+  # for now we use a allowlist which we'll gradually expand.
   # make sure to avoid including "hop-by-hop" headers here.
-  @forwarded_headers_whitelist [
+  @forwarded_headers_allowlist [
     "content-type",
     "content-length",
     "date",
@@ -221,7 +221,7 @@ defmodule Unlock.Controller do
   # Inspiration (MIT) here https://github.com/tallarium/reverse_proxy_plug
   defp filter_response_headers(headers) do
     headers
-    |> Enum.filter(fn {h, _v} -> Enum.member?(@forwarded_headers_whitelist, h) end)
+    |> Enum.filter(fn {h, _v} -> Enum.member?(@forwarded_headers_allowlist, h) end)
   end
 
   defp prepare_response_headers(headers) do

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -100,7 +100,7 @@ defmodule Unlock.Controller do
   # RAM consumption
   @max_allowed_cached_byte_size 20 * 1024 * 1024
 
-  defp process_resource(%{method: "GET"} = conn, %Unlock.Config.Item.GTFS.RT{} = item) do
+  defp process_resource(%{method: "GET"} = conn, %Unlock.Config.Item.Generic.HTTP{} = item) do
     Telemetry.trace_request(item.identifier, :external)
     response = fetch_remote(item)
 
@@ -113,7 +113,7 @@ defmodule Unlock.Controller do
     |> send_resp(response.status, response.body)
   end
 
-  defp process_resource(conn, %Unlock.Config.Item.GTFS.RT{}), do: send_not_allowed(conn)
+  defp process_resource(conn, %Unlock.Config.Item.Generic.HTTP{}), do: send_not_allowed(conn)
 
   # NOTE: this code is designed for private use for now. I have tracked
   # what is required or useful for public opening later here:

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -25,6 +25,8 @@ defmodule Unlock.ConfigFetcherTest do
                    %Unlock.Config.Item.Generic.HTTP{
                      identifier: "httpbin-get",
                      target_url: "https://httpbin.org/get",
+                     # gtfs-rt must be stored
+                     subtype: "gtfs-rt",
                      ttl: 10
                    }
                  ]
@@ -45,6 +47,8 @@ defmodule Unlock.ConfigFetcherTest do
                  %Unlock.Config.Item.Generic.HTTP{
                    identifier: "httpbin-get",
                    target_url: "https://httpbin.org/get",
+                   # default value
+                   subtype: unquote(config_type),
                    ttl: 10
                  }
                ]

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -3,54 +3,85 @@ defmodule Unlock.ConfigFetcherTest do
 
   def parse_config(yaml), do: Unlock.Config.Fetcher.convert_yaml_to_config_items(yaml)
 
-  describe "for GTFS-RT items" do
-    test "parses and converts configuration" do
-      yaml_config = """
-      ---
-      feeds:
-        - identifier: "httpbin-get"
-          target_url: "https://httpbin.org/get"
-          ttl: 10
-      """
+  [
+    %{config_type: "gtfs-rt"},
+    %{config_type: "generic-http"}
+  ]
+  |> Enum.each(fn %{config_type: config_type} ->
+    describe "for #{config_type} items" do
+      # default value must be respected
+      if config_type == "gtfs-rt" do
+        test "type defaults to gtfs-rt" do
+          yaml_config = """
+          ---
+          feeds:
+            - identifier: "httpbin-get"
+              target_url: "https://httpbin.org/get"
+              # no type provided
+              ttl: 10
+          """
 
-      assert parse_config(yaml_config) == [
-               %Unlock.Config.Item.Generic.HTTP{
-                 identifier: "httpbin-get",
-                 target_url: "https://httpbin.org/get",
-                 ttl: 10
-               }
-             ]
+          assert parse_config(yaml_config) == [
+                   %Unlock.Config.Item.Generic.HTTP{
+                     identifier: "httpbin-get",
+                     target_url: "https://httpbin.org/get",
+                     ttl: 10
+                   }
+                 ]
+        end
+      end
+
+      test "parses and converts configuration" do
+        yaml_config = """
+        ---
+        feeds:
+          - identifier: "httpbin-get"
+            target_url: "https://httpbin.org/get"
+            type: #{unquote(config_type)}
+            ttl: 10
+        """
+
+        assert parse_config(yaml_config) == [
+                 %Unlock.Config.Item.Generic.HTTP{
+                   identifier: "httpbin-get",
+                   target_url: "https://httpbin.org/get",
+                   ttl: 10
+                 }
+               ]
+      end
+
+      test "defaults to TTL 0 if TTL is unspecified" do
+        yaml_config = """
+        ---
+        feeds:
+          - identifier: "httpbin-get"
+            target_url: "https://httpbin.org/get"
+            type: #{unquote(config_type)}
+        """
+
+        [item] = parse_config(yaml_config)
+
+        assert item.ttl == 0
+      end
+
+      # This was the cleanest/most robust way I could find to express this in YAML
+      test "supports requests headers as array of 2-element arrays, mapped into tuples" do
+        yaml_config = """
+        ---
+        feeds:
+          - identifier: "httpbin-header-auth-ok"
+            target_url: "https://httpbin.org/bearer"
+            type: #{unquote(config_type)}
+            request_headers:
+              - ["Authorization", "Bearer some-value"]
+        """
+
+        [item] = parse_config(yaml_config)
+
+        assert item.request_headers == [{"Authorization", "Bearer some-value"}]
+      end
     end
-
-    test "defaults to TTL 0 if TTL is unspecified" do
-      yaml_config = """
-      ---
-      feeds:
-        - identifier: "httpbin-get"
-          target_url: "https://httpbin.org/get"
-      """
-
-      [item] = parse_config(yaml_config)
-
-      assert item.ttl == 0
-    end
-
-    # This was the cleanest/most robust way I could find to express this in YAML
-    test "supports requests headers as array of 2-element arrays, mapped into tuples" do
-      yaml_config = """
-      ---
-      feeds:
-        - identifier: "httpbin-header-auth-ok"
-          target_url: "https://httpbin.org/bearer"
-          request_headers:
-            - ["Authorization", "Bearer some-value"]
-      """
-
-      [item] = parse_config(yaml_config)
-
-      assert item.request_headers == [{"Authorization", "Bearer some-value"}]
-    end
-  end
+  end)
 
   describe "for SIRI items" do
     test "it parses basic information" do

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -14,7 +14,7 @@ defmodule Unlock.ConfigFetcherTest do
       """
 
       assert parse_config(yaml_config) == [
-               %Unlock.Config.Item.GTFS.RT{
+               %Unlock.Config.Item.Generic.HTTP{
                  identifier: "httpbin-get",
                  target_url: "https://httpbin.org/get",
                  ttl: 10

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -199,7 +199,7 @@ defmodule Unlock.ControllerTest do
       ttl_in_seconds = 30
 
       setup_proxy_config(%{
-        slug => %Unlock.Config.Item.GTFS.RT{
+        slug => %Unlock.Config.Item.Generic.HTTP{
           identifier: slug,
           target_url: "http://localhost/some-remote-resource",
           ttl: ttl_in_seconds
@@ -219,7 +219,7 @@ defmodule Unlock.ControllerTest do
       ttl_in_seconds = 30
 
       setup_proxy_config(%{
-        slug => %Unlock.Config.Item.GTFS.RT{
+        slug => %Unlock.Config.Item.Generic.HTTP{
           identifier: slug,
           target_url: target_url = "http://localhost/some-remote-resource",
           ttl: ttl_in_seconds
@@ -320,7 +320,7 @@ defmodule Unlock.ControllerTest do
       slug = "an-existing-identifier"
 
       setup_proxy_config(%{
-        slug => %Unlock.Config.Item.GTFS.RT{
+        slug => %Unlock.Config.Item.Generic.HTTP{
           identifier: slug,
           target_url: target_url = "http://localhost/some-remote-resource",
           ttl: 30
@@ -361,7 +361,7 @@ defmodule Unlock.ControllerTest do
 
     test "handles optional hardcoded request headers" do
       setup_proxy_config(%{
-        "some-identifier" => %Unlock.Config.Item.GTFS.RT{
+        "some-identifier" => %Unlock.Config.Item.Generic.HTTP{
           identifier: "some-identifier",
           target_url: "http://localhost/some-remote-resource",
           ttl: 10,
@@ -395,7 +395,7 @@ defmodule Unlock.ControllerTest do
       identifier = "foo"
 
       setup_proxy_config(%{
-        identifier => %Unlock.Config.Item.GTFS.RT{
+        identifier => %Unlock.Config.Item.Generic.HTTP{
           identifier: identifier,
           target_url: url,
           ttl: 10

--- a/apps/unlock/test/enforce_ttl_test.exs
+++ b/apps/unlock/test/enforce_ttl_test.exs
@@ -16,12 +16,12 @@ defmodule Unlock.EnforceTTLTest do
     ttl_config_value = 10
 
     setup_proxy_config(%{
-      "no_ttl" => %Unlock.Config.Item.GTFS.RT{
+      "no_ttl" => %Unlock.Config.Item.Generic.HTTP{
         identifier: "no_ttl",
         target_url: "https://example.com",
         ttl: ttl_config_value
       },
-      "with_ttl" => %Unlock.Config.Item.GTFS.RT{
+      "with_ttl" => %Unlock.Config.Item.Generic.HTTP{
         identifier: "with_ttl",
         target_url: "https://example.com",
         ttl: ttl_config_value

--- a/apps/unlock/test/github_config_test.exs
+++ b/apps/unlock/test/github_config_test.exs
@@ -52,7 +52,7 @@ defmodule UnlockGitHubConfigTest do
     assert Cachex.ttl(cache_name(), @config_cache_key) == {:ok, nil}
 
     assert data == %{
-             "test-slug" => %Unlock.Config.Item.GTFS.RT{
+             "test-slug" => %Unlock.Config.Item.Generic.HTTP{
                identifier: "test-slug",
                ttl: 0,
                target_url: "http://localhost/real-time"

--- a/scripts/http_generic_testing.exs
+++ b/scripts/http_generic_testing.exs
@@ -1,0 +1,24 @@
+Mix.install([
+  {:req, "~> 0.3.6"},
+  {:yaml_elixir, "~> 2.9"}
+])
+
+IO.puts("starting...")
+
+"config/proxy-config.yml"
+|> File.read!()
+|> YamlElixir.read_from_string!()
+|> Map.fetch!("feeds")
+|> Enum.filter(&(&1["type"] == "generic-http"))
+|> Enum.map(&"http://proxy.localhost:5000/resource/#{&1["identifier"]}")
+# |> IO.inspect(IEx.inspect_opts)
+# |> Enum.take(1)
+|> Enum.each(fn url ->
+  IO.puts("\n============= #{url} =============")
+
+  resp = Req.get!(url)
+
+  IO.inspect(resp.status)
+  IO.inspect(resp.headers)
+  IO.inspect(resp.body, printable_limit: 100)
+end)


### PR DESCRIPTION
:warning: attention à l'ordre de déploiement. Si on veut tester sur prochainement, il faudrait une autre PR à déployer en production pour ignorer les éléments avec une configuration "http-generic", sinon le proxy plantera en production.

Cette PR introduit un nouveau "type" de configuration YAML pour le proxy: "generic-http".

Voir plus bas, elle ne fait en fait (actuellement en tout cas) qu'exactement la même chose que le "gtfs-rt" (qui permet déjà de retourner les headers HTTP requis), mais en dissociant le nom pour qu'on garde bien en configuration les "gtfs-rt" marqués comme tels, et que cette information soit remontée via une variable `subtype` dans la configuration, pour permettre une customisation pas trop compliquée si besoin de la faire plus tard.

Cette approche a permis d'éviter de copier-coller des tests qui auraient été complètement identiques actuellement, sans empêcher de dissocier rapidement si besoin.

On peut tester avec des urls non mentionnées ici mais une config de la forme:

```yml
---
feeds:
  - identifier: gireve-dynamique-irve
    target_url: https://storage.googleapis.com/...
    ttl: 10
    type: generic-http
  - identifier: gireve-static-irve
    target_url: https://storage.googleapis.com/...
    ttl: 10
    type: generic-http
  - identifier: chargepoly-dynamique-irve
    target_url: https://...
    ttl: 10
    type: generic-http
  - identifier: sncf-estimated-timetable-siri-lite
    target_url: https://...
    ttl: 10
    type: generic-http
```

### Cheminement logique pour arriver à cette solution

J'ai commencé par faire des tests sur une autre branche, et me rendre compte qu'en pratique, le type "gtfs-rt" transmettait déjà des headers de réponse probablement suffisants:

https://github.com/etalab/transport-site/blob/bb95ed3d94020e384dc7f6445b9e50250f6e5c58/apps/unlock/lib/controller.ex#L54-L62

Je trouvais toutefois embêtant de juste appeler "gtfs-rt" des éléments ex IRVE dans la configuration.

J'ai ensuite commencé à tester l'introduction d'un vrai item de config séparé "HTTP" (en plus de `Unlock.Config.Item.GTFS.RT` et `Unlock.Config.Item.SIRI`). Mais à l'usage le nombre de modifications était important (duplication dans le contrôleur, mais surtout dans les tests, le parsing de la configuration), et j'ai estimé que ça ne valait pas le coup pour le moment, car le comportement attendu était exactement le même pour le moment.

J'ai au final adopté un compromis qui revient à:
- renommer le module de configuration `GTFS.RT` en `HTTP.Generic`
- continuer à supporter `gtfs-rt` dans la configuration YAML, ainsi qu'un nouveau type `http-generic`
- conserver cette valeur dans un champ `subtype` pour ne pas être trop coincé si on se retrouve à devoir faire une adaptation "rapide", qui pourra être accompagnée de tests spécifiques sans avoir à les dupliquer