### PR TITLE
Renomme titre catégorie locations

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -132,7 +132,7 @@ defmodule DB.Dataset do
       "bike-scooter-sharing" => dgettext("db-dataset", "Bike and scooter sharing"),
       "car-motorbike-sharing" => dgettext("db-dataset", "Car and motorbike sharing"),
       "road-data" => dgettext("db-dataset", "Road data"),
-      "locations" => dgettext("db-dataset", "Locations"),
+      "locations" => dgettext("db-dataset", "Mobility locations"),
       "informations" => dgettext("db-dataset", "Other informations"),
       "private-parking" => dgettext("db-dataset", "Private parking"),
       "bike-way" => dgettext("db-dataset", "Bike networks"),

--- a/apps/transport/priv/gettext/db-dataset.pot
+++ b/apps/transport/priv/gettext/db-dataset.pot
@@ -27,7 +27,7 @@ msgid "See on data.gouv.fr"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Locations"
+msgid "Mobility locations"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
@@ -28,7 +28,7 @@ msgid "See on data.gouv.fr"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Locations"
+msgid "Mobility locations"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
@@ -28,8 +28,8 @@ msgid "See on data.gouv.fr"
 msgstr "Voir sur data.gouv.fr"
 
 #, elixir-autogen, elixir-format
-msgid "Locations"
-msgstr "Lieux d'intérêts"
+msgid "Mobility locations"
+msgstr "Lieux de mobilité"
 
 #, elixir-autogen, elixir-format
 msgid "A dataset cannot be national and regional"

--- a/apps/transport/priv/search_custom_messages.yml
+++ b/apps/transport/priv/search_custom_messages.yml
@@ -79,11 +79,11 @@
       value: locations
   msg:
     fr: |
-      Cette catégorie regroupe des jeux de données décrivant des lieux d'intérêts relatifs à la mobilité comme les adresses ou la position des arrêts de transports et gares.
+      Cette catégorie regroupe des jeux de données décrivant des lieux d'intérêts relatifs à la mobilité comme les descriptions ou la position des arrêts de transports et gares.
 
       Les données d’adresses françaises sont disponibles dans le jeu de données de la [Base Adresse Nationale (BAN)](https://transport.data.gouv.fr/datasets/base-adresse-nationale/) qui a vocation à réunir **l’ensemble des adresses géolocalisées du territoire national**.
     en: |
-      This category includes datasets describing places of interest relating to mobility, such as addresses or positions of transport stops and stations.
+      This category includes datasets describing places of interest relating to mobility, such as descriptions or positions of transport stops and stations.
 
       French address data is available in the [National Address Base (BAN) dataset](https://transport.data.gouv.fr/datasets/base-adresse-nationale/?locale=en), which aims to bring together all the geolocated addresses of the national territory.
 


### PR DESCRIPTION
Lié à #3083

Pour la catégorie `locations` :
- adapte le titre
- adapte la description de la catégorie