### PR TITLE
Job quotidien identifiant JDD article 122 avec licence non LO

### DIFF
--- a/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
+++ b/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
@@ -17,7 +17,7 @@ defmodule Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJob do
       Application.get_env(:transport, :contact_email),
       Application.get_env(:transport, :bizdev_email),
       Application.get_env(:transport, :contact_email),
-      "Jeux de données article 122 avec licence inapproprié",
+      "Jeux de données article 122 avec licence inappropriée",
       "",
       Phoenix.View.render_to_string(
         TransportWeb.EmailView,

--- a/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
+++ b/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
@@ -1,0 +1,47 @@
+defmodule Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJob do
+  @moduledoc """
+  Job in charge of sending email notifications to our bizdev team
+  when datasets are subject to a compulsory data integration obligation (article 122)
+  and switched to an inappropriate licence.
+  """
+  use Oban.Worker, max_attempts: 3, tags: ["moderation"]
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    datasets = relevant_datasets()
+    remove_climate_resilience_bill_tag(datasets)
+
+    Transport.EmailSender.impl().send_mail(
+      "transport.data.gouv.fr",
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :bizdev_email),
+      Application.get_env(:transport, :contact_email),
+      "Jeux de données article 122 avec licence inapproprié",
+      "",
+      Phoenix.View.render_to_string(
+        TransportWeb.EmailView,
+        "datasets_climate_resilience_bill_inappropriate_licence.html",
+        datasets: datasets
+      )
+    )
+
+    :ok
+  end
+
+  def relevant_datasets do
+    DB.Dataset.base_query()
+    |> where([dataset: d], fragment("'loi-climat-resilience' = any(?)", d.custom_tags))
+    |> DB.Repo.all()
+    |> Enum.reject(&DB.Dataset.has_licence_ouverte?/1)
+  end
+
+  def remove_climate_resilience_bill_tag(datasets) do
+    ids = datasets |> Enum.map(& &1.id)
+
+    DB.Dataset.base_query()
+    |> where([dataset: d], d.id in ^ids)
+    |> update([dataset: d], set: [custom_tags: fragment("array_remove(?, 'loi-climat-resilience')", d.custom_tags)])
+    |> DB.Repo.update_all([])
+  end
+end

--- a/apps/transport/lib/transport_web/templates/email/datasets_climate_resilience_bill_inappropriate_licence.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/datasets_climate_resilience_bill_inappropriate_licence.html.heex
@@ -1,0 +1,15 @@
+<p>Bonjour,</p>
+
+<p>
+  Les jeux de données suivants sont soumis à une obligation de réutilisation en vertu de l'article 122 de la loi climat et résilience mais ne sont plus publiés avec une licence ouverte.
+</p>
+
+<ul>
+  <%= for dataset <- @datasets do %>
+    <li><%= raw(link_for_dataset(dataset, :heex)) %></li>
+  <% end %>
+</ul>
+
+<p>
+  Le tag "loi climat et résilience" a été retiré automatiquement, toutefois il faudrait discuter avec les producteurs concernés.
+</p>

--- a/apps/transport/lib/transport_web/views/email_view.ex
+++ b/apps/transport/lib/transport_web/views/email_view.ex
@@ -1,3 +1,12 @@
 defmodule TransportWeb.EmailView do
   use TransportWeb, :view
+
+  def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}, mode) when mode in [:heex, :markdown] do
+    url = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
+
+    case mode do
+      :markdown -> "[#{custom_title}](#{url})"
+      :heex -> link(custom_title, to: url)
+    end
+  end
 end

--- a/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
@@ -27,7 +27,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenc
                              "contact@transport.beta.gouv.fr",
                              "deploiement@transport.beta.gouv.fr",
                              "contact@transport.beta.gouv.fr",
-                             "Jeux de données article 122 avec licence inapproprié",
+                             "Jeux de données article 122 avec licence inappropriée",
                              "",
                              html_content ->
       assert html_content =~ ~s(<a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)

--- a/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
@@ -1,0 +1,48 @@
+defmodule Transport.Test.Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  alias Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    dataset =
+      insert(:dataset,
+        is_active: true,
+        custom_tags: ["foo", "loi-climat-resilience"],
+        licence: "odc-odbl",
+        custom_title: "Bar"
+      )
+
+    lo_dataset = insert(:dataset, is_active: true, custom_tags: ["foo", "loi-climat-resilience"], licence: "fr-lo")
+
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "deploiement@transport.beta.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "Jeux de données article 122 avec licence inapproprié",
+                             "",
+                             html_content ->
+      assert html_content =~ ~s(<a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
+
+      assert html_content =~
+               ~s(Les jeux de données suivants sont soumis à une obligation de réutilisation en vertu de l'article 122 de la loi climat et résilience mais ne sont plus publiés avec une licence ouverte)
+
+      :ok
+    end)
+
+    assert :ok == perform_job(DatasetsClimateResilienceBillNotLOLicenceJob, %{})
+
+    assert [
+             %DB.Dataset{custom_tags: ["foo"], licence: "odc-odbl"},
+             %DB.Dataset{custom_tags: ["foo", "loi-climat-resilience"], licence: "fr-lo"}
+           ] = DB.Repo.reload!([dataset, lo_dataset])
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -125,6 +125,7 @@ oban_crontab_all_envs =
         {"15,45 * * * *", Transport.Jobs.MultiValidationWithErrorNotificationJob},
         {"20,50 * * * *", Transport.Jobs.ResourceUnavailableNotificationJob},
         {"30 6 * * 1", Transport.Jobs.DatasetsSwitchingClimateResilienceBillJob},
+        {"30 6 * * 1-5", Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJob},
         {"10 6 * * 1", Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJob},
         {"45 2 * * *", Transport.Jobs.RemoveHistoryJob,
          args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}},


### PR DESCRIPTION
En lien avec #3228

Détecte les JDD article 122 qui passe à une licence différente de la LO, retire le tag `loi-climat-resilience` et prévient notre équipe bizdev pour prendre contact avec les producteurs.

Le job est planifié du lundi au vendredi.