### PR TITLE
Retirer la barre de défilement de la liste des jeux de données de l’espace producteur

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -108,10 +108,6 @@
         margin-top: -5px;
       }
     }
-    .resource-list {
-      max-height: 60vh;
-      overflow: auto;
-    }
   }
   .dataset-item {
     a:nth-child(1) {


### PR DESCRIPTION
Dans l’espace producteur, actuellement, dans Firefox, la liste de ses propres dataset semble s’arrêter brutalement (voir captures d’écran ci-dessous). En réalité, il s’agit d’une liste scrollable, sauf que la barre de défilement n’apparaît pas, et que l’élément scrollable ne va pas jusqu’en bas de la boîte de gauche, en raison d’une hauteur hardcodée à 60vh.

Conséquence : on peut potentiellement ne pas voir en tant que producteur tous ses datasets et ne pas savoir comment les afficher.

Il y aurait deux façons de régler ça en termes d’UX et de code :

1. Manière propre (j’ai tenté, j’ai échoué) : étendre la zone scrollable jusqu’en bas de la boîte de gauche, et faire apparaître la barre de défilement quel que soit le navigateur / système d’exploitation. Problème : on rentre dans l’enfer des flexbox pour que la colonne de gauche ait la même hauteur que celle de droite (dont la hauteur n’est pas hardcodée). J’ai commencé à bidouiller, je me suis dit que j’allais y perdre trop de temps
2. Laisser tomber le concept de barre de défilement et avoir une colonne de gauche potentiellement très grande. C’est le plus rapide à faire et ce que je propose dans cette PR.

Remarque : avec une rapide requête SQL, on voit que seuls 7 producteurs sur 213 ont plus de 10 datasets, et sur ces 7 seulement 3 en ont plus de 20. On peut imaginer que ces 3 producteurs ont peu besoin des ressources tout en bas de la page, plutôt axés pour des petits producteurs, donc cette longue liste verticale est une solution acceptable pour eux.
![Sélection_014](https://github.com/etalab/transport-site/assets/15861435/cd3fc1f8-ee2d-4d8f-8097-019d109e70e9)



Enfin c’est à débat, j’ouvre cette PR pour ne pas y passer trop de temps et avoir votre avis.

Screenshots avant / après


![Screenshot 2023-06-29 at 09-25-07 Le Point d’Accès National aux données ouvertes de transport](https://github.com/etalab/transport-site/assets/15861435/dcd55ed5-3faa-40f8-b40b-6130446da1c1)

![Screenshot 2023-06-29 at 09-24-47 Le Point d’Accès National aux données ouvertes de transport](https://github.com/etalab/transport-site/assets/15861435/83ef2995-1d7b-445e-835f-2a3629be36aa)
