### PR TITLE
Ne montrer que les 3 plus récentes resources historisées

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -591,12 +591,7 @@ hr {
   border-bottom: 1px solid var(--theme-border-lighter);
 }
 
-.discussion .displayMore {
-  text-align: center;
-  margin-bottom: 1em;
-}
-
-#notifications-sent .displayMore {
+.discussion, #notifications-sent, #backed-up-resources .displayMore {
   text-align: center;
   margin-bottom: 1em;
 }

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -7,8 +7,6 @@ defmodule TransportWeb.DiscussionsLive do
 
   def render(assigns) do
     ~H"""
-    <script src={TransportWeb.Endpoint.static_path("/js/utils.js")} />
-
     <script>
       window.addEventListener('phx:discussions-loaded', (event) => {
         event.detail.ids.forEach(id =>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
@@ -1,76 +1,76 @@
 <% has_validity_period_col = has_validity_period?(@history_resources) %>
 <section class="white pt-48" id="backed-up-resources">
-    <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
-    <div class="panel">
-        <div id="backed-up-resources-see-more-wrapper">
-        <table class="table">
-            <thead>
-            <tr>
-                <th><%= dgettext("page-dataset-details", "File") %></th>
-                <th><%= dgettext("page-dataset-details", "Publication date") %></th>
-                <%= if has_validity_period_col do %>
-                <th>
-                    <%= dgettext("page-dataset-details", "Validity period") %>
-                </th>
-                <% end %>
-                <th><%= dgettext("page-dataset-details", "Format") %></th>
-            </tr>
-            </thead>
-            <tbody>
-            <%= for resource_history <- @history_resources do %>
-                <tr>
-                <td>
-                    <%= link(resource_history.payload["title"],
-                    to: resource_history.payload["permanent_url"],
-                    rel: "nofollow"
-                    ) %>
-                </td>
-                <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(@locale) %></td>
-                <%= if has_validity_period_col do %>
-                    <%= if has_validity_period?(resource_history) do %>
-                    <td>
-                        <%= dgettext(
-                        "page-dataset-details",
-                        "%{start} to %{end}",
-                        start:
-                            resource_history
-                            |> validity_period()
-                            |> Map.get("start_date")
-                            |> DateTimeDisplay.format_date(@locale),
-                        end:
-                            resource_history
-                            |> validity_period()
-                            |> Map.get("end_date")
-                            |> DateTimeDisplay.format_date(@locale)
-                        ) %>
-                    </td>
-                    <% else %>
-                    <td></td>
-                    <% end %>
-                <% end %>
-                <td><span class="label"><%= resource_history.payload["format"] %></span></td>
-                </tr>
+  <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
+  <div class="panel">
+    <div id="backed-up-resources-see-more-wrapper">
+      <table class="table">
+        <thead>
+          <tr>
+            <th><%= dgettext("page-dataset-details", "File") %></th>
+            <th><%= dgettext("page-dataset-details", "Publication date") %></th>
+            <%= if has_validity_period_col do %>
+              <th>
+                <%= dgettext("page-dataset-details", "Validity period") %>
+              </th>
             <% end %>
-            </tbody>
-        </table>
-        
-        <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
-            <p class="small">
-            <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
-                nb: max_nb_history_resources()
-            ) %>
-            </p>
-        <% end %>
-        </div>
+            <th><%= dgettext("page-dataset-details", "Format") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for resource_history <- @history_resources do %>
+            <tr>
+              <td>
+                <%= link(resource_history.payload["title"],
+                  to: resource_history.payload["permanent_url"],
+                  rel: "nofollow"
+                ) %>
+              </td>
+              <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(@locale) %></td>
+              <%= if has_validity_period_col do %>
+                <%= if has_validity_period?(resource_history) do %>
+                  <td>
+                    <%= dgettext(
+                      "page-dataset-details",
+                      "%{start} to %{end}",
+                      start:
+                        resource_history
+                        |> validity_period()
+                        |> Map.get("start_date")
+                        |> DateTimeDisplay.format_date(@locale),
+                      end:
+                        resource_history
+                        |> validity_period()
+                        |> Map.get("end_date")
+                        |> DateTimeDisplay.format_date(@locale)
+                    ) %>
+                  </td>
+                <% else %>
+                  <td></td>
+                <% end %>
+              <% end %>
+              <td><span class="label"><%= resource_history.payload["format"] %></span></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
+        <p class="small">
+          <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
+            nb: max_nb_history_resources()
+          ) %>
+        </p>
+      <% end %>
     </div>
+  </div>
 </section>
 
 <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      addSeeMore("280px",
-        "#backed-up-resources-see-more-wrapper",
-        "<%= dgettext("page-dataset-details", "Display more") %>",
-        "<%= dgettext("page-dataset-details", "Display less") %>"
-      )
-    })
+  document.addEventListener("DOMContentLoaded", function() {
+    addSeeMore("280px",
+      "#backed-up-resources-see-more-wrapper",
+      "<%= dgettext("page-dataset-details", "Display more") %>",
+      "<%= dgettext("page-dataset-details", "Display less") %>"
+    )
+  })
 </script>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
@@ -1,0 +1,76 @@
+<% has_validity_period_col = has_validity_period?(@history_resources) %>
+<section class="white pt-48" id="backed-up-resources">
+    <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
+    <div class="panel">
+        <div id="backed-up-resources-see-more-wrapper">
+        <table class="table">
+            <thead>
+            <tr>
+                <th><%= dgettext("page-dataset-details", "File") %></th>
+                <th><%= dgettext("page-dataset-details", "Publication date") %></th>
+                <%= if has_validity_period_col do %>
+                <th>
+                    <%= dgettext("page-dataset-details", "Validity period") %>
+                </th>
+                <% end %>
+                <th><%= dgettext("page-dataset-details", "Format") %></th>
+            </tr>
+            </thead>
+            <tbody>
+            <%= for resource_history <- @history_resources do %>
+                <tr>
+                <td>
+                    <%= link(resource_history.payload["title"],
+                    to: resource_history.payload["permanent_url"],
+                    rel: "nofollow"
+                    ) %>
+                </td>
+                <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(@locale) %></td>
+                <%= if has_validity_period_col do %>
+                    <%= if has_validity_period?(resource_history) do %>
+                    <td>
+                        <%= dgettext(
+                        "page-dataset-details",
+                        "%{start} to %{end}",
+                        start:
+                            resource_history
+                            |> validity_period()
+                            |> Map.get("start_date")
+                            |> DateTimeDisplay.format_date(@locale),
+                        end:
+                            resource_history
+                            |> validity_period()
+                            |> Map.get("end_date")
+                            |> DateTimeDisplay.format_date(@locale)
+                        ) %>
+                    </td>
+                    <% else %>
+                    <td></td>
+                    <% end %>
+                <% end %>
+                <td><span class="label"><%= resource_history.payload["format"] %></span></td>
+                </tr>
+            <% end %>
+            </tbody>
+        </table>
+        
+        <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
+            <p class="small">
+            <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
+                nb: max_nb_history_resources()
+            ) %>
+            </p>
+        <% end %>
+        </div>
+    </div>
+</section>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+      addSeeMore("280px",
+        "#backed-up-resources-see-more-wrapper",
+        "<%= dgettext("page-dataset-details", "Display more") %>",
+        "<%= dgettext("page-dataset-details", "Display less") %>"
+      )
+    })
+</script>

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -38,7 +38,7 @@
   </div>
 </section>
 
-<script src={static_path(@conn, "/js/utils.js")} />
+
 <script>
   document.addEventListener("DOMContentLoaded", function() {
     addSeeMore("15em",

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -38,7 +38,6 @@
   </div>
 </section>
 
-
 <script>
   document.addEventListener("DOMContentLoaded", function() {
     addSeeMore("15em",

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -232,63 +232,66 @@
       <section class="white pt-48" id="backed-up-resources">
         <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
         <div class="panel">
-          <table class="table">
-            <thead>
-              <tr>
-                <th><%= dgettext("page-dataset-details", "File") %></th>
-                <th><%= dgettext("page-dataset-details", "Publication date") %></th>
-                <%= if has_validity_period_col do %>
-                  <th>
-                    <%= dgettext("page-dataset-details", "Validity period") %>
-                  </th>
-                <% end %>
-                <th><%= dgettext("page-dataset-details", "Format") %></th>
-              </tr>
-            </thead>
-            <tbody>
-              <%= for resource_history <- @history_resources do %>
+          <div id="backed-up-resources-see-more-wrapper">
+            <table class="table">
+              <thead>
                 <tr>
-                  <td>
-                    <%= link(resource_history.payload["title"],
-                      to: resource_history.payload["permanent_url"],
-                      rel: "nofollow"
-                    ) %>
-                  </td>
-                  <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
+                  <th><%= dgettext("page-dataset-details", "File") %></th>
+                  <th><%= dgettext("page-dataset-details", "Publication date") %></th>
                   <%= if has_validity_period_col do %>
-                    <%= if has_validity_period?(resource_history) do %>
-                      <td>
-                        <%= dgettext(
-                          "page-dataset-details",
-                          "%{start} to %{end}",
-                          start:
-                            resource_history
-                            |> validity_period()
-                            |> Map.get("start_date")
-                            |> DateTimeDisplay.format_date(locale),
-                          end:
-                            resource_history
-                            |> validity_period()
-                            |> Map.get("end_date")
-                            |> DateTimeDisplay.format_date(locale)
-                        ) %>
-                      </td>
-                    <% else %>
-                      <td></td>
-                    <% end %>
+                    <th>
+                      <%= dgettext("page-dataset-details", "Validity period") %>
+                    </th>
                   <% end %>
-                  <td><span class="label"><%= resource_history.payload["format"] %></span></td>
+                  <th><%= dgettext("page-dataset-details", "Format") %></th>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
-          <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
-            <p class="small">
-              <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
-                nb: max_nb_history_resources()
-              ) %>
-            </p>
-          <% end %>
+              </thead>
+              <tbody>
+                <%= for resource_history <- @history_resources do %>
+                  <tr>
+                    <td>
+                      <%= link(resource_history.payload["title"],
+                        to: resource_history.payload["permanent_url"],
+                        rel: "nofollow"
+                      ) %>
+                    </td>
+                    <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
+                    <%= if has_validity_period_col do %>
+                      <%= if has_validity_period?(resource_history) do %>
+                        <td>
+                          <%= dgettext(
+                            "page-dataset-details",
+                            "%{start} to %{end}",
+                            start:
+                              resource_history
+                              |> validity_period()
+                              |> Map.get("start_date")
+                              |> DateTimeDisplay.format_date(locale),
+                            end:
+                              resource_history
+                              |> validity_period()
+                              |> Map.get("end_date")
+                              |> DateTimeDisplay.format_date(locale)
+                          ) %>
+                        </td>
+                      <% else %>
+                        <td></td>
+                      <% end %>
+                    <% end %>
+                    <td><span class="label"><%= resource_history.payload["format"] %></span></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          
+            <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
+              <p class="small">
+                <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
+                  nb: max_nb_history_resources()
+                ) %>
+              </p>
+            <% end %>
+          </div>
         </div>
       </section>
     <% end %>
@@ -382,5 +385,15 @@
     createDatasetMap('dataset-covered-area-map', "<%= @dataset.datagouv_id %>")
   })
 </script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+      addSeeMore("280px",
+        "#backed-up-resources-see-more-wrapper",
+        "<%= dgettext("page-dataset-details", "Display more") %>",
+        "<%= dgettext("page-dataset-details", "Display less") %>"
+      )
+    })
+</script>
 <script defer type="text/javascript" src={static_path(@conn, "/js/app.js")}>
 </script>
+<script src={static_path(@conn, "/js/utils.js")} />

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -228,72 +228,7 @@
       </section>
     <% end %>
     <%= unless @history_resources == [] do %>
-      <% has_validity_period_col = has_validity_period?(@history_resources) %>
-      <section class="white pt-48" id="backed-up-resources">
-        <h3><%= dgettext("page-dataset-details", "Backed up resources") %></h3>
-        <div class="panel">
-          <div id="backed-up-resources-see-more-wrapper">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th><%= dgettext("page-dataset-details", "File") %></th>
-                  <th><%= dgettext("page-dataset-details", "Publication date") %></th>
-                  <%= if has_validity_period_col do %>
-                    <th>
-                      <%= dgettext("page-dataset-details", "Validity period") %>
-                    </th>
-                  <% end %>
-                  <th><%= dgettext("page-dataset-details", "Format") %></th>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for resource_history <- @history_resources do %>
-                  <tr>
-                    <td>
-                      <%= link(resource_history.payload["title"],
-                        to: resource_history.payload["permanent_url"],
-                        rel: "nofollow"
-                      ) %>
-                    </td>
-                    <td><%= resource_history.inserted_at |> DateTimeDisplay.format_datetime_to_date(locale) %></td>
-                    <%= if has_validity_period_col do %>
-                      <%= if has_validity_period?(resource_history) do %>
-                        <td>
-                          <%= dgettext(
-                            "page-dataset-details",
-                            "%{start} to %{end}",
-                            start:
-                              resource_history
-                              |> validity_period()
-                              |> Map.get("start_date")
-                              |> DateTimeDisplay.format_date(locale),
-                            end:
-                              resource_history
-                              |> validity_period()
-                              |> Map.get("end_date")
-                              |> DateTimeDisplay.format_date(locale)
-                          ) %>
-                        </td>
-                      <% else %>
-                        <td></td>
-                      <% end %>
-                    <% end %>
-                    <td><span class="label"><%= resource_history.payload["format"] %></span></td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          
-            <%= if Enum.count(@history_resources) == max_nb_history_resources() do %>
-              <p class="small">
-                <%= dgettext("page-dataset-details", "Displaying the last %{nb} backed up resources.",
-                  nb: max_nb_history_resources()
-                ) %>
-              </p>
-            <% end %>
-          </div>
-        </div>
-      </section>
+      <%= render("_dataset_resources_history.html", history_resources: @history_resources, locale: locale, conn: @conn) %>
     <% end %>
     <%= unless is_nil(@other_datasets) or @other_datasets == [] do %>
       <section class="pt-48" id="dataset-other-datasets">
@@ -384,15 +319,6 @@
   document.addEventListener("DOMContentLoaded", function() {
     createDatasetMap('dataset-covered-area-map', "<%= @dataset.datagouv_id %>")
   })
-</script>
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-      addSeeMore("280px",
-        "#backed-up-resources-see-more-wrapper",
-        "<%= dgettext("page-dataset-details", "Display more") %>",
-        "<%= dgettext("page-dataset-details", "Display less") %>"
-      )
-    })
 </script>
 <script defer type="text/javascript" src={static_path(@conn, "/js/app.js")}>
 </script>


### PR DESCRIPTION
Il y a intérêt d’après @AntoineAugusti d’avoir l’historique de toutes les resources liées à un dataset sur une même liste, sur la page du dataset, pour comprendre si ils ont changé le nom des fichiers par exemple. Du coup cette PR laisse le code tel quel et rajoute juste un addseemore, tout en bougeant vers son propre template.

Avec 3 resources historiques / avec plus de 3 :
![Sélection_061](https://github.com/etalab/transport-site/assets/15861435/f9e1ea2d-796c-4b16-8064-21bda52727f5)

![Sélection_062](https://github.com/etalab/transport-site/assets/15861435/4163c9e6-fb56-4f6d-a5de-9854e2ca1046)
