### PR TITLE
Mise en cache `/api/datasets` et `/api/datasets:id`

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -73,17 +73,17 @@ defmodule TransportWeb.API.DatasetController do
     }
 
   @spec by_id(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def by_id(%Plug.Conn{} = conn, %{"id" => id}) do
+  def by_id(%Plug.Conn{} = conn, %{"id" => datagouv_id}) do
     dataset =
       Dataset
       |> preload([:resources, :aom, :region, :communes])
-      |> Repo.get_by(datagouv_id: id)
+      |> Repo.get_by(datagouv_id: datagouv_id)
 
     if is_nil(dataset) do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
       comp_fn = fn -> prepare_dataset_detail_data(conn, dataset) end
-      data = Transport.Cache.API.fetch("api-datasets-#{id}", comp_fn, @cache_ttl)
+      data = Transport.Cache.API.fetch("api-datasets-#{datagouv_id}", comp_fn, @cache_ttl)
 
       conn |> assign(:data, data) |> render()
     end

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -30,57 +30,7 @@ defmodule TransportWeb.API.DatasetController do
 
   @spec datasets(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def datasets(%Plug.Conn{} = conn, _params) do
-    comp_fn = fn ->
-      datasets_with_gtfs_metadata =
-        DB.Dataset.base_query()
-        |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
-        |> preload([resource: r, resource_history: rh, multi_validation: mv, metadata: m], [
-          :aom,
-          :region,
-          :communes,
-          resources: {r, resource_history: {rh, validations: {mv, metadata: m}}}
-        ])
-        |> Repo.all()
-
-      recent_limit = Transport.Jobs.GTFSRTMetadataJob.datetime_limit()
-
-      datasets_with_gtfs_rt_metadata =
-        DB.Dataset.base_query()
-        |> DB.Resource.join_dataset_with_resource()
-        |> DB.ResourceMetadata.join_resource_with_metadata()
-        |> where([resource: r], r.format == "gtfs-rt")
-        |> where([metadata: rm], rm.inserted_at > ^recent_limit)
-        |> preload([resource: r, metadata: m], resources: {r, resource_metadata: m})
-        |> DB.Repo.all()
-
-      datasets_with_metadata =
-        datasets_with_gtfs_metadata
-        |> Kernel.++(datasets_with_gtfs_rt_metadata)
-        |> Enum.group_by(& &1.id, & &1.resources)
-        |> Enum.map(fn {dataset_id, resources} -> {dataset_id, List.flatten(resources)} end)
-        |> Enum.into(%{})
-
-      existing_ids =
-        datasets_with_metadata
-        |> Enum.map(fn {dataset_id, resources} ->
-          {dataset_id,
-           resources
-           |> Enum.map(fn resource -> {resource.id, resource} end)
-           |> Enum.into(%{})}
-        end)
-        |> Enum.into(%{})
-
-      %{}
-      |> Dataset.list_datasets()
-      |> preload([:resources, :aom, :region, :communes])
-      |> Repo.all()
-      |> Enum.map(fn dataset ->
-        enriched_dataset = Map.get(existing_ids, dataset.id)
-        add_enriched_resources_to_dataset(dataset, enriched_dataset)
-      end)
-      |> Enum.map(&transform_dataset(conn, &1))
-    end
-
+    comp_fn = fn -> prepare_datasets_index_data(conn) end
     data = Transport.Cache.API.fetch("api-datasets-index", comp_fn, @cache_ttl)
 
     render(conn, %{data: data})
@@ -132,44 +82,7 @@ defmodule TransportWeb.API.DatasetController do
     if is_nil(dataset) do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
-      comp_fn = fn ->
-        gtfs_resources_with_metadata =
-          DB.Resource.base_query()
-          |> DB.ResourceHistory.join_resource_with_latest_resource_history()
-          |> DB.MultiValidation.join_resource_history_with_latest_validation(
-            Transport.Validators.GTFSTransport.validator_name()
-          )
-          |> DB.ResourceMetadata.join_validation_with_metadata()
-          |> preload([resource_history: rh, multi_validation: mv, metadata: m],
-            resource_history: {rh, validations: {mv, metadata: m}}
-          )
-          |> where([resource: r], r.dataset_id == ^dataset.id)
-          |> select([resource: r], {r.id, r})
-          |> DB.Repo.all()
-
-        recent_limit = Transport.Jobs.GTFSRTMetadataJob.datetime_limit()
-
-        gtfs_rt_resources_with_metadata =
-          DB.Resource.base_query()
-          |> DB.ResourceMetadata.join_resource_with_metadata()
-          |> where([metadata: rm], rm.inserted_at > ^recent_limit)
-          |> where([resource: r], r.dataset_id == ^dataset.id)
-          |> preload([metadata: m], resource_metadata: m)
-          |> select([resource: r], {r.id, r})
-          |> DB.Repo.all()
-
-        resources_with_metadata = Enum.into(gtfs_resources_with_metadata ++ gtfs_rt_resources_with_metadata, %{})
-
-        enriched_resources =
-          dataset
-          |> Dataset.official_resources()
-          |> Enum.map(fn r -> resources_with_metadata |> Map.get(r.id, r) end)
-
-        dataset = dataset |> Map.put(:resources, enriched_resources)
-
-        transform_dataset_with_detail(conn, dataset)
-      end
-
+      comp_fn = fn -> prepare_dataset_detail_data(conn, dataset) end
       data = Transport.Cache.API.fetch("api-datasets-#{id}", comp_fn, @cache_ttl)
 
       conn |> assign(:data, data) |> render()
@@ -394,5 +307,94 @@ defmodule TransportWeb.API.DatasetController do
   defp transform_cities(cities) do
     cities
     |> Enum.map(fn c -> %{"name" => c.nom, "insee" => c.insee} end)
+  end
+
+  defp prepare_datasets_index_data(conn) do
+    datasets_with_gtfs_metadata =
+      DB.Dataset.base_query()
+      |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
+      |> preload([resource: r, resource_history: rh, multi_validation: mv, metadata: m], [
+        :aom,
+        :region,
+        :communes,
+        resources: {r, resource_history: {rh, validations: {mv, metadata: m}}}
+      ])
+      |> Repo.all()
+
+    recent_limit = Transport.Jobs.GTFSRTMetadataJob.datetime_limit()
+
+    datasets_with_gtfs_rt_metadata =
+      DB.Dataset.base_query()
+      |> DB.Resource.join_dataset_with_resource()
+      |> DB.ResourceMetadata.join_resource_with_metadata()
+      |> where([resource: r], r.format == "gtfs-rt")
+      |> where([metadata: rm], rm.inserted_at > ^recent_limit)
+      |> preload([resource: r, metadata: m], resources: {r, resource_metadata: m})
+      |> DB.Repo.all()
+
+    datasets_with_metadata =
+      datasets_with_gtfs_metadata
+      |> Kernel.++(datasets_with_gtfs_rt_metadata)
+      |> Enum.group_by(& &1.id, & &1.resources)
+      |> Enum.map(fn {dataset_id, resources} -> {dataset_id, List.flatten(resources)} end)
+      |> Enum.into(%{})
+
+    existing_ids =
+      datasets_with_metadata
+      |> Enum.map(fn {dataset_id, resources} ->
+        {dataset_id,
+         resources
+         |> Enum.map(fn resource -> {resource.id, resource} end)
+         |> Enum.into(%{})}
+      end)
+      |> Enum.into(%{})
+
+    %{}
+    |> Dataset.list_datasets()
+    |> preload([:resources, :aom, :region, :communes])
+    |> Repo.all()
+    |> Enum.map(fn dataset ->
+      enriched_dataset = Map.get(existing_ids, dataset.id)
+      add_enriched_resources_to_dataset(dataset, enriched_dataset)
+    end)
+    |> Enum.map(&transform_dataset(conn, &1))
+  end
+
+  defp prepare_dataset_detail_data(conn, %DB.Dataset{} = dataset) do
+    gtfs_resources_with_metadata =
+      DB.Resource.base_query()
+      |> DB.ResourceHistory.join_resource_with_latest_resource_history()
+      |> DB.MultiValidation.join_resource_history_with_latest_validation(
+        Transport.Validators.GTFSTransport.validator_name()
+      )
+      |> DB.ResourceMetadata.join_validation_with_metadata()
+      |> preload([resource_history: rh, multi_validation: mv, metadata: m],
+        resource_history: {rh, validations: {mv, metadata: m}}
+      )
+      |> where([resource: r], r.dataset_id == ^dataset.id)
+      |> select([resource: r], {r.id, r})
+      |> DB.Repo.all()
+
+    recent_limit = Transport.Jobs.GTFSRTMetadataJob.datetime_limit()
+
+    gtfs_rt_resources_with_metadata =
+      DB.Resource.base_query()
+      |> DB.ResourceMetadata.join_resource_with_metadata()
+      |> where([metadata: rm], rm.inserted_at > ^recent_limit)
+      |> where([resource: r], r.dataset_id == ^dataset.id)
+      |> preload([metadata: m], resource_metadata: m)
+      |> select([resource: r], {r.id, r})
+      |> DB.Repo.all()
+
+    resources_with_metadata = Enum.into(gtfs_resources_with_metadata ++ gtfs_rt_resources_with_metadata, %{})
+
+    enriched_resources =
+      dataset
+      |> Dataset.official_resources()
+      |> Enum.map(fn r -> resources_with_metadata |> Map.get(r.id, r) end)
+
+    dataset = dataset |> Map.put(:resources, enriched_resources)
+
+    transform_dataset_with_detail(conn, dataset)
   end
 end

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -309,7 +309,7 @@ defmodule TransportWeb.API.DatasetController do
     |> Enum.map(fn c -> %{"name" => c.nom, "insee" => c.insee} end)
   end
 
-  defp prepare_datasets_index_data(conn) do
+  defp prepare_datasets_index_data(%Plug.Conn{} = conn) do
     datasets_with_gtfs_metadata =
       DB.Dataset.base_query()
       |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
@@ -360,7 +360,7 @@ defmodule TransportWeb.API.DatasetController do
     |> Enum.map(&transform_dataset(conn, &1))
   end
 
-  defp prepare_dataset_detail_data(conn, %DB.Dataset{} = dataset) do
+  defp prepare_dataset_detail_data(%Plug.Conn{} = conn, %DB.Dataset{} = dataset) do
     gtfs_resources_with_metadata =
       DB.Resource.base_query()
       |> DB.ResourceHistory.join_resource_with_latest_resource_history()

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -76,7 +76,7 @@ defmodule TransportWeb.API.DatasetController do
       |> Enum.map(&transform_dataset(conn, &1))
     end
 
-    data = Transport.Cache.API.fetch("api-datasets-index", comp_fn)
+    data = Transport.Cache.API.fetch("api-datasets-index", comp_fn, :timer.seconds(30))
 
     render(conn, %{data: data})
   end


### PR DESCRIPTION
Cette PR met en cache les opérations suivantes:
- `/api/datasets` (index de l'API)
- `/api/datasets/:id` (détail API d'un dataset, avec ses ressources et history)

Car, comme vu dans :
- #3302 
- #3334

ces deux opérations comptent parmi les plus utilisées (même si le débit total est faible actuellement), et les plus longues à calculer.

L'objectif de la PR n'est pas tant d'accélérer le comportement pour les utilisateurs (ça ne sera que peu le cas je pense, même si je vérifierai après coup avec AppSignal), que de nous protéger contre un traffic un peu plus poussé qui ferait planter les connections à la base de données.
