### PR TITLE
Formulaire contact : champs obligatoires

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
@@ -10,15 +10,15 @@
       </a>
       <%= form_for @conn, contact_path(@conn, :send_mail), fn f -> %>
         <h3>Contact</h3>
-        <%= email_input(f, :email, placeholder: gettext("Email address")) %>
+        <%= email_input(f, :email, placeholder: gettext("Email address"), type: "email", required: true) %>
         <%= text_input(f, :name,
           placeholder: "your name",
           class: "form-special-field",
           tabindex: "-1",
           autocomplete: "off"
         ) %>
-        <%= text_input(f, :topic, value: gettext("Question about transport.data.gouv.fr")) %>
-        <%= textarea(f, :demande, placeholder: gettext("Ask for help")) %>
+        <%= text_input(f, :topic, value: gettext("Question about transport.data.gouv.fr"), required: true) %>
+        <%= textarea(f, :demande, placeholder: gettext("Ask for help"), required: true) %>
         <%= submit(gettext("Send email")) %>
       <% end %>
     </div>


### PR DESCRIPTION
Les champs n'étaient pas indiqués comme requis dans le HTML. En validant le formulaire sans renseigner une adresse e-mail, on a eu une erreur qui provient de l'API d'e-mail.

Je fais seulement une valide côté HTML, on aura bien une erreur si les champs sont non renseignés côté backend.