### PR TITLE
Récupérer JDD pour un utilisateur

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/user.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/user.ex
@@ -3,8 +3,6 @@ defmodule Datagouvfr.Client.User.Wrapper do
   A wrapper for the User module, useful for testing purposes
   """
   @callback me(Plug.Conn.t()) :: {:error, map()} | {:ok, map()}
-  @callback datasets(Plug.Conn.t()) :: {:error, map()} | {:ok, list()}
-  @callback org_datasets(Plug.Conn.t()) :: {:error, map()} | {:ok, list()}
 
   def impl, do: Application.get_env(:datagouvfr, :user_impl)
 end
@@ -26,12 +24,6 @@ defmodule Datagouvfr.Client.User.Dummy do
          "email" => "email@example.fr",
          "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr", "name" => "PAN"}]
        }}
-
-  @impl Datagouvfr.Client.User.Wrapper
-  def datasets(_), do: {:ok, []}
-
-  @impl Datagouvfr.Client.User.Wrapper
-  def org_datasets(_), do: {:ok, []}
 end
 
 defmodule Datagouvfr.Client.User do
@@ -51,16 +43,6 @@ defmodule Datagouvfr.Client.User do
   @spec me(Plug.Conn.t(), [binary()]) :: {:error, OAuth2.Error.t()} | {:ok, OAuth2.Response.t()}
   def me(%Plug.Conn{} = conn, exclude_fields \\ []) do
     Client.get(conn, "me", [{"x-fields", xfields(exclude_fields)}])
-  end
-
-  @spec datasets(Plug.Conn.t()) :: {:error, OAuth2.Error.t()} | {:ok, OAuth2.Response.t()}
-  def datasets(%Plug.Conn{} = conn) do
-    Client.get(conn, Path.join(["me", "datasets"]))
-  end
-
-  @spec org_datasets(Plug.Conn.t()) :: {:error, OAuth2.Error.t()} | {:ok, OAuth2.Response.t()}
-  def org_datasets(%Plug.Conn{} = conn) do
-    Client.get(conn, Path.join(["me", "org_datasets"]))
   end
 
   # private functions

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -145,6 +145,7 @@ defmodule Transport.ImportData do
       |> Map.put("last_update", parse_datetime(data_gouv_resp["last_update"]))
       |> Map.put("type", type)
       |> Map.put("organization", data_gouv_resp["organization"]["name"])
+      |> Map.put("organization_id", data_gouv_resp["organization"]["id"])
       |> Map.put("resources", get_resources(data_gouv_resp, type))
       |> Map.put("nb_reuses", get_nb_reuses(data_gouv_resp))
       |> Map.put("licence", licence(data_gouv_resp))

--- a/apps/transport/lib/transport_web/templates/resource/list.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/list.html.heex
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="existing">
       <h1><%= dgettext("resource", "Select a dataset to update it.") %></h1>
-      <%= for dataset <- @datasets ++ @org_datasets do %>
+      <%= for dataset <- @datasets do %>
         <div class="panel">
           <h2><%= dataset.datagouv_title %></h2>
           <%= link(

--- a/apps/transport/priv/repo/migrations/20230609122110_dataset_add_organization_id.exs
+++ b/apps/transport/priv/repo/migrations/20230609122110_dataset_add_organization_id.exs
@@ -1,0 +1,10 @@
+defmodule DB.Repo.Migrations.DatasetAddOrganizationId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataset) do
+      add :organization_id, :string, null: true
+    end
+    create_if_not_exists(index(:dataset, [:organization_id]))
+  end
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -31,6 +31,7 @@ defmodule DB.Factory do
       datagouv_title: "Hello",
       slug: sequence(:slug, fn i -> "dataset_slug_#{i}" end),
       datagouv_id: sequence(:datagouv_id, fn i -> "dataset_datagouv_id_#{i}" end),
+      organization_id: sequence(:organization_id, fn i -> "dataset_organization_id_#{i}" end),
       # NOTE: need to figure out how to pass aom/region together with changeset checks here
       aom: build(:aom),
       tags: []

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -54,7 +54,8 @@ defmodule Transport.ImportDataTest do
       "created_at" => DateTime.utc_now() |> to_string(),
       "last_update" => DateTime.utc_now() |> to_string(),
       "slug" => "dataset-slug",
-      "resources" => resources
+      "resources" => resources,
+      "organization" => %{"id" => Ecto.UUID.generate()}
     }
   end
 
@@ -203,6 +204,9 @@ defmodule Transport.ImportDataTest do
     end
 
     assert db_count(DB.Dataset) == 1
+
+    %DB.Dataset{organization_id: organization_id} = DB.Dataset |> DB.Repo.one!()
+    refute is_nil(organization_id)
 
     [resource_updated] = DB.Resource |> DB.Repo.all()
     # assert that the resource has been updated with a new title and a new datagouv_id

--- a/apps/transport/test/transport_web/controllers/notification_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/notification_controller_test.exs
@@ -17,7 +17,7 @@ defmodule TransportWeb.NotificationControllerTest do
     end
 
     test "displays existing subscriptions", %{conn: conn} do
-      %DB.Dataset{id: dataset_id} = insert(:dataset, custom_title: "Mon super JDD")
+      %DB.Dataset{id: dataset_id, organization_id: organization_id} = insert(:dataset, custom_title: "Mon super JDD")
       %DB.Contact{id: contact_id} = insert_contact(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()})
 
       insert(:notification_subscription,
@@ -27,9 +27,8 @@ defmodule TransportWeb.NotificationControllerTest do
         source: :user
       )
 
-      Datagouvfr.Client.User.Mock |> expect(:datasets, fn _conn -> {:ok, []} end)
-
-      Datagouvfr.Client.User.Mock |> expect(:org_datasets, fn _conn -> {:ok, []} end)
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => organization_id}]}} end)
 
       conn = conn |> init_test_session(%{current_user: %{"id" => datagouv_user_id}})
       content = conn |> get(notification_path(conn, :index)) |> html_response(200)

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -68,9 +68,10 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "I can see my datasets", %{conn: conn} do
-    dataset = insert(:dataset, datagouv_title: Ecto.UUID.generate())
-    Datagouvfr.Client.User.Mock |> expect(:datasets, fn _conn -> {:ok, []} end)
-    Datagouvfr.Client.User.Mock |> expect(:org_datasets, fn _conn -> {:ok, [%{"id" => dataset.datagouv_id}]} end)
+    %DB.Dataset{datagouv_title: datagouv_title, organization_id: organization_id} = insert(:dataset)
+
+    Datagouvfr.Client.User.Mock
+    |> expect(:me, fn _conn -> {:ok, %{"organizations" => [%{"id" => organization_id}]}} end)
 
     html =
       conn
@@ -78,7 +79,7 @@ defmodule TransportWeb.ResourceControllerTest do
       |> get(resource_path(conn, :datasets_list))
       |> html_response(200)
 
-    assert html =~ dataset.datagouv_title
+    assert html =~ datagouv_title
   end
 
   test "Non existing resource raises a Ecto.NoResultsError (interpreted as a 404 thanks to phoenix_ecto)", %{conn: conn} do
@@ -614,9 +615,8 @@ defmodule TransportWeb.ResourceControllerTest do
         period: today
       )
 
-      Datagouvfr.Client.User.Mock |> expect(:datasets, fn _conn -> {:ok, []} end)
-
-      Datagouvfr.Client.User.Mock |> expect(:org_datasets, fn _conn -> {:ok, [%{"id" => dataset.datagouv_id}]} end)
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn _conn -> {:ok, %{"organizations" => [%{"id" => dataset.organization_id}]}} end)
 
       html =
         conn

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -46,8 +46,6 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
                  "locale" => "fr"
                }
              )
-
-    :timer.sleep(100)
   end
 
   test "the counter reacts to broadcasted messages", %{conn: conn} do

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -46,6 +46,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
                  "locale" => "fr"
                }
              )
+
+    :timer.sleep(100)
   end
 
   test "the counter reacts to broadcasted messages", %{conn: conn} do


### PR DESCRIPTION
Le retour de #3216

Problème : pour certains utilisateurs qui sont membre d'une organisation sur data.gouv.fr avec beaucoup de JDD (> 250), l'API `/user/org_datasets` peut avoir des temps de réponse > 15s ([voir Mattermost](https://mattermost.incubateur.net/betagouv/pl/67ec6b1j6pn63bpf7gcrfp8uur)), ce qui empêche le chargement de pages comme l'Espace producteur / gestion des notifications.

L'idée est de retrouver les organisations dont est membre l'utilisateur (avec `/api/me`) et d'utiliser ces identifiants d'organisations pour retrouver les JDD correspondants.

- Ajout de `organization_id` sur `dataset`
- Faire en sorte que ce soit rempli lors de l'import
- Supprime l'ancien code/utilise l'endpoint `me` pour retrouver les JDD pertinents

#### Notes pour le déploiement

En mergeant, on va ajouter une colonne `organization_id` sur `dataset` qui va valoir `null` partout. Faut que ce soit rempli, sans ça tout le monde aura un Espace producteur (et features similaires) vide. On peut lancer un import global juste après.