### PR TITLE
Backoffice : envoi e-mail lors du référencement d'un JDD

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -9,11 +9,17 @@ defmodule DB.NotificationSubscription do
 
   # These notification reasons are required to have a `dataset_id` set
   @reasons_related_to_datasets [:expiration, :dataset_with_error, :resource_unavailable]
+  # These notification reasons are also required to have a `dataset_id` set
+  # but are not made visible to users
+  @hidden_reasons_related_to_datasets [:dataset_now_on_nap]
   # These notification reasons are *not* linked to a specific dataset, `dataset_id` should be nil
   @platform_wide_reasons [:new_dataset, :datasets_switching_licences, :daily_new_comments]
 
   typed_schema "notification_subscription" do
-    field(:reason, Ecto.Enum, values: @reasons_related_to_datasets ++ @platform_wide_reasons)
+    field(:reason, Ecto.Enum,
+      values: @reasons_related_to_datasets ++ @platform_wide_reasons ++ @hidden_reasons_related_to_datasets
+    )
+
     field(:source, Ecto.Enum, values: [:admin, :user])
 
     belongs_to(:contact, DB.Contact)
@@ -43,7 +49,7 @@ defmodule DB.NotificationSubscription do
   end
 
   defp maybe_assoc_constraint_dataset(%Ecto.Changeset{} = changeset) do
-    if get_field(changeset, :reason) in reasons_related_to_datasets() do
+    if get_field(changeset, :reason) in (reasons_related_to_datasets() ++ @hidden_reasons_related_to_datasets) do
       changeset |> validate_required(:dataset_id) |> assoc_constraint(:dataset)
     else
       changeset |> validate_inclusion(:dataset_id, [nil])
@@ -57,7 +63,8 @@ defmodule DB.NotificationSubscription do
   def platform_wide_reasons, do: @platform_wide_reasons
 
   @spec possible_reasons :: [atom()]
-  def possible_reasons, do: reasons_related_to_datasets() ++ platform_wide_reasons()
+  def possible_reasons,
+    do: reasons_related_to_datasets() ++ platform_wide_reasons() ++ @hidden_reasons_related_to_datasets
 
   @spec subscriptions_for_reason(atom()) :: [__MODULE__.t()]
   def subscriptions_for_reason(reason) do
@@ -72,6 +79,14 @@ defmodule DB.NotificationSubscription do
     base_query()
     |> preload([:contact])
     |> where([notification_subscription: ns], ns.reason == ^reason and ns.dataset_id == ^dataset_id)
+    |> DB.Repo.all()
+  end
+
+  @spec subscriptions_for_dataset(DB.Dataset.t()) :: [__MODULE__.t()]
+  def subscriptions_for_dataset(%DB.Dataset{id: dataset_id}) do
+    base_query()
+    |> preload([:contact])
+    |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id)
     |> DB.Repo.all()
   end
 
@@ -92,6 +107,7 @@ defmodule DB.NotificationSubscription do
         expiration: dgettext("notification_subscription", "expiration"),
         dataset_with_error: dgettext("notification_subscription", "dataset_with_error"),
         resource_unavailable: dgettext("notification_subscription", "resource_unavailable"),
+        dataset_now_on_nap: dgettext("notification_subscription", "dataset_now_on_nap"),
         new_dataset: dgettext("notification_subscription", "new_dataset"),
         datasets_switching_licences: dgettext("notification_subscription", "datasets_switching_licences"),
         daily_new_comments: dgettext("notification_subscription", "daily_new_comments")

