### PR TITLE
Client OAuth datagouv : réglage du timeout

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/oauth.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/oauth.ex
@@ -48,7 +48,9 @@ defmodule Datagouvfr.Client.OAuth do
   def request(method, %Plug.Conn{} = conn, path, body, headers, opts) do
     client = get_client(conn)
     url = process_url(path)
-    opts = Keyword.put_new(opts, :timeout, 15_000)
+    # See Hackney options
+    # https://github.com/benoitc/hackney/blob/master/doc/hackney.md
+    opts = Keyword.put_new(opts, :recv_timeout, 15_000)
     opts = Keyword.put_new(opts, :follow_redirect, true)
     Logger.debug(fn -> "Request to: #{path}" end)
     Logger.debug(fn -> "Body: #{inspect(body)}" end)


### PR DESCRIPTION
Fixes #3216

Notre librairie OAuth permet de passer des paramètres au client HTTP, qui est Hackney.

https://github.com/ueberauth/oauth2/blob/7589795f0ef30bc63da7789b924f67e82471c0c4/lib/oauth2/client.ex#L96-L98

Il se trouve que le paramètre de timeout qu'on passait n'était pas le bon.

- `timeout` is the time we keep the connection alive in the pool https://github.com/benoitc/hackney/blob/d6d075f9edcbb7e0b5c9418dba5dd34f2c95bc21/README.md?plain=1#L368
- `recv_timeout` timeout used when receiving data over a connection. Default is 5000 https://github.com/benoitc/hackney/blob/d6d075f9edcbb7e0b5c9418dba5dd34f2c95bc21/doc/hackney.md?plain=1#L364

En utilisant la bonne variable et en faisant x3 par rapport à ce qu'on avait avant, j'espère qu'on dira au revoir aux problèmes constatés.