### PR TITLE
Répare un bug introduit dans https://github.com/etalab/transport-site/pull/3116

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_licence.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_licence.html.heex
@@ -6,16 +6,18 @@
   <% else %>
     <%= licence(@dataset) %>
   <% end %>
-  <%= if displays_odbl_osm_conditions?(@dataset) do %>
-    &#32 <%= dgettext("page-dataset-details", "and ") %>
-    <%= link(dgettext("page-dataset-details", "OSM community guidelines"),
-      to: "https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines"
-    ) %>
-  <% else %>
-    &#32 <%= dgettext("page-dataset-details", "and ") %>
-    <%= link(dgettext("page-dataset-details", "Specific usage conditions"),
-      to:
-        "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/conditions-dutilisation-des-donnees/licence-odbl"
-    ) %>
+  <%= if @dataset.licence == "odc-odbl" do %>
+    <%= if displays_odbl_osm_conditions?(@dataset) do %>
+      &#32 <%= dgettext("page-dataset-details", "and ") %>
+      <%= link(dgettext("page-dataset-details", "OSM community guidelines"),
+        to: "https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines"
+      ) %>
+    <% else %>
+      &#32 <%= dgettext("page-dataset-details", "and ") %>
+      <%= link(dgettext("page-dataset-details", "Specific usage conditions"),
+        to:
+          "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/conditions-dutilisation-des-donnees/licence-odbl"
+      ) %>
+    <% end %>
   <% end %>
 </b>

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -175,23 +175,35 @@ defmodule TransportWeb.DatasetControllerTest do
     assert conn |> html_response(200) =~ "Données temps réel"
   end
 
-  test "ODbL licence with specific conditions", %{conn: conn} do
-    insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl"})
+  describe "licence description" do
+    test "ODbL licence with specific conditions", %{conn: conn} do
+      insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl"})
 
-    set_empty_mocks()
+      set_empty_mocks()
 
-    conn = conn |> get(dataset_path(conn, :details, slug))
-    assert conn |> html_response(200) =~ "Conditions Particulières"
-  end
+      conn = conn |> get(dataset_path(conn, :details, slug))
+      assert conn |> html_response(200) =~ "Conditions Particulières"
+    end
 
-  test "ODbL licence with openstreetmap tag", %{conn: conn} do
-    insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl", tags: ["openstreetmap"]})
+    test "ODbL licence with openstreetmap tag", %{conn: conn} do
+      insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl", tags: ["openstreetmap"]})
 
-    set_empty_mocks()
+      set_empty_mocks()
 
-    conn = conn |> get(dataset_path(conn, :details, slug))
-    refute conn |> html_response(200) =~ "Conditions Particulières"
-    assert conn |> html_response(200) =~ "Règles de la communauté OSM"
+      conn = conn |> get(dataset_path(conn, :details, slug))
+      refute conn |> html_response(200) =~ "Conditions Particulières"
+      assert conn |> html_response(200) =~ "Règles de la communauté OSM"
+    end
+
+    test "licence ouverte licence", %{conn: conn} do
+      insert(:dataset, %{slug: slug = "dataset-slug", licence: "lov2"})
+
+      set_empty_mocks()
+
+      conn = conn |> get(dataset_path(conn, :details, slug))
+      assert conn |> html_response(200) =~ "Licence Ouverte — version 2.0"
+      refute conn |> html_response(200) =~ "Conditions Particulières"
+    end
   end
 
   test "does not crash when validation_performed is false", %{conn: conn} do


### PR DESCRIPTION
Le `else` dans la précédente version était bien trop large, ce qui a pour effet d'afficher "Conditions particulières d'utilisation" pour toutes les licences, pas uniquement `odc-odbl`.

Je rajoute des tests.

Navré pour l'erreur.