### PR TITLE
Validateur GTFS-RT : possibilité d'ignorer les shapes

### DIFF
--- a/apps/transport/lib/jobs/on_demand_validation_job.ex
+++ b/apps/transport/lib/jobs/on_demand_validation_job.ex
@@ -155,7 +155,7 @@ defmodule Transport.Jobs.OnDemandValidationJob do
     %{oban_args: oban_args}
   end
 
-  @spec run_save_gtfs_rt_validation(binary(), binary(), ignore_shapes: boolean()) :: map()
+  @spec run_save_gtfs_rt_validation(binary(), binary(), [ignore_shapes: boolean()]) :: map()
   defp run_save_gtfs_rt_validation(gtfs_path, gtfs_rt_path, opts \\ []) do
     opts = Keyword.validate!(opts, ignore_shapes: false)
     ignore_shapes = Keyword.fetch!(opts, :ignore_shapes)

--- a/apps/transport/lib/jobs/on_demand_validation_job.ex
+++ b/apps/transport/lib/jobs/on_demand_validation_job.ex
@@ -155,7 +155,7 @@ defmodule Transport.Jobs.OnDemandValidationJob do
     %{oban_args: oban_args}
   end
 
-  @spec run_save_gtfs_rt_validation(binary(), binary(), [ignore_shapes: boolean()]) :: map()
+  @spec run_save_gtfs_rt_validation(binary(), binary(), ignore_shapes: boolean()) :: map()
   defp run_save_gtfs_rt_validation(gtfs_path, gtfs_rt_path, opts \\ []) do
     opts = Keyword.validate!(opts, ignore_shapes: false)
     ignore_shapes = Keyword.fetch!(opts, :ignore_shapes)

--- a/apps/transport/lib/jobs/on_demand_validation_job.ex
+++ b/apps/transport/lib/jobs/on_demand_validation_job.ex
@@ -147,19 +147,32 @@ defmodule Transport.Jobs.OnDemandValidationJob do
   end
 
   defp process_download([{:ok, gtfs_path}, {:ok, gtfs_rt_path}]) do
-    case GTFSRT.run_validator(gtfs_path, gtfs_rt_path) do
+    run_save_gtfs_rt_validation_with_shapes(gtfs_path, gtfs_rt_path)
+  end
+
+  defp process_download(results) do
+    {_, oban_args} = results |> Enum.find(fn {k, _} -> k !== :ok end)
+    %{oban_args: oban_args}
+  end
+
+  def run_save_gtfs_rt_validation_with_shapes(gtfs_path, gtfs_rt_path) do
+    run_save_gtfs_rt_validation(gtfs_path, gtfs_rt_path, false)
+  end
+
+  defp run_save_gtfs_rt_validation(gtfs_path, gtfs_rt_path, ignore_shapes) when is_boolean(ignore_shapes) do
+    validator_args = GTFSRT.validator_arguments(gtfs_path, gtfs_rt_path, ignore_shapes)
+
+    case GTFSRT.run_validator(validator_args) do
       {:ok, _} ->
-        case GTFSRT.convert_validator_report(gtfs_rt_result_path(gtfs_rt_path)) do
+        case GTFSRT.convert_validator_report(gtfs_rt_result_path(gtfs_rt_path), ignore_shapes) do
           {:ok, validation} ->
             # https://github.com/etalab/transport-site/issues/2390
-            # to do : transport-tools version when available
+            # to do: transport-tools version when available
             %{
-              oban_args: %{
-                "state" => "completed"
-              },
+              oban_args: %{"state" => "completed"},
               result: validation,
               validator: GTFSRT.validator_name(),
-              command: GTFSRT.command(gtfs_path, gtfs_rt_path)
+              command: inspect(validator_args)
             }
 
           :error ->
@@ -172,13 +185,12 @@ defmodule Transport.Jobs.OnDemandValidationJob do
         end
 
       {:error, reason} ->
