### PR TITLE
DatasetHistory : ajoute custom_tags

### DIFF
--- a/apps/transport/lib/jobs/dataset_history_job.ex
+++ b/apps/transport/lib/jobs/dataset_history_job.ex
@@ -40,7 +40,12 @@ defmodule Transport.Jobs.DatasetHistoryJob do
     %DB.DatasetHistory{
       dataset_id: dataset_id,
       dataset_datagouv_id: dataset.datagouv_id,
-      payload: %{"licence" => dataset.licence, "type" => dataset.type, "slug" => dataset.slug},
+      payload: %{
+        "licence" => dataset.licence,
+        "type" => dataset.type,
+        "slug" => dataset.slug,
+        "custom_tags" => dataset.custom_tags
+      },
       dataset_history_resources:
         dataset.resources
         |> Enum.map(fn resource ->

--- a/apps/transport/test/transport/jobs/dataset_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_history_job_test.exs
@@ -14,7 +14,8 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
         datagouv_id: datagouv_id = Ecto.UUID.generate(),
         licence: "love",
         type: "public-transport",
-        slug: "the-slug"
+        slug: "the-slug",
+        custom_tags: ["foo"]
       )
 
     # a resource with multiple resource history
@@ -48,7 +49,12 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
     assert %{
              dataset_id: ^dataset_id,
              dataset_datagouv_id: ^datagouv_id,
-             payload: %{"licence" => "love", "type" => "public-transport", "slug" => "the-slug"}
+             payload: %{
+               "licence" => "love",
+               "type" => "public-transport",
+               "slug" => "the-slug",
+               "custom_tags" => ["foo"]
+             }
            } = dataset_history
 
     dataset_history_resources = dataset_history.dataset_history_resources


### PR DESCRIPTION
Fixes #3153

Ajoute `dataset.custom_tags` à l'archivage quotidien des `DB.Dataset`.

Pourrait être utilisé pour suivre l'application de l'article 122 de la loi climat et résilience et bien plus.