### PR TITLE
Gère erreurs HTTP pour DataChecker

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client.ex
@@ -31,6 +31,9 @@ defmodule Datagouvfr.Client do
           {:ok, %{status_code: status_code, body: body}} when status_code in [200, 201, 202, 204] ->
             {:ok, body}
 
+          {:ok, %{status_code: 404}} ->
+            {:error, :not_found}
+
           {:ok, %{status_code: status_code, body: body} = resp} ->
             maybe_report_error(resp)
             {:error, body}

--- a/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
@@ -144,7 +144,7 @@ defmodule Datagouvfr.Client.Datasets do
   Call to GET /api/1/datasets/:id/
   You can see documentation here: http://www.data.gouv.fr/fr/apidoc/#!/datasets/put_dataset
   """
-  @spec get(String.t()) :: {atom, map}
+  @spec get(String.t()) :: {atom, any}
   def get(id) do
     @endpoint
     |> Path.join(id)

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -83,8 +83,16 @@ defmodule Transport.DataChecker do
 
         :ignore
 
-      {:error, _} ->
+      {:error, :not_found} ->
         :inactive
+
+      {:error, error} ->
+        Sentry.capture_message(
+          "Unable to get Dataset status from data.gouv.fr",
+          extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
+        )
+
+        :ignore
     end
   end
 

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -65,7 +65,7 @@ defmodule Transport.DataChecker do
     |> Enum.map(&{&1, dataset_status(&1)})
   end
 
-  @spec dataset_status(Dataset.t()) :: :active | :inactive | {:archived, DateTime.t()}
+  @spec dataset_status(Dataset.t()) :: :active | :inactive | :ignore | {:archived, DateTime.t()}
   defp dataset_status(%Dataset{datagouv_id: datagouv_id}) do
     case Datasets.get(datagouv_id) do
       {:ok, %{"archived" => nil}} ->
@@ -81,7 +81,7 @@ defmodule Transport.DataChecker do
           extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
         )
 
-        :inactive
+        :ignore
 
       {:error, _} ->
         :inactive

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -78,7 +78,7 @@ defmodule Transport.DataCheckerTest do
       end)
 
       # We create a dataset which is considered active on our side
-      # but we get an error 500 on data.gouv side => we should not deactive it
+      # but we get a 500 error on data gouv side => we should not deactivate it
       dataset_500 = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate())
       api_url_500 = "https://demo.data.gouv.fr/api/1/datasets/#{dataset_500.datagouv_id}/"
 

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -67,7 +67,7 @@ defmodule Transport.DataCheckerTest do
       end)
 
       # We create a dataset which is considered active on our side
-      # but which is not found found (= inactive?) on data gouv side
+      # but which is not found (=> inactive) on data gouv side
       dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate())
       api_url = "https://demo.data.gouv.fr/api/1/datasets/#{dataset.datagouv_id}/"
 
@@ -75,6 +75,17 @@ defmodule Transport.DataCheckerTest do
       |> expect(:request, fn :get, ^api_url, "", [], [follow_redirect: true] ->
         # the dataset is not found on datagouv
         {:ok, %HTTPoison.Response{status_code: 404, body: ""}}
+      end)
+
+      # We create a dataset which is considered active on our side
+      # but we get an error 500 on data.gouv side => we should not deactive it
+      dataset_500 = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate())
+      api_url_500 = "https://demo.data.gouv.fr/api/1/datasets/#{dataset_500.datagouv_id}/"
+
+      Transport.HTTPoison.Mock
+      |> expect(:request, fn :get, ^api_url_500, "", [], [follow_redirect: true] ->
+        # data.gouv answers with a 500
+        {:ok, %HTTPoison.Response{status_code: 500, body: ""}}
       end)
 
       Transport.EmailSender.Mock
@@ -91,8 +102,10 @@ defmodule Transport.DataCheckerTest do
 
       # should result into marking the dataset as inactive
       assert %DB.Dataset{is_active: false} = DB.Repo.reload!(dataset)
-      # we got HTTP timeout errors: we should not desactivate the dataset
+      # we got HTTP timeout errors: we should not deactivate the dataset
       assert %DB.Dataset{is_active: true} = DB.Repo.reload!(dataset_http_error)
+      # we got a 500 error: we should not deactivate the dataset
+      assert %DB.Dataset{is_active: true} = DB.Repo.reload!(dataset_500)
 
       verify!(Transport.HTTPoison.Mock)
       verify!(Transport.EmailSender.Mock)


### PR DESCRIPTION
Fixes #3112

Gère les erreurs HTTP dans le job quotidien qui active/désactive les JDD et les ignore : ne fait rien (surtout pas désactiver le JDD, qui était le comportement précédent).