--- a/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
+++ b/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
@@ -1,0 +1,50 @@
+defmodule Transport.Jobs.DatasetNowOnNAPNotificationJob do
+  @moduledoc """
+  Job in charge of sending a welcome notification to producers when a dataset has been added on the NAP.
+  """
+  use Oban.Worker, max_attempts: 3, tags: ["notifications"], unique: [period: :infinity]
+  import Ecto.Query
+
+  @notification_reason :dataset_now_on_nap
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) do
+    dataset = DB.Repo.get!(DB.Dataset, dataset_id)
+
+    dataset
+    |> DB.NotificationSubscription.subscriptions_for_dataset()
+    |> DB.NotificationSubscription.subscriptions_to_emails()
+    |> MapSet.new()
+    |> MapSet.difference(email_addresses_already_sent(dataset))
+    |> Enum.each(fn email ->
+      Transport.EmailSender.impl().send_mail(
+        "transport.data.gouv.fr",
+        Application.get_env(:transport, :contact_email),
+        email,
+        Application.get_env(:transport, :contact_email),
+        "Votre jeu de données a été référencé sur transport.data.gouv.fr",
+        "",
+        Phoenix.View.render_to_string(TransportWeb.EmailView, "dataset_now_on_nap.html",
+          dataset_url: TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, dataset.slug),
+          dataset_custom_title: dataset.custom_title,
+          contact_email_address: Application.get_env(:transport, :contact_email)
+        )
+      )
+
+      save_notification(dataset, email)
+    end)
+  end
+
+  defp save_notification(%DB.Dataset{} = dataset, email) do
+    DB.Notification.insert!(@notification_reason, dataset, email)
+  end
+
+  @spec email_addresses_already_sent(DB.Dataset.t()) :: MapSet.t()
+  defp email_addresses_already_sent(%DB.Dataset{id: dataset_id}) do
+    DB.Notification
+    |> where([n], n.dataset_id == ^dataset_id and n.reason == @notification_reason)
+    |> select([n], n.email)
+    |> DB.Repo.all()
+    |> MapSet.new()
+  end
+end

--- a/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
+++ b/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
@@ -8,7 +8,7 @@ defmodule Transport.Jobs.DatasetNowOnNAPNotificationJob do
   @notification_reason :dataset_now_on_nap
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) do
+  def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}, id: job_id}) do
     dataset = DB.Repo.get!(DB.Dataset, dataset_id)
 
     dataset
@@ -33,6 +33,8 @@ defmodule Transport.Jobs.DatasetNowOnNAPNotificationJob do
 
       save_notification(dataset, email)
     end)
+
+    Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
   end
 
   defp save_notification(%DB.Dataset{} = dataset, email) do

--- a/apps/transport/lib/transport_web/controllers/notification_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/notification_controller.ex
@@ -71,7 +71,7 @@ defmodule TransportWeb.NotificationController do
   end
 
   defp picked_reasons(%{} = params) do
-    possible_reasons = DB.NotificationSubscription.possible_reasons() |> Enum.map(&to_string/1)
+    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets() |> Enum.map(&to_string/1)
 
     params |> Map.filter(fn {k, v} -> k in possible_reasons and v == "true" end) |> Map.keys()
   end

