### PR TITLE
ImportData : utilisation des infos de la ressource

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -771,10 +771,10 @@ defmodule Transport.ImportData do
     is_documentation = Map.get(resource, "type", "") == "documentation"
 
     cond do
-      is_gtfs_rt?(format) -> "gtfs-rt"
-      is_netex?(format) -> "NeTEx"
+      is_gtfs_rt?(resource) -> "gtfs-rt"
+      is_netex?(resource) -> "NeTEx"
       is_neptune?(format) -> "Neptune"
-      is_gtfs?(format) -> "GTFS"
+      is_gtfs?(resource) -> "GTFS"
       is_siri_lite?(format) -> "SIRI Lite"
       is_siri?(format) -> "SIRI"
       is_geojson?(resource, format) -> "geojson"

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -763,6 +763,9 @@ defmodule Transport.ImportData do
 
       iex> formated_format(%{"format" => "zip", "description" => "Lieux de mobilités au format netex"}, "locations", false)
       "NeTEx"
+
+      iex> formated_format(%{"format" => "zip", "title" => "files-netex-half-summer-autumn-2023.zip"}, "public-transit", false)
+      "NeTEx"
   """
   @spec formated_format(map(), binary(), bool()) :: binary()
   # credo:disable-for-next-line


### PR DESCRIPTION
Fixes #3277

Je suis **hyper** étonné que le code utilise actuellement uniquement le `format` pour le nettoyer alors qu'on a plein de logique qui utilise d'autres signaux dans le même code (titre, URL, description) ! 😱 

https://github.com/etalab/transport-site/blob/10ef2e8862015ae1411eb915f0f9afd88b784d7b/apps/transport/lib/transport/import_data.ex#L665-L675

Je change donc le code actuel où il est important de pouvoir se rattraper à d'autres signaux.