### PR TITLE
Associe un utilisateur à un contact ou crée un contact lors de la connexion

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/user.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/user.ex
@@ -23,7 +23,8 @@ defmodule Datagouvfr.Client.User.Dummy do
          "first_name" => "trotro",
          "last_name" => "rigolo",
          "id" => "user_id_1",
-         "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr"}]
+         "email" => "email@example.fr",
+         "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr", "name" => "PAN"}]
        }}
 
   @impl Datagouvfr.Client.User.Wrapper

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -14,6 +14,7 @@ defmodule DB.Contact do
     field(:last_name, :string)
     # Use `mailing_list_title` for mailing lists and similar
     field(:mailing_list_title, :string)
+    field(:datagouv_user_id, :string)
 
     field(:organization, :string)
     field(:job_title, :string)
@@ -23,6 +24,7 @@ defmodule DB.Contact do
     field(:email_hash, Cloak.Ecto.SHA256)
     field(:phone_number, DB.Encrypted.Binary)
     field(:secondary_phone_number, DB.Encrypted.Binary)
+    field(:last_login_at, :utc_datetime_usec)
 
     timestamps(type: :utc_datetime_usec)
 
@@ -89,7 +91,9 @@ defmodule DB.Contact do
       :job_title,
       :email,
       :phone_number,
-      :secondary_phone_number
+      :secondary_phone_number,
+      :datagouv_user_id,
+      :last_login_at
     ])
     |> trim_fields([:first_name, :last_name, :organization, :job_title])
     |> capitalize_fields([:first_name, :last_name])

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -17,6 +17,14 @@
         </ul>
       </div>
     <% end %>
+    <div :if={@contact.data.datagouv_user_id != nil} class="pb-24">
+      Identifiant de l'utilisateur sur data.gouv.fr <span class="label"><%= @contact.data.datagouv_user_id %></span>
+      <br />
+      Dernière date de connexion : <%= format_datetime_to_paris(
+        @contact.data.last_login_at,
+        get_session(@conn, :locale)
+      ) %>
+    </div>
     <%= form_for @contact, backoffice_contact_path(@conn, :create), [class: "no-margin", method: "post"], fn f -> %>
       <%= hidden_input(f, :id, value: contact_id) %>
       <div class="panel">

--- a/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
@@ -1,5 +1,6 @@
 defmodule TransportWeb.Backoffice.ContactView do
   use TransportWeb, :view
+  import Shared.DateTimeDisplay, only: [format_datetime_to_paris: 2]
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   alias TransportWeb.PaginationHelpers
 

--- a/apps/transport/priv/repo/migrations/20230427083218_contact_add_datagouv_user_id_last_login_at.exs
+++ b/apps/transport/priv/repo/migrations/20230427083218_contact_add_datagouv_user_id_last_login_at.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.ContactAddDatagouvUserIdAndLastLoginAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:contact) do
+      add :datagouv_user_id, :string, null: true
+      add :last_login_at, :utc_datetime_usec, null: true
+    end
+    create_if_not_exists(unique_index(:contact, [:datagouv_user_id]))
+  end
+end

--- a/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
@@ -107,7 +107,7 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
 
   describe "edit" do
     test "can change values", %{conn: conn} do
-      contact = DB.Contact.insert!(sample_contact_args())
+      contact = DB.Contact.insert!(sample_contact_args(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate(), last_login_at: ~U[2023-04-28 09:54:19.458897Z]}))
 
       content =
         conn
@@ -118,6 +118,8 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
       assert content =~ "Éditer un contact"
       assert content =~ contact.first_name
       assert content =~ contact.last_name
+      assert content =~ datagouv_user_id
+      assert content =~ "28/04/2023 à 11h54 Europe/Paris"
 
       args = %{"id" => contact.id, "last_name" => new_last_name = "Bar"}
 
@@ -188,14 +190,17 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
     assert is_nil(DB.Repo.reload(contact))
   end
 