-        %{oban_args: %{"state" => "error", "error_reason" => inspect(reason)}}
+        if not ignore_shapes and String.contains?(reason, "java.lang.OutOfMemoryError") do
+          run_save_gtfs_rt_validation(gtfs_path, gtfs_rt_path, true)
+        else
+          %{oban_args: %{"state" => "error", "error_reason" => inspect(reason)}}
+        end
     end
-  end
-
-  defp process_download(results) do
-    {_, oban_args} = results |> Enum.find(fn {k, _} -> k !== :ok end)
-    %{oban_args: oban_args}
   end
 
   def filename(validation_id, format) when format in ["gtfs", "gtfs-rt"] do

--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -38,6 +38,10 @@
             <% errors_error_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "ERROR")) %>
             <% errors_warning_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "WARNING")) %>
 
+            <p :if={Map.get(details, "ignore_shapes", false)} class="notification">
+              <%= dgettext("validations", "Shapes present in the GTFS have been ignored, some rules are not enforced.") %>
+            </p>
+
             <%= TransportWeb.ValidationView.render("_errors_warnings_count.html",
               nb_errors: Map.fetch!(details, "errors_count"),
               nb_warnings: Map.fetch!(details, "warnings_count")

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
@@ -5,6 +5,9 @@
   <% errors_error_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "ERROR")) %>
   <% errors_warning_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "WARNING")) %>
   <%= render("_errors_warnings_count.html", nb_errors: errors_count(validation), nb_warnings: warnings_count(validation)) %>