--- a/apps/transport/lib/transport_web/live/send_now_on_nap_notification_view.ex
+++ b/apps/transport/lib/transport_web/live/send_now_on_nap_notification_view.ex
@@ -1,0 +1,85 @@
+defmodule TransportWeb.Live.SendNowOnNAPNotificationView do
+  use Phoenix.LiveView
+  import TransportWeb.Gettext, only: [dgettext: 2]
+  require Logger
+
+  @button_disabled [:sending, :sent]
+
+  def render(assigns) do
+    ~H"""
+    <button :if={@display_button} class={@button_class} phx-click="dispatch_job" disabled={@button_disabled}>
+      <%= @button_text %>
+    </button>
+    """
+  end
+
+  def mount(_params, %{"dataset_id" => dataset_id, "locale" => locale, "sent_reasons" => sent_reasons}, socket) do
+    Gettext.put_locale(locale)
+
+    new_socket =
+      socket
+      |> assign(:display_button, display_button?(dataset_id, sent_reasons))
+      |> assign(dataset_id: dataset_id)
+      |> assign_step(:first)
+
+    {:ok, new_socket}
+  end
+
+  defp display_button?(dataset_id, sent_reasons) do
+    dataset = DB.Repo.get!(DB.Dataset, dataset_id)
+    recently_added = DateTime.diff(dataset.inserted_at, DateTime.utc_now(), :day) >= -30
+    not_sent = :dataset_now_on_nap not in sent_reasons
+    recently_added and not_sent
+  end
+
+  def handle_event("dispatch_job", _value, socket) do
+    send(self(), {:dispatch, socket.assigns.dataset_id})
+    {:noreply, socket}
+  end
+
+  def handle_info({:dispatch, dataset_id}, socket) do
+    new_socket =
+      case %{dataset_id: dataset_id} |> Transport.Jobs.DatasetNowOnNAPNotificationJob.new() |> Oban.insert() do
+        {:ok, %Oban.Job{}} ->
+          assign_step(socket, :sending)
+      end
+
+    Process.send_after(self(), :sent, 10_000)
+    {:noreply, new_socket}
+  end
+
+  def handle_info(:sent, socket) do
+    {:noreply, assign_step(socket, :sent)}
+  end
+
+  defp assign_step(socket, step) do
+    assign(
+      socket,
+      button_text: button_texts(step),
+      button_class: button_classes(step),
+      button_disabled: step in @button_disabled
+    )
+  end
+
+  defp button_texts(step) do
+    Map.get(
+      %{
+        sent: dgettext("backoffice_dataset", "Sent"),
+        sending: dgettext("backoffice_dataset", "Sending")
+      },
+      step,
+      dgettext("backoffice_dataset", "Send welcome email to contacts")
+    )
+  end
+
+  defp button_classes(step) do
+    Map.get(
+      %{
+        sent: "button success",
+        sending: "button button-outlined secondary"
+      },
+      step,
+      "button"
+    )
+  end
+end

