### PR TITLE
Adapte message pour licence ODbL provenant d'OSM

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -39,7 +39,7 @@ defmodule DB.Dataset do
     field(:nb_reuses, :integer)
     field(:latest_data_gouv_comment_timestamp, :utc_datetime)
     field(:archived_at, :utc_datetime_usec)
-    field(:custom_tags, {:array, :string})
+    field(:custom_tags, {:array, :string}, default: [])
 
     timestamps(type: :utc_datetime_usec)
 

--- a/apps/transport/lib/transport_web/templates/dataset/_licence.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_licence.html.heex
@@ -6,7 +6,12 @@
   <% else %>
     <%= licence(@dataset) %>
   <% end %>
-  <%= if displays_odbl_specific_usage_conditions?(@dataset) do %>
+  <%= if displays_odbl_osm_conditions?(@dataset) do %>
+    &#32 <%= dgettext("page-dataset-details", "and ") %>
+    <%= link(dgettext("page-dataset-details", "OSM community guidelines"),
+      to: "https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines"
+    ) %>
+  <% else %>
     &#32 <%= dgettext("page-dataset-details", "and ") %>
     <%= link(dgettext("page-dataset-details", "Specific usage conditions"),
       to:

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -500,21 +500,22 @@ defmodule TransportWeb.DatasetView do
   def multi_validation_performed?(nil), do: false
 
   @doc """
-  Determines if we should display "specific usage conditions" for a dataset.
-  We displays it only for datasets under the ODbL license that are not OSM exports. We use the `openstreetmap` tag as a proxy of "this is an export from OSM".
+  Determines if we should display OSM community guidelines for a dataset.
 
   ## Examples
 
-  iex> displays_odbl_specific_usage_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo"]})
-  true
-  iex> displays_odbl_specific_usage_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo", "openstreetmap"]})
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo"]}, custom_tags: nil)
   false
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo", "openstreetmap"]}, custom_tags: [])
+  true
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: [], custom_tags: ["licence-osm"]})
+  true
   """
-  def displays_odbl_specific_usage_conditions?(%Dataset{licence: "odc-odbl", tags: tags}) do
-    "openstreetmap" not in tags
+  def displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: tags, custom_tags: custom_tags}) do
+    "openstreetmap" in tags or "licence-osm" in custom_tags
   end
 
-  def displays_odbl_specific_usage_conditions?(%Dataset{}), do: false
+  def displays_odbl_osm_conditions?(%Dataset{}), do: false
 
   @spec related_gtfs_resource(Resource.t()) :: DB.ResourceRelated.t() | nil
   def related_gtfs_resource(%Resource{format: "gtfs-rt", resources_related: resources_related}) do

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -504,7 +504,7 @@ defmodule TransportWeb.DatasetView do
 
   ## Examples
 
-  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo"]}, custom_tags: nil)
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo"]})
   false
   iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo", "openstreetmap"]}, custom_tags: [])
   true

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -506,7 +506,7 @@ defmodule TransportWeb.DatasetView do
 
   iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo"]})
   false
-  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo", "openstreetmap"]}, custom_tags: [])
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: ["foo", "openstreetmap"], custom_tags: []})
   true
   iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: [], custom_tags: ["licence-osm"]})
   true

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -565,3 +565,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "OSM community guidelines"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -565,3 +565,7 @@ msgstr "Impossible de déterminer le fichier GTFS à utiliser pour effectuer une
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr "Fichier GTFS à utiliser avec le flux GTFS-RT"
+
+#, elixir-autogen, elixir-format
+msgid "OSM community guidelines"
+msgstr "Règles de la communauté OSM"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -565,3 +565,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS file to use with the GTFS-RT feed"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "OSM community guidelines"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -191,6 +191,7 @@ defmodule TransportWeb.DatasetControllerTest do
 
     conn = conn |> get(dataset_path(conn, :details, slug))
     refute conn |> html_response(200) =~ "Conditions Particulières"
+    assert conn |> html_response(200) =~ "Règles de la communauté OSM"
   end
 
   test "does not crash when validation_performed is false", %{conn: conn} do


### PR DESCRIPTION
Fixes #3114

Ajoute un message mentionnant les règles de la communauté OSM pour les JDD avec licence ODbL venant d'OSM.

Un JDD est considéré comme tel
- quand il a le tag `openstreetmap` indiqué sur data.gouv.fr
- OU quand notre équipe a mis le tag `licence-osm` sur le backoffice

![image](https://user-images.githubusercontent.com/295709/235123784-fbd87d10-835a-486e-9a89-ad0b37caa9e6.png)