+  <p :if={Map.get(validation.result, "ignore_shapes", false)} class="notification">
+    <%= dgettext("validations", "Shapes present in the GTFS have been ignored, some rules are not enforced.") %>
+  </p>
   <p>
     <%= raw(
       dgettext(

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -311,11 +311,22 @@ defmodule TransportWeb.ResourceView do
 
   def latest_validations_nb_days, do: 30
 
-  def gtfs_for_gtfs_rt(_resource, nil = _multi_validation), do: nil
-
   def gtfs_for_gtfs_rt(
         %DB.Resource{format: "gtfs-rt", dataset: %DB.Dataset{resources: resources}},
         %DB.MultiValidation{secondary_resource_id: gtfs_id}
       ),
       do: Enum.find(resources, &(&1.id == gtfs_id))
+
+  def gtfs_for_gtfs_rt(
+        %DB.Resource{format: "gtfs-rt", dataset: %DB.Dataset{resources: resources}},
+        nil = _multi_validation
+      ) do
+    gtfs_resources = resources |> Enum.filter(&DB.Resource.is_gtfs?/1)
+
+    if Enum.count(gtfs_resources) == 1 do
+      hd(gtfs_resources)
+    else
+      nil
+    end
+  end
 end

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -66,7 +66,7 @@ defmodule Transport.Validators.GTFSRT do
     end
   end
 
-  @spec validator_arguments(binary(), binary(), boolean()) :: {binary(), binary()}
+  @spec validator_arguments(binary(), binary(), boolean()) :: {binary(), [binary()]}
   def validator_arguments(gtfs_path, gtfs_rt_path, ignore_shapes) when is_boolean(ignore_shapes) do
     binary_path = "java"
 

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -27,33 +27,7 @@ defmodule Transport.Validators.GTFSRT do
       resources
       |> snapshot_gtfs_rts()
       |> Enum.reject(&(elem(&1, 2) == :error))
-      |> Enum.each(fn snapshot ->
-        {gtfs_resource, rt_resource, {:ok, gtfs_rt_path, cellar_filename}} = snapshot
-
-        gtfs_path = download_path(gtfs_resource)
-        gtfs_resource_history = gtfs_resource.resource_history |> Enum.at(0)
-        download_latest_gtfs(gtfs_resource_history, gtfs_path)
-
-        _validator_return =
-          with {:ok, _} <- GTFSRT.run_validator(gtfs_path, gtfs_rt_path),
-               {:ok, report} <- rt_resource |> gtfs_rt_result_path() |> GTFSRT.convert_validator_report() do
-            insert_multi_validation(
-              rt_resource,
-              GTFSRT.build_validation_details(gtfs_resource_history, report, cellar_filename),
-              gtfs_path,
-              gtfs_rt_path,
-              gtfs_resource,
-              gtfs_resource_history
-            )
-          else
-            :error -> {:error, "Could not run validator. Please provide a GTFS and a GTFS-RT."}
-            e -> e
-          end
-
-        # add a validation log when the table is created
-        # https://github.com/etalab/transport-site/issues/2390
-        # log_validation(validator_return, resource)
-      end)
+      |> Enum.each(fn snapshot -> run_validator_and_save(snapshot, false) end)
     after
       Logger.debug("Cleaning up temporary files")
       Enum.each(resources, fn tuple -> tuple |> Tuple.to_list() |> Enum.each(&delete_tmp_files/1) end)
@@ -62,33 +36,71 @@ defmodule Transport.Validators.GTFSRT do
     :ok
   end
 
-  defp validator_arguments(gtfs_path, gtfs_rt_path) do
+  defp run_validator_and_save(
+         {gtfs_resource, rt_resource, {:ok, gtfs_rt_path, cellar_filename}} = snapshot,
+         ignore_shapes
+       )
+       when is_boolean(ignore_shapes) do
+    gtfs_path = download_path(gtfs_resource)
+    gtfs_resource_history = gtfs_resource.resource_history |> Enum.at(0)
+    download_latest_gtfs(gtfs_resource_history, gtfs_path)
+    validator_args = validator_arguments(gtfs_path, gtfs_rt_path, ignore_shapes)
+
+    with {:ok, _} <- GTFSRT.run_validator(validator_args),
+         {:ok, report} <- rt_resource |> gtfs_rt_result_path() |> GTFSRT.convert_validator_report(ignore_shapes) do
+      insert_multi_validation(
+        rt_resource,
+        GTFSRT.build_validation_details(gtfs_resource_history, report, cellar_filename),
+        validator_args,
+        gtfs_resource,
+        gtfs_resource_history
+      )
+    else
+      :error ->
+        {:error, "Could not run validator. Please provide a GTFS and a GTFS-RT."}
+
+      {:error, message} ->
+        if not ignore_shapes and String.contains?(message, "java.lang.OutOfMemoryError") do
+          run_validator_and_save(snapshot, true)
+        end
+    end
+  end
+
+  @spec validator_arguments(binary(), binary(), boolean()) :: {binary(), binary()}
+  def validator_arguments(gtfs_path, gtfs_rt_path, ignore_shapes) when is_boolean(ignore_shapes) do
     binary_path = "java"
 
-    args = [
-      "-jar",
-      Path.join(Application.fetch_env!(:transport, :transport_tools_folder), @validator_filename),
-      "-gtfs",
-      gtfs_path,
-      "-gtfsRealtimePath",
-      Path.dirname(gtfs_rt_path)
-    ]
+    # Do not process shapes.txt: this requires a large amount of memory
+    # https://github.com/MobilityData/gtfs-realtime-validator/blob/master/TROUBLESHOOTING.md#javalangoutofmemoryerror-java-heap-space-when-running-project
+    shapes_args =
+      if ignore_shapes do
+        "-ignoreShapes yes"
+      else
+        ""
+      end
+
+    args =
+      [
+        "-jar",
+        Path.join(Application.fetch_env!(:transport, :transport_tools_folder), @validator_filename),
+        shapes_args,
+        "-gtfs",
+        gtfs_path,
+        "-gtfsRealtimePath",
+        Path.dirname(gtfs_rt_path)
+      ]
+      |> Enum.reject(&(&1 == ""))
 
     {binary_path, args}
   end
 
-  def command(gtfs_path, gtfs_rt_path), do: inspect(validator_arguments(gtfs_path, gtfs_rt_path))
-
-  def run_validator(gtfs_path, gtfs_rt_path) do
+  def run_validator({binary_path, args}) do
     # See https://github.com/MobilityData/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing
-
-    {binary_path, args} = validator_arguments(gtfs_path, gtfs_rt_path)
-
     Transport.RamboLauncher.run(binary_path, args, log: Mix.env() == :dev)
   end
 
-  @spec convert_validator_report(binary()) :: {:ok, map()} | :error
-  def convert_validator_report(path) do
+  @spec convert_validator_report(binary(), boolean()) :: {:ok, map()} | :error
+  def convert_validator_report(path, ignore_shapes) when is_boolean(ignore_shapes) do
     case File.read(path) do
       {:ok, content} ->
         errors =
@@ -129,6 +141,7 @@ defmodule Transport.Validators.GTFSRT do
            "errors_count" => total_errors,
            "warnings_count" => total_warnings,
            "has_errors" => total_errors + total_warnings > 0,
+           "ignore_shapes" => ignore_shapes,
            "errors" => errors
          }}
 
