### PR TITLE
Ajout table organization

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/user.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/user.ex
@@ -22,7 +22,16 @@ defmodule Datagouvfr.Client.User.Dummy do
          "last_name" => "rigolo",
          "id" => "user_id_1",
          "email" => "email@example.fr",
-         "organizations" => [%{"slug" => "equipe-transport-data-gouv-fr", "name" => "PAN"}]
+         "organizations" => [
+           %{
+             "slug" => "equipe-transport-data-gouv-fr",
+             "name" => "PAN",
+             "badges" => [],
+             "id" => "random",
+             "logo" => "https://example.com/pic.jpg",
+             "logo_thumbnail" => "https://example.com/pic.small.jpg"
+           }
+         ]
        }}
 end
 

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -29,6 +29,7 @@ defmodule DB.Contact do
     timestamps(type: :utc_datetime_usec)
 
     has_many(:notification_subscriptions, DB.NotificationSubscription, on_delete: :delete_all)
+    many_to_many(:organizations, DB.Organization, join_through: "contacts_organizations", on_replace: :delete)
   end
 
   def base_query, do: from(c in __MODULE__, as: :contact)
@@ -83,6 +84,7 @@ defmodule DB.Contact do
 
   def changeset(struct, attrs \\ %{}) do
     struct
+    |> DB.Repo.preload([:organizations])
     |> cast(attrs, [
       :first_name,
       :last_name,
@@ -104,6 +106,7 @@ defmodule DB.Contact do
     |> lowercase_email()
     |> put_hashed_fields()
     |> unique_constraint(:email_hash, error_key: :email, name: :contact_email_hash_index)
+    |> cast_assoc(:organizations)
   end
 
   defp validate_names_or_mailing_list_title(%Ecto.Changeset{} = changeset) do

--- a/apps/transport/lib/db/organization.ex
+++ b/apps/transport/lib/db/organization.ex
@@ -1,0 +1,30 @@
+defmodule DB.Organization do
+  @moduledoc """
+  Represents an organization on data.gouv.fr
+  """
+  use TypedEctoSchema
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  typed_schema "organization" do
+    field(:id, :string, primary_key: true)
+    field(:slug, :string)
+    field(:name, :string)
+    field(:acronym, :string)
+    field(:logo, :string)
+    field(:logo_thumbnail, :string)
+    field(:badges, {:array, :map})
+    field(:metrics, :map)
+    field(:created_at, :utc_datetime_usec)
+
+    many_to_many(:contacts, DB.Contact, join_through: "contacts_organizations", on_replace: :delete)
+  end
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, [:id, :slug, :name, :acronym, :logo, :logo_thumbnail, :badges, :metrics, :created_at])
+    |> validate_required([:id, :slug, :name, :logo, :logo_thumbnail, :badges])
+  end
+end

--- a/apps/transport/lib/transport_web/controllers/notification_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/notification_controller.ex
@@ -96,8 +96,9 @@ defmodule TransportWeb.NotificationController do
     |> existing_reasons()
   end
 
-  defp contact_for_user(%Plug.Conn{assigns: %{current_user: current_user}}) do
-    TransportWeb.SessionController.find_or_create_contact(current_user)
+  @spec contact_for_user(Plug.Conn.t()) :: DB.Contact.t()
+  defp contact_for_user(%Plug.Conn{assigns: %{current_user: %{"id" => user_id}}}) do
+    DB.Repo.get_by!(DB.Contact, datagouv_user_id: user_id)
   end
 
   defp existing_reasons(%Ecto.Query{} = query) do

--- a/apps/transport/priv/repo/migrations/20230630074914_add_organization.exs
+++ b/apps/transport/priv/repo/migrations/20230630074914_add_organization.exs
@@ -1,0 +1,24 @@
+defmodule DB.Repo.Migrations.AddOrganization do
+  use Ecto.Migration
+
+  def change do
+    create table(:organization, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :slug, :string
+      add :name, :string
+      add :acronym, :string
+      add :logo, :string
+      add :logo_thumbnail, :string
+      add :badges, {:array, :map}
+      add :metrics, :map
+      add :created_at, :utc_datetime_usec
+    end
+
+    create(unique_index(:organization, [:slug]))
+
+    create table(:contacts_organizations, primary_key: false) do
+      add(:contact_id, references(:contact, on_delete: :delete_all), null: false)
+      add(:organization_id, references(:organization, type: :string, on_delete: :delete_all), null: false)
+    end
+  end
+end

--- a/apps/transport/test/transport_web/controllers/notification_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/notification_controller_test.exs
@@ -56,10 +56,7 @@ defmodule TransportWeb.NotificationControllerTest do
         conn
         |> init_test_session(%{
           current_user: %{
-            "id" => datagouv_user_id,
-            "first_name" => "John",
-            "last_name" => "Doe",
-            "email" => "john@example.fr"
+            "id" => datagouv_user_id
           }
         })
 


### PR DESCRIPTION
Ajout d'une nouvelle table `organization` contenant les données des organisations data.gouv.fr. Ces données sont remplies pour le moment par le biais de la connexion des utilisateurs, plus tard il faudra mettre à jour ces données plus fréquemment et avoir un many-to-many avec `dataset`