### PR TITLE
[WIP] Optimisations pour la carte GTFS nationale

### DIFF
--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -72,10 +72,12 @@ defmodule Transport.GTFSData do
     5 => {0.21972656250000006, 0.15165412371973086},
     6 => {0.10986328125000003, 0.07580875200863536},
     7 => {0.054931640625000014, 0.037900705683396894},
-    8 => {0.027465820312500007, 0.018949562981982936}
+    8 => {0.027465820312500007, 0.018949562981982936},
+    9 => {0.013732910156250003, 0.009474781490991468},
+    10 => {0.006866455078125002, 0.004737390745495734}
   }
 
-  def create_gtfs_stops_materialized_view(zoom_level) when is_integer(zoom_level) and zoom_level in 1..8 do
+  def create_gtfs_stops_materialized_view(zoom_level) when is_integer(zoom_level) and zoom_level in 1..10 do
     north = DB.Repo.aggregate("gtfs_stops", :max, :stop_lat)
     south = DB.Repo.aggregate("gtfs_stops", :min, :stop_lat)
     east = DB.Repo.aggregate("gtfs_stops", :max, :stop_lon)

--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -75,22 +75,18 @@ defmodule Transport.GTFSData do
     8 => {0.027465820312500007, 0.018949562981982936}
   }
 
-  def build_clusters(box = {north, south, east, west}, snap = {snap_x, snap_y}) do
-    IO.inspect(box, label: "box")
-    IO.inspect(snap, label: "snap")
-
-    # box: {68.9110048456202, 8.581021215641854, 103.35937500000001, -98.43750000000001}
-    snap_x = 0.02
-    snap_y = 0.02
+  def build_cacheable_clusters(zoom_level = 8) do
     north = DB.Repo.aggregate("gtfs_stops", :max, :stop_lat)
     south = DB.Repo.aggregate("gtfs_stops", :min, :stop_lat)
     east = DB.Repo.aggregate("gtfs_stops", :max, :stop_lon)
     west = DB.Repo.aggregate("gtfs_stops", :min, :stop_lon)
 
-    IO.inspect({north, south, east, west}, label: "box")
-    IO.inspect({snap_x, snap_y}, label: "snap")
+    {snap_x, snap_y} = @zoom_levels |> Map.fetch!(zoom_level)
 
-    #    north =
+    build_clusters({north, south, east, west}, {snap_x, snap_y})
+  end
+
+  def build_clusters({north, south, east, west}, {snap_x, snap_y}) do
     # NOTE: this query is not horribly slow but not super fast either. When the user
     # scrolls, this will stack up queries. It would be a good idea to cache the result for
     # some precomputed zoom levels when all the data imports are considered (no filtering).

--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -108,14 +108,14 @@ defmodule Transport.GTFSData do
     {:ok, _res} = Ecto.Adapters.SQL.query(DB.Repo, view_query)
   end
 
