### PR TITLE
Réparation de test sur DiscussionsLive

### DIFF
--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -46,6 +46,7 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
                  "locale" => "fr"
                }
              )
+
     # we render the view to make sure the async call to data.gouv is done
     assert render(view) =~ ""
   end

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -37,7 +37,7 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
     # in case of request failure, the function returns an empty list.
     Datagouvfr.Client.Discussions.Mock |> expect(:get, 1, fn ^datagouv_id -> [] end)
 
-    assert {:ok, _view, _html} =
+    assert {:ok, view, _html} =
              live_isolated(conn, TransportWeb.DiscussionsLive,
                session: %{
                  "dataset_datagouv_id" => datagouv_id,
@@ -46,6 +46,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
                  "locale" => "fr"
                }
              )
+    # we render the view to make sure the async call to data.gouv is done
+    assert render(view) =~ ""
   end
 
   test "the counter reacts to broadcasted messages", %{conn: conn} do


### PR DESCRIPTION
Tout est là https://medium.com/elixir-learnings/testing-a-phoenix-liveview-that-does-an-async-operation-after-mount-b8ec27e6c167

Le fait d'appeler `render` envoie un  message à la mailbox de la LiveView, qui arrive après le message envoyé par la fonction `mount` de la LiveView pour faire la requête chez data.gouv. Donc le fait d'appeler `render` dans le test nous assure que l'appel asynchrone dans la LiveView est fait d'abord (mailbox FIFO)