### PR TITLE
Jeu de données : affichage des notifications envoyées

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -595,3 +595,8 @@ hr {
   text-align: center;
   margin-bottom: 1em;
 }
+
+#notifications-sent .displayMore {
+  text-align: center;
+  margin-bottom: 1em;
+}

--- a/apps/transport/lib/db/notification.ex
+++ b/apps/transport/lib/db/notification.ex
@@ -3,8 +3,8 @@ defmodule DB.Notification do
   A list of emails notifications sent, with email addresses encrypted
   """
   use Ecto.Schema
-
   import Ecto.Changeset
+  import Ecto.Query
 
   schema "notifications" do
     field(:reason, Ecto.Enum, values: Ecto.Enum.mappings(DB.NotificationSubscription, :reason))
@@ -20,10 +20,38 @@ defmodule DB.Notification do
     timestamps(type: :utc_datetime_usec)
   end
 
+  def base_query, do: from(n in __MODULE__, as: :notification)
+
   def insert!(reason, %DB.Dataset{id: dataset_id, datagouv_id: datagouv_id}, email) do
     %__MODULE__{}
     |> changeset(%{reason: reason, dataset_id: dataset_id, dataset_datagouv_id: datagouv_id, email: email})
     |> DB.Repo.insert!()
+  end
+
+  @doc """
+  Gets a list of notifications' reasons and times sent related to a specific dataset over a given number of days.
+  Notifications are binned according to a 5-minute window.
+  """
+  @spec recent_reasons_binned(DB.Dataset.t(), pos_integer()) :: [%{reason: atom, timestamp: DateTime.t()}]
+  def recent_reasons_binned(%DB.Dataset{id: dataset_id}, nb_days) when is_integer(nb_days) and nb_days > 0 do
+    datetime_limit = DateTime.add(DateTime.utc_now(), -nb_days, :day)
+    possible_reasons = DB.NotificationSubscription.reasons_related_to_datasets()
+
+    base_query()
+    |> where(
+      [notification: n],
+      n.inserted_at >= ^datetime_limit and n.dataset_id == ^dataset_id and n.reason in ^possible_reasons
+    )
+    # The function date_bin “bins” the input timestamp into the specified interval (the stride)
+    # aligned with a specified origin.
+    # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-BIN
+    |> group_by([notification: n], [n.reason, fragment("date_bin('5 minutes', ?, '2022-01-01')", n.inserted_at)])
+    |> order_by([notification: n], desc: fragment("timestamp"))
+    |> select([notification: n], %{
+      reason: n.reason,
+      timestamp: fragment("date_bin('5 minutes', ?, '2022-01-01') at time zone 'utc' as timestamp", n.inserted_at)
+    })
+    |> DB.Repo.all()
   end
 
   def changeset(struct, attrs \\ %{}) do

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -5,7 +5,10 @@ defmodule TransportWeb.DatasetController do
   alias DB.{AOM, Commune, Dataset, DatasetGeographicView, Region, Repo}
   alias Transport.ClimateResilienceBill
   import Ecto.Query
-  import TransportWeb.DatasetView, only: [availability_number_days: 0, max_nb_history_resources: 0]
+
+  import TransportWeb.DatasetView,
+    only: [availability_number_days: 0, days_notifications_sent: 0, max_nb_history_resources: 0]
+
   import Phoenix.HTML
   require Logger
 
@@ -58,6 +61,7 @@ defmodule TransportWeb.DatasetController do
       |> assign(:resources_infos, resources_infos(dataset))
       |> assign(:history_resources, Transport.History.Fetcher.history_resources(dataset, max_nb_history_resources()))
       |> assign(:latest_resources_history_infos, DB.ResourceHistory.latest_dataset_resources_history_infos(dataset.id))
+      |> assign(:notifications_sent, DB.Notification.recent_reasons_binned(dataset, days_notifications_sent()))
       |> put_status(if dataset.is_active, do: :ok, else: :not_found)
       |> render("details.html")
     else

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -1,0 +1,45 @@
+<section class="white pt-48" id="notifications-sent">
+  <h2><%= dgettext("page-dataset-details", "Notifications sent") %></h2>
+  <div class="panel">
+    <p>
+      <%= raw(
+        dgettext(
+          "page-dataset-details",
+          ~s(transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href="%{url}" target="_blank">manage how they receive these notifications</a>.),
+          url:
+            "https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications",
+          nb: days_notifications_sent()
+        )
+      ) %>
+    </p>
+    <div id="notifications-sent-content">
+      <table class="table">
+        <thead>
+          <tr>
+            <th><%= dgettext("page-dataset-details", "Notification reason") %></th>
+            <th><%= dgettext("page-dataset-details", "Date") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for notification_sent <- @notifications_sent do %>
+            <tr>
+              <td><%= DB.NotificationSubscription.reason_to_str(notification_sent.reason) %></td>
+              <td><%= DateTimeDisplay.format_datetime_to_paris(notification_sent.timestamp, @locale) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<script src={static_path(@conn, "/js/utils.js")} />
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    addSeeMore("15em",
+      "#notifications-sent-content",
+      "<%= dgettext("page-dataset-details", "Display more") %>",
+      "<%= dgettext("page-dataset-details", "Display less") %>"
+    )
+  })
+</script>

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -4,7 +4,7 @@
     <p>
       <%= dgettext(
         "page-dataset-details",
-        ~s(transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days.),
+        ~s(transport.data.gouv.fr automatically sends notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days.),
         nb: days_notifications_sent()
       ) %>
     </p>

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -2,14 +2,10 @@
   <h2><%= dgettext("page-dataset-details", "Notifications sent") %></h2>
   <div class="panel">
     <p>
-      <%= raw(
-        dgettext(
-          "page-dataset-details",
-          ~s(transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href="%{url}" target="_blank">manage how they receive these notifications</a>.),
-          url:
-            "https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications",
-          nb: days_notifications_sent()
-        )
+      <%= dgettext(
+        "page-dataset-details",
+        ~s(transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days.),
+        nb: days_notifications_sent()
       ) %>
     </p>
     <div id="notifications-sent-content">
@@ -30,6 +26,15 @@
         </tbody>
       </table>
     </div>
+    <p>
+      ℹ️ <%= raw(
+        dgettext(
+          "page-dataset-details",
+          ~s(If you are a data producer, you can <a href="%{url}" target="_blank">manage how you receive these notifications</a> from your Producer section.),
+          url: "https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications"
+        )
+      ) %>
+    </p>
   </div>
 </section>
 

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -46,6 +46,11 @@
       <%= unless is_nil(@reuses) or @reuses == [] do %>
         <div class="menu-item"><a href="#dataset-reuses"><%= dgettext("page-dataset-details", "Reuses") %></a></div>
       <% end %>
+      <div :if={Enum.count(@notifications_sent) > 0} class="menu-item">
+        <a href="#notifications-sent">
+          <%= dgettext("page-dataset-details", "Notifications sent") %> (<%= Enum.count(@notifications_sent) %>)
+        </a>
+      </div>
       <div class="menu-item">
         <a href="#dataset-discussions">Discussions (<%= count_discussions(@discussions) %>)</a>
       </div>
@@ -184,6 +189,9 @@
           <% end %>
         </div>
       </section>
+    <% end %>
+    <%= unless Enum.empty?(@notifications_sent) do %>
+      <%= render("_notifications_sent.html", notifications_sent: @notifications_sent, locale: locale, conn: @conn) %>
     <% end %>
     <%= if @dataset.is_active do %>
       <section class="pt-48" id="dataset-discussions">

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -259,6 +259,7 @@ defmodule TransportWeb.DatasetView do
 
   def availability_number_days, do: 30
   def max_nb_history_resources, do: 25
+  def days_notifications_sent, do: 90
 
   def availability_ratio_class(ratio) when ratio >= 0 and ratio <= 100 do
     cond do

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -68,6 +68,8 @@ defmodule Transport.Validators.GTFSRT do
     args = [
       "-jar",
       Path.join(Application.fetch_env!(:transport, :transport_tools_folder), @validator_filename),
+      "-ignoreShapes",
+      "yes",
       "-gtfs",
       gtfs_path,
       "-gtfsRealtimePath",

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -68,8 +68,6 @@ defmodule Transport.Validators.GTFSRT do
     args = [
       "-jar",
       Path.join(Application.fetch_env!(:transport, :transport_tools_folder), @validator_filename),
-      "-ignoreShapes",
-      "yes",
       "-gtfs",
       gtfs_path,
       "-gtfsRealtimePath",

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -581,3 +581,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "compulsory data reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Date"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -599,5 +599,5 @@ msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
+msgid "transport.data.gouv.fr automatically sends notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -595,5 +595,9 @@ msgid "Notifications sent"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
+msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">manage how you receive these notifications</a> from your Producer section."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -599,5 +599,5 @@ msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">
 msgstr "Si vous êtes producteur de données, vous pouvez <a href=\"%{url}\" target=\"_blank\">personnaliser ces notifications</a> depuis votre Espace producteur."
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
+msgid "transport.data.gouv.fr automatically sends notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
 msgstr "transport.data.gouv.fr envoie automatiquement des notifications au producteur du jeu de données afin d'en améliorer la qualité. Les notifications suivantes ont été envoyées au cours des %{nb} derniers jours."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -581,3 +581,19 @@ msgstr "Loi climat et résilience"
 #, elixir-autogen, elixir-format
 msgid "compulsory data reuse"
 msgstr "intégration obligatoire de données"
+
+#, elixir-autogen, elixir-format
+msgid "Date"
+msgstr "Date"
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr "Motif de notification"
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr "Notifications envoyées"
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
+msgstr "transport.data.gouv.fr envoie des notifications pertinentes pour améliorer la qualité des données. Les notifications suivantes ont été envoyées au cours des %{nb} derniers jours. Les producteurs peuvent <a href=\"%{url}\" target=\"_blank\">gérer comment ils reçoivent ces notifications</a>."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -595,5 +595,9 @@ msgid "Notifications sent"
 msgstr "Notifications envoyées"
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
-msgstr "transport.data.gouv.fr envoie des notifications pertinentes pour améliorer la qualité des données. Les notifications suivantes ont été envoyées au cours des %{nb} derniers jours. Les producteurs peuvent <a href=\"%{url}\" target=\"_blank\">gérer comment ils reçoivent ces notifications</a>."
+msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">manage how you receive these notifications</a> from your Producer section."
+msgstr "Si vous êtes producteur de données, vous pouvez <a href=\"%{url}\" target=\"_blank\">personnaliser ces notifications</a> depuis votre Espace producteur."
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
+msgstr "transport.data.gouv.fr envoie automatiquement des notifications au producteur du jeu de données afin d'en améliorer la qualité. Les notifications suivantes ont été envoyées au cours des %{nb} derniers jours."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -581,3 +581,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "compulsory data reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Date"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification reason"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notifications sent"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
+msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -599,5 +599,5 @@ msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
+msgid "transport.data.gouv.fr automatically sends notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
 msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -595,5 +595,9 @@ msgid "Notifications sent"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "transport.data.gouv.fr sends relevant notifications to improve the quality of data. The following notifications have been sent in the last %{nb} days. Data producers can <a href=\"%{url}\" target=\"_blank\">manage how they receive these notifications</a>."
+msgid "If you are a data producer, you can <a href=\"%{url}\" target=\"_blank\">manage how you receive these notifications</a> from your Producer section."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr sends automatically notifications to data producers in order to improve the quality of data. The following notifications have been sent in the last %{nb} days."
 msgstr ""

--- a/apps/transport/test/db/notification_test.exs
+++ b/apps/transport/test/db/notification_test.exs
@@ -27,4 +27,39 @@ defmodule DB.NotificationTest do
     # But values are properly decrypted
     assert MapSet.new([email, other_email]) == DB.Notification |> select([n], n.email) |> DB.Repo.all() |> MapSet.new()
   end
+
+  test "recent_reasons_binned" do
+    dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate())
+    yesterday = DateTime.add(DateTime.utc_now(), -1, :day)
+    email = Ecto.UUID.generate() <> "@example.com"
+    other_email = Ecto.UUID.generate() <> "@example.com"
+
+    # Should be ignored, this is an hidden reason
+    insert_notification(%{dataset: dataset, reason: :dataset_now_on_nap, email: email})
+
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: email}, %{
+      yesterday
+      | hour: 10,
+        minute: 22
+    })
+
+    insert_notification(%{dataset: dataset, reason: :dataset_with_error, email: other_email}, %{
+      yesterday
+      | hour: 10,
+        minute: 22
+    })
+
+    insert_notification(%{dataset: dataset, reason: :expiration, email: email}, %{yesterday | hour: 12, minute: 44})
+
+    yesterday_time = fn hour, minute -> %{yesterday | hour: hour, minute: minute, second: 0, microsecond: {0, 6}} end
+
+    assert [
+             %{reason: :expiration, timestamp: yesterday_time.(12, 40)},
+             %{reason: :dataset_with_error, timestamp: yesterday_time.(10, 20)}
+           ] == DB.Notification.recent_reasons_binned(dataset, 7)
+  end
+
+  defp insert_notification(%{} = args, %DateTime{} = inserted_at) do
+    args |> insert_notification() |> Ecto.Changeset.change(%{inserted_at: inserted_at}) |> DB.Repo.update!()
+  end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -348,6 +348,16 @@ defmodule TransportWeb.DatasetControllerTest do
              ~s{<i class="icon fa fa-link" aria-hidden="true"></i>\n<a class="dark" href="#{resource_path(conn, :details, gtfs.id)}">GTFS</a>}
   end
 
+  test "dataset#details with notifications sent recently", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true)
+    insert_notification(%{dataset: dataset, reason: :expiration, email: Ecto.UUID.generate() <> "@example.com"})
+    set_empty_mocks()
+
+    doc = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200) |> Floki.parse_document!()
+    [msg] = Floki.find(doc, "#notifications-sent")
+    assert Floki.text(msg) =~ "Expiration de données"
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")


### PR DESCRIPTION
Affiche les notifications envoyées par le PAN lors des 90 derniers jours sur la page de détails d'un jeu de données.

Objectif :
- être transparent sur le fait que le PAN agit pour la qualité des données
- faire découvrir la fonctionnalité des notifications

Voir [la discussion sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/1gjkp6d1cpnztg9xs1unsrkoew)

![image](https://github.com/etalab/transport-site/assets/295709/e8cca41b-8ed9-448f-a829-ec2bb4d9b08d)

ℹ️  Il faut la v14 de PostgreSQL en local pour la fonction `date_bin`