### PR TITLE
Notification GTFS-RT vers GTFS : prend en compte JDD à jour

### DIFF
--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -179,7 +179,7 @@ defmodule Transport.Validators.GTFSRT do
     |> ResourceHistory.join_resource_with_latest_resource_history()
     |> MultiValidation.join_resource_history_with_latest_validation(GTFSTransport.validator_name())
     |> ResourceMetadata.join_validation_with_metadata()
-    |> where([resource: r], r.format == "GTFS" and r.dataset_id == ^dataset_id)
+    |> where([resource: r], r.format == "GTFS" and not r.is_community_resource and r.dataset_id == ^dataset_id)
     |> ResourceMetadata.where_gtfs_up_to_date()
     |> preload([resource_history: rh], resource_history: rh)
     |> Repo.all()
@@ -214,7 +214,10 @@ defmodule Transport.Validators.GTFSRT do
     gtfs_rt_resources =
       Resource.base_query()
       |> preload([:resources_related])
-      |> where([resource: r], r.format == "gtfs-rt" and r.is_available and r.dataset_id == ^dataset_id)
+      |> where(
+        [resource: r],
+        r.format == "gtfs-rt" and not r.is_community_resource and r.is_available and r.dataset_id == ^dataset_id
+      )
       |> Repo.all()
 
     case Enum.count(gtfs_resources) do

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -185,6 +185,7 @@ defmodule DB.Factory do
         insert(:resource,
           dataset_id: dataset.id,
           is_available: Keyword.get(opts, :resource_available),
+          is_community_resource: Keyword.get(opts, :is_community_resource, false),
           format: "GTFS",
           datagouv_id: Ecto.UUID.generate()
         )

--- a/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
@@ -13,35 +13,48 @@ defmodule Transport.Test.Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNot
 
   test "relevant_datasets" do
     # 2 GTFS and 2 GTFS-RT with resource_related set for all GTFS-RT
-    %{id: d1_id} = insert(:dataset, is_active: true)
-    # 1 GTFS and 1 GTFS-RT
-    %{id: d2_id} = insert(:dataset, is_active: true)
-    # 2 GTFS and 1 GTFS-RT
-    %{id: d3_id} = insert(:dataset, is_active: true)
-    gtfs_1_1 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "GTFS")
-    insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "GTFS")
+    %{dataset: %DB.Dataset{id: d1_id} = d1, resource: %DB.Resource{format: "GTFS"} = gtfs_1_1} =
+      insert_up_to_date_resource_and_friends()
+
+    insert_up_to_date_resource_and_friends(dataset: d1)
     gtfs_rt_1 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "gtfs-rt")
     gtfs_rt_2 = insert(:resource, dataset_id: d1_id, is_community_resource: false, format: "gtfs-rt")
-
-    insert(:resource, dataset_id: d2_id, is_community_resource: false, format: "GTFS")
-    insert(:resource, dataset_id: d2_id, is_community_resource: false, format: "gtfs-rt")
-
-    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "GTFS")
-    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "GTFS")
-    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "gtfs-rt")
 
     insert(:resource_related, resource_src: gtfs_rt_1, resource_dst: gtfs_1_1, reason: :gtfs_rt_gtfs)
     insert(:resource_related, resource_src: gtfs_rt_2, resource_dst: gtfs_1_1, reason: :gtfs_rt_gtfs)
 
-    assert [%DB.Dataset{id: ^d3_id}] =
+    # 1 GTFS and 1 GTFS-RT
+    %{dataset: %DB.Dataset{id: d2_id}, resource: %DB.Resource{format: "GTFS"}} =
+      insert_up_to_date_resource_and_friends()
+
+    insert(:resource, dataset_id: d2_id, is_community_resource: false, format: "gtfs-rt")
+
+    # 1 up-to-date GTFS, 1 outdated GTFS and 1 GTFS-RT
+    %{dataset: %DB.Dataset{id: d3_id} = d3, resource: %DB.Resource{format: "GTFS"}} =
+      insert_up_to_date_resource_and_friends()
+
+    insert_outdated_resource_and_friends(dataset: d3)
+    insert(:resource, dataset_id: d3_id, is_community_resource: false, format: "gtfs-rt")
+
+    # 2 GTFS and 1 GTFS-RT, without resource_related set
+    %{dataset: %DB.Dataset{id: d4_id} = d4, resource: %DB.Resource{format: "GTFS"}} =
+      insert_up_to_date_resource_and_friends()
+
+    insert_up_to_date_resource_and_friends(dataset: d4)
+    insert(:resource, dataset_id: d4_id, is_community_resource: false, format: "gtfs-rt")
+
+    assert [%DB.Dataset{id: ^d4_id}] =
              DatasetsWithoutGTFSRTRelatedResourcesNotificationJob.relevant_datasets() |> Enum.sort()
   end
 
   test "perform" do
