### PR TITLE
Resource#download : ajout méthode HEAD explicite

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -233,8 +233,8 @@ defmodule TransportWeb.ResourceController do
     resource = Resource |> Repo.get!(id)
 
     if Resource.can_direct_download?(resource) do
-       # should not happen
-       # if direct download is possible, we don't expect the function `download` to be called
+      # should not happen
+      # if direct download is possible, we don't expect the function `download` to be called
       conn |> Plug.Conn.send_resp(:not_found, "")
     else
       case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -238,6 +238,7 @@ defmodule TransportWeb.ResourceController do
       case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do
         {:ok, %HTTPoison.Response{status_code: status_code, headers: headers}} ->
           send_response_with_status_headers(conn, status_code, headers)
+
         _ ->
           conn |> Plug.Conn.send_resp(:bad_gateway, "")
       end

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -233,6 +233,8 @@ defmodule TransportWeb.ResourceController do
     resource = Resource |> Repo.get!(id)
 
     if Resource.can_direct_download?(resource) do
+       # should not happen
+       # if direct download is possible, we don't expect the function `download` to be called
       conn |> Plug.Conn.send_resp(:not_found, "")
     else
       case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -51,7 +51,7 @@ defmodule TransportWeb.Endpoint do
   plug(Sentry.PlugContext)
 
   plug(Plug.MethodOverride)
-  plug(Plug.Head)
+  plug(TransportWeb.Plugs.Head)
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/apps/transport/lib/transport_web/plugs/head.ex
+++ b/apps/transport/lib/transport_web/plugs/head.ex
@@ -1,0 +1,19 @@
+defmodule TransportWeb.Plugs.Head do
+  @moduledoc """
+  A Plug to convert `HEAD` requests to `GET` requests but it remembers that
+  it was originally a `HEAD` request.
+
+  A fork from the original [Plug.Head](https://hexdocs.pm/plug/Plug.Head.html)
+  """
+  @behaviour Plug
+
+  @impl true
+  def init([]), do: []
+
+  @impl true
+  def call(%Plug.Conn{method: "HEAD"} = conn, []) do
+    %{conn | method: "GET"} |> Plug.Conn.assign(:original_method, "HEAD")
+  end
+
+  def call(conn, []), do: conn
+end


### PR DESCRIPTION
Gère la méthode `HEAD` explicitement pour le téléchargement de ressources diffusées en HTTP. Dans ces cas, on fait "relai" et on rediffuse les données du producteur.

Il arrive que la réponse soit lente (téléchargement long/réponse lente) de notre côté, alors qu'une requête `HEAD` à la source est rapide. Ceci est susceptible de porter préjudice au producteur, par exemple avec une indisponibilité de la ressource suite à une réponse trop lente (voir [sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/or4rbmt4r7yg5my7s5a59yx59r)).