### PR TITLE
Affiche GTFS pertinent pour GTFS-RT sur dataset#details

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -235,6 +235,10 @@
   }
 }
 
+.dark {
+  color: var(--theme-dark-text) !important;
+}
+
 .light-grey {
   color: var(--theme-label-text) !important;
 }

--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -1,5 +1,10 @@
 .icon {
   @extend .fas !optional;
+  margin-right: 0.5em;
+}
+
+.icon--logout {
+  margin: 0;
 }
 
 .icon--badge {
@@ -90,6 +95,7 @@
   vertical-align: middle;
   width: 1.25em;
   height: 1.25em;
+  margin-right: 0.4em;
 }
 
 .icon--validation {

--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -1,10 +1,7 @@
 .icon {
   @extend .fas !optional;
-  margin-right: 0.5em;
-}
 
-.icon--logout {
-  margin: 0;
+  margin-right: 0.5em;
 }
 
 .icon--badge {
@@ -33,6 +30,8 @@
 
 .icon--logout {
   @extend .fa-sign-out-alt !optional;
+
+  margin: 0;
 }
 
 .icon--open {

--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -32,14 +32,6 @@ main {
   height: 70px;
 }
 
-.icon {
-  margin-right: 0.5em;
-}
-
-.icon--logout {
-  margin: 0;
-}
-
 .nav__links {
   display: flex;
   align-items: center;

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -563,7 +563,7 @@ defmodule DB.Dataset do
   def get_by_slug(slug) do
     preload_without_validations()
     |> where(slug: ^slug)
-    |> preload([:region, :aom, :communes])
+    |> preload([:region, :aom, :communes, resources: [:resources_related]])
     |> Repo.one()
     |> case do
       nil -> {:error, "Dataset with slug #{slug} not found"}

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -8,6 +8,7 @@
 <% [validation] = @resources_infos.validations |> Map.get(@resource.id) %>
 <% is_gtfs_outdated = Transport.Validators.GTFSTransport.is_gtfs_outdated(validation) %>
 <% resource_modes = get_metadata_modes(validation, []) %>
+<% related_gtfs_resource = related_gtfs_resource(@resource) %>
 
 <div
   class={"panel resource #{valid_panel_class(@resource, is_gtfs_outdated)}"}
@@ -57,6 +58,12 @@
         <%= resource_ttl %>s
       </span>
     <% end %>
+    <div :if={related_gtfs_resource != nil}>
+      <span title={dgettext("page-dataset-details", "GTFS file to use with the GTFS-RT feed")}>
+        <i class="icon fa fa-link" aria-hidden="true"></i>
+        <%= link("GTFS", to: resource_path(@conn, :details, related_gtfs_resource.resource_dst_id), class: "dark") %>
+      </span>
+    </div>
     <%= if Map.has_key?(unavailabilities, @resource.id) do %>
       <div>
         <span title={

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -515,4 +515,11 @@ defmodule TransportWeb.DatasetView do
   end
 
   def displays_odbl_specific_usage_conditions?(%Dataset{}), do: false
+
+  @spec related_gtfs_resource(Resource.t()) :: DB.ResourceRelated.t() | nil
+  def related_gtfs_resource(%Resource{format: "gtfs-rt", resources_related: resources_related}) do
+    Enum.find(resources_related, fn %DB.ResourceRelated{reason: reason} -> reason == :gtfs_rt_gtfs end)
+  end
+
+  def related_gtfs_resource(%Resource{}), do: nil
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -561,3 +561,7 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "GTFS file to use with the GTFS-RT feed"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -561,3 +561,7 @@ msgstr "Pas d'impact"
 #, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation."
 msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une validation du GTFS-RT."
+
+#, elixir-autogen, elixir-format
+msgid "GTFS file to use with the GTFS-RT feed"
+msgstr "Fichier GTFS à utiliser avec le flux GTFS-RT"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -561,3 +561,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Cannot determine the relevant GTFS file to use to perform a GTFS-RT validation."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "GTFS file to use with the GTFS-RT feed"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -298,6 +298,18 @@ defmodule TransportWeb.DatasetControllerTest do
     with_log(fn -> conn |> get(dataset_path(conn, :details, old_slug)) |> html_response(404) end)
   end
 
+  test "dataset#details with resources_related for gtfs-rt resources", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, slug: slug = "dataset-slug")
+    gtfs = insert(:resource, dataset: dataset, url: "https://example.com/gtfs.zip", format: "GTFS")
+    gtfs_rt = insert(:resource, dataset: dataset, url: "https://example.com/gtfs-rt", format: "gtfs-rt")
+    insert(:resource_related, resource_src: gtfs_rt, resource_dst: gtfs, reason: :gtfs_rt_gtfs)
+
+    set_empty_mocks()
+
+    assert conn |> get(dataset_path(conn, :details, slug)) |> html_response(200) =~
+             ~s{<i class="icon fa fa-link" aria-hidden="true"></i>\n<a class="dark" href="#{resource_path(conn, :details, gtfs.id)}">GTFS</a>}
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")


### PR DESCRIPTION
En lien avec #3035.

Cette PR adapte la page de détails d'un jeu de données, `dataset#details` pour afficher la ressource GTFS à utiliser pour un GTFS-RT quand il n'est pas évident de savoir quelle ressource utiliser et qu'on a eu un lien entre ressources renseigné.

Ceci est représenté par "🔗 GTFS" avec un lien vers la page `resource#details` du GTFS associé.

On peut discuter de l'interface !

cc @cyrilmorin 

![image](https://user-images.githubusercontent.com/295709/233081095-afa83426-91c3-4f25-b699-fa8363848259.png)

