### PR TITLE
Page stats : suppression mention covoit FabMob

### DIFF
--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -318,11 +318,6 @@
         <a href="/datasets/base-nationale-des-lieux-de-covoiturage/">La base nationale des lieux de covoiturage</a>
         est consolidée par l'équipe du Point d’Accès National.
       </p>
-      <p>
-        La Fabrique des Mobilités a également ouvert un
-        <a href="/datasets/aires-de-covoiturage-base-de-donnees-commune-des-lieux-et/">fichier</a>
-        relatif à des lieux de rendez-vous de covoiturage (grande variété de points, fichier non consolidé).
-      </p>
     </div>
     <div class="domain irve">
       <h2>Infrastructures de recharge pour véhicules électriques (IRVE)</h2>


### PR DESCRIPTION
Lien mort, déplacé ailleurs. [Voir Mattermost](https://mattermost.incubateur.net/betagouv/pl/x47puq7rxj873qm6mpp3k3hfma)