### PR TITLE
Data checker : indique si JDD est soumis à l'article 122

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -234,6 +234,7 @@ defmodule Transport.DataChecker do
   defp make_str({delay, datasets}) do
     dataset_str = fn %Dataset{} = dataset ->
       "#{link_and_name(dataset, :custom_title)} (#{expiration_notification_enabled_str(dataset)}) #{climate_resilience_str(dataset)}"
+      |> String.trim()
     end
 
     """

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -223,9 +223,17 @@ defmodule Transport.DataChecker do
     end
   end
 
+  defp climate_resilience_str(%Dataset{} = dataset) do
+    if DB.Dataset.climate_resilience_bill?(dataset) do
+      "⚖️🗺️ article 122"
+    else
+      ""
+    end
+  end
+
   defp make_str({delay, datasets}) do
     dataset_str = fn %Dataset{} = dataset ->
-      "#{link_and_name(dataset, :custom_title)} (#{expiration_notification_enabled_str(dataset)})"
+      "#{link_and_name(dataset, :custom_title)} (#{expiration_notification_enabled_str(dataset)}) #{climate_resilience_str(dataset)}"
     end
 
     """

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -196,7 +196,10 @@ defmodule Transport.DataCheckerTest do
 
   describe "outdated_data job" do
     test "sends email to our team + relevant contact before expiry" do
-      dataset = insert(:dataset, is_active: true, custom_title: "Dataset custom title")
+      dataset =
+        insert(:dataset, is_active: true, custom_title: "Dataset custom title", custom_tags: ["loi-climat-resilience"])
+
+      assert DB.Dataset.climate_resilience_bill?(dataset)
       # fake a resource expiring today
       resource = insert(:resource, dataset: dataset, format: "GTFS")
 
@@ -232,7 +235,7 @@ defmodule Transport.DataCheckerTest do
         assert body =~ ~r/Jeux de données expirant demain :/
 
         assert body =~
-                 "#{dataset.custom_title} - http://127.0.0.1:5100/datasets/#{dataset.slug} (✅ notification automatique)"
+                 "#{dataset.custom_title} - http://127.0.0.1:5100/datasets/#{dataset.slug} (✅ notification automatique) ⚖️🗺️ article 122"
 
         :ok
       end)
@@ -245,6 +248,7 @@ defmodule Transport.DataCheckerTest do
         assert subject == "Jeu de données arrivant à expiration"
         assert body =~ ~r/Une ressource associée au jeu de données expire demain/
         refute body =~ "notification automatique"
+        refute body =~ "article 122"
         :ok
       end)
 


### PR DESCRIPTION
Indique si un JDD est soumis à l'article 122 pour l'e-mail adressé à notre équipe pour faciliter le suivi de la péremption des JDDs.

[Exemple d'un e-mail existant](https://app.frontapp.com/open/cnv_xrpw1ue?key=IIwRSvbyroXRloYRL8Dj9aU32nEWuIL7)