### PR TITLE
Ajout d'un filtre pour JDD loi climat et résilience

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -216,6 +216,13 @@ defmodule DB.Dataset do
 
   defp filter_by_category(query, _), do: query
 
+  @spec filter_by_climate_resilience_bill(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  defp filter_by_climate_resilience_bill(%Ecto.Query{} = query, %{"loi-climat-resilience" => "true"}) do
+    where(query, [dataset: d], fragment("'loi-climat-resilience' = any(?)", d.custom_tags))
+  end
+
+  defp filter_by_climate_resilience_bill(%Ecto.Query{} = query, _), do: query
+
   @spec filter_by_feature(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_feature(query, %{"features" => [feature]})
        when feature in ["service_alerts", "trip_updates", "vehicle_positions"] do
@@ -363,6 +370,7 @@ defmodule DB.Dataset do
       |> filter_by_aom(params)
       |> filter_by_commune(params)
       |> filter_by_licence(params)
+      |> filter_by_climate_resilience_bill(params)
       |> filter_by_fulltext(params)
       |> select([dataset: d], d.id)
 

--- a/apps/transport/lib/transport/climate_resilience_bill.ex
+++ b/apps/transport/lib/transport/climate_resilience_bill.ex
@@ -8,17 +8,22 @@ defmodule Transport.ClimateResilienceBill do
   @doc """
   Should we display the data reuse panel when listing/searching datasets.
 
+  iex> display_data_reuse_panel?(%{"loi-climat-resilience" => "true", "page" => 2})
+  true
   iex> display_data_reuse_panel?(%{"type" => "public-transit", "page" => 2})
   true
   iex> display_data_reuse_panel?(%{"type" => "private-parking", "page" => 2})
   false
   """
   @spec display_data_reuse_panel?(map()) :: boolean()
+  def display_data_reuse_panel?(%{"loi-climat-resilience" => "true"}), do: true
   def display_data_reuse_panel?(%{"type" => dataset_type}), do: dataset_type in relevant_dataset_types()
 
   def display_data_reuse_panel?(_), do: false
 
   @doc """
+  iex> data_reuse_message(%{"loi-climat-resilience" => "true"}, ~D[2022-12-01])
+  "Ces jeux de données font l'objet d'une intégration obligatoire."
   iex> data_reuse_message("public-transit", ~D[2022-12-01])
   "Certaines données de cette catégorie font l'objet d'une intégration obligatoire depuis décembre 2022."
   iex> data_reuse_message("public-transit", ~D[2022-11-01])
@@ -27,6 +32,10 @@ defmodule Transport.ClimateResilienceBill do
   :ok
   """
   @spec data_reuse_message(binary() | map(), Date.t()) :: binary()
+  def data_reuse_message(%{"loi-climat-resilience" => "true"}, %Date{} = _) do
+    dgettext("dataset", "These datasets are subject to a data reuse obligation.")
+  end
+
   def data_reuse_message(dataset_type, %Date{} = date) when is_binary(dataset_type) do
     data_reuse_message(%{"type" => dataset_type}, date)
   end

--- a/apps/transport/lib/transport_web/templates/dataset/_climate_resilience_bill_panel.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_climate_resilience_bill_panel.html.heex
@@ -19,7 +19,7 @@
   </div>
 
   <div class="main-pane">
-    <div class="panel" id="custom-message">
+    <div :if={@category_custom_message} class="panel" id="custom-message">
       <%= markdown_to_safe_html!(@category_custom_message) %>
     </div>
   </div>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -35,7 +35,7 @@
   <%= render(TransportWeb.DatasetView, "_climate_resilience_bill_panel.html",
     conn: @conn,
     climate_resilience_msg: @climate_resilience_bill_message,
-    category_custom_message: @category_custom_message
+    category_custom_message: @conn.assigns[:category_custom_message]
   ) %>
 <% end %>
 
@@ -111,6 +111,28 @@
                   </li>
                 </li>
               <% end %>
+
+              <li class="side-pane__title">
+                <h3><%= dgettext("page-shortlist", "Climate and Resilience bill") %></h3>
+                <li class="side-pane__dropdown unfolded">
+                  <ul class="side-pane__submenu">
+                    <li>
+                      <%= climate_resilience_bill_link(@conn, %{
+                        only_climate_climate_resilience_bill: false,
+                        msg: dgettext("page-shortlist", "Any"),
+                        count: @number_climate_resilience_bill_datasets.all
+                      }) %>
+                    </li>
+                    <li>
+                      <%= climate_resilience_bill_link(@conn, %{
+                        only_climate_climate_resilience_bill: true,
+                        msg: dgettext("page-shortlist", "Compulsory data integration"),
+                        count: @number_climate_resilience_bill_datasets.true
+                      }) %>
+                    </li>
+                  </ul>
+                </li>
+              </li>
 
               <%= unless Enum.empty?(@licences) do %>
                 <li class="side-pane__title">

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -126,7 +126,7 @@
                     <li>
                       <%= climate_resilience_bill_link(@conn, %{
                         only_climate_climate_resilience_bill: true,
-                        msg: dgettext("page-shortlist", "Compulsory data integration"),
+                        msg: dgettext("page-shortlist", "Data reuse obligation"),
                         count: @number_climate_resilience_bill_datasets.true
                       }) %>
                     </li>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -163,7 +163,7 @@ defmodule TransportWeb.DatasetView do
           only_climate_climate_resilience_bill: boolean(),
           msg: binary(),
           count: non_neg_integer()
-        }) :: binary()
+        }) :: any()
   def climate_resilience_bill_link(conn, %{only_climate_climate_resilience_bill: only, msg: msg, count: count}) do
     full_url =
       case only do