@@ -252,15 +265,14 @@ defmodule Transport.Validators.GTFSRT do
   defp insert_multi_validation(
          %Resource{format: "gtfs-rt"} = gtfs_rt_resource,
          %{} = validation_details,
-         gtfs_path,
-         gtfs_rt_path,
+         {_, _} = validator_arguments,
          %Resource{format: "GTFS"} = gtfs_resource,
          %ResourceHistory{} = gtfs_resource_history
        ) do
     %MultiValidation{
       validation_timestamp: DateTime.utc_now(),
       validator: validator_name(),
-      command: command(gtfs_path, gtfs_rt_path),
+      command: inspect(validator_arguments),
       result: validation_details,
       resource_id: gtfs_rt_resource.id,
       secondary_resource_id: gtfs_resource.id,

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -404,3 +404,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Job is running…"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Shapes present in the GTFS have been ignored, some rules are not enforced."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -404,3 +404,7 @@ msgstr "[stops.txt] Une information d'accessibilité wheelchair_boarding a été
 #, elixir-autogen, elixir-format
 msgid "Job is running…"
 msgstr "Comparaison en cours…"
+
+#, elixir-autogen, elixir-format
+msgid "Shapes present in the GTFS have been ignored, some rules are not enforced."
+msgstr "Les shapes présentes dans le GTFS ont été ignorées, certaines règles de validation n'ont pas été vérifiées."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -403,3 +403,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Job is running…"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Shapes present in the GTFS have been ignored, some rules are not enforced."
+msgstr ""

--- a/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
@@ -204,7 +204,7 @@ defmodule Transport.Test.Transport.Jobs.OnDemandValidationJobTest do
 
       assert :ok == run_job(validation)
 
-      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
+      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
 
       assert %{
                result: ^expected_details,
@@ -371,7 +371,7 @@ defmodule Transport.Test.Transport.Jobs.OnDemandValidationJobTest do
 
       assert :ok == run_job(validation)
 
-      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, true)
+      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, ignore_shapes: true)
 
       assert %{
                result: ^expected_details,

--- a/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
@@ -204,7 +204,7 @@ defmodule Transport.Test.Transport.Jobs.OnDemandValidationJobTest do
 
       assert :ok == run_job(validation)
 
-      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
+      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
 
       assert %{
                result: ^expected_details,
@@ -311,6 +311,82 @@ defmodule Transport.Test.Transport.Jobs.OnDemandValidationJobTest do
 
       refute File.exists?(gtfs_path)
       refute File.exists?(gtfs_rt_path)
+    end
+
+    test "with a gtfs-rt, validation fails, retries without shapes" do
+      gtfs_url = "https://example.com/gtfs.zip"
+      gtfs_rt_url = "https://example.com/gtfs-rt"
+      validation = create_validation(%{"type" => "gtfs-rt", "gtfs_url" => gtfs_url, "gtfs_rt_url" => gtfs_rt_url})
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn ^gtfs_url, [], _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: "gtfs"}}
+      end)
+
+      gtfs_path = OnDemandValidationJob.filename(validation.id, "gtfs")
+      gtfs_rt_path = OnDemandValidationJob.filename(validation.id, "gtfs-rt")
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn ^gtfs_rt_url, [], _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: "gtfs-rt"}}
+      end)
+
+      Transport.Rambo.Mock
+      |> expect(:run, fn binary, args, [log: false] ->
+        assert binary == "java"
+        assert File.exists?(gtfs_path)
+        assert File.exists?(gtfs_rt_path)
+
+        assert [
+                 "-jar",
+                 validator_path(),
+                 "-gtfs",
+                 gtfs_path,
+                 "-gtfsRealtimePath",
+                 Path.dirname(gtfs_rt_path)
+               ] == args
+
+        {:error, "Exception in thread main java.lang.OutOfMemoryError: Java heap space"}
+      end)
+
+      Transport.Rambo.Mock
+      |> expect(:run, fn binary, args, [log: false] ->
+        assert binary == "java"
+        assert File.exists?(gtfs_path)
+        assert File.exists?(gtfs_rt_path)
+
+        assert [
+                 "-jar",
+                 validator_path(),
+                 "-ignoreShapes yes",
+                 "-gtfs",
+                 gtfs_path,
+                 "-gtfsRealtimePath",
+                 Path.dirname(gtfs_rt_path)
+               ] == args
+
+        File.write!(OnDemandValidationJob.gtfs_rt_result_path(gtfs_rt_path), File.read!(@gtfs_rt_report_path))
+        {:ok, nil}
+      end)
+
+      assert :ok == run_job(validation)
+
+      {:ok, expected_details} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, true)
+
+      assert %{
+               result: ^expected_details,
+               oban_args: %{
+                 "state" => "completed",
+                 "type" => "gtfs-rt",
+                 "gtfs_url" => ^gtfs_url,
+                 "gtfs_rt_url" => ^gtfs_rt_url
+               },
+               data_vis: nil
+             } = DB.Repo.reload(validation)
+
+      refute File.exists?(gtfs_path)
+      refute File.exists?(gtfs_rt_path)
+      refute File.exists?(OnDemandValidationJob.gtfs_rt_result_path(gtfs_rt_path))
     end
   end
 

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -36,6 +36,7 @@ defmodule Transport.Validators.GTFSRTTest do
               "warnings_count" => 26,
               "errors_count" => 4,
               "has_errors" => true,
