### PR TITLE
3246 Rajout des IRVE dans les GeoData

### DIFF
--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -65,12 +65,12 @@ defmodule Transport.Jobs.BaseGeoData do
     stream
     |> IO.binstream(:line)
     |> CSV.decode(
-      separator: opts[:separator_char],
-      escape_character: opts[:escape_char],
+      separator: Keyword.fetch!(opts, :separator_char),
+      escape_character: Keyword.fetch!(opts, :escape_char),
       headers: true,
       validate_row_length: true
     )
-    |> Stream.filter(opts[:filter_fn])
+    |> Stream.filter(Keyword.fetch!(opts, :filter_fn))
     |> Stream.map(fn {:ok, m} -> m end)
     |> Stream.map(prepare_data_fn)
   end

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -58,6 +58,16 @@ defmodule Transport.Jobs.BaseGeoData do
     s |> string_to_float() |> Float.round(6)
   end
 
+  def prepare_csv_data_for_import(body, prepare_data_fn, {separator_char, escape_char} \\ {?, , ?"}) do
+    {:ok, stream} = StringIO.open(body)
+
+    stream
+    |> IO.binstream(:line)
+    |> CSV.decode(separator: separator_char, escape_character: escape_char, headers: true, validate_row_length: true)
+    |> Stream.map(fn {:ok, m} -> m end)
+    |> Stream.map(prepare_data_fn)
+  end
+
   # remove spaces (U+0020) and non-break spaces (U+00A0) from the string
   defp string_to_float(s), do: s |> String.trim() |> String.replace([" ", " "], "") |> String.to_float()
 end

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -64,7 +64,12 @@ defmodule Transport.Jobs.BaseGeoData do
 
     stream
     |> IO.binstream(:line)
-    |> CSV.decode(separator: opts[:separator_char], escape_character: opts[:escape_char], headers: true, validate_row_length: true)
+    |> CSV.decode(
+      separator: opts[:separator_char],
+      escape_character: opts[:escape_char],
+      headers: true,
+      validate_row_length: true
+    )
     |> Stream.filter(opts[:filter_fn])
     |> Stream.map(fn {:ok, m} -> m end)
     |> Stream.map(prepare_data_fn)

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -58,13 +58,14 @@ defmodule Transport.Jobs.BaseGeoData do
     s |> string_to_float() |> Float.round(6)
   end
 
-  def prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {separator_char, escape_char} \\ {?,, ?"}) do
+  def prepare_csv_data_for_import(body, prepare_data_fn, opts \\ []) do
+    opts = Keyword.validate!(opts, separator_char: ?,, escape_char: ?", filter_fn: fn _ -> true end)
     {:ok, stream} = StringIO.open(body)
 
     stream
     |> IO.binstream(:line)
-    |> CSV.decode(separator: separator_char, escape_character: escape_char, headers: true, validate_row_length: true)
-    |> Stream.filter(filter_fn || (& &1))
+    |> CSV.decode(separator: opts[:separator_char], escape_character: opts[:escape_char], headers: true, validate_row_length: true)
+    |> Stream.filter(opts[:filter_fn])
     |> Stream.map(fn {:ok, m} -> m end)
     |> Stream.map(prepare_data_fn)
   end

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -49,7 +49,7 @@ defmodule Transport.Jobs.BaseGeoData do
         %{status_code: 200, body: body} = http_client.get!(permanent_url)
         insert_data(body, geo_data_import_id, prepare_data_for_insert_fn)
       end,
-      timeout: 1_000_000
+      timeout: 60_000
     )
   end
 

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -58,13 +58,13 @@ defmodule Transport.Jobs.BaseGeoData do
     s |> string_to_float() |> Float.round(6)
   end
 
-  def prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {separator_char, escape_char} \\ {?, , ?"}) do
+  def prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {separator_char, escape_char} \\ {?,, ?"}) do
     {:ok, stream} = StringIO.open(body)
 
     stream
     |> IO.binstream(:line)
     |> CSV.decode(separator: separator_char, escape_character: escape_char, headers: true, validate_row_length: true)
-    |> Stream.filter(filter_fn || &(&1))
+    |> Stream.filter(filter_fn || (& &1))
     |> Stream.map(fn {:ok, m} -> m end)
     |> Stream.map(prepare_data_fn)
   end

--- a/apps/transport/lib/jobs/geo_data/base.ex
+++ b/apps/transport/lib/jobs/geo_data/base.ex
@@ -58,12 +58,13 @@ defmodule Transport.Jobs.BaseGeoData do
     s |> string_to_float() |> Float.round(6)
   end
 
-  def prepare_csv_data_for_import(body, prepare_data_fn, {separator_char, escape_char} \\ {?, , ?"}) do
+  def prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {separator_char, escape_char} \\ {?, , ?"}) do
     {:ok, stream} = StringIO.open(body)
 
     stream
     |> IO.binstream(:line)
     |> CSV.decode(separator: separator_char, escape_character: escape_char, headers: true, validate_row_length: true)
+    |> Stream.filter(filter_fn || &(&1))
     |> Stream.map(fn {:ok, m} -> m end)
     |> Stream.map(prepare_data_fn)
   end

--- a/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
@@ -38,6 +38,6 @@ defmodule Transport.Jobs.BNLCToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn)
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, nil, prepare_data_fn)
   end
 end

--- a/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/bnlc_to_geo_data.ex
@@ -38,6 +38,6 @@ defmodule Transport.Jobs.BNLCToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, nil, prepare_data_fn)
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn)
   end
 end

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -1,0 +1,8 @@
+defmodule Transport.Jobs.IRVEToGeoData do
+  @moduledoc """
+  Job in charge of taking the charge stations stored in the Base nationale des Infrastructures de Recharge pour Véhicules Électriques and storing the result in the `geo_data` table.
+  """
+
+  def prepare_data_for_insert(body, geo_data_import_id) do
+  end
+end

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -10,8 +10,10 @@ defmodule Transport.Jobs.IRVEToGeoData do
 
 
   def perform(%{}) do # This could be shared with some options between files
-    [resource] = relevant_dataset() |> DB.Dataset.official_resources() |> Enum.filter(&(&1.format == "csv"))
+  # This is ugly, I need to learn more about Ecto queries
+   resource = relevant_dataset() |> DB.Dataset.official_resources() |> Enum.filter(&(&1.format == "csv" && &1.type == "main")) |> hd |> dbg
 
+   # The following line crashes with my dev database
     Transport.Jobs.BaseGeoData.import_replace_data(resource, &prepare_data_for_insert/2)
 
     :ok

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -6,7 +6,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
   import Ecto.Query
   require Logger
 
-  @etalab_organization_id "534fff75a3a7292c64a77de4"
+  @datagouv_organization_id "646b7187b50b2a93b1ae3d45"
   @resource_datagouv_id "8d9398ae-3037-48b2-be19-412c24561fbb"
 
   @impl Oban.Worker
@@ -41,7 +41,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
   def relevant_dataset do
     DB.Dataset.base_query()
     |> preload(:resources)
-    |> where([d], d.type == "charging-stations" and d.organization_id == @etalab_organization_id)
+    |> where([d], d.type == "charging-stations" and d.organization_id == @datagouv_organization_id)
     |> DB.Repo.one!()
   end
 end

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -2,8 +2,20 @@ defmodule Transport.Jobs.IRVEToGeoData do
   @moduledoc """
   Job in charge of taking the charge stations stored in the Base nationale des Infrastructures de Recharge pour Véhicules Électriques and storing the result in the `geo_data` table.
   """
+
+  use Oban.Worker, max_attempts: 3
   import Ecto.Query
   alias NimbleCSV.RFC4180, as: CSV
+  require Logger
+
+
+  def perform(%{}) do # This could be shared with some options between files
+    [resource] = relevant_dataset() |> DB.Dataset.official_resources() |> Enum.filter(&(&1.format == "csv"))
+
+    Transport.Jobs.BaseGeoData.import_replace_data(resource, &prepare_data_for_insert/2)
+
+    :ok
+  end
 
 
   def prepare_data_for_insert(body, geo_data_import_id) do

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -35,7 +35,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, nil, prepare_data_fn)
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn)
   end
 
   def relevant_dataset do

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -2,7 +2,30 @@ defmodule Transport.Jobs.IRVEToGeoData do
   @moduledoc """
   Job in charge of taking the charge stations stored in the Base nationale des Infrastructures de Recharge pour Véhicules Électriques and storing the result in the `geo_data` table.
   """
+  alias NimbleCSV.RFC4180, as: CSV
+
 
   def prepare_data_for_insert(body, geo_data_import_id) do
+    body
+    |> CSV.parse_string(skip_headers: false)
+    |> Stream.transform([], fn r, acc ->
+      if acc == [] do
+        {%{}, r}
+      else
+        {[acc |> Enum.zip(r) |> Enum.into(%{})], acc}
+      end
+    end)
+    |> Stream.map(fn m -> # Purquoi dans les parkings relais on met un :ok ?
+      %{
+        geo_data_import_id: geo_data_import_id,
+        geom: %Geo.Point{
+          coordinates:
+            {m["consolidated_longitude"] |> Transport.Jobs.BaseGeoData.parse_coordinate(),
+             m["consolidated_latitude"] |> Transport.Jobs.BaseGeoData.parse_coordinate()},
+          srid: 4326
+        },
+        payload: m |> Map.drop(["consolidated_longitude", "consolidated_latitude", "coordonnesXY"])
+      }
+    end)
   end
 end

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -2,7 +2,6 @@ defmodule Transport.Jobs.IRVEToGeoData do
   @moduledoc """
   Job in charge of taking the charge stations stored in the Base nationale des Infrastructures de Recharge pour Véhicules Électriques and storing the result in the `geo_data` table.
   """
-
   use Oban.Worker, max_attempts: 3
   import Ecto.Query
   require Logger

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -35,7 +35,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn)
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, nil, prepare_data_fn)
   end
 
   def relevant_dataset do

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -22,13 +22,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
   end
 
   def prepare_data_for_insert(body, geo_data_import_id) do
