### PR TITLE
Nettoyage des logs d'un test

### DIFF
--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -705,7 +705,9 @@ defmodule TransportWeb.ResourceControllerTest do
       {:ok, %HTTPoison.Response{status_code: 200, body: ""}}
     end)
 
-    html_response = conn |> get(resource_path(conn, :details, gtfs_rt_resource.id)) |> html_response(200)
+    {html_response, _logs} =
+      with_log(fn -> conn |> get(resource_path(conn, :details, gtfs_rt_resource.id)) |> html_response(200) end)
+
     assert html_response =~ ~s(<h2 id="related-resources">Ressources associées</h2>)
     assert html_response =~ "Fichier GTFS associé"
   end


### PR DESCRIPTION
Vous aviez peut-être vu passer ça dans les logs des tests

![image](https://github.com/etalab/transport-site/assets/15341118/5e9317a5-1365-44c3-80a3-065e5fa80137)

ça faisait pas joli :man_artist: 
J'ai eu du mal à localiser le test :hot_face: 