+              "ignore_shapes" => false,
               "errors" => [
                 %{
                   "description" => "vehicle_id should be populated for TripUpdates and VehiclePositions",
@@ -75,11 +76,11 @@ defmodule Transport.Validators.GTFSRTTest do
                   "title" => "Sequential stop_time_updates have the same stop_sequence"
                 }
               ]
-            }} == GTFSRT.convert_validator_report(@gtfs_rt_report_path)
+            }} == GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
   end
 
   test "convert_validator_report when file does not exist" do
-    assert :error == GTFSRT.convert_validator_report(Ecto.UUID.generate())
+    assert :error == GTFSRT.convert_validator_report(Ecto.UUID.generate(), false)
   end
 
   describe "validate_and_save" do
@@ -180,7 +181,7 @@ defmodule Transport.Validators.GTFSRTTest do
       end)
 
       assert :ok == GTFSRT.validate_and_save(dataset)
-      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
+      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
       expected_errors = Map.fetch!(report, "errors")
 
       gtfs_rt_validation =
@@ -321,7 +322,7 @@ defmodule Transport.Validators.GTFSRTTest do
       end)
 
       assert :ok == GTFSRT.validate_and_save(gtfs_rt)
-      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
+      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
       expected_errors = Map.fetch!(report, "errors")
 
       gtfs_rt_validation =
@@ -432,6 +433,94 @@ defmodule Transport.Validators.GTFSRTTest do
         |> DB.Repo.all()
 
       assert [] == gtfs_rt_validation