-    {:ok, stream} = StringIO.open(body)
-
-    stream
-    |> IO.binstream(:line)
-    |> CSV.decode(separator: ?,, escape_character: ?", headers: true, validate_row_length: true)
-    |> Stream.map(fn {:ok, m} -> m end)
-    |> Stream.map(fn m ->
+    prepare_data_fn = fn m ->
       %{
         geo_data_import_id: geo_data_import_id,
         geom: %Geo.Point{
@@ -39,7 +33,9 @@ defmodule Transport.Jobs.IRVEToGeoData do
         },
         payload: m |> Map.drop(["consolidated_longitude", "consolidated_latitude", "coordonnesXY"])
       }
-    end)
+    end
+
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn)
   end
 
   def relevant_dataset do

--- a/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/irve_to_geo_data.ex
@@ -2,6 +2,7 @@ defmodule Transport.Jobs.IRVEToGeoData do
   @moduledoc """
   Job in charge of taking the charge stations stored in the Base nationale des Infrastructures de Recharge pour Véhicules Électriques and storing the result in the `geo_data` table.
   """
+  import Ecto.Query
   alias NimbleCSV.RFC4180, as: CSV
 
 
@@ -27,5 +28,13 @@ defmodule Transport.Jobs.IRVEToGeoData do
         payload: m |> Map.drop(["consolidated_longitude", "consolidated_latitude", "coordonnesXY"])
       }
     end)
