### PR TITLE
Backoffice : fix bug changement région

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -935,7 +935,7 @@ defmodule DB.Dataset do
         |> where([r], r.nom == "National")
         |> Repo.one!()
 
-      change(changeset, region: national, region_id: national.id)
+      put_change(changeset, :region_id, national.id)
     else
       add_error(changeset, :region, dgettext("db-dataset", "A dataset cannot be national and regional"))
     end

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -490,8 +490,6 @@ defmodule DB.Dataset do
     |> cast_nation_dataset(params)
     |> cast_assoc(:resources)
     |> validate_required([:slug])
-    |> cast_assoc(:region)
-    |> cast_assoc(:aom)
     |> validate_territory_mutual_exclusion()
     |> maybe_overwrite_licence()
     |> has_real_time()

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -515,4 +515,15 @@ defmodule DB.DatasetDBTest do
     dataset = DB.Dataset |> preload(:legal_owners_region) |> DB.Repo.get!(dataset.id)
     assert [%DB.Region{id: ^region_id}] = dataset.legal_owners_region
   end
+
+  test "changeset to national dataset" do
+    %{id: region_id} = insert(:region)
+    insert(:dataset, region_id: region_id, datagouv_id: datagouv_id = "1234", aom: nil)
+
+    {:ok, changeset} =
+      DB.Dataset.changeset(%{"datagouv_id" => datagouv_id, "national_dataset" => "true", "region_id" => ""})
+
+    %{region_id: national_region_id} = DB.Repo.update!(changeset)
+    assert national_region_id != region_id
+  end
 end


### PR DESCRIPTION
On ne peut actuellement pas passer d'un jeu de donnée associé à une région à un jeu de données national, à cause d'un bug dans le code du changeset.

Je rajoute un test + la correction.

Je me rends aussi compte que deux `cast_assoc` n'ont à priori rien à faire dans le changeset du dataset. De ce que je comprend cette fonction est utile pour mettre à jour les associations enfants d'un schéma, par exemple les `Comments` depuis le changeset d'un `Post`. Mais ici le dataset `belongs_to` une Région, dont il faut juste mettre à jour le `region_id`, pas besoin de `cast_assoc` quoi que ce soit, on ne veut pas modifier la région depuis le changeset du dataset.

closes #3202 