### PR TITLE
Backoffice : affichage icône climat et résilience

### DIFF
--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -112,4 +112,9 @@
     height: 5em;
     margin-right: 3em;
   }
+  &.small {
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: .5em;
+  }
 }

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -999,4 +999,16 @@ defmodule DB.Dataset do
   end
 
   def has_licence_ouverte?(%__MODULE__{licence: licence}), do: licence in @licences_ouvertes
+
+  @doc """
+  iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: ["licence-osm"]})
+  false
+  iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: nil})
+  false
+  iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: ["loi-climat-resilience", "foo"]})
+  true
+  """
+  def climate_resilience_bill?(%__MODULE__{custom_tags: custom_tags}) do
+    "loi-climat-resilience" in (custom_tags || [])
+  end
 end

--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
@@ -1,5 +1,10 @@
 <tr>
   <td>
+    <img
+      :if={DB.Dataset.climate_resilience_bill?(@dataset)}
+      class="icon---climate-resilience-bill small"
+      src={static_path(@conn, "/images/loi-climat-resilience.png")}
+    />
     <strong>
       <%= @dataset.custom_title %>
     </strong>

--- a/apps/transport/lib/transport_web/templates/dataset/_climate_resilience_bill_badge.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_climate_resilience_bill_badge.html.heex
@@ -1,4 +1,4 @@
-<div :if={display_climate_resilience_bill_badge?(@dataset)} class="climate-resilience-bill-bg">
+<div :if={DB.Dataset.climate_resilience_bill?(@dataset)} class="climate-resilience-bill-bg">
   <section class="section-white p-6">
     <div class="climate-resilience-bill">
       <div>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -528,21 +528,6 @@ defmodule TransportWeb.DatasetView do
 
   def display_odbl_osm_conditions?(%Dataset{}), do: false
 
-  @doc """
-  Should we display the climate and resilience bill/article 122 badge for a dataset?
-
-
-  iex> display_climate_resilience_bill_badge?(%Dataset{custom_tags: ["licence-osm"]})
-  false
-  iex> display_climate_resilience_bill_badge?(%Dataset{custom_tags: nil})
-  false
-  iex> display_climate_resilience_bill_badge?(%Dataset{custom_tags: ["loi-climat-resilience", "foo"]})
-  true
-  """
-  def display_climate_resilience_bill_badge?(%Dataset{custom_tags: custom_tags}) do
-    "loi-climat-resilience" in (custom_tags || [])
-  end
-
   @spec related_gtfs_resource(Resource.t()) :: DB.ResourceRelated.t() | nil
   def related_gtfs_resource(%Resource{format: "gtfs-rt", resources_related: resources_related}) do
     Enum.find(resources_related, fn %DB.ResourceRelated{reason: reason} -> reason == :gtfs_rt_gtfs end)


### PR DESCRIPTION
En lien avec #3228

Affiche le badge "Climat et résilience" sur les JDD pour identifier d'un coup d'oeil ces JDD lors d'utilisation de filtres : JDD périmés/erreurs etc.