### PR TITLE
Page loi climat et résilience : ajout tuiles

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -77,7 +77,16 @@ defmodule TransportWeb.PageController do
   end
 
   def loi_climat_resilience(conn, _params) do
+    datasets_counts =
+      DB.Dataset.base_query()
+      |> where([dataset: d], fragment("'loi-climat-resilience' = any(?)", d.custom_tags))
+      |> group_by([dataset: d], d.type)
+      |> select([dataset: d], %{type: d.type, count: count(d.id)})
+      |> order_by([dataset: d], desc: count(d.id))
+      |> DB.Repo.all()
+
     conn
+    |> assign(:tiles, Enum.map(datasets_counts, &climate_resilience_bill_type_tile(conn, &1)))
     |> assign(:page, "loi_climat_resilience.html")
     |> render("loi_climat_resilience.html")
   end
@@ -230,6 +239,16 @@ defmodule TransportWeb.PageController do
       type_tile(conn, "locations"),
       type_tile(conn, "informations")
     ]
+  end
+
+  defp climate_resilience_bill_type_tile(%Plug.Conn{} = conn, %{count: count, type: type}) do
+    %Tile{
+      type: type,
+      link: dataset_path(conn, :index, type: type, "loi-climat-resilience": true),
+      icon: icon_type_path(type),
+      title: DB.Dataset.type_to_str(type),
+      count: count
+    }
   end
 
   defp type_tile(conn, type, options \\ []) do

--- a/apps/transport/lib/transport_web/templates/page/loi_climat_resilience.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/loi_climat_resilience.html.heex
@@ -128,3 +128,21 @@ arrete_url = "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046144276" %>
     </div>
   </section>
 </section>
+<section class="section section-grey">
+  <div class="container">
+    <div id="datasets">
+      <h1><%= dgettext("page-index", "Available data by theme") %></h1>
+      <div class="available-data grid">
+        <%= for tile <- @tiles do %>
+          <a class="tile" href={tile.link}>
+            <img class="tile__icon" src={tile.icon} />
+            <div class="tile__text">
+              <h4 class=""><%= tile.title %></h4>
+              <div><%= dngettext("page-index", "dataset", "datasets", tile.count) %></div>
+            </div>
+          </a>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
En lien avec #3149

Ajout de tuiles, comme sur la page d'accueil, sur la page "Loi climat et résilience" indiquant le nombre de JDDs concernés par l'article 122 pour chaque type de données et renvoie vers la liste à l'aide du filtre spécifique ajouté dans #3180

![image](https://github.com/etalab/transport-site/assets/295709/18e746a8-467d-4632-b363-37c7a10ce7ff)
