### PR TITLE
CommentsChecker : ne pas stocker notification quand pas de comms

### DIFF
--- a/apps/transport/lib/transport/comments_checker.ex
+++ b/apps/transport/lib/transport/comments_checker.ex
@@ -84,10 +84,10 @@ defmodule Transport.CommentsChecker do
   end
 
   def save_notifications(comments_with_context, emails) do
-    Enum.each(comments_with_context, fn {%Dataset{} = dataset, _datagouv_id, _title, _comments} ->
-      Enum.each(emails, fn email ->
-        DB.Notification.insert!(@notification_reason, dataset, email)
-      end)
+    comments_with_context
+    |> Enum.reject(fn {%Dataset{}, _datagouv_id, _title, comments} -> Enum.empty?(comments) end)
+    |> Enum.each(fn {%Dataset{} = dataset, _datagouv_id, _title, _comments} ->
+      Enum.each(emails, fn email -> DB.Notification.insert!(@notification_reason, dataset, email) end)
     end)
   end
 


### PR DESCRIPTION
Fixes #3110

Adapte le code pour ne pas stocker de logs d'envoi de notifications par e-mail quand il n'y a pas eu de nouveau commentaire et donc pas d'e-mail envoyé.

C'est une méprise de ma part, je pensais qu'on avait qu'une liste de données avec des JDD ayant eu de nouveaux commentaires, ce qui n'est pas le cas.

ℹ️ J'irai nettoyer les données en BDD en prod ensuite.