### PR TITLE
Update mapbox vector tiles url and key

### DIFF
--- a/apps/transport/client/javascripts/dataset-map.js
+++ b/apps/transport/client/javascripts/dataset-map.js
@@ -5,10 +5,12 @@ import L from 'leaflet'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 function initilizeMap (id) {
@@ -16,7 +18,9 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom
+        maxZoom: Mapbox.maxZoom,
+        tileSize: Mapbox.tileSize,
+        zoomOffset: Mapbox.zoomOffset
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/dataset-map.js
+++ b/apps/transport/client/javascripts/dataset-map.js
@@ -1,17 +1,5 @@
 import L from 'leaflet'
-
-/**
- * Represents a Mapbox object.
- * @type {Object}
- */
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)

--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -4,6 +4,7 @@ import { LeafletLayer } from 'deck.gl-leaflet'
 import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers'
 
 import { MapView } from '@deck.gl/core'
+import { Mapbox } from './mapbox-credentials'
 
 const socket = new Socket('/socket', { params: { token: window.userToken } })
 socket.connect()
@@ -11,15 +12,6 @@ const channel = socket.channel('explore', {})
 channel.join()
     .receive('ok', resp => { console.log('Joined successfully', resp) })
     .receive('error', resp => { console.log('Unable to join', resp) })
-
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
 
 const metropolitanFranceBounds = [[51.1, -4.9], [41.2, 9.8]]
 const map = Leaflet.map('map', { renderer: Leaflet.canvas() }).fitBounds(metropolitanFranceBounds)

--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -13,10 +13,12 @@ channel.join()
     .receive('error', resp => { console.log('Unable to join', resp) })
 
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 const metropolitanFranceBounds = [[51.1, -4.9], [41.2, 9.8]]
@@ -25,7 +27,9 @@ const map = Leaflet.map('map', { renderer: Leaflet.canvas() }).fitBounds(metropo
 Leaflet.tileLayer(Mapbox.url, {
     accessToken: Mapbox.accessToken,
     attribution: Mapbox.attribution,
-    maxZoom: Mapbox.maxZoom
+    maxZoom: Mapbox.maxZoom,
+    tileSize: Mapbox.tileSize,
+    zoomOffset: Mapbox.zoomOffset
 }).addTo(map)
 
 const visibility = { gtfsrt: true }

--- a/apps/transport/client/javascripts/gtfs.js
+++ b/apps/transport/client/javascripts/gtfs.js
@@ -5,10 +5,12 @@ import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers'
 import { MapView } from '@deck.gl/core'
 
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 const metropolitanFranceBounds = [[51.1, -4.9], [41.2, 9.8]]
@@ -17,7 +19,9 @@ const map = Leaflet.map('map', { renderer: Leaflet.canvas() })
 Leaflet.tileLayer(Mapbox.url, {
     accessToken: Mapbox.accessToken,
     attribution: Mapbox.attribution,
-    maxZoom: Mapbox.maxZoom
+    maxZoom: Mapbox.maxZoom,
+    tileSize: Mapbox.tileSize,
+    zoomOffset: Mapbox.zoomOffset
 }).addTo(map)
 
 const deckGLLayer = new LeafletLayer({

--- a/apps/transport/client/javascripts/gtfs.js
+++ b/apps/transport/client/javascripts/gtfs.js
@@ -3,15 +3,7 @@ import { LeafletLayer } from 'deck.gl-leaflet'
 import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers'
 
 import { MapView } from '@deck.gl/core'
-
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 const metropolitanFranceBounds = [[51.1, -4.9], [41.2, 9.8]]
 const map = Leaflet.map('map', { renderer: Leaflet.canvas() })

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -1,18 +1,5 @@
 import L from 'leaflet'
-
-/**
- * Represents a Mapbox object.
- * @type {Object}
- */
-
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -4,11 +4,14 @@ import L from 'leaflet'
  * Represents a Mapbox object.
  * @type {Object}
  */
+
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 function initilizeMap (id) {
@@ -16,7 +19,9 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom
+        maxZoom: Mapbox.maxZoom,
+        tileSize: Mapbox.tileSize,
+        zoomOffset: Mapbox.zoomOffset
     }).addTo(map)
 
     const markersfg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -1,18 +1,6 @@
 import Leaflet from 'leaflet'
 import 'leaflet.pattern'
-
-/**
- * Represents a Mapbox object.
- * @type {Object}
- */
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 const regionsUrl = '/api/stats/regions'
 const aomsUrl = '/api/stats/'

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -6,10 +6,12 @@ import 'leaflet.pattern'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 const regionsUrl = '/api/stats/regions'
@@ -31,7 +33,9 @@ const makeMapOnView = (id, view) => {
     Leaflet.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom
+        maxZoom: Mapbox.maxZoom,
+        tileSize: Mapbox.tileSize,
+        zoomOffset: Mapbox.zoomOffset
     }).addTo(map)
 
     return map

--- a/apps/transport/client/javascripts/mapbox-credentials.js
+++ b/apps/transport/client/javascripts/mapbox-credentials.js
@@ -1,0 +1,8 @@
+export const Mapbox = {
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
+    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
+}

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -6,10 +6,12 @@ import Papa from 'papaparse'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 // possible field names in csv files
@@ -30,7 +32,9 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom
+        maxZoom: Mapbox.maxZoom,
+        tileSize: Mapbox.tileSize,
+        zoomOffset: Mapbox.zoomOffset
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -1,18 +1,6 @@
 import L from 'leaflet'
 import Papa from 'papaparse'
-
-/**
- * Represents a Mapbox object.
- * @type {Object}
- */
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 // possible field names in csv files
 const latLabels = ['Lat', 'Ylat', 'Ylatitude', 'consolidated_latitude']

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -5,10 +5,12 @@ import L from 'leaflet'
  * @type {Object}
  */
 const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/istopopoki/ckg98kpoc010h19qusi9kxcct/tiles/256/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoiaXN0b3BvcG9raSIsImEiOiJjaW12eWw2ZHMwMGFxdzVtMWZ5NHcwOHJ4In0.VvZvyvK0UaxbFiAtak7aVw',
+    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
+    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20
+    maxZoom: 20,
+    tileSize: 512,
+    zoomOffset: -1
 }
 
 function initilizeMap (id) {
@@ -16,7 +18,9 @@ function initilizeMap (id) {
     L.tileLayer(Mapbox.url, {
         accessToken: Mapbox.accessToken,
         attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom
+        maxZoom: Mapbox.maxZoom,
+        tileSize: Mapbox.tileSize,
+        zoomOffset: Mapbox.zoomOffset
     }).addTo(map)
 
     const fg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -1,17 +1,5 @@
 import L from 'leaflet'
-
-/**
- * Represents a Mapbox object.
- * @type {Object}
- */
-const Mapbox = {
-    url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
-    accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    maxZoom: 20,
-    tileSize: 512,
-    zoomOffset: -1
-}
+import { Mapbox } from './mapbox-credentials'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)


### PR DESCRIPTION
closes #2214 

Ne pas merger tout de suite, on va attendre de mettre la carte de Pathtech sur le nouveau compte Mapbox
Mais je pense qu'on va peut être plus devoir payer, parce qu'on peut demander des tuiles de 512*512 au lieu de 256*256 et donc en consommer 4 fois moins ! Il y a moyen qu'on revienne dans le free tier avec ça.