### PR TITLE
Contact : mise à jour des organisations explicite

### DIFF
--- a/apps/transport/lib/transport_web/controllers/session_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/session_controller.ex
@@ -71,20 +71,19 @@ defmodule TransportWeb.SessionController do
         |> DB.Contact.changeset(%{
           first_name: first_name,
           last_name: last_name,
-          email: email,
-          organizations: organizations
+          email: email
         })
         |> DB.Repo.update!()
 
       %DB.Contact{mailing_list_title: mailing_list_title} = contact when mailing_list_title != nil ->
         contact
-        |> DB.Contact.changeset(%{email: email, organizations: organizations})
+        |> DB.Contact.changeset(%{email: email})
         |> DB.Repo.update!()
 
       nil ->
         find_contact_by_email_or_create(user_params)
     end
-    |> DB.Contact.changeset(%{last_login_at: DateTime.utc_now()})
+    |> DB.Contact.changeset(%{last_login_at: DateTime.utc_now(), organizations: organizations})
     |> DB.Repo.update!()
   end
 
@@ -92,8 +91,7 @@ defmodule TransportWeb.SessionController do
          "id" => user_id,
          "first_name" => first_name,
          "last_name" => last_name,
-         "email" => email,
-         "organizations" => organizations
+         "email" => email
        }) do
     case DB.Repo.get_by(DB.Contact, email_hash: email) do
       %DB.Contact{mailing_list_title: nil} = contact ->
@@ -101,14 +99,13 @@ defmodule TransportWeb.SessionController do
         |> DB.Contact.changeset(%{
           datagouv_user_id: user_id,
           first_name: first_name,
-          last_name: last_name,
-          organizations: organizations
+          last_name: last_name
         })
         |> DB.Repo.update!()
 
       %DB.Contact{mailing_list_title: mailing_list_title} = contact when mailing_list_title != nil ->
         contact
-        |> DB.Contact.changeset(%{datagouv_user_id: user_id, organizations: organizations})
+        |> DB.Contact.changeset(%{datagouv_user_id: user_id})
         |> DB.Repo.update!()
 
       nil ->
@@ -116,8 +113,7 @@ defmodule TransportWeb.SessionController do
           datagouv_user_id: user_id,
           first_name: first_name,
           last_name: last_name,
-          email: email,
-          organizations: organizations
+          email: email
         }
         |> DB.Contact.insert!()
     end

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -223,6 +223,18 @@ defmodule DB.ContactTest do
              |> Enum.count()
 
     assert 2 == DB.Organization |> DB.Repo.all() |> Enum.count()
+
+    # Not passing orgs should not delete orgs associated to the contact
+    contact
+    |> DB.Contact.changeset(%{first_name: "Robert"})
+    |> DB.Repo.update!()
+
+    assert 1 ==
+         contact
+         |> DB.Repo.reload!()
+         |> DB.Repo.preload([:organizations])
+         |> Map.fetch!(:organizations)
+         |> Enum.count()
   end
 
   defp sample_contact_args do

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -230,11 +230,11 @@ defmodule DB.ContactTest do
     |> DB.Repo.update!()
 
     assert 1 ==
-         contact
-         |> DB.Repo.reload!()
-         |> DB.Repo.preload([:organizations])
-         |> Map.fetch!(:organizations)
-         |> Enum.count()
+             contact
+             |> DB.Repo.reload!()
+             |> DB.Repo.preload([:organizations])
+             |> Map.fetch!(:organizations)
+             |> Enum.count()
   end
 
   defp sample_contact_args do

--- a/apps/transport/test/transport_web/controllers/session_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/session_controller_test.exs
@@ -69,6 +69,10 @@ defmodule TransportWeb.SessionControllerTest do
              }
            ] = DB.Repo.all(DB.Organization)
 
+    assert [
+             %DB.Organization{id: ^organization_id}
+           ] = DB.Contact |> DB.Repo.one!() |> DB.Repo.preload(:organizations) |> Map.fetch!(:organizations)
+
     assert_in_delta last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
   end
 


### PR DESCRIPTION
Corrige un bug lié aux organisations des contacts : quand les infos sur les organisations n'étaient pas passées, le contact n'était plus associé aux organisations.

J'adapte le code pour mettre à jour les infos sur ses organisations uniquement quand on passe les clés pertinentes, le reste du temps on n'y touche pas.

En regardant [put_assoc/4](https://hexdocs.pm/ecto/Ecto.Changeset.html#put_assoc/4)

> This function is used to work with associations as a whole. For example, if a Post has many Comments, it allows you to add, remove or change all comments at once.

Le code précédent donnait `[]` à `put_assoc` quand la clé était absente, supprimant les associations existantes.

À noter que le bug n'était pas si voyant car https://github.com/etalab/transport-site/pull/3271 met à jour les organisations toutes les nuits.