### PR TITLE
Gestion des retours à la ligne simples dans les commentaires datagouv

### DIFF
--- a/apps/transport/lib/transport_web/views/markdown_handler.ex
+++ b/apps/transport/lib/transport_web/views/markdown_handler.ex
@@ -14,7 +14,7 @@ defmodule TransportWeb.MarkdownHandler do
   def markdown_to_safe_html!(md) do
     {:safe, txt} =
       md
-      |> Earmark.as_html!([gfm_tables: true, breaks: true])
+      |> Earmark.as_html!(gfm_tables: true, breaks: true)
       |> HtmlSanitizeEx.basic_html()
       |> HTML.raw()
 

--- a/apps/transport/lib/transport_web/views/markdown_handler.ex
+++ b/apps/transport/lib/transport_web/views/markdown_handler.ex
@@ -14,7 +14,7 @@ defmodule TransportWeb.MarkdownHandler do
   def markdown_to_safe_html!(md) do
     {:safe, txt} =
       md
-      |> Earmark.as_html!(gfm_tables: true)
+      |> Earmark.as_html!([gfm_tables: true, breaks: true])
       |> HtmlSanitizeEx.basic_html()
       |> HTML.raw()
 

--- a/apps/transport/test/transport_web/views/markdown_handler_test.exs
+++ b/apps/transport/test/transport_web/views/markdown_handler_test.exs
@@ -36,7 +36,6 @@ defmodule TransportWeb.MarkdownHandlerTest do
               "<p>\nCela pourrait être une bonne chose de rajouter tout de meme l’url en <code>license_url</code> (du fichier <code>system_information.json</code>)</p>\n"}
   end
 
-  # This is weird, I keep this as the current behaviour, but do we want this?
   test "does render HTML elements inside Markdown code" do
     content = "<h1>This is a title</h1>"
     assert content |> MarkdownHandler.markdown_to_safe_html!() == {:safe, "<h1>\n  This is a title</h1>\n"}

--- a/apps/transport/test/transport_web/views/markdown_handler_test.exs
+++ b/apps/transport/test/transport_web/views/markdown_handler_test.exs
@@ -9,13 +9,42 @@ defmodule TransportWeb.MarkdownHandlerTest do
 
   test "a markdown keeps linebreaks" do
     content_with_r = "Bonjour,\r\n\r\nLes données seront périmées à la fin du mois d'Août."
-    content_with_only_n = "Bonjour  \nmerci de votre vigilance."
+    content_with_only_n = "Bonjour\nmerci de votre vigilance."
 
     assert content_with_r |> MarkdownHandler.markdown_to_safe_html!() ==
              {:safe, "<p>\nBonjour,</p>\n<p>\nLes données seront périmées à la fin du mois d’Août.</p>\n"}
 
     assert content_with_only_n |> MarkdownHandler.markdown_to_safe_html!() ==
              {:safe, "<p>\nBonjour  <br />\nmerci de votre vigilance.</p>\n"}
+  end
+
+  test "renders links" do
+    content =
+      "Bonjour,\r\nLa page précise une licence odc-oDbl et sur le site de vélib on trouve la licence d'etalab https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole\r\n"
+
+    assert content |> MarkdownHandler.markdown_to_safe_html!() ==
+             {:safe,
+              "<p>\nBonjour,  <br />\nLa page précise une licence odc-oDbl et sur le site de vélib on trouve la licence d’etalab <a href=\"https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole\">https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole</a></p>\n"}
+  end
+
+  test "renders code" do
+    content =
+      "Cela pourrait être une bonne chose de rajouter tout de meme l'url en `license_url` (du fichier `system_information.json`)"
+
+    assert content |> MarkdownHandler.markdown_to_safe_html!() ==
+             {:safe,
+              "<p>\nCela pourrait être une bonne chose de rajouter tout de meme l’url en <code>license_url</code> (du fichier <code>system_information.json</code>)</p>\n"}
+  end
+
+  # This is weird, I keep this as the current behaviour, but do we want this?
+  test "does render HTML elements inside Markdown code" do
+    content = "<h1>This is a title</h1>"
+    assert content |> MarkdownHandler.markdown_to_safe_html!() == {:safe, "<h1>\n  This is a title</h1>\n"}
+  end
+
+  test "does escape dangerous HTML tags" do
+    content = "<script>alert('Boo!');</script>"
+    assert content |> MarkdownHandler.markdown_to_safe_html!() == {:safe, "\n  alert('Boo!');\n"}
   end
 
   test "renders tables" do

--- a/apps/transport/test/transport_web/views/markdown_handler_test.exs
+++ b/apps/transport/test/transport_web/views/markdown_handler_test.exs
@@ -7,6 +7,17 @@ defmodule TransportWeb.MarkdownHandlerTest do
     assert content |> MarkdownHandler.markdown_to_safe_html!() == {:safe, "<h1>\nBonjour</h1>\n\n  alert(\"xxx\")\n"}
   end
 
+  test "a markdown keeps linebreaks" do
+    content_with_r = "Bonjour,\r\n\r\nLes données seront périmées à la fin du mois d'Août."
+    content_with_only_n = "Bonjour  \nmerci de votre vigilance."
+
+    assert content_with_r |> MarkdownHandler.markdown_to_safe_html!() ==
+             {:safe, "<p>\nBonjour,</p>\n<p>\nLes données seront périmées à la fin du mois d’Août.</p>\n"}
+
+    assert content_with_only_n |> MarkdownHandler.markdown_to_safe_html!() ==
+             {:safe, "<p>\nBonjour  <br />\nmerci de votre vigilance.</p>\n"}
+  end
+
   test "renders tables" do
     content = """
     State | Abbrev


### PR DESCRIPTION
Cette MR utilise une option de EarmarkParser, ici https://github.com/RobertDober/earmark_parser#breaks sur laquelle s’appuie le wrapper Earmark que l’on utilise, qui permet de gérer les retours à la ligne simple de Markdown sans créer de nouveau paragraphe. Un simple `\n` dans le markdown va donc créer un line break html `<br \>` au lieu d’être ignoré.

J’en profite pour rajouter de nouveaux tests.

# Avant

![Sélection_007](https://github.com/etalab/transport-site/assets/15861435/602d4ac9-f4a6-4b36-8bf7-b4bb008f5bd6)

# Après

![Sélection_008](https://github.com/etalab/transport-site/assets/15861435/d1bec2c3-16f4-4fd1-99bc-2f0e2650a93a)



Fixes #3163