### PR TITLE
Espace producteur : ajout CSS pour filler

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -119,3 +119,10 @@
     }
   }
 }
+
+a.filler {
+  margin-right: .3em;
+  &:first-child {
+    margin-left: .5em;
+  }
+}

--- a/apps/transport/lib/transport_web/templates/resource/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.heex
@@ -55,7 +55,8 @@
                     [
                       dgettext("resource", "Format"),
                       content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
-                      content_tag(:a, "NeTEx", class: "filler", onclick: "fill(this);")
+                      content_tag(:a, "NeTEx", class: "filler", onclick: "fill(this);"),
+                      content_tag(:a, "gtfs-rt", class: "filler", onclick: "fill(this);")
                     ]
                   end,
                 placeholder: "GTFS, NeTEx, …",

--- a/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
+++ b/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
@@ -20,7 +20,7 @@ defmodule TransportWeb.HeadersAndCookiesTest do
       "expires" => datetime
     } = Plug.Conn.Cookies.decode(header)
 
-    datetime = Timex.parse!(datetime, "{WDshort}, {D} {Mfull} {YYYY} {h24}:{m}:{s} GMT")
+    datetime = Timex.parse!(datetime, "{WDshort}, {D} {Mshort} {YYYY} {h24}:{m}:{s} GMT")
     assert_in_delta Timex.diff(datetime, Timex.now(), :hours), 15 * 24, 1
   end
 end


### PR DESCRIPTION
Ajout de règles CSS manquantes sur l'espace producteur, lors de l'ajout d'une ressource.

## Captures d'écran

### Avant
![image](https://github.com/etalab/transport-site/assets/295709/832a898d-dba4-477f-8805-43af00dc9f9b)

### Après
![Screenshot 2023-05-17 at 09 44 15](https://github.com/etalab/transport-site/assets/295709/a511cdf1-c3c9-4f63-8298-2f9824a32e5f)
