### PR TITLE
Page stats : ajout nombre de requêtes sur le proxy (live)

### DIFF
--- a/apps/transport/client/stylesheets/components/_stats.scss
+++ b/apps/transport/client/stylesheets/components/_stats.scss
@@ -249,3 +249,15 @@
   width: 9px;
   height: 9px;
 }
+
+.proxy-external-requests {
+  font-weight: bold;
+  font-size: 2em;
+  text-align: center;
+  margin: 1em 0 .5em 0;
+}
+.proxy-legend {
+  text-align: center;
+  color: $dark-grey;
+  margin-bottom: 1em;
+}

--- a/apps/transport/lib/transport_web/live/proxy_requests_count_live.ex
+++ b/apps/transport/lib/transport_web/live/proxy_requests_count_live.ex
@@ -1,0 +1,55 @@
+defmodule TransportWeb.ProxyRequestsCountLive do
+  @moduledoc """
+  A live counter of dicussions for the dataset
+  """
+  use Phoenix.LiveView, container: {:div, [class: "domain", id: "proxy-requests"]}
+  import Ecto.Query
+
+  @doc_url "https://doc.transport.data.gouv.fr/foire-aux-questions-1/donnees-temps-reel-des-transports-en-commun#proxy-gtfs-rt"
+
+  def render(assigns) do
+    ~H"""
+    <h2>Requêtes temps-réel sur le proxy</h2>
+    <p>
+      transport.data.gouv.fr met à disposition des producteurs de données <a href={@doc_url}>un service de proxy</a>
+      permettant de diffuser des données temps réel aux formats GTFS-RT, GBFS et SIRI.
+    </p>
+    <div :if={assigns[:data]}>
+      <% ratio = Map.get(assigns[:data], "external", 0) / Map.get(assigns[:data], "internal", 1) %>
+      <div class="proxy-external-requests"><%= Helpers.format_number(Map.get(assigns[:data], "external", 0)) %></div>
+      <div class="proxy-legend">Nombre de requêtes au cours des 30 derniers jours</div>
+      <p>
+        Ce service facilite la diffusion de données temps réel et diminue
+        les coûts de mise à disposition des producteurs.
+        Notre proxy a diminué le nombre de requêtes que doivent gérer les producteurs
+        par un facteur de <%= ratio |> Float.round(1) |> Helpers.format_number() %> sur cette période.
+      </p>
+    </div>
+    """
+  end
+
+  def mount(_, _, socket) do
+    send(self(), :update_data)
+    {:ok, socket |> assign(:doc_url, @doc_url)}
+  end
+
+  def handle_info(:update_data, socket) do
+    query =
+      from(m in DB.Metrics,
+        group_by: [fragment("case when ? like '%internal' then 'internal' else 'external' end", m.event)],
+        where: fragment("? >= (now() - interval '30 day')", m.period),
+        where: fragment("? ~ ':(internal|external)$'", m.event),
+        select: %{
+          sum: sum(m.count),
+          event: fragment("case when ? like '%internal' then 'internal' else 'external' end", m.event)
+        }
+      )
+
+    socket =
+      socket
+      |> assign(:data, query |> DB.Repo.all() |> Enum.into(%{}, fn %{event: event, sum: sum} -> {event, sum} end))
+
+    Process.send_after(self(), :update_data, 5_000)
+    {:noreply, socket}
+  end
+end

--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -101,7 +101,7 @@
       <div class="domain-stats">
         <%= render("_maps.html", droms: @droms, prefix: "pt_format_map") %>
         <div class="panel">
-          <div class="description" id="public-transport-format">
+          <div class="description">
             <h3>Zoom sur les formats de données</h3>
             <span class="stat-link" id="public-transport-format">
               <a href="#public-transport-format"><i class="fa fa-link fa-small"></i></a>
@@ -312,6 +312,7 @@
         </div>
       </div>
     </div>
+    <%= live_render(@conn, TransportWeb.ProxyRequestsCountLive) %>
     <div class="domain carpooling">
       <h2>Lieux de covoiturage</h2>
       <p>
@@ -338,5 +339,5 @@
     </div>
   </div>
 </section>
-<script src={static_path(@conn, "/js/map.js")}>
-</script>
+<script src={static_path(@conn, "/js/map.js")} />
+<script defer src={static_path(@conn, "/js/app.js")} />

--- a/apps/transport/lib/transport_web/views/stats_view.ex
+++ b/apps/transport/lib/transport_web/views/stats_view.ex
@@ -1,5 +1,6 @@
 defmodule TransportWeb.StatsView do
   use TransportWeb, :view
+  import Phoenix.Component, only: [live_render: 2]
 
   def friendly_gtfs_type(type) when is_binary(type) do
     Map.fetch!(


### PR DESCRIPTION
Affiche sur la page stats le nombre de requêtes gérées par notre proxy au cours des 30 derniers jours. Le chiffre est mis-à-jour toutes les 5s avec LiveView :sparkles: