### PR TITLE
Augmenter le timeout pour historisation des ressources et validation jsonschema

### DIFF
--- a/apps/shared/lib/validation/jsonschema_validator.ex
+++ b/apps/shared/lib/validation/jsonschema_validator.ex
@@ -63,7 +63,7 @@ defmodule Shared.Validation.JSONSchemaValidator do
 
   @impl true
   def validate(schema, url) when is_binary(url) do
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(url, [], follow_redirect: true),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(url, [], follow_redirect: true, recv_timeout: 180_000),
          {:ok, json} <- Jason.decode(body) do
       validate(schema, json)
     else

--- a/apps/shared/lib/validation/jsonschema_validator.ex
+++ b/apps/shared/lib/validation/jsonschema_validator.ex
@@ -63,7 +63,8 @@ defmodule Shared.Validation.JSONSchemaValidator do
 
   @impl true
   def validate(schema, url) when is_binary(url) do
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(url, [], follow_redirect: true, recv_timeout: 180_000),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
+           http_client().get(url, [], follow_redirect: true, recv_timeout: 180_000),
          {:ok, json} <- Jason.decode(body) do
       validate(schema, json)
     else

--- a/apps/shared/test/validation/jsonschema_validator_test.exs
+++ b/apps/shared/test/validation/jsonschema_validator_test.exs
@@ -79,7 +79,7 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
       url = "http://example.com/file"
 
       Transport.HTTPoison.Mock
-      |> expect(:get, fn ^url, [], follow_redirect: true ->
+      |> expect(:get, fn ^url, [], follow_redirect: true, recv_timeout: _ ->
         {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"name" => "foo"})}}
       end)
 
@@ -95,7 +95,7 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
       url = "http://example.com/file"
 
       Transport.HTTPoison.Mock
-      |> expect(:get, fn ^url, [], follow_redirect: true ->
+      |> expect(:get, fn ^url, [], follow_redirect: true, recv_timeout: _ ->
         {:ok, %HTTPoison.Response{status_code: 500, body: "error"}}
       end)
 
@@ -106,7 +106,7 @@ defmodule Shared.Validation.JSONSchemaValidatorTest do
       url = "http://example.com/file"
 
       Transport.HTTPoison.Mock
-      |> expect(:get, fn ^url, [], follow_redirect: true ->
+      |> expect(:get, fn ^url, [], follow_redirect: true, recv_timeout: _ ->
         {:ok, %HTTPoison.Response{status_code: 200, body: "error"}}
       end)
 

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -243,7 +243,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   end
 
   defp download_resource(%Resource{id: resource_id, url: url}, file_path) do
-    case http_client().get(url, [], follow_redirect: true) do
+    case http_client().get(url, [], follow_redirect: true, recv_timeout: 180_000) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body} = r} ->
         Logger.debug("Saving resource##{resource_id} to #{file_path}")
         File.write!(file_path, body)

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -244,7 +244,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       Transport.HTTPoison.Mock
       |> expect(:get, fn ^resource_url, _headers, options ->
-        assert options == [follow_redirect: true]
+        assert options |> Keyword.fetch!(:follow_redirect) == true
 
         {:ok,
          %HTTPoison.Response{
@@ -332,7 +332,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       Transport.HTTPoison.Mock
       |> expect(:get, fn ^resource_url, _headers, options ->
-        assert options == [follow_redirect: true]
+        assert options |> Keyword.fetch!(:follow_redirect) == true
 
         {:ok,
          %HTTPoison.Response{
@@ -437,7 +437,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       Transport.HTTPoison.Mock
       |> expect(:get, fn ^resource_url, _headers, options ->
-        assert options == [follow_redirect: true]
+        assert options |> Keyword.fetch!(:follow_redirect) == true
         {:ok, %HTTPoison.Response{status_code: 200, body: @gtfs_content, headers: []}}
       end)
 


### PR DESCRIPTION
lié à https://github.com/etalab/transport-site/issues/2428

Pour l'instant la validation des [aménagements cyclables nationaux](https://transport.data.gouv.fr/datasets/amenagements-cyclables-france-metropolitaine#dataset-top) échoue pour 2 raisons : l'historisation de la ressource échoue lors du téléchargement, à cause du timeout par défaut de HTTPoison, puis la validation échoue pour la même raison. J'augmente ces 2 timeouts à 3 minutes, comme c'est déjà fait ailleurs dans le code.