### PR TITLE
Ajustements pour AppSignal

### DIFF
--- a/apps/gbfs/lib/gbfs/router.ex
+++ b/apps/gbfs/lib/gbfs/router.ex
@@ -5,6 +5,7 @@ defmodule GBFS.Router do
     plug(:accepts, ["json"])
     plug(CORSPlug, origin: "*", credentials: false)
     plug(PageCache, ttl_seconds: 30, cache_name: GBFS.Application.cache_name())
+    plug(TransportWeb.Plugs.AppSignalFilter)
   end
 
   pipeline :jcdecaux do

--- a/apps/gbfs/mix.exs
+++ b/apps/gbfs/mix.exs
@@ -49,7 +49,9 @@ defmodule GBFS.MixProject do
       {:shared, in_umbrella: true},
       {:exvcr, "~> 0.13", only: :test},
       {:mock, "~> 0.3.6", only: :test},
-      {:bypass, "~> 2.1", only: :test}
+      {:bypass, "~> 2.1", only: :test},
+      {:appsignal, "~> 2.0"},
+      {:appsignal_phoenix, "~> 2.0"}
     ]
   end
 end

--- a/apps/gbfs/mix.exs
+++ b/apps/gbfs/mix.exs
@@ -49,9 +49,7 @@ defmodule GBFS.MixProject do
       {:shared, in_umbrella: true},
       {:exvcr, "~> 0.13", only: :test},
       {:mock, "~> 0.3.6", only: :test},
-      {:bypass, "~> 2.1", only: :test},
-      {:appsignal, "~> 2.0"},
-      {:appsignal_phoenix, "~> 2.0"}
+      {:bypass, "~> 2.1", only: :test}
     ]
   end
 end

--- a/apps/shared/lib/appsignal_filter.ex
+++ b/apps/shared/lib/appsignal_filter.ex
@@ -15,7 +15,7 @@ defmodule TransportWeb.Plugs.AppSignalFilter do
 
   def init(options), do: options
 
-  def call(conn, _opts) do
+  def call(%Plug.Conn{} = conn, _opts) do
     if function_exported?(Appsignal.Tracer, :root_span, 0) do
       if must_ignore?(conn) do
         Appsignal.Tracer.root_span()

--- a/apps/shared/lib/appsignal_filter.ex
+++ b/apps/shared/lib/appsignal_filter.ex
@@ -1,0 +1,33 @@
+defmodule TransportWeb.Plugs.AppSignalFilter do
+  @moduledoc """
+  An attempt to reduce the volume of events sent to AppSignal in order to keep a lower bill.
+
+  This sets the namespace to a well-known "ignore" value, which must be added to the
+  AppSignal `ignore_namespaces` config value.
+
+  See: https://github.com/etalab/transport-site/issues/3274
+
+  The plug must be activated low-enough in the pipeline, otherwise the "ignore" value
+  won't be used and instead the middleware value will take precedence.
+
+  See: https://github.com/appsignal/appsignal-elixir/issues/865
+  """
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    if function_exported?(Appsignal.Tracer, :root_span, 0) do
+      if must_ignore?(conn) do
+        Appsignal.Tracer.root_span()
+        |> Appsignal.Span.set_namespace("ignore")
+      end
+    end
+
+    conn
+  end
+
+  # this method allows us to filter programmatically as needed
+  defp must_ignore?(conn) do
+    conn.host =~ ~r/proxy/i or conn.request_path =~ ~r/\/gbfs/i
+  end
+end

--- a/apps/shared/lib/appsignal_filter.ex
+++ b/apps/shared/lib/appsignal_filter.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.Plugs.AppSignalFilter do
   end
 
   # this method allows us to filter programmatically as needed
-  defp must_ignore?(conn) do
+  defp must_ignore?(%Plug.Conn{} = conn) do
     conn.host =~ ~r/proxy/i or conn.request_path =~ ~r/\/gbfs/i
   end
 end

--- a/apps/shared/mix.exs
+++ b/apps/shared/mix.exs
@@ -57,7 +57,10 @@ defmodule Shared.MixProject do
       {:jason, ">= 0.0.0"},
       {:ex_cldr_numbers, "~> 2.0"},
       {:cachex, "~> 3.5"},
-      {:ex_json_schema, "~> 0.9.1"}
+      {:ex_json_schema, "~> 0.9.1"},
+      {:appsignal, "~> 2.0"},
+      {:appsignal_phoenix, "~> 2.0"}
+
     ]
   end
 end

--- a/apps/shared/mix.exs
+++ b/apps/shared/mix.exs
@@ -61,7 +61,6 @@ defmodule Shared.MixProject do
       # added because of `TransportWeb.Plugs.AppSignalFilter`
       {:appsignal, "~> 2.0"},
       {:appsignal_phoenix, "~> 2.0"}
-
     ]
   end
 end

--- a/apps/shared/mix.exs
+++ b/apps/shared/mix.exs
@@ -58,6 +58,7 @@ defmodule Shared.MixProject do
       {:ex_cldr_numbers, "~> 2.0"},
       {:cachex, "~> 3.5"},
       {:ex_json_schema, "~> 0.9.1"},
+      # added because of `TransportWeb.Plugs.AppSignalFilter`
       {:appsignal, "~> 2.0"},
       {:appsignal_phoenix, "~> 2.0"}
 

--- a/apps/unlock/lib/router.ex
+++ b/apps/unlock/lib/router.ex
@@ -3,6 +3,7 @@ defmodule Unlock.Router do
 
   pipeline :api do
     plug(CORSPlug, origin: "*", expose: ["*"], credentials: false)
+    plug(TransportWeb.Plugs.AppSignalFilter)
   end
 
   scope "/" do