+    end
+
+    test "when there is a memory error, run the validator another time and ignore shapes" do
+      gtfs_permanent_url = "https://example.com/gtfs.zip"
+      gtfs_rt_url = "https://example.com/gtfs-rt"
+
+      %{dataset: dataset, resource: gtfs} =
+        insert_up_to_date_resource_and_friends(
+          resource_history_payload: %{
+            "format" => "GTFS",
+            "permanent_url" => gtfs_permanent_url,
+            "uuid" => Ecto.UUID.generate()
+          }
+        )
+
+      %DB.Resource{} =
+        gtfs_rt =
+        insert(:resource,
+          dataset_id: dataset.id,
+          is_available: true,
+          format: "gtfs-rt",
+          is_community_resource: false,
+          url: gtfs_rt_url
+        )
+
+      Transport.HTTPoison.Mock
+      |> expect(:get!, fn ^gtfs_permanent_url, [], [follow_redirect: true] ->
+        %HTTPoison.Response{status_code: 200, body: "gtfs"}
+      end)
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn ^gtfs_rt_url, [], [follow_redirect: true] ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: "gtfs-rt"}}
+      end)
+
+      S3TestUtils.s3_mocks_upload_file(gtfs_rt.id |> to_string())
+
+      gtfs_path = GTFSRT.download_path(gtfs)
+      gtfs_rt_path = GTFSRT.download_path(gtfs_rt)
+
+      Transport.Rambo.Mock
+      |> expect(:run, fn binary, args, [log: false] ->
+        assert binary == "java"
+        assert File.exists?(gtfs_path)
+        assert File.exists?(gtfs_rt_path)
+
+        assert [
+                 "-jar",
+                 validator_path(),
+                 "-gtfs",
+                 gtfs_path,
+                 "-gtfsRealtimePath",
+                 Path.dirname(gtfs_rt_path)
+               ] == args
+
+        {:error, "Exception in thread main java.lang.OutOfMemoryError: Java heap space"}
+      end)
+
+      # Runs the validator another time, this time it should ignore shapes validation
+      Transport.Rambo.Mock
+      |> expect(:run, fn binary, args, [log: false] ->
+        assert binary == "java"
+        assert File.exists?(gtfs_path)
+        assert File.exists?(gtfs_rt_path)
+
+        assert [
+                 "-jar",
+                 validator_path(),
+                 "-ignoreShapes yes",
+                 "-gtfs",
+                 gtfs_path,
+                 "-gtfsRealtimePath",
+                 Path.dirname(gtfs_rt_path)
+               ] == args
+
+        File.write!(GTFSRT.gtfs_rt_result_path(gtfs_rt), File.read!(@gtfs_rt_report_path))
+        {:ok, nil}
+      end)
+
+      assert :ok == GTFSRT.validate_and_save(dataset)
+
+      assert DB.MultiValidation
+             |> where([mv], mv.resource_id == ^gtfs_rt.id and mv.validator == ^GTFSRT.validator_name())
+             |> DB.Repo.exists?()
+
+      # No temporary files left
+      refute File.exists?(Path.dirname(gtfs_path))
+      refute File.exists?(Path.dirname(gtfs_rt_path))
     end
   end
 

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -76,11 +76,11 @@ defmodule Transport.Validators.GTFSRTTest do
                   "title" => "Sequential stop_time_updates have the same stop_sequence"
                 }
               ]
-            }} == GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
+            }} == GTFSRT.convert_validator_report(@gtfs_rt_report_path)
   end
 
   test "convert_validator_report when file does not exist" do
-    assert :error == GTFSRT.convert_validator_report(Ecto.UUID.generate(), false)
+    assert :error == GTFSRT.convert_validator_report(Ecto.UUID.generate())
   end
 
   describe "validate_and_save" do
@@ -181,7 +181,7 @@ defmodule Transport.Validators.GTFSRTTest do
       end)
 
       assert :ok == GTFSRT.validate_and_save(dataset)
