### PR TITLE
Amélioration du nettoyage import carte nationale (890k points à 670k)

### DIFF
--- a/apps/transport/lib/jobs/gtfs_import_stops_job.ex
+++ b/apps/transport/lib/jobs/gtfs_import_stops_job.ex
@@ -70,7 +70,8 @@ defmodule Transport.Jobs.GTFSImportStopsJob do
       |> select([di, rh, r], di.id)
       |> DB.Repo.all()
 
-    from(di in DB.DataImport, where: di.id in ^data_import_ids) |> DB.Repo.delete_all()
+    query = from(di in DB.DataImport, where: di.id in ^data_import_ids)
+    query |> DB.Repo.delete_all()
 
     Logger.info("Removing DataImports for inactive datasets")
 
@@ -85,7 +86,8 @@ defmodule Transport.Jobs.GTFSImportStopsJob do
       |> select([di, rh, r], di.id)
       |> DB.Repo.all()
 
-    from(di in DB.DataImport, where: di.id in ^data_import_ids) |> DB.Repo.delete_all()
+    query = from(di in DB.DataImport, where: di.id in ^data_import_ids)
+    query |> DB.Repo.delete_all()
   end
 
   def active_datasets_resource_history_items do

--- a/apps/transport/lib/jobs/gtfs_import_stops_job.ex
+++ b/apps/transport/lib/jobs/gtfs_import_stops_job.ex
@@ -48,6 +48,21 @@ defmodule Transport.Jobs.GTFSImportStopsJob do
       |> DB.Repo.all()
 
     from(di in DB.DataImport, where: di.id in ^data_import_ids) |> DB.Repo.delete_all()
+
+    Logger.info("Removing DataImports for inactive datasets")
+
+    query = from(di in DB.DataImport)
+
+    data_import_ids =
+      query
+      |> join(:left, [di], rh in DB.ResourceHistory, on: di.resource_history_id == rh.id)
+      |> join(:left, [di, rh], r in DB.Resource, on: rh.resource_id == r.id)
+      |> join(:left, [di, rh, r], d in DB.Dataset, on: r.dataset_id == d.id)
+      |> where([di, rh, r, d], d.is_active == false)
+      |> select([di, rh, r], di.id)
+      |> DB.Repo.all()
+
+    from(di in DB.DataImport, where: di.id in ^data_import_ids) |> DB.Repo.delete_all()
   end
 
   def active_datasets_resource_history_items do

--- a/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
@@ -4,11 +4,22 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
   import DB.Factory
   import Mox
   import Transport.Test.FileStreamUtils
+  import Ecto.Query
 
   setup :verify_on_exit!
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  def import_some_data() do
+    %{id: dataset_id} = insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+    %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "GTFS")
+
+    %{id: resource_history_id} =
+      insert(:resource_history, %{resource_id: resource_id, payload: %{"filename" => "some-file.zip"}})
+
+    {dataset_id, resource_id, resource_history_id}
   end
 
   test "import without error" do
@@ -28,5 +39,34 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
     } = result
 
     assert DB.Repo.get(DB.DataImportBatch, data_import_batch_id)
+  end
+
+  # NOTE: ultimately, a better approach would be to reimport stops & everything in temporary tables
+  # then drop previous tables, instead of manually removing items, but for now that will do.
+  test "import must remove data imports for removed resource" do
+    # create a situation with 2 data imports for 2 resources
+    {_dataset_id, resource_id, _resource_history_id} = import_some_data()
+    # import another one to make sure we can still create the materialized views
+    import_some_data()
+
+    setup_get_file_stream_mox("some-file.zip")
+    setup_get_file_stream_mox("some-file.zip")
+
+    {:ok, _result} = perform_job(Transport.Jobs.GTFSImportStopsJob, %{})
+    assert DB.Repo.aggregate(DB.DataImport, :count, :id) == 2
+    assert DB.Repo.aggregate(DB.GTFS.Stops, :count, :id) == 4
+
+    # then delete one of the resource
+    from(r in DB.Resource, where: r.id == ^resource_id) |> DB.Repo.delete_all()
+
+    # resource history & data imports must still be there at this point
+    assert DB.Repo.aggregate(DB.ResourceHistory, :count, :id) == 2
+    assert DB.Repo.aggregate(DB.DataImport, :count, :id) == 2
+    assert DB.Repo.aggregate(DB.GTFS.Stops, :count, :id) == 4
+
+    # deleting the resource and re-importing must result into data import removal
+    {:ok, _result} = perform_job(Transport.Jobs.GTFSImportStopsJob, %{})
+    assert DB.Repo.aggregate(DB.DataImport, :count, :id) == 1
+    assert DB.Repo.aggregate(DB.GTFS.Stops, :count, :id) == 2
   end
 end

--- a/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
@@ -12,22 +12,32 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  def import_some_data() do
-    %{id: dataset_id} = insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+  def import_some_data do
+    %{id: dataset_id} =
+      insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+
     %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "GTFS")
 
     %{id: resource_history_id} =
-      insert(:resource_history, %{resource_id: resource_id, payload: %{"filename" => "some-file.zip"}})
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        payload: %{"filename" => "some-file.zip"}
+      })
 
     {dataset_id, resource_id, resource_history_id}
   end
 
   test "import without error" do
-    %{id: dataset_id} = insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+    %{id: dataset_id} =
+      insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+
     %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "GTFS")
 
     %{id: resource_history_id} =
-      insert(:resource_history, %{resource_id: resource_id, payload: %{"filename" => "some-file.zip"}})
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        payload: %{"filename" => "some-file.zip"}
+      })
 
     setup_get_file_stream_mox("some-file.zip")
 

--- a/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
@@ -56,7 +56,8 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
     assert DB.Repo.aggregate(DB.GTFS.Stops, :count, :id) == 4
 
     # then delete one of the resource
-    from(r in DB.Resource, where: r.id == ^resource_id) |> DB.Repo.delete_all()
+    query = from(r in DB.Resource, where: r.id == ^resource_id)
+    query |> DB.Repo.delete_all()
 
     # resource history & data imports must still be there at this point
     assert DB.Repo.aggregate(DB.ResourceHistory, :count, :id) == 2
@@ -82,7 +83,8 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
     assert DB.Repo.aggregate(DB.GTFS.Stops, :count, :id) == 2 * 2
 
     # make one dataset inactive
-    DB.Repo.get_by(DB.Dataset, id: dataset_id)
+    DB.Dataset
+    |> DB.Repo.get_by(id: dataset_id)
     |> Ecto.Changeset.change(%{is_active: false})
     |> DB.Repo.update!()
 

--- a/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_import_stops_job_test.exs
@@ -13,8 +13,7 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
   end
 
   def import_some_data do
-    %{id: dataset_id} =
-      insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+    %{id: dataset_id} = insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
 
     %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "GTFS")
 
@@ -28,8 +27,7 @@ defmodule Transport.Test.Transport.Jobs.GTFSImportJobTest do
   end
 
   test "import without error" do
-    %{id: dataset_id} =
-      insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
+    %{id: dataset_id} = insert(:dataset, %{datagouv_id: Ecto.UUID.generate(), datagouv_title: "coucou"})
 
     %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "GTFS")
 


### PR DESCRIPTION
Voir:
- #3179
- https://github.com/etalab/transport-site/issues/3178

Fait passer le nombre de `data_import` de 544 à 435, et le nombre de `gtfs_stops` de 890344 à 670898.

Donc on devrait voir un certain nombre de doublons supprimés, ainsi que des soucis comme #3178 réglés.