### PR TITLE
DataChecker : mise à jour lien vers discussion data.gouv.fr

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/index.html.heex
@@ -12,7 +12,7 @@
         "<%= comment["content"] %>" <br />
         <%= link("voir la discussion",
           to:
-            "#{Application.fetch_env!(:transport, :datagouvfr_site)}/datasets/#{datagouv_id}/#discussion-#{comment["discussion_id"]}"
+            "#{Application.fetch_env!(:transport, :datagouvfr_site)}/datasets/#{datagouv_id}/#/discussions/#{comment["discussion_id"]}"
         ) %>
       </div>
     <% end %>


### PR DESCRIPTION
Les liens semblent avoir changés avec une refonte graphique de data.gouv.fr et le passage à des onglets.

Report de bug https://github.com/etalab/data.gouv.fr/issues/1078

Exemple de nouveau lien valide : https://www.data.gouv.fr/fr/datasets/642a93532f52c89ac0ecb689/#/discussions/642d904f84040c1ac56bfa18