+  end
+
+  def relevant_dataset do
+    # Etalab org ID is hardcoded, do not merge while it is the case
+    DB.Dataset.base_query()
+    |> preload(:resources)
+    |> where([d], d.type == "charging-stations" and d.organization_id == "534fff75a3a7292c64a77de4")
+    |> DB.Repo.one!()
   end
 end

--- a/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
@@ -32,6 +32,7 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
 
   def prepare_data_for_insert(body, geo_data_import_id) do
     filter_fn = fn {:ok, line} -> pr_count(line["nb_pr"]) > 0 end
+
     prepare_data_fn = fn m ->
       %{
         geo_data_import_id: geo_data_import_id,
@@ -45,6 +46,6 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {?;,?"})
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {?;, ?"})
   end
 end

--- a/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
@@ -46,6 +46,10 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn, filter_fn: filter_fn, separator_char: ?;, escape_char: ?")
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn,
+      filter_fn: filter_fn,
+      separator_char: ?;,
+      escape_char: ?"
+    )
   end
 end

--- a/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
@@ -31,13 +31,8 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
   defp pr_count(str), do: String.to_integer(str)
 
   def prepare_data_for_insert(body, geo_data_import_id) do
-    {:ok, stream} = StringIO.open(body)
-
-    stream
-    |> IO.binstream(:line)
-    |> CSV.decode(separator: ?;, headers: true, validate_row_length: true)
-    |> Stream.filter(fn {:ok, line} -> pr_count(line["nb_pr"]) > 0 end)
-    |> Stream.map(fn {:ok, m} ->
+    filter_fn = fn {:ok, line} -> pr_count(line["nb_pr"]) > 0 end
+    prepare_data_fn = fn m ->
       %{
         geo_data_import_id: geo_data_import_id,
         geom: %Geo.Point{
@@ -48,6 +43,8 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
         },
         payload: m |> Map.drop(["Xlong", "Ylat"])
       }
-    end)
+    end
+
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {?;,?"})
   end
 end

--- a/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
+++ b/apps/transport/lib/jobs/geo_data/parkings_relais_to_geo_data.ex
@@ -46,6 +46,6 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoData do
       }
     end
 
-    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, filter_fn, prepare_data_fn, {?;, ?"})
+    Transport.Jobs.BaseGeoData.prepare_csv_data_for_import(body, prepare_data_fn, filter_fn: filter_fn, separator_char: ?;, escape_char: ?")
   end
 end

--- a/apps/transport/test/transport/jobs/dataset_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_history_job_test.exs
@@ -104,7 +104,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
     %{id: id_2} = insert(:dataset)
     %{id: id_3} = insert(:dataset, is_active: false)
 
-    perform_job(Transport.Jobs.DatasetHistoryDispatcherJob, %{})
+    assert :ok = perform_job(Transport.Jobs.DatasetHistoryDispatcherJob, %{})
 
     assert_enqueued([worker: Transport.Jobs.DatasetHistoryJob, args: %{"dataset_id" => id_1}], 50)
     assert_enqueued([worker: Transport.Jobs.DatasetHistoryJob, args: %{"dataset_id" => id_2}], 50)

--- a/apps/transport/test/transport/jobs/dataset_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_history_job_test.exs
@@ -104,7 +104,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
     %{id: id_2} = insert(:dataset)
     %{id: id_3} = insert(:dataset, is_active: false)
 
-    Transport.Jobs.DatasetHistoryDispatcherJob.perform(%{})
+    perform_job(Transport.Jobs.DatasetHistoryDispatcherJob, %{})
 
     assert_enqueued([worker: Transport.Jobs.DatasetHistoryJob, args: %{"dataset_id" => id_1}], 50)
     assert_enqueued([worker: Transport.Jobs.DatasetHistoryJob, args: %{"dataset_id" => id_2}], 50)

--- a/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
@@ -71,14 +71,14 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @bnlc_content} end)
 
     # launch job
-    perform_job(BNLCToGeoData, %{})
+    assert :ok = perform_job(BNLCToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
 
     # relaunch job
-    perform_job(BNLCToGeoData, %{})
+    assert :ok = perform_job(BNLCToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -92,7 +92,7 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
       })
 
     # relaunch job
-    perform_job(BNLCToGeoData, %{})
+    assert :ok = perform_job(BNLCToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
@@ -1,5 +1,6 @@
 defmodule Transport.Jobs.BNLCToGeoDataTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.{BaseGeoData, BNLCToGeoData}
   import DB.Factory
   import Mox
@@ -70,14 +71,14 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @bnlc_content} end)
 
     # launch job
-    Transport.Jobs.BNLCToGeoData.perform(%{})
+    perform_job(BNLCToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
 
     # relaunch job
-    Transport.Jobs.BNLCToGeoData.perform(%{})
+    perform_job(BNLCToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -91,7 +92,7 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
       })
 
     # relaunch job
-    Transport.Jobs.BNLCToGeoData.perform(%{})
+    perform_job(BNLCToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -89,14 +89,14 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @irve_content} end)
 
     # launch job