--- a/apps/transport/priv/gettext/dataset.pot
+++ b/apps/transport/priv/gettext/dataset.pot
@@ -107,3 +107,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "starting from"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "These datasets are subject to a data reuse obligation."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/dataset.po
@@ -107,3 +107,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "starting from"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "These datasets are subject to a data reuse obligation."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -231,3 +231,11 @@ msgstr "All"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licences"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Climate and Resilience bill"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Compulsory data integration"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-shortlist.po
@@ -237,5 +237,5 @@ msgid "Climate and Resilience bill"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Compulsory data integration"
+msgid "Data reuse obligation"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/dataset.po
@@ -107,3 +107,7 @@ msgstr "depuis"
 #, elixir-autogen, elixir-format
 msgid "starting from"
 msgstr "à partir de"
+
+#, elixir-autogen, elixir-format
+msgid "These datasets are subject to a data reuse obligation."
+msgstr "Ces jeux de données font l'objet d'une intégration obligatoire."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
@@ -110,4 +110,3 @@ msgstr "Carte consolidée des arrêts GTFS (beta)"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Consolidated GTFS stops map explanation"
 msgstr "Cette carte consolide tous les GTFS référencés sur ce site. En beta, peut inclure des éléments expirés ou des doublons (voir %{link}). Vos retours sont les bienvenus."
-

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -231,3 +231,11 @@ msgstr "Toutes"
 #, elixir-autogen, elixir-format
 msgid "Licences"
 msgstr "Licences"
+
+#, elixir-autogen, elixir-format
+msgid "Climate and Resilience bill"
+msgstr "Loi climat et résilience"
+
+#, elixir-autogen, elixir-format
+msgid "Compulsory data integration"
+msgstr "Intégration obligatoire de données"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-shortlist.po
@@ -237,5 +237,5 @@ msgid "Climate and Resilience bill"
 msgstr "Loi climat et résilience"
 
 #, elixir-autogen, elixir-format
-msgid "Compulsory data integration"
-msgstr "Intégration obligatoire de données"
+msgid "Data reuse obligation"
+msgstr "Données à intégration obligatoire"

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -237,5 +237,5 @@ msgid "Climate and Resilience bill"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Compulsory data integration"
+msgid "Data reuse obligation"
 msgstr ""

--- a/apps/transport/priv/gettext/page-shortlist.pot
+++ b/apps/transport/priv/gettext/page-shortlist.pot
@@ -231,3 +231,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Licences"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Climate and Resilience bill"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Compulsory data integration"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -115,6 +115,14 @@ defmodule TransportWeb.DatasetControllerTest do
                "Certaines données de cette catégorie font l'objet d'une intégration obligatoire depuis décembre 2022"
     end
 
+    test "displayed when filtering for climate resilience bill datasets", %{conn: conn} do
+      conn = conn |> get(dataset_path(conn, :index, "loi-climat-resilience": true))
+      doc = conn |> html_response(200) |> Floki.parse_document!()
+      [msg] = Floki.find(doc, "#climate-resilience-bill-panel")
+
+      assert Floki.text(msg) =~ "Ces jeux de données font l'objet d'une intégration obligatoire."
+    end
+
     test "not displayed for locations", %{conn: conn} do
       conn = conn |> get(dataset_path(conn, :index, type: "locations"))
       doc = conn |> html_response(200) |> Floki.parse_document!()

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -1,6 +1,5 @@
 defmodule TransportWeb.DatasetSearchControllerTest do
-  use TransportWeb.ConnCase, async: false
-  use TransportWeb.ExternalCase
+  use TransportWeb.ConnCase, async: true
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   import DB.Factory
   alias DB.{AOM, Dataset, Repo, Resource}
@@ -178,6 +177,17 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     # searching for an unknown AOM should lead to a 404
     conn = conn |> get(dataset_path(conn, :by_aom, 999_999))
     assert html_response(conn, 404)
