### PR TITLE
Tentative de suppression de l'instrumentation AppSignal sur les proxies

### DIFF
--- a/apps/gbfs/mix.exs
+++ b/apps/gbfs/mix.exs
@@ -49,9 +49,7 @@ defmodule GBFS.MixProject do
       {:shared, in_umbrella: true},
       {:exvcr, "~> 0.13", only: :test},
       {:mock, "~> 0.3.6", only: :test},
-      {:bypass, "~> 2.1", only: :test},
-      {:appsignal, "~> 2.0"},
-      {:appsignal_phoenix, "~> 2.0"}
+      {:bypass, "~> 2.1", only: :test}
     ]
   end
 end

--- a/apps/unlock/mix.exs
+++ b/apps/unlock/mix.exs
@@ -48,10 +48,7 @@ defmodule Unlock.MixProject do
       {:saxy, "~> 1.5"},
       {:mox, "~> 1.0.0", only: :test},
       {:ymlr, "~> 3.0", only: :test},
-      {:ecto, "~> 3.7", only: :test},
-      {:appsignal, "~> 2.0"},
-      {:appsignal_phoenix, "~> 2.0"}
-
+      {:ecto, "~> 3.7", only: :test}
     ]
   end
 end


### PR DESCRIPTION
Ils consomment l'essentiel des events et on va dépasser le quota rapidement au final.

Voir:
- #3274 

Je propose de déployer en l'état et de vérifier que ça suffit (sachant qu'on a une application umbrella).