### PR TITLE
Permettre de rafraichir les conversions NeTEx

### DIFF
--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -51,11 +51,8 @@ defmodule DB.DataConversion do
     conversions = last_data_conversions(dataset_id, "NeTEx")
     delete_data_conversions(conversions)
 
-    conversions
-    |> Enum.each(fn %{resource_history_id: rh_id} ->
-      %{"resource_history_id" => rh_id}
-      |> Transport.Jobs.SingleGtfsToNetexConverterJob.new()
-      |> Oban.insert()
-    end)
+    %{"dataset_id" => dataset_id}
+    |> Transport.Jobs.DatasetGtfsToNetexConverterJob.new()
+    |> Oban.insert()
   end
 end

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -25,4 +25,37 @@ defmodule DB.DataConversion do
     )
     |> where([data_conversion: dc], dc.convert_to in ^list_of_convert_to)
   end
+
+  def last_data_conversions(dataset_id, convert_to) do
+    DB.Dataset.base_query()
+    |> DB.ResourceHistory.join_dataset_with_latest_resource_history()
+    |> join_resource_history_with_data_conversion([convert_to])
+    |> where([dataset: d], d.id == ^dataset_id)
+    |> select([resource_history: rh, data_conversion: dc], %{
+      resource_history_id: rh.id,
+      data_conversion_id: dc.id,
+      s3_path: fragment("?->>'filename'", dc.payload)
+    })
+    |> DB.Repo.all()
+  end
+
+  def delete_data_conversions(conversions) do
+    conversions
+    |> Enum.each(fn %{data_conversion_id: dc_id, s3_path: s3_path} ->
+      Transport.S3.delete_object!(:history, s3_path)
+      DB.DataConversion |> DB.Repo.get(dc_id) |> DB.Repo.delete!()
+    end)
+  end
+
+  def force_refresh_netex_conversions(dataset_id) do
+    conversions = last_data_conversions(dataset_id, "NeTEx")
+    delete_data_conversions(conversions)
+
+    conversions
+    |> Enum.each(fn %{resource_history_id: rh_id} ->
+      %{"resource_history_id" => rh_id}
+      |> Transport.Jobs.SingleGtfsToNetexConverterJob.new()
+      |> Oban.insert()
+    end)
+  end
 end

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -39,7 +39,7 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
   alias Transport.Jobs.GTFSGenericConverter
   import Ecto.Query
 
-  def list_GTFS_last_resource_history(dataset_id) do
+  def list_gtfs_last_resource_history(dataset_id) do
     DB.Dataset.base_query()
     |> DB.Resource.join_dataset_with_resource()
     |> DB.ResourceHistory.join_resource_with_latest_resource_history()
@@ -51,7 +51,7 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
   @impl true
   def perform(%{args: %{"dataset_id" => dataset_id}}) do
     dataset_id
-    |> list_GTFS_last_resource_history()
+    |> list_gtfs_last_resource_history()
     |> Enum.each(fn rh_id ->
       GTFSGenericConverter.perform_single_conversion_job(rh_id, "NeTEx", Transport.GtfsToNeTExConverter)
     end)

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -39,15 +39,6 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
   alias Transport.Jobs.GTFSGenericConverter
   import Ecto.Query
 
-  def list_gtfs_last_resource_history(dataset_id) do
-    DB.Dataset.base_query()
-    |> DB.Resource.join_dataset_with_resource()
-    |> DB.ResourceHistory.join_resource_with_latest_resource_history()
-    |> where([dataset: d, resource: r], d.id == ^dataset_id and r.format == "GTFS")
-    |> select([resource_history: rh], rh.id)
-    |> DB.Repo.all()
-  end
-
   @impl true
   def perform(%{args: %{"dataset_id" => dataset_id}}) do
     dataset_id
@@ -55,6 +46,16 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
     |> Enum.each(fn rh_id ->
       GTFSGenericConverter.perform_single_conversion_job(rh_id, "NeTEx", Transport.GtfsToNeTExConverter)
     end)
+  end
+
+  @spec list_gtfs_last_resource_history(binary()) :: list()
+  def list_gtfs_last_resource_history(dataset_id) do
+    DB.Dataset.base_query()
+    |> DB.Resource.join_dataset_with_resource()
+    |> DB.ResourceHistory.join_resource_with_latest_resource_history()
+    |> where([dataset: d, resource: r], d.id == ^dataset_id and r.format == "GTFS")
+    |> select([resource_history: rh], rh.id)
+    |> DB.Repo.all()
   end
 end
 

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -31,6 +31,33 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJob do
   end
 end
 
+defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
+  @moduledoc """
+  This will enqueue GTFS -> NeTEx conversions jobs for all GTFS resources linked to a dataset, but only for the most recent resource history
+  """
+  use Oban.Worker, max_attempts: 3, queue: :heavy
+  alias Transport.Jobs.GTFSGenericConverter
+  import Ecto.Query
+
+  def list_GTFS_last_resource_history(dataset_id) do
+    DB.Dataset.base_query()
+    |> DB.Resource.join_dataset_with_resource()
+    |> DB.ResourceHistory.join_resource_with_latest_resource_history()
+    |> where([dataset: d, resource: r], d.id == ^dataset_id and r.format == "GTFS")
+    |> select([resource_history: rh], rh.id)
+    |> DB.Repo.all()
+  end
+
+  @impl true
+  def perform(%{args: %{"dataset_id" => dataset_id}}) do
+    dataset_id
+    |> list_GTFS_last_resource_history()
+    |> Enum.each(fn rh_id ->
+      GTFSGenericConverter.perform_single_conversion_job(rh_id, "NeTEx", Transport.GtfsToNeTExConverter)
+    end)
+  end
+end
+
 defmodule Transport.GtfsToNeTExConverter do
   @moduledoc """
   Given a GTFS file path, convert it to NeTEx.

--- a/apps/transport/lib/transport_web/live/force_netex_conversion.ex
+++ b/apps/transport/lib/transport_web/live/force_netex_conversion.ex
@@ -1,0 +1,44 @@
+defmodule TransportWeb.Live.ForceNeTExConversion do
+  use Phoenix.LiveView
+  import TransportWeb.Gettext, only: [dgettext: 2]
+
+  def render(assigns) do
+    ~H"""
+    <button class="button" phx-click="force_conversion">
+      <%= if @running do %>
+        <%= dgettext("backoffice", "Conversions launched") %>
+        ✅
+      <% else %>
+        <%= dgettext("backoffice", "Refresh NeTEx conversions") %>
+      <% end %>
+    </button>
+    """
+  end
+
+  def mount(_params, %{"dataset_id" => dataset_id, "locale" => locale}, socket) do
+    Gettext.put_locale(locale)
+
+    new_socket =
+      socket
+      |> assign(dataset_id: dataset_id)
+      |> assign(running: false)
+
+    {:ok, new_socket}
+  end
+
+  def handle_event("force_conversion", _value, socket) do
+    send(self(), {:force_conversion, socket.assigns.dataset_id})
+    socket = socket |> assign(running: true)
+    {:noreply, socket}
+  end
+
+  def handle_info({:force_conversion, dataset_id}, socket) do
+    DB.DataConversion.force_refresh_netex_conversions(dataset_id)
+    Process.send_after(self(), :stop_running, 3000)
+    {:noreply, socket}
+  end
+
+  def handle_info({:stop_running}, socket) do
+    {:noreply, socket |> assign(:running, false)}
+  end
+end

--- a/apps/transport/lib/transport_web/live/force_netex_conversion.ex
+++ b/apps/transport/lib/transport_web/live/force_netex_conversion.ex
@@ -7,7 +7,7 @@ defmodule TransportWeb.Live.ForceNeTExConversion do
 
   def render(assigns) do
     ~H"""
-    <button class="button" phx-click="force_conversion">
+    <button class="button" phx-click="force_conversion" disabled={@running}>
       <%= if @running do %>
         <%= dgettext("backoffice", "Conversions launched") %> ✅
       <% else %>
@@ -36,7 +36,7 @@ defmodule TransportWeb.Live.ForceNeTExConversion do
 
   def handle_info({:force_conversion, dataset_id}, socket) do
     DB.DataConversion.force_refresh_netex_conversions(dataset_id)
-    Process.send_after(self(), :stop_running, 3000)
+    Process.send_after(self(), :stop_running, 60_000)
     {:noreply, socket}
   end
 

--- a/apps/transport/lib/transport_web/live/force_netex_conversion.ex
+++ b/apps/transport/lib/transport_web/live/force_netex_conversion.ex
@@ -1,4 +1,7 @@
 defmodule TransportWeb.Live.ForceNeTExConversion do
+  @moduledoc """
+  A button to launch NeTEx conversions from backoffice
+  """
   use Phoenix.LiveView
   import TransportWeb.Gettext, only: [dgettext: 2]
 