-  def find_closest_zoom_level({snap_x, snap_y}) do
-    Enum.min_by(@zoom_levels, fn {zoom_level, {sx, sy}} ->
+  def find_closest_zoom_level({_snap_x, snap_y}) do
+    Enum.min_by(@zoom_levels, fn {_zoom_level, {_sx, sy}} ->
       abs(sy - snap_y)
     end)
   end
 
   def build_clusters({north, south, east, west}, {snap_x, snap_y}) do
-    {zoom_level, {sx, sy}} = find_closest_zoom_level({snap_x, snap_y})
+    {zoom_level, {_sx, _sy}} = find_closest_zoom_level({snap_x, snap_y})
 
     # TODO: skip create earlier if exist
     create_gtfs_stops_materialized_view(zoom_level)

--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -63,7 +63,34 @@ defmodule Transport.GTFSData do
     |> DB.Repo.aggregate(:count, :id)
   end
 
-  def build_clusters({north, south, east, west}, {snap_x, snap_y}) do
+  # exploratory values, zoom level is map.getZoom()
+  @zoom_levels %{
+    1 => {3.5, 2.0},
+    2 => {1.7578125000000004, 1.189324575526938},
+    3 => {0.8789062500000002, 0.6065068377804875},
+    4 => {0.4394531250000001, 0.3034851814036069},
+    5 => {0.21972656250000006, 0.15165412371973086},
+    6 => {0.10986328125000003, 0.07580875200863536},
+    7 => {0.054931640625000014, 0.037900705683396894},
+    8 => {0.027465820312500007, 0.018949562981982936}
+  }
+
+  def build_clusters(box = {north, south, east, west}, snap = {snap_x, snap_y}) do
+    IO.inspect(box, label: "box")
+    IO.inspect(snap, label: "snap")
+
+    # box: {68.9110048456202, 8.581021215641854, 103.35937500000001, -98.43750000000001}
+    snap_x = 0.02
+    snap_y = 0.02
+    north = DB.Repo.aggregate("gtfs_stops", :max, :stop_lat)
+    south = DB.Repo.aggregate("gtfs_stops", :min, :stop_lat)
+    east = DB.Repo.aggregate("gtfs_stops", :max, :stop_lon)
+    west = DB.Repo.aggregate("gtfs_stops", :min, :stop_lon)
+
+    IO.inspect({north, south, east, west}, label: "box")
+    IO.inspect({snap_x, snap_y}, label: "snap")
+
+    #    north =
     # NOTE: this query is not horribly slow but not super fast either. When the user
     # scrolls, this will stack up queries. It would be a good idea to cache the result for
     # some precomputed zoom levels when all the data imports are considered (no filtering).

--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -95,17 +95,27 @@ defmodule Transport.GTFSData do
     #{sql}
     """
 
-    {:ok, _res} = Ecto.Adapters.SQL.query(DB.Repo, view_query, params)
+    # TODO: replace this by cleaner solutions (https://dba.stackexchange.com/a/208599)
+    view_query =
+      view_query
+      |> String.replace("$1", params |> Enum.at(0) |> Float.to_string())
+      |> String.replace("$2", params |> Enum.at(1) |> Float.to_string())
+      |> String.replace("$3", params |> Enum.at(2) |> Float.to_string())
+      |> String.replace("$4", params |> Enum.at(3) |> Float.to_string())
+      |> String.replace("$5", params |> Enum.at(4) |> Float.to_string())
+      |> String.replace("$6", params |> Enum.at(5) |> Float.to_string())
 
-    q = from(gs in "gtfs_stops_clusters_level_8")
+    {:ok, _res} = Ecto.Adapters.SQL.query(DB.Repo, view_query)
+
+    q = from(gs in "gtfs_stops_clusters_level_8", select: [:cluster_lat, :cluster_lon, :count])
 
     q
     |> DB.Repo.all()
     |> Enum.map(fn x ->
       [
-        x |> Map.fetch!(:lat) |> Decimal.from_float() |> Decimal.round(4) |> Decimal.to_float(),
-        x |> Map.fetch!(:lon) |> Decimal.from_float() |> Decimal.round(4) |> Decimal.to_float(),
-        x |> Map.fetch!(:c)
+        x |> Map.fetch!(:cluster_lat) |> Decimal.from_float() |> Decimal.round(4) |> Decimal.to_float(),
+        x |> Map.fetch!(:cluster_lon) |> Decimal.from_float() |> Decimal.round(4) |> Decimal.to_float(),
+        x |> Map.fetch!(:count)
       ]
     end)
   end

--- a/apps/transport/lib/transport/gtfs_data.ex
+++ b/apps/transport/lib/transport/gtfs_data.ex
@@ -125,7 +125,11 @@ defmodule Transport.GTFSData do
     q = from(gs in "gtfs_stops_clusters_level_#{zoom_level}", select: [:cluster_lat, :cluster_lon, :count])
 
     q
-    # TODO: filter based on bounding box
+    |> where(
+      [c],
+      fragment("? between ? and ?", c.cluster_lon, ^west, ^east) and
+        fragment("? between ? and ?", c.cluster_lat, ^south, ^north)
+    )
     |> DB.Repo.all()
     |> Enum.map(fn x ->
       [

--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -52,7 +52,7 @@ defmodule TransportWeb.ExploreController do
         %{
           type: "clustered",
           # TODO: change zoom level of cached cluster dynamically
-          data: Transport.GTFSData.build_cacheable_clusters(8)
+          data: Transport.GTFSData.build_clusters({north, south, east, west}, {snap_x, snap_y})
         }
       end
 

--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -51,7 +51,8 @@ defmodule TransportWeb.ExploreController do
       else
         %{
           type: "clustered",
-          data: Transport.GTFSData.build_clusters({north, south, east, west}, {snap_x, snap_y})
+          # TODO: change zoom level of cached cluster dynamically
+          data: Transport.GTFSData.build_cacheable_clusters(8)
         }
       end
 


### PR DESCRIPTION
Dans cette PR je travaille à optimiser le rendu de la carte GTFS nationale, de façon à pouvoir la rendre publique (performance suffisante pour ne pas faire planter le reste du size).

J'ajouterai des informations ici.

Pour l'instant la piste de travail est une mise sous cache des clusters par zoom level, avec des materialized views correspondantes. Je dois optimiser le renvoi JSON vers le client également, qui prend à présent plus de temps que le calcul.

Il faudra également vérifier le fonctionnement sur différentes tailles d'écran, et peut-être ajuster le comportement du calcul (sélection du bon zoom level / snap pour avoir un rendu potable).

### Vérification de la taille des caches

```sql
select schemaname as table_schema,
    relname as table_name,
    pg_size_pretty(pg_total_relation_size(relid)) as total_size,
    pg_size_pretty(pg_relation_size(relid)) as data_size,
    pg_size_pretty(pg_total_relation_size(relid) - pg_relation_size(relid))
      as external_size
from pg_catalog.pg_statio_user_tables
where relname like 'gtfs_stops_clusters_level%'
order by pg_total_relation_size(relid) desc,
         pg_relation_size(relid) desc
limit 20;
```

| table_schema | table_name                  | total_size | data_size  | external_size |
|--------------|-----------------------------|------------|------------|---------------|
| public       | gtfs_stops_clusters_level_9 | 3928 kB    | 3896 kB    | 32 kB         |
| public       | gtfs_stops_clusters_level_8 | 2248 kB    | 2216 kB    | 32 kB         |
| public       | gtfs_stops_clusters_level_7 | 1048 kB    | 1016 kB    | 32 kB         |
| public       | gtfs_stops_clusters_level_6 | 440 kB     | 408 kB     | 32 kB         |
| public       | gtfs_stops_clusters_level_5 | 200 kB     | 168 kB     | 32 kB         |
| public       | gtfs_stops_clusters_level_4 | 112 kB     | 80 kB      | 32 kB         |
| public       | gtfs_stops_clusters_level_3 | 40 kB      | 40 kB      | 0 bytes       |
| public       | gtfs_stops_clusters_level_2 | 16 kB      | 16 kB      | 0 bytes       |
| public       | gtfs_stops_clusters_level_1 | 8192 bytes | 8192 bytes | 0 bytes       |