-  defp sample_contact_args do
-    %{
-      first_name: "John",
-      last_name: "Doe",
-      email: "john#{Ecto.UUID.generate()}@example.fr",
-      job_title: "Boss",
-      organization: "Big Corp Inc",
-      phone_number: "06 92 22 88 03"
-    }
+  defp sample_contact_args(%{} = args \\ %{}) do
+    Map.merge(
+      %{
+        first_name: "John",
+        last_name: "Doe",
+        email: "john#{Ecto.UUID.generate()}@example.fr",
+        job_title: "Boss",
+        organization: "Big Corp Inc",
+        phone_number: "06 92 22 88 03"
+      },
+      args
+    )
   end
 end

--- a/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
@@ -107,7 +107,13 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
 
   describe "edit" do
     test "can change values", %{conn: conn} do
-      contact = DB.Contact.insert!(sample_contact_args(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate(), last_login_at: ~U[2023-04-28 09:54:19.458897Z]}))
+      contact =
+        DB.Contact.insert!(
+          sample_contact_args(%{
+            datagouv_user_id: datagouv_user_id = Ecto.UUID.generate(),
+            last_login_at: ~U[2023-04-28 09:54:19.458897Z]
+          })
+        )
 
       content =
         conn

--- a/apps/transport/test/transport_web/controllers/session_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/session_controller_test.exs
@@ -1,22 +1,51 @@
 defmodule TransportWeb.SessionControllerTest do
-  use TransportWeb.ConnCase, async: false
-  use TransportWeb.ExternalCase
+  use TransportWeb.ConnCase, async: true
+  import DB.Factory
+  import Mox
+  import Plug.Test
+  import TransportWeb.SessionController
 
   doctest TransportWeb.SessionController
+  setup :verify_on_exit!
 
   setup do
     Mox.stub_with(Datagouvfr.Authentication.Mock, Datagouvfr.Authentication.Dummy)
     Mox.stub_with(Datagouvfr.Client.User.Mock, Datagouvfr.Client.User.Dummy)
-    :ok
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
   test "GET /login/callback", %{conn: conn} do
+    user_params = %{
+      "first_name" => first_name = "John",
+      "last_name" => last_name = "Doe",
+      "id" => datagouv_user_id = "user_id_1",
+      "email" => email = "email@example.fr",
+      "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr", "name" => organization = "PAN"}]
+    }
+
+    expect(Datagouvfr.Client.User.Mock, :me, fn %Plug.Conn{} -> {:ok, user_params} end)
+
+    assert [] == DB.Repo.all(DB.Contact)
     conn = conn |> get(session_path(conn, :create, %{"code" => "secret"}))
     current_user = get_session(conn, :current_user)
 
     assert redirected_to(conn, 302) == "/"
     assert Map.has_key?(current_user, "id") == true
     assert Map.has_key?(current_user, "avatar") == false
+
+    # A `DB.Contact` has been created for this user
+    assert [
+             %DB.Contact{
+               first_name: ^first_name,
+               last_name: ^last_name,
+               email: ^email,
+               organization: ^organization,
+               datagouv_user_id: ^datagouv_user_id,
+               last_login_at: last_login_at
+             }
+           ] = DB.Repo.all(DB.Contact)
+
+    assert_in_delta last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
   end
 
   test "GET /login/callback and redirection to /datasets", %{conn: conn} do
@@ -26,5 +55,80 @@ defmodule TransportWeb.SessionControllerTest do
       |> get(session_path(conn, :create, %{"code" => "secret"}))
 
     assert redirected_to(conn, 302) == "/datasets"
