### PR TITLE
Contacts : ignorer valeurs nulles

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/contact_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/contact_controller.ex
@@ -77,7 +77,7 @@ defmodule TransportWeb.Backoffice.ContactController do
     |> render("index.html")
   end
 
-  defp search_datalist do
+  def search_datalist do
     :organization
     |> contact_values_for_field()
     |> Enum.concat(contact_values_for_field(:last_name))
@@ -87,6 +87,7 @@ defmodule TransportWeb.Backoffice.ContactController do
   defp contact_values_for_field(field) when is_atom(field) do
     DB.Contact.base_query()
     |> select([contact: c], field(c, ^field))
+    |> where([contact: c], not is_nil(field(c, ^field)))
     |> order_by([contact: c], asc: ^field)
     |> distinct(true)
     |> DB.Repo.all()

--- a/apps/transport/lib/transport_web/views/backoffice/page_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/page_view.ex
@@ -66,13 +66,17 @@ defmodule TransportWeb.Backoffice.PageView do
 
   @doc """
   Replaces accented letters by their regular versions.
-
-  From https://stackoverflow.com/a/68724296
+  Taken from https://stackoverflow.com/a/68724296
 
   iex> unaccent("Et Ça sera sa moitié.")
   "Et Ca sera sa moitie."
+  iex> unaccent(nil)
+  ""
   """
-  def unaccent(value) do
+  @spec unaccent(nil | binary()) :: binary()
+  def unaccent(nil), do: ""
+
+  def unaccent(value) when is_binary(value) do
     ~R<\p{Mn}>u
     |> Regex.replace(value |> :unicode.characters_to_nfd_binary(), "")
     |> :unicode.characters_to_nfc_binary()

--- a/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/contact_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule TransportWeb.Backoffice.ContactControllerTest do
   use TransportWeb.ConnCase, async: true
   import DB.Factory
+  alias TransportWeb.Backoffice.ContactController
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
@@ -197,6 +198,17 @@ defmodule TransportWeb.Backoffice.ContactControllerTest do
     assert redirected_to(conn, 302) == backoffice_contact_path(conn, :index)
     assert get_flash(conn, :info) =~ "Le contact a été supprimé"
     assert is_nil(DB.Repo.reload(contact))
+  end
+
+  test "search_datalist" do
+    DB.Contact.insert!(sample_contact_args(%{last_name: "Doe", organization: "FooBar"}))
+    DB.Contact.insert!(sample_contact_args(%{last_name: "Oppenheimer", organization: "FooBar"}))
+
+    DB.Contact.insert!(
+      sample_contact_args(%{first_name: nil, last_name: nil, organization: "Disney", mailing_list_title: "Data"})
+    )
+
+    assert ["Disney", "Doe", "FooBar", "Oppenheimer"] == ContactController.search_datalist()
   end
 
   defp sample_contact_args(%{} = args \\ %{}) do


### PR DESCRIPTION
Répare un bug introduit dans https://github.com/etalab/transport-site/pull/3348 : on avait une exception pour les contacts qui ont `last_name = null` provoqué par `unaccent`.

```
:unicode.characters_to_nfd_binary/1 at line 895

errors were found at the given arguments:
  * 1st argument: not valid character data (an iodata term)
```

- ignore les valeurs nulles
- gère `nil` pour `unaccent`