### PR TITLE
Add a job to update subscriptions to appropriate role values

### DIFF
--- a/apps/transport/lib/jobs/notification_subscription_producer_job.ex
+++ b/apps/transport/lib/jobs/notification_subscription_producer_job.ex
@@ -1,0 +1,29 @@
+defmodule Transport.Jobs.NotificationSubscriptionProducerJob do
+  @moduledoc """
+  Job in charge of updating `NotificationSubscription` objects to set the role
+  to `producer` for relevant contacts (they are members of an organization for which
+  we have datasets and they are subscribed to).
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    ids =
+      DB.NotificationSubscription.base_query()
+      |> join(:inner, [notification_subscription: ns], c in assoc(ns, :contact), as: :contact)
+      |> join(:inner, [contact: c], c in assoc(c, :organizations), as: :organization)
+      |> join(:inner, [notification_subscription: ns, contact: c, organization: o], d in assoc(ns, :dataset),
+        on: d.organization_id == o.id,
+        as: :dataset
+      )
+      |> where([notification_subscription: ns], ns.role == :reuser)
+      |> select([notification_subscription: ns], ns.id)
+
+    DB.NotificationSubscription.base_query()
+    |> where([notification_subscription: ns], ns.id in subquery(ids))
+    |> DB.Repo.update_all(set: [role: :producer])
+
+    :ok
+  end
+end

--- a/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
+++ b/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
@@ -1,0 +1,56 @@
+defmodule Transport.Test.Transport.Jobs.NotificationSubscriptionProducerJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.NotificationSubscriptionProducerJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "updates relevant notification subscriptions" do
+    reuser = insert_contact()
+
+    producer =
+      insert_contact(%{
+        organizations: [
+          %{
+            "acronym" => nil,
+            "badges" => [],
+            "id" => org_id = Ecto.UUID.generate(),
+            "logo" => "https://example.com/original.png",
+            "logo_thumbnail" => "https://example.com/100.png",
+            "name" => "Big Corp",
+            "slug" => "foo"
+          }
+        ]
+      })
+
+    dataset = insert(:dataset, organization_id: org_id)
+
+    ns_reuser =
+      insert(:notification_subscription, %{
+        reason: :expiration,
+        source: :admin,
+        dataset_id: dataset.id,
+        contact_id: reuser.id,
+        role: :reuser
+      })
+
+    # Should be updated: the contact is a producer for this dataset and
+    # the subscription's role is set to `reuser`
+    ns_producer =
+      insert(:notification_subscription, %{
+        reason: :expiration,
+        source: :admin,
+        dataset_id: dataset.id,
+        contact_id: producer.id,
+        role: :reuser
+      })
+
+    assert :ok == perform_job(NotificationSubscriptionProducerJob, %{})
+
+    assert [%DB.NotificationSubscription{role: :reuser}, %DB.NotificationSubscription{role: :producer}] =
+             DB.Repo.reload!([ns_reuser, ns_producer])
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -130,7 +130,8 @@ oban_crontab_all_envs =
         {"45 2 * * *", Transport.Jobs.RemoveHistoryJob,
          args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}},
         {"0 16 * * *", Transport.Jobs.DatasetQualityScoreDispatcher},
-        {"40 3 * * *", Transport.Jobs.UpdateContactsJob}
+        {"40 3 * * *", Transport.Jobs.UpdateContactsJob},
+        {"10 5 * * *", Transport.Jobs.NotificationSubscriptionProducerJob}
       ]
 
     :dev ->


### PR DESCRIPTION
Ajout d'un job quotidien en charge de mettre à jour les abonnements aux notifications.

Pour les abonnements à un JDD, identifie les abonnements où le role a été indiqué comme `reuser` mais où le contact associé à un role de producteur pour le JDD faisant l'objet de l'abonnement.