-      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
+      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
       expected_errors = Map.fetch!(report, "errors")
 
       gtfs_rt_validation =
@@ -322,7 +322,7 @@ defmodule Transport.Validators.GTFSRTTest do
       end)
 
       assert :ok == GTFSRT.validate_and_save(gtfs_rt)
-      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path, false)
+      {:ok, report} = GTFSRT.convert_validator_report(@gtfs_rt_report_path)
       expected_errors = Map.fetch!(report, "errors")
 
       gtfs_rt_validation =

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -390,6 +390,8 @@ defmodule TransportWeb.ResourceControllerTest do
 
     {conn1, _} = with_log(fn -> conn |> get(resource_path(conn, :details, resource_id)) end)
     assert conn1 |> html_response(200) =~ "Pas de validation disponible"
+    # Even without a multi-validation we can validate now as we have a single GTFS resource
+    assert conn1 |> html_response(200) =~ "Valider ce GTFS-RT maintenant"
 
     %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource_id})
 

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -411,6 +411,7 @@ defmodule TransportWeb.ResourceControllerTest do
         ],
         "has_errors" => true,
         "errors_count" => 1,
+        "ignore_shapes" => true,
         "files" => %{
           "gtfs_permanent_url" => "url",
           "gtfs_rt_permanent_url" => "url"
@@ -423,6 +424,7 @@ defmodule TransportWeb.ResourceControllerTest do
     {conn2, _} = with_log(fn -> conn |> get(resource_path(conn, :details, resource_id)) end)
     assert conn2 |> html_response(200) =~ "Rapport de validation"
     assert conn2 |> html_response(200) =~ "1 erreur"
+    assert conn2 |> html_response(200) =~ "Les shapes présentes dans le GTFS ont été ignorées"
     assert conn2 |> html_response(200) =~ "Valider ce GTFS-RT maintenant"
     refute conn2 |> html_response(200) =~ "Pas de validation disponible"
   end

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -403,7 +403,7 @@ defmodule TransportWeb.ValidationControllerTest do
       {:ok, view, _html} = live(conn)
 
       # Validation is displayed
-      {:ok, report} = Transport.Validators.GTFSRT.convert_validator_report(@gtfs_rt_report_path, true)
+      {:ok, report} = Transport.Validators.GTFSRT.convert_validator_report(@gtfs_rt_report_path, ignore_shapes: true)
 
       validation
       |> Ecto.Changeset.change(

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -403,7 +403,7 @@ defmodule TransportWeb.ValidationControllerTest do
       {:ok, view, _html} = live(conn)
 
       # Validation is displayed
-      {:ok, report} = Transport.Validators.GTFSRT.convert_validator_report(@gtfs_rt_report_path)
+      {:ok, report} = Transport.Validators.GTFSRT.convert_validator_report(@gtfs_rt_report_path, true)
 
       validation
       |> Ecto.Changeset.change(
@@ -415,6 +415,7 @@ defmodule TransportWeb.ValidationControllerTest do
       send(view.pid, :update_data)
 
       assert render(view) =~ "4 erreurs, 26 avertissements"
+      assert render(view) =~ "Les shapes présentes dans le GTFS ont été ignorées"
       assert render(view) =~ "stop_times_updates not strictly sorted"
       assert render(view) =~ "vehicle_id should be populated for TripUpdates and VehiclePositions"
       assert render(view) =~ "Ligne 5 Travaux à compter 22/11 pour 5 semaines"


### PR DESCRIPTION
Fixes #3206
Fixes #2832

Pour le validateur GTFS-RT + la validation à la demande :

- Gère le cas où on a une erreur `OutOfMemory` lors d'une validation GTFS-RT, qui survient lorsqu'on essaie d'analyser les shapes d'un GTFS avec les flux. Dans ce cas la validation est réessayée, en ignorant le traitement des shapes
- Affiche un message pour informer que certaines règles n'ont pas été vérifiées
- Les métadonnées de validation renseignent sur le fait que cette option a été activée `"ignore_shapes": true`