-    perform_job(IRVEToGeoData, %{})
+    assert :ok = perform_job(IRVEToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
 
     # relaunch job
-    perform_job(IRVEToGeoData, %{})
+    assert :ok = perform_job(IRVEToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -110,7 +110,7 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
       })
 
     # relaunch job
-    perform_job(IRVEToGeoData, %{})
+    assert :ok = perform_job(IRVEToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -25,8 +25,6 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
 
   test "import an IRVE to the DB" do
     %{id: id} = insert(:geo_data_import)
-    # Uncomment to test only the prepare_data_for_insert function
-    # row1 = IRVEToGeoData.prepare_data_for_insert(@irve_content, id) |> Enum.take(1) |> hd
     BaseGeoData.insert_data(@irve_content, id, &IRVEToGeoData.prepare_data_for_insert/2)
     [row1 | _t] = DB.GeoData |> DB.Repo.all()
 

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -1,5 +1,6 @@
 defmodule Transport.Jobs.IRVEToGeoDataTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.{BaseGeoData, IRVEToGeoData}
   import DB.Factory
   import Mox
@@ -88,14 +89,14 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @irve_content} end)
 
     # launch job
-    Transport.Jobs.IRVEToGeoData.perform(%{})
+    perform_job(IRVEToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
 
     # relaunch job
-    Transport.Jobs.IRVEToGeoData.perform(%{})
+    perform_job(IRVEToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -109,7 +110,7 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
       })
 
     # relaunch job
-    Transport.Jobs.IRVEToGeoData.perform(%{})
+    perform_job(IRVEToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -23,7 +23,6 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     organization_id: "534fff75a3a7292c64a77de4"
   }
 
-
   test "import an IRVE to the DB" do
     %{id: id} = insert(:geo_data_import)
     # Uncomment to test only the prepare_data_for_insert function