-    dataset = insert(:dataset, is_active: true, custom_title: "Super JDD")
-    insert(:resource, dataset: dataset, is_community_resource: false, format: "GTFS")
-    insert(:resource, dataset: dataset, is_community_resource: false, format: "GTFS")
+    %{dataset: %DB.Dataset{id: dataset_id} = dataset, resource: %DB.Resource{format: "GTFS"}} =
+      insert_up_to_date_resource_and_friends(custom_title: "Super JDD")
+
+    insert_up_to_date_resource_and_friends(dataset: dataset)
     insert(:resource, dataset: dataset, is_community_resource: false, format: "gtfs-rt")
+
+    assert [%DB.Dataset{id: ^dataset_id}] = DatasetsWithoutGTFSRTRelatedResourcesNotificationJob.relevant_datasets()
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -99,21 +99,23 @@ defmodule Transport.Validators.GTFSRTTest do
           }
         )
 
-      %{id: gtfs_rt_id} =
+      %DB.Resource{id: gtfs_rt_id} =
         gtfs_rt =
         insert(:resource,
           dataset_id: dataset.id,
           is_available: true,
           format: "gtfs-rt",
+          is_community_resource: false,
           url: gtfs_rt_url
         )
 
-      %{id: gtfs_rt_no_errors_id} =
+      %DB.Resource{id: gtfs_rt_no_errors_id} =
         gtfs_rt_no_errors =
         insert(:resource,
           dataset_id: dataset.id,
           is_available: true,
           format: "gtfs-rt",
+          is_community_resource: false,
           url: gtfs_rt_no_errors_url
         )
 
@@ -265,12 +267,13 @@ defmodule Transport.Validators.GTFSRTTest do
           }
         )
 
-      %{id: gtfs_rt_id} =
+      %DB.Resource{id: gtfs_rt_id} =
         gtfs_rt =
         insert(:resource,
           dataset_id: dataset.id,
           is_available: true,
           format: "gtfs-rt",
+          is_community_resource: false,
           url: gtfs_rt_url
         )
 
@@ -279,6 +282,7 @@ defmodule Transport.Validators.GTFSRTTest do
           dataset_id: dataset.id,
           is_available: true,
           format: "gtfs-rt",
+          is_community_resource: false,
           url: gtfs_rt_no_errors_url
         )
 
@@ -375,11 +379,13 @@ defmodule Transport.Validators.GTFSRTTest do
           }
         )
 
-      gtfs_rt =
+      %DB.Resource{} =
+        gtfs_rt =
         insert(:resource,
           dataset_id: dataset.id,
           is_available: true,
           format: "gtfs-rt",
+          is_community_resource: false,
           url: gtfs_rt_url
         )
 
@@ -440,7 +446,11 @@ defmodule Transport.Validators.GTFSRTTest do
       %{dataset: dataset, resource: gtfs_1} = insert_outdated_resource_and_friends()
       %{resource: gtfs_2} = insert_up_to_date_resource_and_friends(dataset: dataset)
       %{id: gtfs_2_id} = gtfs_2
-      %{id: gtfs_rt_1_id} = gtfs_rt_1 = insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt")
+
+      %DB.Resource{id: gtfs_rt_1_id} =
+        gtfs_rt_1 =
+        insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt", is_community_resource: false)
+
       insert(:resource_related, resource_src: gtfs_rt_1, resource_dst: gtfs_1, reason: :gtfs_rt_gtfs)
 
       assert [
@@ -454,8 +464,14 @@ defmodule Transport.Validators.GTFSRTTest do
 
       %{resource: %DB.Resource{format: "GTFS"}} = insert_up_to_date_resource_and_friends(dataset: dataset)
 
-      %{id: gtfs_rt_1_id} = gtfs_rt_1 = insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt")
-      %{id: gtfs_rt_2_id} = gtfs_rt_2 = insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt")
+      %DB.Resource{id: gtfs_rt_1_id} =
+        gtfs_rt_1 =
+        insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt", is_community_resource: false)
+
+      %DB.Resource{id: gtfs_rt_2_id} =
+        gtfs_rt_2 =
+        insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt", is_community_resource: false)
+
       # Should be ignored because no `resource_related` exists
       _ignored_gtfs_rt = insert(:resource, dataset: dataset, is_available: true, format: "gtfs-rt")
 


### PR DESCRIPTION
Fixes #3117

Adapte le job pour ignorer les GTFS qui sont périmés, sans ceci on envoyait une notification pour un JDD qui ne requiert pas notre attention en réalité.

Dans une logique "boy scout", adapte le validateur GTFS-RT pour éliminer expliciter les ressources `is_community_resource = true` (pas un bug, mais vaut mieux se prémunir).