### PR TITLE
Licence ODbL : gère nil pour custom_tags

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -510,9 +510,11 @@ defmodule TransportWeb.DatasetView do
   true
   iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: [], custom_tags: ["licence-osm"]})
   true
+  iex> displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: [], custom_tags: nil})
+  false
   """
   def displays_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: tags, custom_tags: custom_tags}) do
-    "openstreetmap" in tags or "licence-osm" in custom_tags
+    "openstreetmap" in tags or "licence-osm" in (custom_tags || [])
   end
 
   def displays_odbl_osm_conditions?(%Dataset{}), do: false


### PR DESCRIPTION
Répare un bug introduit dans https://github.com/etalab/transport-site/pull/3116

Ne gère pas le cas où `custom_tags = nil`, visiblement la valeur par défaut mis dans le modèle Ecto n'est pas suffisant :cry:.

Voir [erreurs](https://transport-data-gouv-fr.sentry.io/issues/4135720909/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream&stream_index=0) sur Sentry, déjà près de 4k exceptions.