--- a/apps/transport/lib/transport_web/live/validate_dataset_view.ex
+++ b/apps/transport/lib/transport_web/live/validate_dataset_view.ex
@@ -70,7 +70,7 @@ defmodule TransportWeb.Live.ValidateDatasetView do
     Map.get(
       %{
         validated: "button success",
-        validating: "button-outlined secondary"
+        validating: "button button-outlined secondary"
       },
       step,
       "button"

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -145,6 +145,16 @@
       <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
         Il n'y a pas d'abonnements à des notifications pour ce jeu de données.
       </p>
+      <div :if={Enum.count(@dataset.notification_subscriptions) > 0}>
+        <%= live_render(@conn, TransportWeb.Live.SendNowOnNAPNotificationView,
+          session: %{
+            "dataset_id" => @dataset.id,
+            "locale" => get_session(@conn, :locale),
+            "sent_reasons" =>
+              @notifications_sent |> Enum.map(fn {{reason, _datetime}, _emails} -> reason end) |> Enum.uniq()
+          }
+        ) %>
+      </div>
     </div>
     <div :if={Enum.count(@notifications_sent) > 0} class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Notifications sent") %></h3>

--- a/apps/transport/lib/transport_web/templates/email/dataset_now_on_nap.html.md
+++ b/apps/transport/lib/transport_web/templates/email/dataset_now_on_nap.html.md
@@ -1,0 +1,9 @@
+Bonjour,
+
+Votre jeu de données [<%= @dataset_custom_title %>](<%= @dataset_url %>) a bien été référencé sur le [Point d'Accès National aux données de transport, transport.data.gouv.fr](https://doc.transport.data.gouv.fr/guide-du-pan).
+
+Pour gérer la qualité de vos données : [les mettre à jour](https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees), vous [inscrire à des notifications](https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications) etc. nous vous encourageons à passer par l'[espace producteur du PAN](https://transport.data.gouv.fr/espace_producteur).
+
+Si vous avez des questions, n'hésitez pas à contacter notre équipe à l'adresse : <%= @contact_email_address %>.
+
+Bien à vous,

--- a/apps/transport/priv/gettext/backoffice_dataset.pot
+++ b/apps/transport/priv/gettext/backoffice_dataset.pot
@@ -61,3 +61,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS Transport Validator has been force launched on all GTFS resources"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Send welcome email to contacts"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Sending"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Sent"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice_dataset.po
@@ -62,3 +62,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "GTFS Transport Validator has been force launched on all GTFS resources"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Send welcome email to contacts"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Sending"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Sent"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/notification_subscription.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/notification_subscription.po
@@ -34,3 +34,7 @@ msgstr "Daily list of new datasets"
 #, elixir-autogen, elixir-format
 msgid "resource_unavailable"
 msgstr "Unavailable resources"
+
+#, elixir-autogen, elixir-format
+msgid "dataset_now_on_nap"
+msgstr "Dataset has been added to the NAP"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice_dataset.po
@@ -62,3 +62,15 @@ msgstr "Voir la page du jeu de données"
 #, elixir-autogen, elixir-format
 msgid "GTFS Transport Validator has been force launched on all GTFS resources"
 msgstr "Le validateur GTFS Transport a été lancé sur toutes les ressources GTFS"
+
+#, elixir-autogen, elixir-format
+msgid "Send welcome email to contacts"
+msgstr "Envoyer e-mail de bienvenue aux contacts"
+
+#, elixir-autogen, elixir-format
+msgid "Sending"
+msgstr "Envoi en cours"
+
+#, elixir-autogen, elixir-format
+msgid "Sent"
+msgstr "Envoyé"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/notification_subscription.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/notification_subscription.po
@@ -34,3 +34,7 @@ msgstr "Jeux de données référencés récemment"
 #, elixir-autogen, elixir-format
 msgid "resource_unavailable"
 msgstr "Ressources indisponibles"
+
+#, elixir-autogen, elixir-format
+msgid "dataset_now_on_nap"
+msgstr "Le jeu de données a été référencé sur le PAN"

--- a/apps/transport/priv/gettext/notification_subscription.pot
+++ b/apps/transport/priv/gettext/notification_subscription.pot
@@ -34,3 +34,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "resource_unavailable"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "dataset_now_on_nap"
+msgstr ""

--- a/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
@@ -1,0 +1,54 @@
+defmodule Transport.Test.Transport.Jobs.DatasetNowOnNAPNotificationJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Ecto.Query
+  import Mox
+  alias Transport.Jobs.DatasetNowOnNAPNotificationJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    %{id: dataset_id} = dataset = insert(:dataset, slug: Ecto.UUID.generate(), is_active: true, custom_title: "Mon JDD")
+
+    # We already sent a notification to someone for this dataset, it should be ignored
+    insert_notification(%{
+      dataset: dataset,
+      reason: :dataset_now_on_nap,
+      email: already_sent_email = Ecto.UUID.generate() <> "@example.fr"
+    })
+
+    %DB.Contact{email: email} = contact = insert_contact()
+
+    ~w(resource_unavailable expiration)a
+    |> Enum.each(fn reason ->
+      insert(:notification_subscription, %{reason: reason, source: :admin, contact: contact, dataset: dataset})
+    end)
+
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             ^email,
+                             "contact@transport.beta.gouv.fr",
+                             "Votre jeu de données a été référencé sur transport.data.gouv.fr",
+                             "",
+                             html_content ->
+      assert html_content =~
+               ~s(Votre jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">Mon JDD</a> a bien été référencé)
+
+      :ok
+    end)
+
+    assert :ok == perform_job(DatasetNowOnNAPNotificationJob, %{"dataset_id" => dataset_id})
+
+    # Logs have been saved
+    assert [
+             %DB.Notification{reason: :dataset_now_on_nap, dataset_id: ^dataset_id, email: ^already_sent_email},
+             %DB.Notification{reason: :dataset_now_on_nap, dataset_id: ^dataset_id, email: ^email}
+           ] = DB.Notification |> order_by([n], asc: n.inserted_at) |> DB.Repo.all()
+  end
+end


### PR DESCRIPTION
Fixes #3184

- Ajout d'un bouton permettant d'envoyer un e-mail de bienvenue aux contacts ajoutés à un JDD sur le backoffice. Ce bouton n'est présent que si le JDD a été référencé récemment (< 30 jours) et qu'un e-mail n'a pas encore été envoyé
- Ajout d'un job envoyant cet e-mail aux contacts déjà associés à ce JDD