+  end
+
+  describe "find_or_create_contact" do
+    test "when contact exists, updates attributes coming from data.gouv.fr and the last_login_at" do
+      contact = insert_contact(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()})
+      assert contact.last_login_at == nil
+
+      find_or_create_contact(%{
+        "id" => datagouv_user_id,
+        "first_name" => contact.first_name,
+        "last_name" => contact.last_name,
+        "email" => new_email = "#{Ecto.UUID.generate()}@example.fr"
+      })
+
+      contact = DB.Repo.reload!(contact)
+
+      assert contact.email == new_email
+      assert_in_delta contact.last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
+    end
+
+    test "when contact exists with a mailing_list_title, don't update (first|last)_name" do
+      contact =
+        insert_contact(%{
+          first_name: nil,
+          last_name: nil,
+          mailing_list_title: mailing_list_title = "Équipe data",
+          datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()
+        })
+
+      find_or_create_contact(%{
+        "id" => datagouv_user_id,
+        "first_name" => "Équipe data",
+        "last_name" => "CD42",
+        "email" => contact.email
+      })
+
+      contact = DB.Repo.reload!(contact)
+
+      assert %DB.Contact{first_name: nil, last_name: nil, mailing_list_title: ^mailing_list_title} = contact
+      assert_in_delta contact.last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
+    end
+
+    test "can find a contact using its email address and sets the datagouv_user_id" do
+      %DB.Contact{datagouv_user_id: nil} = contact = insert_contact()
+
+      find_or_create_contact(%{
+        "id" => datagouv_user_id = Ecto.UUID.generate(),
+        "first_name" => new_first_name = "Oka",
+        "last_name" => last_name = contact.last_name,
+        "email" => contact.email,
+        "organizations" => []
+      })
+
+      contact = DB.Repo.reload!(contact)
+
+      assert %DB.Contact{first_name: ^new_first_name, last_name: ^last_name, datagouv_user_id: ^datagouv_user_id} =
+               contact
+
+      assert_in_delta contact.last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
+    end
+
+    test "creates a contact when it doesn't exist" do
+      assert DB.Contact |> DB.Repo.all() |> Enum.empty?()
+
+      find_or_create_contact(%{
+        "id" => datagouv_user_id = Ecto.UUID.generate(),
+        "first_name" => first_name = "John",
+        "last_name" => last_name = "Doe",
+        "email" => email = "email@example.fr",
+        "organizations" => [%{"name" => org_name = "Corp Inc"}]
+      })
+
+      assert [%DB.Contact{first_name: ^first_name, last_name: ^last_name, datagouv_user_id: ^datagouv_user_id, email: ^email, organization: ^org_name, last_login_at: last_login_at}] = DB.Contact |> DB.Repo.all()
+      assert_in_delta last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
+    end
   end
 end

--- a/apps/transport/test/transport_web/controllers/session_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/session_controller_test.exs
@@ -127,7 +127,17 @@ defmodule TransportWeb.SessionControllerTest do
         "organizations" => [%{"name" => org_name = "Corp Inc"}]
       })
 
-      assert [%DB.Contact{first_name: ^first_name, last_name: ^last_name, datagouv_user_id: ^datagouv_user_id, email: ^email, organization: ^org_name, last_login_at: last_login_at}] = DB.Contact |> DB.Repo.all()
+      assert [
+               %DB.Contact{
+                 first_name: ^first_name,
+                 last_name: ^last_name,
+                 datagouv_user_id: ^datagouv_user_id,
+                 email: ^email,
+                 organization: ^org_name,
+                 last_login_at: last_login_at
+               }
+             ] = DB.Contact |> DB.Repo.all()
+
       assert_in_delta last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
     end
   end


### PR DESCRIPTION
Cette PR permet d'associer un utilisateur data.gouv.fr à un `DB.Contact` dans notre base de données, lors de la connexion. Si un contact n'existe pas, le contact est créé à partir des informations récupérées depuis data.gouv.fr.

- 2 colonnes sont ajoutées à `contact`
  - `datagouv_user_id` identifiant data.gouv.fr d'un contact
  - `last_login_at` dernier datetime de connexion
- l'association d'un utilisateur à un contact est fait lors de la connexion
  - en cherchant en priorité à retrouver un contact déjà associé à l'aide de son identifiant
  - avec l'adresse e-mail renseignée sur data.gouv.fr
  - les infos sur data.gouv.fr sont utilisées pour mettre à jour les données ou créer un contact si on n'a pas pu trouver de contact
- dans tous les cas la date de dernière connexion est enregistrée

La connexion depuis data.gouv.fr se fait a minima tous les 15 jours https://github.com/etalab/transport-site/pull/3108