--- a/apps/transport/lib/transport_web/live/force_netex_conversion.ex
+++ b/apps/transport/lib/transport_web/live/force_netex_conversion.ex
@@ -6,8 +6,7 @@ defmodule TransportWeb.Live.ForceNeTExConversion do
     ~H"""
     <button class="button" phx-click="force_conversion">
       <%= if @running do %>
-        <%= dgettext("backoffice", "Conversions launched") %>
-        ✅
+        <%= dgettext("backoffice", "Conversions launched") %> ✅
       <% else %>
         <%= dgettext("backoffice", "Refresh NeTEx conversions") %>
       <% end %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -25,6 +25,12 @@
           <%= submit("Supprimer", class: "button", nodiv: true) %>
         <% end %>
       </div>
+
+      <div :if={@dataset.type == "public-transit"}>
+        <%= live_render(@conn, TransportWeb.Live.ForceNeTExConversion,
+          session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
+        ) %>
+      </div>
     </div>
 
     <div class="dashboard-description mt-48">

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -282,3 +282,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Company SIREN code"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Refresh NeTEx conversions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Conversions launched"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -282,3 +282,11 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Company SIREN code"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Refresh NeTEx conversions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Conversions launched"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -282,3 +282,11 @@ msgstr "ou"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Company SIREN code"
 msgstr "Code SIREN d'une entreprise"
+
+#, elixir-autogen, elixir-format
+msgid "Refresh NeTEx conversions"
+msgstr "Regénérer les conversions NeTEx"
+
+#, elixir-autogen, elixir-format
+msgid "Conversions launched"
+msgstr "Conversions relancées"

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -144,7 +144,7 @@ defmodule DB.DataConversionTest do
 
     # list candidate resource history for future conversions
     resource_history_ids =
-      Transport.Jobs.DatasetGtfsToNetexConverterJob.list_GTFS_last_resource_history(dataset.id) |> Enum.sort()
+      dataset.id |> Transport.Jobs.DatasetGtfsToNetexConverterJob.list_gtfs_last_resource_history() |> Enum.sort()
 
     assert [resource_history_1.id, resource_history_2.id] == resource_history_ids
   end

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -1,5 +1,6 @@
 defmodule DB.DataConversionTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   import DB.Factory
 
   setup do
@@ -55,5 +56,115 @@ defmodule DB.DataConversionTest do
         payload: %{}
       )
     end)
+  end
+
+  test "list data conversions of a dataset" do
+    dataset = insert(:dataset)
+    resource_1 = insert(:resource, dataset_id: dataset.id)
+
+    # not listed as there is more recent
+    insert(:resource_history,
+      resource_id: resource_1.id,
+      payload: %{uuid: uuid_old = Ecto.UUID.generate(), inserted_at: DateTime.utc_now() |> DateTime.add(-1, :day)}
+    )
+
+    insert(:data_conversion,
+      convert_from: "GTFS",
+      convert_to: "NeTEx",
+      resource_history_uuid: uuid_old,
+      payload: %{filename: "filename_old"}
+    )
+
+    # listed
+    resource_history_1 =
+      insert(:resource_history, resource_id: resource_1.id, payload: %{uuid: uuid = Ecto.UUID.generate()})
+
+    data_conversion =
+      insert(:data_conversion,
+        convert_from: "GTFS",
+        convert_to: "NeTEx",
+        resource_history_uuid: uuid,
+        payload: %{filename: "filename"}
+      )
+
+    # not listed bad format
+    insert(:data_conversion,
+      convert_from: "GTFS",
+      convert_to: "GeoJSON",
+      resource_history_uuid: uuid,
+      payload: %{filename: "filename_bad_format"}
+    )
+
+    # listed (other resource same dataset)
+    resource_2 = insert(:resource, dataset_id: dataset.id)
+
+    resource_history_2 =
+      insert(:resource_history, resource_id: resource_2.id, payload: %{uuid: uuid_2 = Ecto.UUID.generate()})
+
+    data_conversion_2 =
+      insert(:data_conversion,
+        convert_from: "GTFS",
+        convert_to: "NeTEx",
+        resource_history_uuid: uuid_2,
+        payload: %{filename: "filename_2"}
+      )
+
+    # not listed, other dataset
+    dataset_other = insert(:dataset)
+    resource_other = insert(:resource, dataset_id: dataset_other.id)
+
+    _resource_history_other =
+      insert(:resource_history, resource_id: resource_other.id, payload: %{uuid: uuid_other = Ecto.UUID.generate()})
+
+    _data_conversion_other =
+      insert(:data_conversion,
+        convert_from: "GTFS",
+        convert_to: "NeTEx",
+        resource_history_uuid: uuid_other,
+        payload: %{filename: "filename"}
+      )
+
+    conversions =
+      dataset.id
+      |> DB.DataConversion.last_data_conversions("NeTEx")
+      |> Enum.sort_by(fn %{data_conversion_id: dc_id} -> dc_id end, :asc)
+
+    assert [
+             %{
+               data_conversion_id: data_conversion.id,
+               resource_history_id: resource_history_1.id,
+               s3_path: "filename"
+             },
+             %{
+               data_conversion_id: data_conversion_2.id,
+               resource_history_id: resource_history_2.id,
+               s3_path: "filename_2"
+             }
+           ] == conversions
+  end
+
+  test "force refresh a NeTEx conversion" do
+    dataset = insert(:dataset)
+    resource = insert(:resource, dataset_id: dataset.id)
+
+    resource_history =
+      insert(:resource_history, resource_id: resource.id, payload: %{uuid: uuid = Ecto.UUID.generate()})
+
+    data_conversion =
+      insert(:data_conversion,
+        convert_from: "GTFS",
+        convert_to: "NeTEx",
+        resource_history_uuid: uuid,
+        payload: %{filename: filename = "filepath/filename"}
+      )
+
+      Transport.Test.S3TestUtils.s3_mocks_delete_object(Transport.S3.bucket_name(:history), filename)
+
+      DB.DataConversion.force_refresh_netex_conversions(dataset.id)
+
+      # data conversion has been deleted
+      assert_raise Ecto.NoResultsError, fn -> DB.DataConversion |> DB.Repo.get!(data_conversion.id) end
+      # new conversion is enqueued
+      assert_enqueued([worker: Transport.Jobs.SingleGtfsToNetexConverterJob, args: %{"resource_history_id" => resource_history.id}])
   end
 end

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -153,8 +153,7 @@ defmodule DB.DataConversionTest do
     dataset = insert(:dataset)
     resource = insert(:resource, dataset_id: dataset.id)
 
-    resource_history =
-      insert(:resource_history, resource_id: resource.id, payload: %{uuid: uuid = Ecto.UUID.generate()})
+    insert(:resource_history, resource_id: resource.id, payload: %{uuid: uuid = Ecto.UUID.generate()})
 
     data_conversion =
       insert(:data_conversion,
@@ -172,8 +171,8 @@ defmodule DB.DataConversionTest do
     assert_raise Ecto.NoResultsError, fn -> DB.DataConversion |> DB.Repo.get!(data_conversion.id) end
     # new conversion is enqueued
     assert_enqueued(
-      worker: Transport.Jobs.SingleGtfsToNetexConverterJob,
-      args: %{"resource_history_id" => resource_history.id}
+      worker: Transport.Jobs.DatasetGtfsToNetexConverterJob,
+      args: %{"dataset_id" => dataset.id}
     )
   end
 end

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -60,7 +60,7 @@ defmodule DB.DataConversionTest do
 
   test "list data conversions of a dataset" do
     dataset = insert(:dataset)
-    resource_1 = insert(:resource, dataset_id: dataset.id)
+    resource_1 = insert(:resource, dataset_id: dataset.id, format: "GTFS")
 
     # not listed as there is more recent
     insert(:resource_history,
@@ -96,7 +96,7 @@ defmodule DB.DataConversionTest do
     )
 
     # listed (other resource same dataset)
-    resource_2 = insert(:resource, dataset_id: dataset.id)
+    resource_2 = insert(:resource, dataset_id: dataset.id, format: "GTFS")
 
     resource_history_2 =
       insert(:resource_history, resource_id: resource_2.id, payload: %{uuid: uuid_2 = Ecto.UUID.generate()})
@@ -141,6 +141,10 @@ defmodule DB.DataConversionTest do
                s3_path: "filename_2"
              }
            ] == conversions
+
+     # list candidate resource history for future conversions
+     resource_history_ids = Transport.Jobs.DatasetGtfsToNetexConverterJob.list_GTFS_last_resource_history(dataset.id) |> Enum.sort()
+     assert [resource_history_1.id, resource_history_2.id] == resource_history_ids
   end
 
   test "force refresh a NeTEx conversion" do


### PR DESCRIPTION
Suite à une mise à jour du convertisseur NeTEx, il est pour le moment fastidieux de relancer les conversions NeTEx existantes, car il faut à la fois nettoyer la base et supprimer les fichiers du S3. Je rajoute la possibilité de le faire depuis notre Backoffice pour un dataset donné.

![image](https://user-images.githubusercontent.com/15341118/235120946-ffe32010-ad62-416f-a976-5a4ee48b108b.png)
