### PR TITLE
Affiche ressources associées sur resource#details

### DIFF
--- a/apps/transport/lib/db/resource_related.ex
+++ b/apps/transport/lib/db/resource_related.ex
@@ -3,11 +3,21 @@ defmodule DB.ResourceRelated do
   A module to deal with `DB.Resource` related to other `DB.Resource`
   """
   use TypedEctoSchema
+  import TransportWeb.Gettext
 
   @primary_key false
   typed_schema "resource_related" do
     belongs_to(:resource_src, DB.Resource, foreign_key: :resource_src_id, references: :id)
     belongs_to(:resource_dst, DB.Resource, foreign_key: :resource_dst_id, references: :id)
     field(:reason, Ecto.Enum, values: [:gtfs_rt_gtfs])
+  end
+
+  def reason_to_str(%__MODULE__{reason: reason}) do
+    Map.fetch!(
+      %{
+        :gtfs_rt_gtfs => dgettext("db-resource-related", "Associated GTFS file")
+      },
+      reason
+    )
   end
 end

--- a/apps/transport/lib/db/resource_related.ex
+++ b/apps/transport/lib/db/resource_related.ex
@@ -12,6 +12,12 @@ defmodule DB.ResourceRelated do
     field(:reason, Ecto.Enum, values: [:gtfs_rt_gtfs])
   end
 
+  @doc """
+  A human-friendly description for a `reason`.
+
+  iex> Enum.each(Ecto.Enum.values(DB.ResourceRelated, :reason), & reason_to_str(%DB.ResourceRelated {reason: &1}))
+  :ok
+  """
   def reason_to_str(%__MODULE__{reason: reason}) do
     Map.fetch!(
       %{

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -19,7 +19,7 @@ defmodule TransportWeb.ResourceController do
                       ])
 
   def details(conn, %{"id" => id} = params) do
-    resource = Resource |> preload(dataset: [:resources]) |> Repo.get!(id)
+    resource = Resource |> preload([:resources_related, dataset: [:resources]]) |> Repo.get!(id)
 
     conn =
       conn

--- a/apps/transport/lib/transport_web/templates/resource/_related_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_related_resources.html.heex
@@ -1,8 +1,9 @@
+<% resources_by_id = Enum.into(@resource.dataset.resources, %{}, fn %DB.Resource{id: id} = r -> {id, r} end) %>
 <h2 id="related-resources"><%= dgettext("page-dataset-details", "Related resources") %></h2>
-<div class="">
+<section>
   <div class="ressources-list">
     <%= for resource_related_details <- @resource.resources_related do %>
-      <% related_resource = Enum.find(@resource.dataset.resources, &(&1.id == resource_related_details.resource_dst_id)) %>
+      <% related_resource = Map.fetch!(resources_by_id, resource_related_details.resource_dst_id) %>
       <div class="panel resource">
         <h4><a href={resource_path(@conn, :details, related_resource.id)}><%= related_resource.title %></a></h4>
         <div class="pt-12">
@@ -13,4 +14,4 @@
       </div>
     <% end %>
   </div>
-</div>
+</section>

--- a/apps/transport/lib/transport_web/templates/resource/_related_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_related_resources.html.heex
@@ -1,0 +1,16 @@
+<h2 id="related-resources"><%= dgettext("page-dataset-details", "Related resources") %></h2>
+<div class="">
+  <div class="ressources-list">
+    <%= for resource_related_details <- @resource.resources_related do %>
+      <% related_resource = Enum.find(@resource.dataset.resources, &(&1.id == resource_related_details.resource_dst_id)) %>
+      <div class="panel resource">
+        <h4><a href={resource_path(@conn, :details, related_resource.id)}><%= related_resource.title %></a></h4>
+        <div class="pt-12">
+          <i class="icon fa fa-link" aria-hidden="true"></i><%= DB.ResourceRelated.reason_to_str(
+            resource_related_details
+          ) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -25,6 +25,11 @@
           ) %>.
         </p>
       </div>
+
+      <%= unless Enum.empty?(@resource.resources_related) do %>
+        <%= render("_related_resources.html", resource: @resource, conn: @conn) %>
+      <% end %>
+
       <h2 id="download-availability"><%= dgettext("page-dataset-details", "Download availability") %></h2>
       <%= render("_download_availability.html", uptime_per_day: @uptime_per_day, conn: @conn) %>
 

--- a/apps/transport/priv/gettext/db-resource-related.pot
+++ b/apps/transport/priv/gettext/db-resource-related.pot
@@ -1,0 +1,16 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Associated GTFS file"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/db-resource-related.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/db-resource-related.po
@@ -1,0 +1,16 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "Associated GTFS file"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -565,3 +565,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Related resources"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/db-resource-related.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/db-resource-related.po
@@ -1,0 +1,16 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n>1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "Associated GTFS file"
+msgstr "Fichier GTFS associé"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -565,3 +565,7 @@ msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr "Fichier GTFS à utiliser avec le flux GTFS-RT"
+
+#, elixir-autogen, elixir-format
+msgid "Related resources"
+msgstr "Ressources associées"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -565,3 +565,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Related resources"
+msgstr ""

--- a/apps/transport/test/db/resource_related_test.exs
+++ b/apps/transport/test/db/resource_related_test.exs
@@ -2,6 +2,8 @@ defmodule DB.ResourceRelatedTest do
   use ExUnit.Case, async: true
   import DB.Factory
 
+  doctest DB.ResourceRelated, import: true
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end


### PR DESCRIPTION
En lien avec #3035.

Affiche une liste de ressources associées sur la page affichant les détails d'une ressource, lorsque des ressources associées existent.

Merci @fchabouis pour les échanges que nous avons eu à propos de l'interface :pray:

![image](https://user-images.githubusercontent.com/295709/234522085-73135aaa-f4c0-4e3e-84fe-5216d81ee72d.png)