@@ -47,8 +46,8 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
   end
 
   test "Finds the relevant dataset" do
-     %DB.Dataset{id: dataset_id} = insert(:dataset, @dataset_info)
-     assert %DB.Dataset{id: ^dataset_id} = IRVEToGeoData.relevant_dataset()
+    %DB.Dataset{id: dataset_id} = insert(:dataset, @dataset_info)
+    assert %DB.Dataset{id: ^dataset_id} = IRVEToGeoData.relevant_dataset()
   end
 
   test "IRVE data update logic" do
@@ -93,7 +92,6 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     # launch job
     Transport.Jobs.IRVEToGeoData.perform(%{})
 
-
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
@@ -119,6 +117,6 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()
     assert geo_data_import_2 !== geo_data_import_1
 
-    [%{geo_data_import_id: ^geo_data_import_2},%{geo_data_import_id: ^geo_data_import_2}] = DB.GeoData |> DB.Repo.all()
+    [%{geo_data_import_id: ^geo_data_import_2}, %{geo_data_import_id: ^geo_data_import_2}] = DB.GeoData |> DB.Repo.all()
   end
 end

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -37,4 +37,15 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
              }
            } = row1
   end
+
+  test "Finds the relevant dataset" do
+    %DB.Dataset{id: dataset_id} =
+      insert(:dataset, %{
+        type: "charging-stations",
+        custom_title: "Infrastructures de Recharge pour Véhicules Électriques - IRVE",
+        organization: "Etalab",
+        organization_id: "534fff75a3a7292c64a77de4"
+      })
+    assert %DB.Dataset{id: ^dataset_id} = IRVEToGeoData.relevant_dataset()
+  end
 end

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -65,7 +65,7 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
     insert(:resource, %{
       dataset_id: dataset_id,
       is_community_resource: true,
-      datagouv_id: "8d9398ae-3037-48b2-be19-412c24561fbb"
+      datagouv_id: Ecto.UUID.generate()
     })
 
     %{id: resource_id} =

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -1,0 +1,102 @@
+defmodule Transport.Jobs.BNLCToGeoDataTest do
+  use ExUnit.Case, async: true
+  alias Transport.Jobs.{BaseGeoData, BNLCToGeoData}
+  import DB.Factory
+  import Mox
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  setup :verify_on_exit!
+
+  @bnlc_content ~s("id_lieu","Xlong","Ylat","nbre_pl"\n"2A004-C-001","8.783403","41.9523692","0"\n"01024-C-001","5.158352778","46.28957222","5")
+
+  test "import a BNLC to the DB" do
+    geo_data_import = %{id: id} = insert(:geo_data_import)
+    BaseGeoData.insert_data(@bnlc_content, id, &BNLCToGeoData.prepare_data_for_insert/2)
+
+    [row1, row2] = DB.GeoData |> DB.Repo.all()
+
+    assert %{
+             geo_data_import_id: ^id,
+             geom: %Geo.Point{coordinates: {8.783403, 41.952369}, srid: 4326},
+             payload: %{"id_lieu" => "2A004-C-001", "nbre_pl" => "0"}
+           } = row1
+
+    assert %{
+             geo_data_import_id: ^id,
+             geom: %Geo.Point{coordinates: {5.158353, 46.289572}, srid: 4326},
+             payload: %{"id_lieu" => "01024-C-001", "nbre_pl" => "5"}
+           } = row2
+
+    # test cascading delete: if geo_data_import is deleted, associated geo_data are deleted too
+    geo_data_import |> DB.Repo.delete!()
+    assert [] = DB.GeoData |> DB.Repo.all()
+  end
+
+  test "bnlc data update logic" do
+    now = DateTime.utc_now()
+    now_100 = now |> DateTime.add(-100)
+    now_50 = now |> DateTime.add(-50)
+    now_25 = now |> DateTime.add(-25)
+
+    assert [] = DB.GeoData |> DB.Repo.all()
+    assert [] = DB.GeoDataImport |> DB.Repo.all()
+
+    # insert bnlc dataset
+    %DB.Dataset{id: dataset_id} =
+      insert(:dataset, %{
+        type: "carpooling-areas",
+        organization: Application.fetch_env!(:transport, :datagouvfr_transport_publisher_label)
+      })
+
+    # insert bnlc resources
+    insert(:resource, %{dataset_id: dataset_id, is_community_resource: true})
+    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id})
+    # insert bnlc resource history
+    %{id: id_0} =
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        inserted_at: now_100,
+        payload: %{"dataset_id" => dataset_id, "permanent_url" => "url"}
+      })
+
+    # another random resource history, just in case
+    insert(:resource_history, %{inserted_at: now_25, payload: %{"dataset_id" => dataset_id + 5}})
+
+    # download BNLC Mock
+    Transport.HTTPoison.Mock
+    |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @bnlc_content} end)
+
+    # launch job
+    Transport.Jobs.BNLCToGeoData.perform(%{})
+
+    # data is imported
+    [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
+    assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
+
+    # relaunch job
+    Transport.Jobs.BNLCToGeoData.perform(%{})
+
+    # no change
+    [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
+
+    # new (more recent) resource history
+    %{id: id_1} =
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        inserted_at: now_50,
+        payload: %{"dataset_id" => dataset_id, "permanent_url" => "url"}
+      })
+
+    # relaunch job
+    Transport.Jobs.BNLCToGeoData.perform(%{})
+
+    # geo_data and geo_data_import are updated accordingly
+    [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()
+    assert geo_data_import_2 !== geo_data_import_1
+
+    [%{geo_data_import_id: ^geo_data_import_2}, %{geo_data_import_id: ^geo_data_import_2}] = DB.GeoData |> DB.Repo.all()
+  end
+end

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.Jobs.BNLCToGeoDataTest do
+defmodule Transport.Jobs.IRVEToGeoDataTest do
   use ExUnit.Case, async: true
   alias Transport.Jobs.{BaseGeoData, IRVEToGeoData}
   import DB.Factory
@@ -21,20 +21,20 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
     # Uncomment to test only the prepare_data_for_insert function
     # row1 = IRVEToGeoData.prepare_data_for_insert(@irve_content, id) |> Enum.take(1) |> hd
     BaseGeoData.insert_data(@irve_content, id, &IRVEToGeoData.prepare_data_for_insert/2)
-    [row1| _t] = DB.GeoData |> DB.Repo.all()
+    [row1 | _t] = DB.GeoData |> DB.Repo.all()
 
     assert %{
-      geo_data_import_id: ^id,
-      geom: %Geo.Point{
-        coordinates: {-1.429227, 46.776249},
-        srid: 4326
-      },
-      payload: %{
-        "nom_enseigne" => "STATION SUPER U BELLEVIGNY 4",
-        "nom_station" => "STATION SUPER U BELLEVIGNY 4",
-        "id_station_itinerance" => "FRCPIE6610355",
-        "nbre_pdc" => "6"
-      }
-    } = row1
+             geo_data_import_id: ^id,
+             geom: %Geo.Point{
+               coordinates: {-1.429227, 46.776249},
+               srid: 4326
+             },
+             payload: %{
+               "nom_enseigne" => "STATION SUPER U BELLEVIGNY 4",
+               "nom_station" => "STATION SUPER U BELLEVIGNY 4",
+               "id_station_itinerance" => "FRCPIE6610355",
+               "nbre_pdc" => "6"
+             }
+           } = row1
   end
 end

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -20,8 +20,8 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
   @dataset_info %{
     type: "charging-stations",
     custom_title: "Infrastructures de Recharge pour Véhicules Électriques - IRVE",
-    organization: "Etalab",
-    organization_id: "534fff75a3a7292c64a77de4"
+    organization: "data.gouv.fr",
+    organization_id: "646b7187b50b2a93b1ae3d45"
   }
 
   test "import an IRVE to the DB" do

