### PR TITLE
Correction bug CSS text-align

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -591,7 +591,9 @@ hr {
   border-bottom: 1px solid var(--theme-border-lighter);
 }
 
-.discussion, #notifications-sent, #backed-up-resources .displayMore {
-  text-align: center;
-  margin-bottom: 1em;
+.discussion, #notifications-sent, #backed-up-resources {
+  .displayMore {
+    text-align: center;
+    margin-bottom: 1em;
+  }
 }

--- a/apps/transport/client/stylesheets/components/_discussions.scss
+++ b/apps/transport/client/stylesheets/components/_discussions.scss
@@ -29,7 +29,7 @@
   }
 
   .discussion-comment + .discussion-comment {
-    padding: 1vw 0;
+    padding: 1vw 0 1vw 1vw;
   }
 
   .discussion-comment__content p:last-child {


### PR DESCRIPTION
Corrige un bug introduit dans https://github.com/etalab/transport-site/pull/3358, les sélecteurs CSS n'étaient pas bon : on ciblait par exemple `.discussion` au lieu `.discussion .displayMore`. Résultat : tous les commentaires étaient centrés, et non seulement le bouton "voir plus".

J'en profite pour corriger un padding-left.