### PR TITLE
Contacts : ajout 2nde colonne pour téléphone

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -62,7 +62,11 @@
         E-mail <%= text_input(f, :email, required: true, type: "email") %>
       <% end %>
       <%= label f, :phone_number, class: "pt-12" do %>
-        Numéro de téléphone <%= text_input(f, :phone_number, type: "tel") %>
+        Numéro de téléphone principal <%= text_input(f, :phone_number, type: "tel") %>
+        <div class="small">Optionnel</div>
+      <% end %>
+      <%= label f, :secondary_phone_number, class: "pt-12" do %>
+        Numéro de téléphone secondaire <%= text_input(f, :secondary_phone_number, type: "tel") %>
         <div class="small">Optionnel</div>
       <% end %>
       <%= submit("Envoyer") %>

--- a/apps/transport/priv/repo/migrations/20230412080437_contact_add_secondary_phone_number.exs
+++ b/apps/transport/priv/repo/migrations/20230412080437_contact_add_secondary_phone_number.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ContactAddSecondaryPhoneNumber do
+  use Ecto.Migration
+
+  def change do
+    alter table(:contact) do
+      add :secondary_phone_number, :binary, null: true
+    end
+  end
+end

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -15,7 +15,8 @@ defmodule DB.ContactTest do
       email: email = "john@example.fr",
       job_title: "Chef SIG",
       organization: "Big Corp Inc",
-      phone_number: "06 92 22 88 03"
+      phone_number: "06 92 22 88 03",
+      secondary_phone_number: "+33 1 99 00 17 45"
     }
     |> DB.Contact.insert!()
 
@@ -25,7 +26,8 @@ defmodule DB.ContactTest do
              job_title: "Chef SIG",
              last_name: "Doe",
              organization: "Big Corp Inc",
-             phone_number: "+33692228803"
+             phone_number: "+33692228803",
+             secondary_phone_number: "+33199001745"
            } = DB.Repo.one!(DB.Contact)
 
     # Can search using `email_hash`
@@ -33,7 +35,8 @@ defmodule DB.ContactTest do
 
     # Cannot get rows by using the email/phone_number values, because values are encrypted
     assert DB.Contact |> where([n], n.email == ^email) |> DB.Repo.all() |> Enum.empty?()
-    assert DB.Contact |> where([n], n.email == ^"+33692228803") |> DB.Repo.all() |> Enum.empty?()
+    assert DB.Contact |> where([n], n.phone_number == ^"+33692228803") |> DB.Repo.all() |> Enum.empty?()
+    assert DB.Contact |> where([n], n.secondary_phone_number == ^"+33199001745") |> DB.Repo.all() |> Enum.empty?()
 
     # Can save a contact with a `title`
     %{sample_contact_args() | first_name: nil, last_name: nil, mailing_list_title: "title"}


### PR DESCRIPTION
Fixes #3076

![image](https://user-images.githubusercontent.com/295709/231402737-fd8f5a6c-417a-4c43-9e31-42681e68da08.png)

Ajoute une nouvelle colonne `:secondary_phone_number` pour les contacts, afin de gérer le cas fixe + portable.

Je n'ai pas cherché à attribuer le fixe ou le portable à une colonne en particulier, pas sûr que ce soit un véritable besoin. Si on a vraiment besoin de trouver que des numéros fixes ou portables à un moment, on _devrait_ pouvoir le faire à l'aide de libraries/simplement étant donné qu'on gère quasi exclusivement des numéros de téléphones FR.

La donnée est stockée chiffré en BDD, comme pour `:phone_number`.