--- a/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/irve_to_geodata_test.exs
@@ -16,6 +16,14 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
   ,,info2@example.com,,info2@example.com,,Giberville Sud,FRIONE4171,FRIONE4171,Giberville Sud,Station dédiée à la recharge rapide,"Aire de Giberville Sud, A13, km 220, 14730 Giberville",,"[-0.276864, 49.166746]",5,FRIONE41715,FRIONE41715,50,false,true,true,true,false,false,true,true,,,Accès libre,false,24/7,Accessibilité inconnue,inconnu,false,,,2021-11-20,EF connector is available at the site separately,2023-07-11,false,2023-07-11T03:08:58.394000+00:00,64060c2ac773dcf3fabbe5d2,b11113db-875d-41c7-8673-0cf8ad43e917,eco-movement,-0.276864,49.166746,,,False,False
   """
 
+  @dataset_info %{
+    type: "charging-stations",
+    custom_title: "Infrastructures de Recharge pour Véhicules Électriques - IRVE",
+    organization: "Etalab",
+    organization_id: "534fff75a3a7292c64a77de4"
+  }
+
+
   test "import an IRVE to the DB" do
     %{id: id} = insert(:geo_data_import)
     # Uncomment to test only the prepare_data_for_insert function
@@ -39,13 +47,78 @@ defmodule Transport.Jobs.IRVEToGeoDataTest do
   end
 
   test "Finds the relevant dataset" do
-    %DB.Dataset{id: dataset_id} =
-      insert(:dataset, %{
-        type: "charging-stations",
-        custom_title: "Infrastructures de Recharge pour Véhicules Électriques - IRVE",
-        organization: "Etalab",
-        organization_id: "534fff75a3a7292c64a77de4"
+     %DB.Dataset{id: dataset_id} = insert(:dataset, @dataset_info)
+     assert %DB.Dataset{id: ^dataset_id} = IRVEToGeoData.relevant_dataset()
+  end
+
+  test "IRVE data update logic" do
+    now = DateTime.utc_now()
+    now_100 = now |> DateTime.add(-100)
+    now_50 = now |> DateTime.add(-50)
+    now_25 = now |> DateTime.add(-25)
+
+    assert [] = DB.GeoData |> DB.Repo.all()
+    assert [] = DB.GeoDataImport |> DB.Repo.all()
+
+    %DB.Dataset{id: dataset_id} = insert(:dataset, @dataset_info)
+
+    # We don’t want to match community resources (but want to have them in base)
+    insert(:resource, %{
+      dataset_id: dataset_id,
+      is_community_resource: true,
+      datagouv_id: "8d9398ae-3037-48b2-be19-412c24561fbb"
+    })
+
+    %{id: resource_id} =
+      insert(:resource, %{
+        dataset_id: dataset_id,
+        datagouv_id: "8d9398ae-3037-48b2-be19-412c24561fbb",
+        format: "csv"
       })
-    assert %DB.Dataset{id: ^dataset_id} = IRVEToGeoData.relevant_dataset()
+
+    %{id: id_0} =
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        inserted_at: now_100,
+        payload: %{"dataset_id" => dataset_id, "permanent_url" => "url"}
+      })
+
+    # another random resource history, just in case
+    insert(:resource_history, %{inserted_at: now_25, payload: %{"dataset_id" => dataset_id + 5}})
+
+    # download IRVE Mock
+    Transport.HTTPoison.Mock
+    |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @irve_content} end)
+
+    # launch job
+    Transport.Jobs.IRVEToGeoData.perform(%{})
+
+
+    # data is imported
+    [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
+    assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 2
+
+    # relaunch job
+    Transport.Jobs.IRVEToGeoData.perform(%{})
+
+    # no change
+    [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
+
+    # new (more recent) resource history
+    %{id: id_1} =
+      insert(:resource_history, %{
+        resource_id: resource_id,
+        inserted_at: now_50,
+        payload: %{"dataset_id" => dataset_id, "permanent_url" => "url"}
+      })
+
+    # relaunch job
+    Transport.Jobs.IRVEToGeoData.perform(%{})
+
+    # geo_data and geo_data_import are updated accordingly
+    [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()
+    assert geo_data_import_2 !== geo_data_import_1
+
+    [%{geo_data_import_id: ^geo_data_import_2},%{geo_data_import_id: ^geo_data_import_2}] = DB.GeoData |> DB.Repo.all()
   end
 end

--- a/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
@@ -95,14 +95,14 @@ defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @lez_aires_content} end)
 
     # launch job
-    perform_job(LowEmissionZonesToGeoData, %{})
+    assert :ok = perform_job(LowEmissionZonesToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 1
 
     # relaunch job
-    perform_job(LowEmissionZonesToGeoData, %{})
+    assert :ok = perform_job(LowEmissionZonesToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -116,7 +116,7 @@ defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
       })
 
     # relaunch job
-    perform_job(LowEmissionZonesToGeoData, %{})
+    assert :ok = perform_job(LowEmissionZonesToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
@@ -1,5 +1,6 @@
 defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.{BaseGeoData, LowEmissionZonesToGeoData}
   import DB.Factory
   import Mox
@@ -94,14 +95,14 @@ defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @lez_aires_content} end)
 
     # launch job
-    Transport.Jobs.LowEmissionZonesToGeoData.perform(%{})
+    perform_job(LowEmissionZonesToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 1
 
     # relaunch job
-    Transport.Jobs.LowEmissionZonesToGeoData.perform(%{})
+    perform_job(LowEmissionZonesToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -115,7 +116,7 @@ defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
       })
 
     # relaunch job
-    Transport.Jobs.LowEmissionZonesToGeoData.perform(%{})
+    perform_job(LowEmissionZonesToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
@@ -10,15 +10,15 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
 
   setup :verify_on_exit!
 
-  @bnls_content ~S"""
+  @parking_relais_content ~S"""
   id;nom;Xlong;Ylat;nb_pr
   04070-P-001;Parking Gassendi;6.2366534;44.0932836;
   04070-P-002;Parking Deux;6.22;44.10;5
   """
 
