### PR TITLE
Carte des arrêts GTFS : correction couleur

### DIFF
--- a/apps/transport/client/javascripts/gtfs.js
+++ b/apps/transport/client/javascripts/gtfs.js
@@ -50,7 +50,7 @@ map.on('moveend', function (event) {
     const palette = [[38, 85, 255], [92, 102, 200], [147, 119, 145], [201, 135, 89], [255, 152, 34], [243, 119, 30], [231, 86, 27], [218, 52, 23], [206, 19, 19]]
 
     const colorFunc = function (v) {
-        return palette[Math.min(Math.floor(v * 10), 9)]
+        return palette[Math.min(Math.floor(v * 9), 8)]
     }
 
     fetch(url)


### PR DESCRIPTION
J'avais fait une petite erreur pour attraper la bonne couleur dans la palette, parce que j'ai pris une palette à 9 couleurs et pas à 10 couleurs.
C'est pour ça que là ou on a le pus d'arrêts, ça s'affiche en bleu au lieu de rouge.

![image](https://github.com/etalab/transport-site/assets/15341118/6c2a45fb-76aa-4cf4-b352-04accd97e783)

devient

![image](https://github.com/etalab/transport-site/assets/15341118/c69e7583-f7b2-456b-9f46-08e6cb42fe01)

je me demandais pourquoi on avait toujours un point bleu au milieu de Paris...

![image](https://github.com/etalab/transport-site/assets/15341118/417ce617-237d-481c-bd6b-cf65bf077b13)
