### PR TITLE
Améliore les performances pour /aoms

### DIFF
--- a/apps/transport/test/transport_web/controllers/aoms_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/aoms_controller_test.exs
@@ -26,7 +26,16 @@ defmodule TransportWeb.AOMsControllerTest do
     aom2 = insert(:aom)
 
     dataset =
-      insert(:dataset, legal_owners_aom: [aom, aom2], is_active: true, type: "public-transit", has_realtime: true)
+      insert(:dataset,
+        region: insert(:region),
+        aom: nil,
+        legal_owners_aom: [aom, aom2],
+        is_active: true,
+        type: "public-transit",
+        has_realtime: true
+      )
+
+    assert is_nil(dataset.aom_id)
 
     DB.Factory.insert_resource_and_friends(Date.utc_today() |> Date.add(10), dataset: dataset)
 


### PR DESCRIPTION
Fixes #3276

J'ai retravaillé le controller pour éviter de faire 2 fois une requête. Je rends la première requête légèrement plus générique et j'utilise `Enum.group_by` pour assembler les bouts nécessaires.

En local, avec un dump de prod du jour je suis sous les 2s.