--- a/apps/unlock/mix.exs
+++ b/apps/unlock/mix.exs
@@ -48,10 +48,7 @@ defmodule Unlock.MixProject do
       {:saxy, "~> 1.5"},
       {:mox, "~> 1.0.0", only: :test},
       {:ymlr, "~> 3.0", only: :test},
-      {:ecto, "~> 3.7", only: :test},
-      {:appsignal, "~> 2.0"},
-      {:appsignal_phoenix, "~> 2.0"}
-
+      {:ecto, "~> 3.7", only: :test}
     ]
   end
 end

--- a/apps/unlock/mix.exs
+++ b/apps/unlock/mix.exs
@@ -48,7 +48,11 @@ defmodule Unlock.MixProject do
       {:saxy, "~> 1.5"},
       {:mox, "~> 1.0.0", only: :test},
       {:ymlr, "~> 3.0", only: :test},
-      {:ecto, "~> 3.7", only: :test}
+      {:ecto, "~> 3.7", only: :test},
+      # required for `TransportWeb.Plugs.AppSignalFilter`
+      {:shared, in_umbrella: true},
+      {:appsignal, "~> 2.0"},
+      {:appsignal_phoenix, "~> 2.0"}
     ]
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -216,7 +216,14 @@ config :appsignal, :config,
   send_session_data: false,
   # https://docs.appsignal.com/ruby/configuration/options.html#option-send_params
   send_params: false,
-  ignore_namespaces: ["ignore"]
+  ignore_namespaces: ["ignore"],
+  ignore_actions: [
+    # this one results in aggregates of everything already there
+    "GET /*_path",
+    # these ones kept to make sure we really filter out (double check)
+    "GET /gbfs/*_",
+    "Unlock.Controller#fetch"
+  ]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -216,6 +216,8 @@ config :appsignal, :config,
   send_session_data: false,
   # https://docs.appsignal.com/ruby/configuration/options.html#option-send_params
   send_params: false
+  send_params: false,
+  ignore_namespaces: ["ignore"]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -218,10 +218,15 @@ config :appsignal, :config,
   send_params: false,
   ignore_namespaces: ["ignore"],
   ignore_actions: [
-    # this one results in aggregates of everything already there
+    # without this action, requests will be counted twice
+    # I presume this is triggered by the way we route requests
+    # https://github.com/etalab/transport-site/blob/master/apps/transport/lib/transport_web/plugs/router.ex
     "GET /*_path",
-    # these ones kept to make sure we really filter out (double check)
+    # Same for GBFS - although it is filtered in the plug, a request
+    # will also be double-counted at the router level for some reason
     "GET /gbfs/*_",
+    # Here this is a duplicate precaution to ensure we exclude proxy
+    # traffic which generates a lot of AppSignal events
     "Unlock.Controller#fetch"
   ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -215,7 +215,6 @@ config :appsignal, :config,
   # https://docs.appsignal.com/ruby/configuration/options.html#option-send_session_data
   send_session_data: false,
   # https://docs.appsignal.com/ruby/configuration/options.html#option-send_params
-  send_params: false
   send_params: false,
   ignore_namespaces: ["ignore"]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -216,7 +216,10 @@ config :appsignal, :config,
   send_session_data: false,
   # https://docs.appsignal.com/ruby/configuration/options.html#option-send_params
   send_params: false,
+  # we use a plug which sets the namespace as ignore programmatically
+  # and here declare that the corresponding requests should be ignored
   ignore_namespaces: ["ignore"],
+  # but this is not always enough:
   ignore_actions: [
     # without this action, requests will be counted twice
     # I presume this is triggered by the way we route requests

--- a/config/config.exs
+++ b/config/config.exs
@@ -208,6 +208,15 @@ config :transport,
   security_email: "contact@transport.beta.gouv.fr",
   transport_tools_folder: Path.absname("transport-tools/")
 
+# For now, never send session data (containing sensitive data in our case) nor params,
+# even if this means less useful information.
+# See https://github.com/etalab/transport_deploy/issues/64
+config :appsignal, :config,
+  # https://docs.appsignal.com/ruby/configuration/options.html#option-send_session_data
+  send_session_data: false,
+  # https://docs.appsignal.com/ruby/configuration/options.html#option-send_params
+  send_params: false
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "datagouvfr.exs"


### PR DESCRIPTION
~~:warning: ce n'est pas bon, je ne reçois plus aucune donnée (EDIT: tout agrégé sous `[GET /*_path](https://appsignal.com/transport-dot-data-dot-gouv-dot-fr/sites/64a294f583eb67b60f035246/actions/web/GET%20%2F*_path)`) sur le staging après réactivation de la clé d'API, donc la PR semble poser un problème quelque part~~

Dans cette PR:
- Je tente de réduire l'utilisation du quota en filtrant les requêtes proxy et GBFS (https://github.com/etalab/transport-site/issues/3274, https://github.com/appsignal/appsignal-elixir/issues/865)
- Je supprime les données de session et les paramètres de ce qui est envoyé, car cela contient de la donnée sensible (https://github.com/etalab/transport_deploy/issues/64) - mais ça ne purgera pas ce qui a déjà été envoyé (je verrai avec le support si on peut faire quelque chose, sinon cela sera purgé dans 60 jours automatiquement)
- Je supprime des doublons de reporting (`"GET /*_path"`) liés à la façon dont on fait le routage, et je fais ceinture et bretelle sur le filtrage du GBFS et du reporting avec `ignore_actions`

C'est un peu plus "involved" que ce que j'aurais aimé je dois dire...

Prêt pour review mais je vais déployer et tester sur `prochainement`.