### PR TITLE
Validateur GTFS-RT : option ignoreShapes

### DIFF
--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -73,9 +73,9 @@ defmodule Transport.Validators.GTFSRT do
     # https://github.com/MobilityData/gtfs-realtime-validator/blob/master/TROUBLESHOOTING.md#javalangoutofmemoryerror-java-heap-space-when-running-project
     shapes_args =
       if Keyword.fetch!(opts, :ignore_shapes) do
-        "-ignoreShapes yes"
+        ["-ignoreShapes", "yes"]
       else
-        ""
+        []
       end
 
     args =
@@ -88,6 +88,7 @@ defmodule Transport.Validators.GTFSRT do
         "-gtfsRealtimePath",
         Path.dirname(gtfs_rt_path)
       ]
+      |> List.flatten()
       |> Enum.reject(&(&1 == ""))
 
     {binary_path, args}

--- a/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/on_demand_validation_job_test.exs
@@ -358,7 +358,8 @@ defmodule Transport.Test.Transport.Jobs.OnDemandValidationJobTest do
         assert [
                  "-jar",
                  validator_path(),
-                 "-ignoreShapes yes",
+                 "-ignoreShapes",
+                 "yes",
                  "-gtfs",
                  gtfs_path,
                  "-gtfsRealtimePath",

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -501,7 +501,8 @@ defmodule Transport.Validators.GTFSRTTest do
         assert [
                  "-jar",
                  validator_path(),
-                 "-ignoreShapes yes",
+                 "-ignoreShapes",
+                 "yes",
                  "-gtfs",
                  gtfs_path,
                  "-gtfsRealtimePath",


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/3209

L'argument était mal passé à l'exécutable java :cry:

Ça donnait

```
Exception in thread "main" org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -ignoreShapes yes
```

J'adapte comment cet argument est donné (et cette fois j'ai bien testé en local :angel:).