### PR TITLE
JDD à référencer : ajout format SSIM

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -30,7 +30,7 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
                    "vélo",
                    "zfe"
                  ])
-  @relevant_formats MapSet.new(["gtfs", "netex", "gbfs", "gtfs-rt", "gtfsrt", "siri"])
+  @relevant_formats MapSet.new(["gtfs", "netex", "gbfs", "gtfs-rt", "gtfsrt", "siri", "ssim"])
 
   @impl Oban.Worker
   def perform(%Oban.Job{inserted_at: %DateTime{} = inserted_at}) do


### PR DESCRIPTION
Adapte le job permettant de détecter les JDD ajoutés récemment sur data.gouv.fr potentiellement pertinents pour le PAN pour prendre en compte le format SSIM, spécifique aux données aériennes.