### PR TITLE
Ajout page humans.txt

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -58,6 +58,7 @@ defmodule TransportWeb.Router do
     get("/infos_producteurs", PageController, :infos_producteurs)
     get("/robots.txt", PageController, :robots_txt)
     get("/.well-known/security.txt", PageController, :security_txt)
+    get("/humans.txt", PageController, :humans_txt)
 
     scope "/espace_producteur" do
       pipe_through([:authenticated])

--- a/apps/transport/lib/transport_web/templates/layout/app.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.heex
@@ -26,6 +26,7 @@
 
     <link rel="stylesheet" media="all" href={static_path(@conn, "/css/app.css")} />
     <link rel="alternate" type="application/atom+xml" href={atom_url(@conn, :index)} title="Resources feed" />
+    <link type="text/plain" rel="author" href={page_url(@conn, :humans_txt)} />
     <%= if assigns[:mix_env] == :prod do %>
       <!-- Polyfill for css grid-->
       <script type="text/javascript">


### PR DESCRIPTION
Ajout d'une page [humans.txt](https://humanstxt.org/) pour rendre hommage aux personnes qui font/ont fait le PAN. Utilise [l'API de beta.gouv.fr](https://github.com/betagouv/beta.gouv.fr/tree/master/api)

![image](https://github.com/etalab/transport-site/assets/295709/2645eb4d-066c-4299-8e46-043a44a6c76c)
