### PR TITLE
Contact et organisations : ne pas créer de doublons

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -106,8 +106,16 @@ defmodule DB.Contact do
     |> lowercase_email()
     |> put_hashed_fields()
     |> unique_constraint(:email_hash, error_key: :email, name: :contact_email_hash_index)
-    |> cast_assoc(:organizations)
+    |> put_assoc(:organizations, attrs |> organizations() |> Enum.map(&DB.Organization.changeset(find_org(&1), &1)))
   end
+
+  defp organizations(%{"organizations" => orgs}), do: orgs
+  defp organizations(%{organizations: orgs}), do: orgs
+  defp organizations(%{}), do: []
+
+  defp find_org(%{"id" => id}), do: DB.Repo.get(DB.Organization, id) || %DB.Organization{}
+  defp find_org(%{id: id}), do: DB.Repo.get(DB.Organization, id) || %DB.Organization{}
+  defp find_org(%{}), do: %DB.Organization{}
 
   defp validate_names_or_mailing_list_title(%Ecto.Changeset{} = changeset) do
     case Enum.map(~w(first_name last_name mailing_list_title)a, &get_field(changeset, &1)) do

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -1,5 +1,6 @@
 defmodule DB.ContactTest do
   use ExUnit.Case, async: true
+  import DB.Factory
   import Ecto.Query
 
   setup do
@@ -175,18 +176,22 @@ defmodule DB.ContactTest do
   end
 
   test "organisations" do
+    pan_org = %{
+      acronym: nil,
+      badges: [],
+      id: Ecto.UUID.generate(),
+      logo: "https://static.data.gouv.fr/avatars/85/53e0a3845e43eb87fb905032aaa389-original.png",
+      logo_thumbnail: "https://static.data.gouv.fr/avatars/85/53e0a3845e43eb87fb905032aaa389-100.png",
+      name: "PAN",
+      slug: "equipe-transport-data-gouv-fr"
+    }
+
+    insert(:organization, pan_org)
+
     sample_contact_args()
     |> Map.merge(%{
       organizations: [
-        %{
-          "acronym" => nil,
-          "badges" => [],
-          "id" => Ecto.UUID.generate(),
-          "logo" => "https://static.data.gouv.fr/avatars/85/53e0a3845e43eb87fb905032aaa389-original.png",
-          "logo_thumbnail" => "https://static.data.gouv.fr/avatars/85/53e0a3845e43eb87fb905032aaa389-100.png",
-          "name" => "PAN",
-          "slug" => "equipe-transport-data-gouv-fr"
-        },
+        pan_org,
         %{
           "acronym" => nil,
           "badges" => [],

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -252,6 +252,10 @@ defmodule DB.Factory do
     %DB.ResourceRelated{}
   end
 
+  def organization_factory do
+    %DB.Organization{}
+  end
+
   def insert_contact(%{} = args \\ %{}) do
     %{
       first_name: "John",


### PR DESCRIPTION
Fixes #3281

Bug constaté : quand on crée/met à jour un contact, le code actuel tente dans tous les cas de créer une organisation, même si celle-ci existe.

Cette  PR adapte le code pour gérer le cas. Doc pertinente, [Constraints and Upserts](https://hexdocs.pm/ecto/constraints-and-upserts.html)