### PR TITLE
Article 122 avec mauvaise licence : gère cas sans JDD

### DIFF
--- a/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
+++ b/apps/transport/lib/jobs/datasets_climate_resilience_bill_not_lo_licence_job.ex
@@ -12,19 +12,21 @@ defmodule Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenceJob do
     datasets = relevant_datasets()
     remove_climate_resilience_bill_tag(datasets)
 
-    Transport.EmailSender.impl().send_mail(
-      "transport.data.gouv.fr",
-      Application.get_env(:transport, :contact_email),
-      Application.get_env(:transport, :bizdev_email),
-      Application.get_env(:transport, :contact_email),
-      "Jeux de données article 122 avec licence inappropriée",
-      "",
-      Phoenix.View.render_to_string(
-        TransportWeb.EmailView,
-        "datasets_climate_resilience_bill_inappropriate_licence.html",
-        datasets: datasets
+    unless Enum.empty?(datasets) do
+      Transport.EmailSender.impl().send_mail(
+        "transport.data.gouv.fr",
+        Application.get_env(:transport, :contact_email),
+        Application.get_env(:transport, :bizdev_email),
+        Application.get_env(:transport, :contact_email),
+        "Jeux de données article 122 avec licence inappropriée",
+        "",
+        Phoenix.View.render_to_string(
+          TransportWeb.EmailView,
+          "datasets_climate_resilience_bill_inappropriate_licence.html",
+          datasets: datasets
+        )
       )
-    )
+    end
 
     :ok
   end

--- a/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
@@ -45,4 +45,10 @@ defmodule Transport.Test.Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenc
              %DB.Dataset{custom_tags: ["foo", "loi-climat-resilience"], licence: "fr-lo"}
            ] = DB.Repo.reload!([dataset, lo_dataset])
   end
+
+  test "does not send an email if there are no datasets to handle" do
+    insert(:dataset, is_active: true, custom_tags: ["loi-climat-resilience"], licence: "fr-lo")
+    assert :ok == perform_job(DatasetsClimateResilienceBillNotLOLicenceJob, %{})
+    # No e-mails have been sent
+  end
 end


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/3229

Inutile d'envoyer un e-mail quand il y a 0 JDD concernés, sinon on envoie un corps vide. Je gère donc ce cas, et j'ajoute un test.

Navré !