### PR TITLE
Backoffice : ajout d'un export général

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -291,7 +291,7 @@ defmodule TransportWeb.Backoffice.PageController do
 
   def download_resources_csv(%Plug.Conn{} = conn, _) do
     %Postgrex.Result{columns: columns, rows: rows} = resources_query()
-    filename = "resource-#{Date.utc_today() |> Date.to_iso8601()}.csv"
+    filename = "ressources-#{Date.utc_today() |> Date.to_iso8601()}.csv"
 
     content =
       rows

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -288,4 +288,74 @@ defmodule TransportWeb.Backoffice.PageController do
       _ -> query
     end
   end
+
+  def download_resources_csv(%Plug.Conn{} = conn, _) do
+    %Postgrex.Result{columns: columns, rows: rows} = resources_query()
+    filename = "resource-#{Date.utc_today() |> Date.to_iso8601()}.csv"
+
+    content =
+      rows
+      |> Enum.map(fn row -> columns |> Enum.zip(row) |> Enum.into(%{}) end)
+      |> CSV.encode(headers: columns)
+      |> Enum.to_list()
+      |> to_string()
+
+    conn
+    |> put_resp_content_type("text/csv")
+    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
+    |> send_resp(200, content)
+  end
+
+  defp resources_query do
+    DB.Repo
+    |> Ecto.Adapters.SQL.query!("""
+    select
+      d.organization nom_organisation,
+      d.datagouv_title dataset_titre_datagouv,
+      d.custom_title dataset_titre_pan,
+      'https://transport.data.gouv.fr/datasets/' || d.slug dataset_url,
+      d.licence licence,
+      d.type dataset_type,
+      case when d.custom_tags is null or cardinality(d.custom_tags) = 0 then null else d.custom_tags end dataset_custom_tags,
+      d.organization_type type_publicateur,
+      coalesce(a.nom, re.nom) nom_territoire,
+      coalesce(legal_owners.noms_aoms, d.legal_owner_company_siren::varchar) representants_legaux,
+      case when d.is_active and d.archived_at is null then 'actif' when not d.is_active then 'supprimé' when d.archived_at is not null then 'archivé' end statut_datagouv,
+      r.title titre_ressource,
+      r.format format_ressource,
+      case when r.url like 'https://static.data.gouv.fr%' then 'manuelle' else 'automatique' end methode_maj,
+      rh.inserted_at derniere_maj,
+      case when mv.validator = 'GTFS transport-validator' then mv.max_error else mv.result->>'errors_count' end validation_errors,
+      rm.metadata->>'end_date' gtfs_date_fin,
+      d.organization_id id_organisation,
+      d.id id_dataset,
+      r.id id_ressource,
+      freshness.score score_fraicheur
+    from resource r
+    join dataset d on d.id = r.dataset_id
+    left join aom a on a.id = d.aom_id
+    left join region re on re.id = d.region_id
+    left join (
+      select
+        rh.*,
+        row_number() over (partition by rh.resource_id order by rh.inserted_at desc) row_number
+      from resource_history rh
+    ) rh on rh.resource_id = r.id and rh.row_number = 1
+    left join (
+      select da.dataset_id, string_agg(a.nom, ', ' order by a.nom) noms_aoms
+      from dataset_aom_legal_owner da
+      join aom a on da.aom_id = a.id
+      group by 1
+    ) legal_owners on legal_owners.dataset_id = d.id
+    left join multi_validation mv on mv.resource_history_id = rh.id
+    left join resource_metadata rm on rm.multi_validation_id = mv.id
+    left join (
+      select
+        ds.*,
+        row_number() over (partition by ds.dataset_id order by ds.timestamp desc) row_number
+      from dataset_score ds
+      where ds.topic = 'freshness'
+    ) freshness on freshness.dataset_id = d.id and freshness.row_number = 1
+    """)
+  end
 end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -193,6 +193,7 @@ defmodule TransportWeb.Router do
 
       get("/breaking_news", BreakingNewsController, :index)
       post("/breaking_news", BreakingNewsController, :update_breaking_news)
+      get("/download_resources_csv", PageController, :download_resources_csv)
     end
 
     # Authentication

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -75,6 +75,13 @@
     </a>
   </div>
 
+  <h2>Exports</h2>
+  <div>
+    <a class="button" href={backoffice_page_path(@conn, :download_resources_csv)} title="Export CSV des ressources">
+      🗳 Export des ressources
+    </a>
+  </div>
+
   <h2><%= dgettext("backoffice", "Validations") %></h2>
   <div>
     <%= form_for @conn, backoffice_dataset_path(@conn, :force_validate_gtfs_transport), [class: "no-margin"], fn _f -> %>

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -114,6 +114,20 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     assert emails_2 |> Enum.sort() == ["bar@example.fr", "baz@example.fr"]
   end
 
+  test "can download the resources CSV", %{conn: conn} do
+    response =
+      conn
+      |> setup_admin_in_session()
+      |> get(Routes.backoffice_page_path(conn, :download_resources_csv))
+
+    assert response(response, 200)
+    assert response_content_type(response, :csv) == "text/csv; charset=utf-8"
+
+    assert Plug.Conn.get_resp_header(response, "content-disposition") == [
+             ~s(attachment; filename="resource-#{Date.utc_today() |> Date.to_iso8601()}.csv")
+           ]
+  end
+
   defp insert_notification_at_datetime(%{} = args, %DateTime{} = datetime) do
     args
     |> insert_notification()

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -124,7 +124,7 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     assert response_content_type(response, :csv) == "text/csv; charset=utf-8"
 
     assert Plug.Conn.get_resp_header(response, "content-disposition") == [
-             ~s(attachment; filename="resource-#{Date.utc_today() |> Date.to_iso8601()}.csv")
+             ~s(attachment; filename="ressources-#{Date.utc_today() |> Date.to_iso8601()}.csv")
            ]
   end
 


### PR DESCRIPTION
Fixes #3321

Ajout d'un bouton pour télécharger un CSV depuis le backoffice qui contient les données décrites par @cyrilmorin dans l'issue. L'échelle est celui des ressources mais on va remonter au JDD, validations, métadonnées etc.

La requête SQL est "assez moche" mais elle fait le travail et s'exécute en 250ms en production. Elle n'est pas testée vu l'usage beta actuel et le fait que c'est réservé à notre équipe. Une review est bienvenue pour autant !