### PR TITLE
Logger.warn est déprécié

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -200,7 +200,7 @@ defmodule Datagouvfr.Client.API do
     {:ok, fetch_all_pages!(path, method)}
   rescue
     error ->
-      Logger.warn(error)
+      Logger.warning(error)
       {:error, error}
   end
 end

--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -42,7 +42,7 @@ defmodule Transport.Shared.GBFSMetadata do
     }
   rescue
     e ->
-      Logger.warn("Could not compute GBFS feed metadata. Reason: #{inspect(e)}")
+      Logger.warning("Could not compute GBFS feed metadata. Reason: #{inspect(e)}")
       %{}
   end
 

--- a/apps/shared/lib/hasher.ex
+++ b/apps/shared/lib/hasher.ex
@@ -32,7 +32,7 @@ defmodule Hasher do
         get_content_hash_http(url)
 
       _ ->
-        Logger.warn("Cannot process #{scheme |> inspect} url (#{url}) at the moment. Skipping.")
+        Logger.warning("Cannot process #{scheme |> inspect} url (#{url}) at the moment. Skipping.")
         nil
     end
   end
@@ -60,7 +60,7 @@ defmodule Hasher do
         hash
 
       {:error, msg} ->
-        Logger.warn("Cannot compute hash for url #{url |> inspect}, returning empty hash. Error : #{msg |> inspect}")
+        Logger.warning("Cannot compute hash for url #{url |> inspect}, returning empty hash. Error : #{msg |> inspect}")
 
         # NOTE: this mimics the legacy code, and maybe we could return nil instead, but the whole
         # thing isn't under tests, so I prefer to keep it like before for now.

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -501,7 +501,7 @@ defmodule DB.Dataset do
         {:ok, changeset}
 
       %{valid?: false} = errors ->
-        Logger.warn("error while importing dataset: #{format_error(errors)}")
+        Logger.warning("error while importing dataset: #{format_error(errors)}")
         {:error, format_error(errors)}
     end
   end
@@ -925,7 +925,7 @@ defmodule DB.Dataset do
     |> Repo.get_by(insee: insee)
     |> case do
       nil ->
-        Logger.warn("Unable to find zone with INSEE #{insee}")
+        Logger.warning("Unable to find zone with INSEE #{insee}")
         nil
 
       commune ->

--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -10,7 +10,7 @@ defmodule Transport.ObanLogger do
         %{args: args, error: error, id: id, worker: worker},
         nil
       ) do
-    Logger.warn(
+    Logger.warning(
       "Job #{id} handled by #{worker} called with args #{inspect(args)} failed in #{duration}. Error: #{inspect(error)}"
     )
   end

--- a/apps/transport/lib/mix/tasks/transport/import_epci.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_epci.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Transport.ImportEPCI do
       :ok
     else
       e ->
-        Logger.warn("impossible to fetch epci file, error #{inspect(e)}")
+        Logger.warning("impossible to fetch epci file, error #{inspect(e)}")
         :error
     end
   end

--- a/apps/transport/lib/opendatasoft/url_extractor.ex
+++ b/apps/transport/lib/opendatasoft/url_extractor.ex
@@ -40,10 +40,10 @@ defmodule Opendatasoft.UrlExtractor do
       resources
     else
       {:error, error} ->
-        Logger.warn(" <message>  #{inspect(error)}")
+        Logger.warning(" <message>  #{inspect(error)}")
 
         Enum.each(csv_resources, fn resource ->
-          Logger.warn(" <resource> #{resource["url"]}")
+          Logger.warning(" <resource> #{resource["url"]}")
         end)
 
         []

--- a/apps/transport/lib/transport/community_resource_cleaner.ex
+++ b/apps/transport/lib/transport/community_resource_cleaner.ex
@@ -24,7 +24,7 @@ defmodule Transport.CommunityResourcesCleaner do
       |> Enum.frequencies_by(fn {r, _} -> r end)
 
     with %{error: error_n} <- result do
-      Logger.warn("#{error_n} community resources were listed as orphans but could not be deleted")
+      Logger.warning("#{error_n} community resources were listed as orphans but could not be deleted")
     end
 
     ok_n = Map.get(result, :ok, 0)
@@ -86,7 +86,7 @@ defmodule Transport.CommunityResourcesCleaner do
       |> Enum.frequencies_by(fn {r, _} -> r end)
 
     with %{error: error_n} <- result do
-      Logger.warn("#{error_n} transport community resources could not be deleted")
+      Logger.warning("#{error_n} transport community resources could not be deleted")
     end
 
     ok_n = Map.get(result, :ok, 0)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -267,7 +267,7 @@ defmodule Transport.ImportData do
     |> Repo.get_by(code: code)
     |> case do
       nil ->
-        Logger.warn("impossible to find epci #{code}, no cities associated to the dataset")
+        Logger.warning("impossible to find epci #{code}, no cities associated to the dataset")
         []
 
       epci ->
@@ -430,7 +430,7 @@ defmodule Transport.ImportData do
         |> Enum.map(fn r -> Map.put(r, "is_community_resource", true) end)
 
       {:error, error} ->
-        Logger.warn("impossible to get community ressource for dataset #{datagouv_id} => #{inspect(error)}")
+        Logger.warning("impossible to get community ressource for dataset #{datagouv_id} => #{inspect(error)}")
 
         []
     end

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -185,7 +185,7 @@ defmodule Unlock.Controller do
         size = byte_size(response.body)
 
         if size > @max_allowed_cached_byte_size do
-          Logger.warn("Payload is too large (#{size} bytes > #{@max_allowed_cached_byte_size}). Skipping cache.")
+          Logger.warning("Payload is too large (#{size} bytes > #{@max_allowed_cached_byte_size}). Skipping cache.")
           {:ignore, response}
         else
           {:commit, response, ttl: :timer.seconds(item.ttl)}


### PR DESCRIPTION
Lié à #3307, [gère la hard deprecation de Elixir 1.15](https://hexdocs.pm/elixir/1.15/changelog.html#4-hard-deprecations)