### PR TITLE
Amélioration du script d'analyse des IRVE dynamiques

### DIFF
--- a/scripts/irve/dynamic-irve.exs
+++ b/scripts/irve/dynamic-irve.exs
@@ -71,7 +71,7 @@ defmodule IRVECheck do
       |> Enum.to_list()
       |> Enum.sort()
 
-    {List.first(data), List.last(data)}
+    {List.first(data), List.last(data), Enum.count(data)}
   end
 end
 

--- a/scripts/irve/dynamic-irve.exs
+++ b/scripts/irve/dynamic-irve.exs
@@ -31,8 +31,13 @@ unless is_nil(datasets["next_page"]), do: raise("should not have next page")
 resources =
   datasets["data"]
   |> Enum.flat_map(fn dataset ->
+    # IO.inspect(dataset, IEx.inspect_opts())
+
     dataset["resources"]
     |> Enum.filter(fn r -> r["schema"]["name"] == "etalab/schema-irve-dynamique" end)
+    |> Enum.map(fn r ->
+      Map.put(r, "dataset_url", dataset["page"])
+    end)
   end)
   |> Enum.reject(fn r ->
     # https://www.data.gouv.fr/en/datasets/exemple-jeu-de-donnees-points-de-recharge-de-xxxxxx-donnees-statiques-et-dynamiques/
@@ -72,6 +77,8 @@ end
 
 resources
 |> Enum.each(fn r ->
+  IO.puts("\n" <> r["dataset_url"])
+
   IO.puts(
     r["url"] <>
       " --- " <>

--- a/scripts/irve/req_custom_cache.exs
+++ b/scripts/irve/req_custom_cache.exs
@@ -17,7 +17,7 @@ defmodule CustomCache do
     # TODO: handle a form of expiration - for now it is acceptable to wipe out the whole folder manually for me
     # NOTE: race condition here, for parallel queries
     if File.exists?(path = cache_path(request)) do
-      Logger.info("File found in cache (#{path})")
+      # Logger.info("File found in cache (#{path})")
       {request, load_cache(path)}
     else
       request


### PR DESCRIPTION
En lien avec:
- https://github.com/etalab/transport-site/issues/3219

Cela permet d'afficher l'url du dataset et aussi le nombre de lignes dans la ressource CSV, ça nous a servi avec @cyrilmorin aujourd'hui.