### PR TITLE
Refactoring: keywords sur HistoryFetcher

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -260,7 +260,12 @@ defmodule TransportWeb.API.DatasetController do
     |> add_conversions(dataset)
     |> Map.put(
       "history",
-      Transport.History.Fetcher.history_resources(dataset, TransportWeb.DatasetView.max_nb_history_resources(), false)
+      Transport.History.Fetcher.history_resources(dataset,
+        max_records: TransportWeb.DatasetView.max_nb_history_resources(),
+        # see https://github.com/etalab/transport-site/issues/3324, not needed currently
+        # in the API output
+        preload_validations: false
+      )
     )
   end
 

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -50,9 +50,15 @@ defmodule TransportWeb.DatasetController do
       |> assign(:is_subscribed, Datasets.current_user_subscribed?(conn, dataset.datagouv_id))
       |> assign(:other_datasets, Dataset.get_other_datasets(dataset))
       |> assign(:resources_infos, resources_infos(dataset))
-      |> assign(:history_resources, Transport.History.Fetcher.history_resources(dataset, max_nb_history_resources()))
       |> assign(:latest_resources_history_infos, DB.ResourceHistory.latest_dataset_resources_history_infos(dataset.id))
       |> assign(:notifications_sent, DB.Notification.recent_reasons_binned(dataset, days_notifications_sent()))
+      |> assign(
+        :history_resources,
+        Transport.History.Fetcher.history_resources(dataset,
+          max_records: max_nb_history_resources(),
+          preload_validations: true
+        )
+      )
       |> assign(:freshness_score, DB.DatasetScore.get_latest(dataset, "freshness"))
       |> put_status(if dataset.is_active, do: :ok, else: :not_found)
       |> render("details.html")

--- a/apps/transport/test/transport/history_fetcher_test.exs
+++ b/apps/transport/test/transport/history_fetcher_test.exs
@@ -48,7 +48,9 @@ defmodule Transport.History.FetcherTest do
       [validation] = rh_with_metadata.validations
       assert validation.metadata.metadata == %{"a" => 2}
 
-      assert Enum.count(Transport.History.Fetcher.Database.history_resources(dataset, 1)) == 1
+      assert Enum.count(
+               Transport.History.Fetcher.Database.history_resources(dataset, max_records: 1)
+             ) == 1
 
       assert Transport.History.Fetcher.Database.history_resources(insert(:dataset)) == []
     end

--- a/apps/transport/test/transport/history_fetcher_test.exs
+++ b/apps/transport/test/transport/history_fetcher_test.exs
@@ -35,7 +35,9 @@ defmodule Transport.History.FetcherTest do
       # Should be ignored
       insert(:resource_history, resource_id: other_resource.id, payload: %{})
 
-      resources_history = Transport.History.Fetcher.Database.history_resources(dataset)
+      resources_history =
+        Transport.History.Fetcher.Database.history_resources(dataset, preload_validations: true)
+
       assert length(resources_history) == 3
 
       # check results are ordered by descending insertion date

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -165,7 +165,11 @@ defmodule TransportWeb.API.DatasetControllerTest do
 
     # check the result is in line with a query on this dataset
     # only difference: individual dataset adds information about history and conversions
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, false -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: false, max_records: 25)
+      []
+    end)
 
     dataset_res =
       dataset_res
@@ -271,7 +275,11 @@ defmodule TransportWeb.API.DatasetControllerTest do
       |> DB.Repo.insert!()
       |> DB.Repo.preload(:resources)
 
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, false -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: false, max_records: 25)
+      []
+    end)
 
     path = Helpers.dataset_path(conn, :by_id, dataset.datagouv_id)
 
@@ -382,7 +390,11 @@ defmodule TransportWeb.API.DatasetControllerTest do
       payload: %{"permanent_url" => "https://example.com/url1", "filesize" => filesize = 43}
     )
 
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, false -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: false, max_records: 25)
+      []
+    end)
 
     path = Helpers.dataset_path(conn, :by_id, dataset.datagouv_id)
 
