### PR TITLE
ImportData: plus restrictif pour GTFS-RT

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -755,6 +755,9 @@ defmodule Transport.ImportData do
 
       iex> formated_format(%{"format" => "zip", "title" => "files-netex-half-summer-autumn-2023.zip"}, "public-transit", false)
       "NeTEx"
+
+      iex> formated_format(%{"format" => "zip", "title" => "gtfs.zip", "description" => "GTFS qui va avec le GTFS-RT"}, "public-transit", false)
+      "GTFS"
   """
   @spec formated_format(map(), binary(), bool()) :: binary()
   # credo:disable-for-next-line
@@ -763,7 +766,7 @@ defmodule Transport.ImportData do
     is_documentation = Map.get(resource, "type", "") == "documentation"
 
     cond do
-      is_gtfs_rt?(resource) -> "gtfs-rt"
+      is_gtfs_rt?(format) -> "gtfs-rt"
       is_netex?(resource) -> "NeTEx"
       is_gtfs?(resource) -> "GTFS"
       is_siri_lite?(format) -> "SIRI Lite"


### PR DESCRIPTION
#3278 a amené quelques problèmes : des ressources GTFS ont été détectées comme étant désormais du GTFS-RT, à cause de la description de la ressource principalement.

Je rétablis ce qu'on avait avant pour le GTFS-RT et j'ajoute un test représentatif d'un cas classique.