### PR TITLE
AvailabilityChecker : autorise 401 ou 405 pour SIRI Lite

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -31,7 +31,7 @@ defmodule Transport.AvailabilityChecker do
   @spec available?(binary(), binary()) :: boolean
   def available?(format, target, use_http_streaming \\ false)
 
-  def available?("SIRI", url, _) when is_binary(url) do
+  def available?(format, url, _) when is_binary(url) and format in ["SIRI", "SIRI Lite"] do
     case http_client().get(url, [], follow_redirect: true) do
       {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code in [401, 405] ->
         true

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -360,7 +360,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful."
+msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI and SIRI Lite feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -360,7 +360,7 @@ msgstr "En savoir plus"
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible."
+msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI et SIRI Lite, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible."
 
 #, elixir-autogen, elixir-format
 msgid "last content modification"

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -33,23 +33,25 @@ defmodule Transport.AvailabilityCheckerTest do
     refute AvailabilityChecker.available?("GTFS", "url500")
   end
 
-  describe "SIRI resource" do
+  describe "SIRI or SIRI Lite resource" do
     test "401" do
       Transport.HTTPoison.Mock
-      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+      |> expect(:get, 2, fn _url, [], [follow_redirect: true] ->
         {:ok, %HTTPoison.Response{status_code: 401}}
       end)
 
       assert AvailabilityChecker.available?("SIRI", "url401")
+      assert AvailabilityChecker.available?("SIRI Lite", "url401")
     end
 
     test "405" do
       Transport.HTTPoison.Mock
-      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+      |> expect(:get, 2, fn _url, [], [follow_redirect: true] ->
         {:ok, %HTTPoison.Response{status_code: 405}}
       end)
 
       assert AvailabilityChecker.available?("SIRI", "url405")
+      assert AvailabilityChecker.available?("SIRI Lite", "url405")
     end
   end
 


### PR DESCRIPTION
Similaire à https://github.com/etalab/transport-site/pull/3287

Autorise les réponses 401 ou 405 pour les flux SIRI Lite, ce qu'on autorise déjà pour les flux SIRI. Ces 2 fluxs ont souvent des authentifications, on ne souhaite pas considérer ces ressources comme indisponibles.

[Voir ticket](https://app.frontapp.com/open/cnv_xm25uc6?key=jKJI2Biljhp1W1pzz8GLNt8JCACa20oV)