### PR TITLE
AvailabilityChecker : accepte réponse 405 pour SIRI

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -33,7 +33,7 @@ defmodule Transport.AvailabilityChecker do
 
   def available?("SIRI", url, _) when is_binary(url) do
     case http_client().get(url, [], follow_redirect: true) do
-      {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code == 401 ->
+      {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code in [401, 405] ->
         true
 
       _ ->

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -360,7 +360,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 status code is considered successful."
+msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -360,7 +360,7 @@ msgstr "En savoir plus"
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 comme étant disponible."
+msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -33,13 +33,24 @@ defmodule Transport.AvailabilityCheckerTest do
     refute AvailabilityChecker.available?("GTFS", "url500")
   end
 
-  test "SIRI resource, 401" do
-    Transport.HTTPoison.Mock
-    |> expect(:get, fn _url, [], [follow_redirect: true] ->
-      {:ok, %HTTPoison.Response{status_code: 401}}
-    end)
+  describe "SIRI resource" do
+    test "401" do
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+        {:ok, %HTTPoison.Response{status_code: 401}}
+      end)
 
-    assert AvailabilityChecker.available?("SIRI", "url401")
+      assert AvailabilityChecker.available?("SIRI", "url401")
+    end
+
+    test "405" do
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+        {:ok, %HTTPoison.Response{status_code: 405}}
+      end)
+
+      assert AvailabilityChecker.available?("SIRI", "url405")
+    end
   end
 
   test "head NOT supported, fallback on stream method" do


### PR DESCRIPTION
Il arrive que des endpoints SIRI répondent des 405 en HEAD ou en GET, ce qui n'est pas si étonnant que ça.

Pour ne pas les pénaliser pour le moment, on accepte ces réponses, uniquement pour des ressources SIRI.

Il faudra supprimer l'indisponibilité de [la ressource SIRI](https://transport.data.gouv.fr/resources/81029)

```sql
delete from resource_unavailability where resource_id = 81029;
```