### PR TITLE
Metadata GBFS : ajout info "fraicheur" du flux

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -108,10 +108,22 @@ defmodule Transport.Shared.GBFSMetadata do
   iex> last_updated = DateTime.utc_now() |> DateTime.add(-1, :minute) |> DateTime.to_unix()
   iex> freshness_in_seconds(%{"last_updated" => last_updated})
   60
+  iex> freshness_in_seconds(%{"x" => 1})
+  nil
+  iex> freshness_in_seconds(%{"last_updated" => "F6"})
+  nil
   """
-  def freshness_in_seconds(%{"last_updated" => last_updated}) do
-    DateTime.utc_now() |> DateTime.diff(last_updated |> DateTime.from_unix!())
+  @spec freshness_in_seconds(any()) :: nil | integer
+  def freshness_in_seconds(%{"last_updated" => last_updated}) when is_integer(last_updated) do
+    last_updated
+    |> DateTime.from_unix()
+    |> case do
+      {:ok, t} -> DateTime.utc_now() |> DateTime.diff(t)
+      _ -> nil
+    end
   end
+
+  def freshness_in_seconds(_), do: nil
 
   @doc """
   Determines the feed to use as the ttl value of a GBFS feed.

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -16,25 +16,24 @@ defmodule Transport.Shared.GBFSMetadataTest do
       setup_feeds([:gbfs, :system_information, :station_information])
       setup_validation_result()
 
-      expected = %{
-        languages: ["fr"],
-        system_details: %{name: "velhop", timezone: "Europe/Paris"},
-        ttl: 3600,
-        types: ["stations"],
-        versions: ["1.1"],
-        feeds: ["system_information", "station_information", "station_status"],
-        validation: %GBFSValidationSummary{
-          errors_count: 0,
-          has_errors: false,
-          version_detected: "1.1",
-          version_validated: "1.1",
-          validator_version: "31c5325",
-          validator: :validator_module
-        },
-        cors_header_value: "*"
-      }
-
-      assert expected == compute_feed_metadata(@gbfs_url, "http://example.com")
+      assert %{
+               languages: ["fr"],
+               system_details: %{name: "velhop", timezone: "Europe/Paris"},
+               ttl: 3600,
+               types: ["stations"],
+               versions: ["1.1"],
+               feeds: ["system_information", "station_information", "station_status"],
+               validation: %GBFSValidationSummary{
+                 errors_count: 0,
+                 has_errors: false,
+                 version_detected: "1.1",
+                 version_validated: "1.1",
+                 validator_version: "31c5325",
+                 validator: :validator_module
+               },
+               cors_header_value: "*",
+               freshness_in_seconds: _
+             } = compute_feed_metadata(@gbfs_url, "http://example.com")
     end
 
     test "for a stations + free floating feed with a multiple versions" do
@@ -53,27 +52,28 @@ defmodule Transport.Shared.GBFSMetadataTest do
            }}
       )
 
-      expected = %{
-        languages: ["fr"],
-        system_details: %{name: "velhop", timezone: "Europe/Paris"},
-        ttl: 60,
-        types: ["free_floating", "stations"],
-        validation: summary,
-        versions: ["2.2", "2.1"],
-        feeds: [
-          "system_information",
-          "free_bike_status",
-          "vehicle_types",
-          "system_pricing_plans",
-          "station_information",
-          "station_status",
-          "geofencing_zones",
-          "gbfs_versions"
-        ],
-        cors_header_value: "*"
-      }
+      assert %{
+               languages: ["fr"],
+               system_details: %{name: "velhop", timezone: "Europe/Paris"},
+               ttl: 60,
+               types: ["free_floating", "stations"],
+               validation: ^summary,
+               versions: ["2.2", "2.1"],
+               feeds: [
+                 "system_information",
+                 "free_bike_status",
+                 "vehicle_types",
+                 "system_pricing_plans",
+                 "station_information",
+                 "station_status",
+                 "geofencing_zones",
+                 "gbfs_versions"
+               ],
+               cors_header_value: "*",
+               freshness_in_seconds: freshness_in_seconds
+             } = compute_feed_metadata(@gbfs_url, "http://example.com")
 
-      assert expected == compute_feed_metadata(@gbfs_url, "http://example.com")
+      assert freshness_in_seconds > 0
     end
 
     test "for feed with a 500 error on the root URL" do

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -32,7 +32,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
                  validator: :validator_module
                },
                cors_header_value: "*",
-               freshness_in_seconds: _
+               feed_timestamp_delay: _
              } = compute_feed_metadata(@gbfs_url, "http://example.com")
     end
 
@@ -70,10 +70,10 @@ defmodule Transport.Shared.GBFSMetadataTest do
                  "gbfs_versions"
                ],
                cors_header_value: "*",
-               freshness_in_seconds: freshness_in_seconds
+               feed_timestamp_delay: feed_timestamp_delay
              } = compute_feed_metadata(@gbfs_url, "http://example.com")
 
-      assert freshness_in_seconds > 0
+      assert feed_timestamp_delay > 0
     end
 
     test "for feed with a 500 error on the root URL" do


### PR DESCRIPTION
Pour un futur calcul de score de fraicheur, on va avoir besoin de l'information