+  end
+
+  test "searching with the climate and resilience bill filter" do
+    %DB.Dataset{id: dataset_id} =
+      insert(:dataset, type: "public-transit", is_active: true, custom_tags: ["loi-climat-resilience", "foo"])
+
+    results = %{"type" => "public-transit"} |> Dataset.list_datasets() |> Repo.all()
+    assert Enum.count(results) == 3
+
+    assert [%DB.Dataset{id: ^dataset_id}] =
+             %{"type" => "public-transit", "loi-climat-resilience" => "true"} |> Dataset.list_datasets() |> Repo.all()
   end
 
   test "a dataset labelled as base nationale published by us is first without filters" do

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -175,11 +175,11 @@ defmodule TransportWeb.DatasetViewTest do
     test "inactive filter", %{conn: conn} do
       conn = conn |> get(dataset_path(conn, :index))
 
-      assert ~s{<a href="http://127.0.0.1:5100/datasets?loi-climat-resilience=true">Intégration obligatoire de données (3)</a>} ==
+      assert ~s{<a href="http://127.0.0.1:5100/datasets?loi-climat-resilience=true">Données à intégration obligatoire (3)</a>} ==
                conn
                |> climate_resilience_bill_link(%{
                  only_climate_climate_resilience_bill: true,
-                 msg: "Intégration obligatoire de données",
+                 msg: "Données à intégration obligatoire",
                  count: 3
                })
                |> to_html()
@@ -188,11 +188,11 @@ defmodule TransportWeb.DatasetViewTest do
     test "active filter", %{conn: conn} do
       conn = conn |> get(dataset_path(conn, :index, "loi-climat-resilience": "true"))
 
-      assert ~s{<span class="activefilter">Intégration obligatoire de données (3)</span>} ==
+      assert ~s{<span class="activefilter">Données à intégration obligatoire (3)</span>} ==
                conn
                |> climate_resilience_bill_link(%{
                  only_climate_climate_resilience_bill: true,
-                 msg: "Intégration obligatoire de données",
+                 msg: "Données à intégration obligatoire",
                  count: 3
                })
                |> to_html()

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -171,6 +171,60 @@ defmodule TransportWeb.DatasetViewTest do
     end
   end
 
+  describe "climate_resilience_bill_link" do
+    test "inactive filter", %{conn: conn} do
+      conn = conn |> get(dataset_path(conn, :index))
+
+      assert ~s{<a href="http://127.0.0.1:5100/datasets?loi-climat-resilience=true">Intégration obligatoire de données (3)</a>} ==
+               conn
+               |> climate_resilience_bill_link(%{
+                 only_climate_climate_resilience_bill: true,
+                 msg: "Intégration obligatoire de données",
+                 count: 3
+               })
+               |> to_html()
+    end
+
+    test "active filter", %{conn: conn} do
+      conn = conn |> get(dataset_path(conn, :index, "loi-climat-resilience": "true"))
+
+      assert ~s{<span class="activefilter">Intégration obligatoire de données (3)</span>} ==
+               conn
+               |> climate_resilience_bill_link(%{
+                 only_climate_climate_resilience_bill: true,
+                 msg: "Intégration obligatoire de données",
+                 count: 3
+               })
+               |> to_html()
+    end
+
+    test "all unselected", %{conn: conn} do
+      conn = conn |> get(dataset_path(conn, :index))
+
+      assert ~s{<span class="activefilter">Peu importe (3)</span>} ==
+               conn
+               |> climate_resilience_bill_link(%{
+                 only_climate_climate_resilience_bill: false,
+                 msg: "Peu importe",
+                 count: 3
+               })
+               |> to_html()
+    end
+
+    test "all resets filter", %{conn: conn} do
+      conn = conn |> get(dataset_path(conn, :index, "loi-climat-resilience": "true", type: "public-transit"))
+
+      assert ~s{<a href="http://127.0.0.1:5100/datasets?type=public-transit">Peu importe (3)</a>} ==
+               conn
+               |> climate_resilience_bill_link(%{
+                 only_climate_climate_resilience_bill: false,
+                 msg: "Peu importe",
+                 count: 3
+               })
+               |> to_html()
+    end
+  end
+
   test "order_resources_by_format does not reorder GTFS and NeTEx" do
     gtfs = insert(:resource, format: "GTFS")
     netex = insert(:resource, format: "NeTEx")


### PR DESCRIPTION
Lié à #3149

- Ajoute un filtre pour n'afficher que les JDD concernés par l'article 122 de la loi climat et résilience
- Adapte le panel "climat et résilience" quand ce filtre est présent

## Captures d'écran

![image](https://github.com/etalab/transport-site/assets/295709/1ea90625-3526-444b-bad7-3389814070ba)
![Screenshot 2023-05-24 at 11 20 13](https://github.com/etalab/transport-site/assets/295709/c1a6e8b3-6bf3-4eea-bffd-1b33fb75e6c8)