@@ -454,7 +466,11 @@ defmodule TransportWeb.API.DatasetControllerTest do
     insert(:resource_metadata, resource_id: resource_1.id, features: ["a", "b"])
     insert(:resource_metadata, resource_id: resource_1.id, features: ["c"])
 
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, false -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: false, max_records: 25)
+      []
+    end)
 
     # call to specific dataset
     path = Helpers.dataset_path(conn, :by_id, datagouv_id_1)

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -34,7 +34,11 @@ defmodule TransportWeb.DatasetControllerTest do
     assert Enum.empty?(TransportWeb.DatasetView.other_official_resources(dataset))
     assert 1 == Enum.count(TransportWeb.DatasetView.official_documentation_resources(dataset))
 
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, true -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: true, max_records: 25)
+      []
+    end)
 
     with_mocks [
       {Datagouvfr.Client.Reuses, [], [get: fn _dataset -> {:ok, []} end]},
@@ -58,7 +62,11 @@ defmodule TransportWeb.DatasetControllerTest do
       payload: %{"permanent_url" => conversion_url = "https://super-cellar-url.com/netex"}
     )
 
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, true -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: true, max_records: 25)
+      []
+    end)
 
     with_mocks [
       {Datagouvfr.Client.Reuses, [], [get: fn _dataset -> {:ok, []} end]},
@@ -397,6 +405,10 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   defp set_empty_mocks do
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, true -> [] end)
+    Transport.History.Fetcher.Mock
+    |> expect(:history_resources, fn _, options ->
+      assert Keyword.equal?(options, preload_validations: true, max_records: 25)
+      []
+    end)
   end
 end

--- a/apps/transport/test/transport_web/controllers/nav_test.exs
+++ b/apps/transport/test/transport_web/controllers/nav_test.exs
@@ -35,7 +35,7 @@ defmodule TransportWeb.NavTest do
   end
 
   test "I can list available datasets to find and download transport data", %{conn: conn} do
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, _ -> [] end)
+    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _ -> [] end)
     # NOTE: we cannot easily mock the API exchanges, so just stubbing the known bits for now, and
     # we'll later use a proper stubbed implementation for all tests.
     with_mock Datagouvfr.Client.Discussions, get: fn _ -> [] end do

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -91,8 +91,8 @@ defmodule TransportWeb.SeoMetadataTest do
   end
 
   test "GET /dataset/:id ", %{conn: conn} do
-    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _, _ -> [] end)
     title = conn |> get("/datasets/horaires-et-arrets-du-reseau-irigo-format-gtfs") |> html_response(200) |> title
+    Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _ -> [] end)
     assert title =~ "Horaires Angers - Données (GTFS) ouvertes - Angers Métropôle"
   end
 

--- a/apps/transport/test/transport_web/controllers/seo_test.exs
+++ b/apps/transport/test/transport_web/controllers/seo_test.exs
@@ -91,8 +91,14 @@ defmodule TransportWeb.SeoMetadataTest do
   end
 
   test "GET /dataset/:id ", %{conn: conn} do
-    title = conn |> get("/datasets/horaires-et-arrets-du-reseau-irigo-format-gtfs") |> html_response(200) |> title
     Transport.History.Fetcher.Mock |> expect(:history_resources, fn _, _ -> [] end)
+
+    title =
+      conn
+      |> get("/datasets/horaires-et-arrets-du-reseau-irigo-format-gtfs")
+      |> html_response(200)
+      |> title
+
     assert title =~ "Horaires Angers - Données (GTFS) ouvertes - Angers Métropôle"
   end
 


### PR DESCRIPTION
Dans:
- https://github.com/etalab/transport-site/pull/3326

Le code devenait un peu bancal, avec plusieurs paramètres (max records & preload) à la queuleuleu.

Dans la présente PR je refactore pour introduire un Keyword à la place.

À bien relire et en pratique dans les tests les messages d'erreur ne sont pas clairs quand ça ne matche pas, mais ça sera améliorable, et c'est plus flexible pour la suite.