### PR TITLE
Score de fraicheur sur le site pour l'équipe PAN

### DIFF
--- a/apps/transport/lib/db/dataset_score.ex
+++ b/apps/transport/lib/db/dataset_score.ex
@@ -27,4 +27,16 @@ defmodule DB.DatasetScore do
   def between_0_and_1_if_exists(:score, _score), do: [score: "must be between 0.0 and 1.0"]
 
   def base_query, do: from(ds in DB.DatasetScore, as: :dataset_score)
+
+  @spec get_latest(DB.Dataset.t(), any) :: DB.DatasetScore.t() | nil
+  @doc """
+  Latest score for a given dataset and topic
+  """
+  def get_latest(%DB.Dataset{id: dataset_id}, topic) do
+    __MODULE__.base_query()
+    |> where([dataset_score: ds], ds.dataset_id == ^dataset_id and ds.topic == ^topic)
+    |> order_by([ds], desc: ds.timestamp)
+    |> limit(1)
+    |> DB.Repo.one()
+  end
 end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -61,6 +61,7 @@ defmodule TransportWeb.DatasetController do
       |> assign(:history_resources, Transport.History.Fetcher.history_resources(dataset, max_nb_history_resources()))
       |> assign(:latest_resources_history_infos, DB.ResourceHistory.latest_dataset_resources_history_infos(dataset.id))
       |> assign(:notifications_sent, DB.Notification.recent_reasons_binned(dataset, days_notifications_sent()))
+      |> assign(:freshness_score, DB.DatasetScore.get_latest(dataset, "freshness"))
       |> put_status(if dataset.is_active, do: :ok, else: :not_found)
       |> render("details.html")
     else

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -19,6 +19,14 @@
   <%= if admin?(assigns[:current_user]) do %>
     <i class="fa fa-external-link-alt"></i>
     <%= link("backoffice", to: backoffice_page_path(@conn, :edit, @dataset.id)) %>
+    <div class="light-grey pt-6">
+      <%= if not is_nil(@freshness_score) do %>
+        Score fraicheur : <%= @freshness_score.score %><br />
+        <%= @freshness_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(locale) %>
+      <% else %>
+        Pas de score fraicheur
+      <% end %>
+    </div>
   <% end %>
 </div>
 <div class="dataset-page">

--- a/apps/transport/test/db/dataset_score_test.exs
+++ b/apps/transport/test/db/dataset_score_test.exs
@@ -1,5 +1,10 @@
 defmodule DB.DatasetScoreTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+  import DB.Factory
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
 
   describe "save dataset score" do
     test "some fields are mandatory" do
@@ -27,5 +32,39 @@ defmodule DB.DatasetScoreTest do
                ]
              } = changeset
     end
+  end
+
+  test "get latest score" do
+    dataset = insert(:dataset)
+    other_dataset = insert(:dataset)
+
+    # old
+    insert(:dataset_score,
+      dataset_id: dataset.id,
+      timestamp: DateTime.utc_now() |> DateTime.add(-1, :day),
+      score: 1.0,
+      topic: "freshness"
+    )
+
+    # the expected result
+    score =
+      insert(:dataset_score,
+        dataset_id: dataset.id,
+        timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour),
+        score: 0.55,
+        topic: "freshness"
+      )
+
+    # bad dataset
+    insert(:dataset_score, dataset_id: other_dataset.id, timestamp: DateTime.utc_now(), score: 1.0, topic: "freshness")
+
+    # bad topic
+    insert(:dataset_score, dataset_id: dataset.id, timestamp: DateTime.utc_now(), score: 1.0, topic: "fun")
+
+    assert score == DB.DatasetScore.get_latest(dataset, "freshness")
+  end
+
+  test "get unexisting latest score" do
+    assert %DB.Dataset{id: 123_456} |> DB.DatasetScore.get_latest("freshness") |> is_nil()
   end
 end


### PR DESCRIPTION
je rajoute sur chaque page dataset le score de fraicheur du dataset, uniquement pour les membre de l'équipe lorsqu'ils sont connectés.

![image](https://github.com/etalab/transport-site/assets/15341118/4789c1b0-1da5-4af6-b270-ab47a141b0e3)
