### PR TITLE
Ajout d'une notification pour les JDD avec liens GTFS-RT manquants

### DIFF
--- a/apps/transport/lib/jobs/datasets_without_gtfs_rt_related_resources_notification_job.ex
+++ b/apps/transport/lib/jobs/datasets_without_gtfs_rt_related_resources_notification_job.ex
@@ -1,0 +1,75 @@
+defmodule Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJob do
+  @moduledoc """
+  Job in charge of detecting datasets with missing related resources
+  for GTFS-RT resources and sending a notification email to our team.
+  """
+  use Oban.Worker, max_attempts: 3, tags: ["notifications"]
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    relevant_datasets() |> send_email()
+  end
+
+  def send_email([]), do: :ok
+
+  def send_email(datasets) do
+    Transport.EmailSender.impl().send_mail(
+      "transport.data.gouv.fr",
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :contact_email),
+      "Jeux de données GTFS-RT sans ressources liées",
+      """
+      Bonjour,
+
+      Les jeux de données suivants contiennent plusieurs GTFS et des liens entre les ressources GTFS-RT et GTFS sont manquants :
+
+      #{Enum.map_join(datasets, "\n", &link/1)}
+
+      L’équipe transport.data.gouv.fr
+      """,
+      ""
+    )
+
+    :ok
+  end
+
+  def link(%DB.Dataset{slug: slug, custom_title: custom_title}) do
+    link = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
+    "* #{custom_title} - #{link}"
+  end
+
+  def relevant_datasets do
+    dataset_ids_sub =
+      DB.Dataset.base_query()
+      |> DB.Resource.join_dataset_with_resource()
+      |> where([resource: r], not r.is_community_resource)
+      |> group_by([dataset: d], d.id)
+      |> having(
+        [resource: r],
+        # > 1 GTFS and >= 1 GTFS-RT
+        fragment(
+          ~s{sum(case when ? = 'GTFS' then 1 else 0 end) > 1 and sum(case when ? = 'gtfs-rt' then 1 else 0 end) >= 1},
+          r.format,
+          r.format
+        )
+      )
+      |> select([dataset: d], d.id)
+
+    DB.Dataset.base_query()
+    |> DB.Resource.join_dataset_with_resource()
+    |> join(:left, [resource: r], rr in DB.ResourceRelated,
+      on: rr.resource_src_id == r.id and rr.reason == :gtfs_rt_gtfs,
+      as: :resource_related
+    )
+    |> where(
+      [resource: r, resource_related: rr, dataset: d],
+      r.format == "gtfs-rt" and is_nil(rr.reason) and d.id in subquery(dataset_ids_sub)
+    )
+    |> distinct(true)
+    |> select([dataset: d], d)
+    |> order_by([dataset: d], asc: d.custom_title)
+    |> DB.Repo.all()
+  end
+end

--- a/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
@@ -1,0 +1,61 @@
+defmodule Transport.Test.Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  alias Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "relevant_datasets" do
+    # 2 GTFS and 2 GTFS-RT with resource_related set for all GTFS-RT
+    %{id: d1_id} = insert(:dataset, is_active: true)
+    # 1 GTFS and 1 GTFS-RT
+    %{id: d2_id} = insert(:dataset, is_active: true)
+    # 2 GTFS and 1 GTFS-RT
+    %{id: d3_id} = insert(:dataset, is_active: true)
+    gtfs_1_1 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "GTFS")
+    gtfs_rt_1 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "gtfs-rt")
+    gtfs_rt_2 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "gtfs-rt")
+
+    insert(:resource, dataset_id: d2_id, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset_id: d2_id, is_community_resource: false, format: "gtfs-rt")
+
+    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "gtfs-rt")
+
+    insert(:resource_related, resource_src: gtfs_rt_1, resource_dst: gtfs_1_1, reason: :gtfs_rt_gtfs)
+    insert(:resource_related, resource_src: gtfs_rt_2, resource_dst: gtfs_1_1, reason: :gtfs_rt_gtfs)
+
+    assert [%DB.Dataset{id: ^d3_id}] =
+             DatasetsWithoutGTFSRTRelatedResourcesNotificationJob.relevant_datasets() |> Enum.sort()
+  end
+
+  test "perform" do
+    dataset = insert(:dataset, is_active: true, custom_title: "Super JDD")
+    insert(:resource, dataset: dataset, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset: dataset, is_community_resource: false, format: "GTFS")
+    insert(:resource, dataset: dataset, is_community_resource: false, format: "gtfs-rt")
+
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "Jeux de données GTFS-RT sans ressources liées" = _subject,
+                             plain_text_body,
+                             "" = _html_part ->
+      assert plain_text_body =~ ~r/des liens entre les ressources GTFS-RT et GTFS sont manquants/
+      assert plain_text_body =~ ~r/Super JDD/
+      :ok
+    end)
+
+    assert :ok == perform_job(DatasetsWithoutGTFSRTRelatedResourcesNotificationJob, %{})
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -121,6 +121,7 @@ oban_crontab_all_envs =
         {"0 22 * * *", Transport.Jobs.ArchiveMetricsJob},
         {"15,45 * * * *", Transport.Jobs.MultiValidationWithErrorNotificationJob},
         {"20,50 * * * *", Transport.Jobs.ResourceUnavailableNotificationJob},
+        {"10 6 * * 1", Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJob},
         {"45 2 * * *", Transport.Jobs.RemoveHistoryJob,
          args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}}
       ]


### PR DESCRIPTION
En lien avec #3035, voir #3072 pour la PR précédente et le contexte.

Cette PR ajoute un job hebdomadaire (le lundi) qui identifie les JDD où un lien GTFS-RT -> GTFS est nécessaire et n'est pas renseigné.

Si on reçoit cet e-mail, on devra ajouter quelques lignes dans la table `resource_related`.