### PR TITLE
Mise à jour code Matomo

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/app.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.heex
@@ -37,15 +37,16 @@
       <!-- Matomo -->
       <script type="text/javascript">
         var _paq = _paq || [];
-        _paq.push(["setDomains", ["*.transport.data.gouv.fr","*.transport.data.gouv.fr"]]);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
+        _paq.push(["setCookieDomain", "*.transport.data.gouv.fr"]);
+        _paq.push(["setDomains", "*.transport.data.gouv.fr"]);
+        _paq.push(["trackPageView"]);
+        _paq.push(["enableLinkTracking"]);
         (function() {
           var u="//stats.data.gouv.fr/";
-          _paq.push(['setTrackerUrl', u+'matomo.php']);
-          _paq.push(['setSiteId', '58']);
-          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-          g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          _paq.push(["setTrackerUrl", u+"matomo.php"]);
+          _paq.push(["setSiteId", "58"]);
+          var d=document, g=d.createElement('script'), s=d.getElementsByTagName("script")[0];
+          g.type="text/javascript"; g.async=true; g.defer=true; g.src=u+"matomo.js"; s.parentNode.insertBefore(g,s);
         })();
       </script>
       <!-- End Matomo Code -->


### PR DESCRIPTION
En lien avec #3123

Adapte le code Matomo pour les propriétés `setCookieDomain` et `setDomains`.

Lien [vers la documentation](https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website), "Tracking one domain and its subdomains in the same website"