### PR TITLE
Change type pour dataset.legal_owner_company_siren

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -56,7 +56,7 @@ defmodule DB.Dataset do
       on_replace: :delete
     )
 
-    field(:legal_owner_company_siren, :integer)
+    field(:legal_owner_company_siren, :string)
 
     has_many(:resources, Resource, on_replace: :delete, on_delete: :delete_all)
     has_many(:logs_import, LogsImport, on_replace: :delete, on_delete: :delete_all)
@@ -486,6 +486,7 @@ defmodule DB.Dataset do
     |> cast_nation_dataset(params)
     |> cast_assoc(:resources)
     |> validate_required([:slug])
+    |> validate_siren()
     |> validate_territory_mutual_exclusion()
     |> maybe_overwrite_licence()
     |> has_real_time()
@@ -834,6 +835,20 @@ defmodule DB.Dataset do
   end
 
   def get_resources_related_files(_), do: %{}
+
+  defp validate_siren(%Ecto.Changeset{} = changeset) do
+    case get_change(changeset, :legal_owner_company_siren) do
+      nil ->
+        changeset
+
+      siren ->
+        unless Transport.Companies.is_valid_siren?(siren) do
+          add_error(changeset, :legal_owner_company_siren, "SIREN is not valid")
+        else
+          changeset
+        end
+    end
+  end
 
   @spec validate_territory_mutual_exclusion(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_territory_mutual_exclusion(changeset) do

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -842,10 +842,10 @@ defmodule DB.Dataset do
         changeset
 
       siren ->
-        unless Transport.Companies.is_valid_siren?(siren) do
-          add_error(changeset, :legal_owner_company_siren, "SIREN is not valid")
-        else
+        if Transport.Companies.is_valid_siren?(siren) do
           changeset
+        else
+          add_error(changeset, :legal_owner_company_siren, "SIREN is not valid")
         end
     end
   end

--- a/apps/transport/priv/repo/migrations/20230719124102_dataset_legal_owner_company_siren_type.exs
+++ b/apps/transport/priv/repo/migrations/20230719124102_dataset_legal_owner_company_siren_type.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.DatasetLegalOwnerCompanySirenType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataset) do
+      modify :legal_owner_company_siren, :string, size: 9, from: :integer
+    end
+  end
+end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -130,6 +130,28 @@ defmodule DB.DatasetDBTest do
 
       assert {:ok, %Ecto.Changeset{changes: %{has_realtime: false}}} = changeset
     end
+
+    test "siren is validated" do
+      {{:error, _}, logs} =
+        with_log(fn ->
+          Dataset.changeset(%{
+            "datagouv_id" => "1",
+            "slug" => "slug",
+            "national_dataset" => "true",
+            "legal_owner_company_siren" => "123456789"
+          })
+        end)
+
+      assert logs =~ "error while importing dataset: %{legal_owner_company_siren:"
+
+      assert {:ok, %Ecto.Changeset{}} =
+               Dataset.changeset(%{
+                 "datagouv_id" => "1",
+                 "slug" => "slug",
+                 "national_dataset" => "true",
+                 "legal_owner_company_siren" => "552049447"
+               })
+    end
   end
 
   describe "mobility-licence" do

--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -117,7 +117,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
 
     set_expectations()
 
-    siren = 123_456_789
+    siren = "552049447"
 
     conn
     |> setup_admin_in_session()
@@ -126,7 +126,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
         "custom_title" => "title",
         "url" => slug,
         "type" => "public-transit",
-        "legal_owner_company_siren" => siren |> Integer.to_string(),
+        "legal_owner_company_siren" => siren,
         "legal_owners_aom[0]" => aom_0.id |> Integer.to_string(),
         "legal_owners_aom[1]" => aom_1.id |> Integer.to_string(),
         "legal_owners_region[0]" => region_0.id |> Integer.to_string(),

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -150,7 +150,7 @@ defmodule TransportWeb.EditDatasetLiveTest do
     dataset =
       insert(:dataset,
         datagouv_id: "1234",
-        legal_owner_company_siren: siren = 123_456_789,
+        legal_owner_company_siren: siren = "552049447",
         legal_owners_aom: [],
         legal_owners_region: []
       )
@@ -166,7 +166,7 @@ defmodule TransportWeb.EditDatasetLiveTest do
       )
 
     assert render(view) =~ "Représentants légaux"
-    assert render(view) =~ siren |> Integer.to_string()
+    assert render(view) =~ siren
   end
 
   test "form inputs are persisted", %{conn: conn} do


### PR DESCRIPTION
Fixes #3338

- Passe de integer à string
- Vérifie que le SIREN a le bon format lors de l'insertion