-  test "import a BNLS to the DB" do
+  test "import a Parking Relais to the DB" do
     geo_data_import = %{id: id} = insert(:geo_data_import)
-    BaseGeoData.insert_data(@bnls_content, id, &ParkingsRelaisToGeoData.prepare_data_for_insert/2)
+    BaseGeoData.insert_data(@parking_relais_content, id, &ParkingsRelaisToGeoData.prepare_data_for_insert/2)
 
     [row1] = DB.GeoData |> DB.Repo.all()
 
@@ -33,7 +33,7 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
     assert [] = DB.GeoData |> DB.Repo.all()
   end
 
-  test "BNLS data update logic" do
+  test "Parking relais data update logic" do
     now = DateTime.utc_now()
     now_100 = now |> DateTime.add(-100)
     now_50 = now |> DateTime.add(-50)
@@ -62,9 +62,9 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
     # another random resource history, just in case
     insert(:resource_history, %{inserted_at: now_25, payload: %{"dataset_id" => dataset_id + 5}})
 
-    # download BNLS Mock
+    # download Parking Relais Mock
     Transport.HTTPoison.Mock
-    |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @bnls_content} end)
+    |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @parking_relais_content} end)
 
     # launch job
     Transport.Jobs.ParkingsRelaisToGeoData.perform(%{})

