### PR TITLE
Correction calcul fraicheur

### DIFF
--- a/apps/transport/lib/jobs/dataset_quality_score.ex
+++ b/apps/transport/lib/jobs/dataset_quality_score.ex
@@ -267,7 +267,15 @@ defmodule Transport.Jobs.DatasetQualityScore do
     freshness
   end
 
-  def resource_freshness(%DB.Resource{}), do: nil
+  def resource_freshness(%DB.Resource{format: format, id: resource_id}),
+    do: %{
+      format: format,
+      resource_id: resource_id,
+      freshness: nil,
+      raw_measure: nil,
+      metadata_id: nil,
+      metadata_inserted_at: nil
+    }
 
   @doc """
   the freshness of a GTFS resource, base on its validity dates

--- a/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
@@ -383,6 +383,19 @@ defmodule Transport.Test.Transport.Jobs.DatasetQualityScoreTest do
       assert %{id: id2, topic: "freshness", score: 0.55, timestamp: _timestamp} = score
       assert id2 > id1
     end
+
+    test "dataset without scorable resource" do
+      dataset = insert(:dataset, is_active: true)
+      %{id: resource_id} = insert(:resource, dataset_id: dataset.id, format: "csv", is_community_resource: false)
+
+      {:ok, score} = save_dataset_freshness_score(dataset.id)
+
+      assert %{
+               topic: "freshness",
+               score: nil,
+               details: %{previous_score: nil, resources: [%{resource_id: ^resource_id, format: "csv", freshness: nil}]}
+             } = score
+    end
   end
 
   describe "jobs are enqueued" do


### PR DESCRIPTION
J'avais un trou dans la raquette pour les ressources qu'on ne sait pas noter pour le moment. Ca fait que les jobs correspondants étaient en erreur au lieu de sauvegarder en base des scores `nil`