--- a/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
@@ -1,5 +1,6 @@
 defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.{BaseGeoData, ParkingsRelaisToGeoData}
   import DB.Factory
   import Mox
@@ -67,14 +68,14 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @parking_relais_content} end)
 
     # launch job
-    Transport.Jobs.ParkingsRelaisToGeoData.perform(%{})
+    perform_job(ParkingsRelaisToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 1
 
     # relaunch job
-    Transport.Jobs.ParkingsRelaisToGeoData.perform(%{})
+    perform_job(ParkingsRelaisToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -88,7 +89,7 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
       })
 
     # relaunch job
-    Transport.Jobs.ParkingsRelaisToGeoData.perform(%{})
+    perform_job(ParkingsRelaisToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/parkings_relais_to_geo_data_test.exs
@@ -68,14 +68,14 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
     |> expect(:get!, 2, fn "url" -> %HTTPoison.Response{status_code: 200, body: @parking_relais_content} end)
 
     # launch job
-    perform_job(ParkingsRelaisToGeoData, %{})
+    assert :ok = perform_job(ParkingsRelaisToGeoData, %{})
 
     # data is imported
     [%{id: geo_data_import_1, resource_history_id: ^id_0}] = DB.GeoDataImport |> DB.Repo.all()
     assert DB.GeoData |> DB.Repo.all() |> Enum.count() == 1
 
     # relaunch job
-    perform_job(ParkingsRelaisToGeoData, %{})
+    assert :ok = perform_job(ParkingsRelaisToGeoData, %{})
 
     # no change
     [%{id: ^geo_data_import_1}] = DB.GeoDataImport |> DB.Repo.all()
@@ -89,7 +89,7 @@ defmodule Transport.Jobs.ParkingsRelaisToGeoDataTest do
       })
 
     # relaunch job
-    perform_job(ParkingsRelaisToGeoData, %{})
+    assert :ok = perform_job(ParkingsRelaisToGeoData, %{})
 
     # geo_data and geo_data_import are updated accordingly
     [%{id: geo_data_import_2, resource_history_id: ^id_1}] = DB.GeoDataImport |> DB.Repo.all()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -111,6 +111,7 @@ oban_crontab_all_envs =
         {"30 */6 * * *", Transport.Jobs.BNLCToGeoData},
         {"30 */6 * * *", Transport.Jobs.ParkingsRelaisToGeoData},
         {"30 */6 * * *", Transport.Jobs.LowEmissionZonesToGeoData},
+        {"30 */6 * * *", Transport.Jobs.IRVEToGeoData},
         {"15 10 * * *", Transport.Jobs.DatabaseBackupReplicationJob},
         {"0 7 * * *", Transport.Jobs.GTFSRTMultiValidationDispatcherJob},
         {"30 7 * * *", Transport.Jobs.GBFSMultiValidationDispatcherJob},


### PR DESCRIPTION
Cette PR rajoute un job Oban pour importer la base de donnée consolidée des IRVE dans la table GeoData. Cela permettra par la suite d’afficher ces IRVE dans la carte d’exploration (voir #3246).