### PR TITLE
Validation GTFS : erreur coordonnées pour shapes

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_coordinates_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_coordinates_issue.html.heex
@@ -1,19 +1,15 @@
 <p>
-  <%= dgettext("validations-explanations", "Impacted file:") %> <tt>stops.txt</tt>
-</p>
-<p>
   <%= dgettext("validations-explanations", "CoordinatesIssue") %>
 </p>
 <table class="table">
   <tr>
-    <th><%= dgettext("validations-explanations", "Stop ID") %></th>
-    <th><%= dgettext("validations-explanations", "Stop name") %></th>
+    <th><%= dgettext("validations-explanations", "Object type") %></th>
+    <th><%= dgettext("validations-explanations", "Object ID") %></th>
   </tr>
-
-  <%= for issue <- @issues do %>
+  <%= for issue <- @issues |> Enum.sort_by(& &1["object_type"]) do %>
     <tr>
+      <td><%= issue["object_type"] %></td>
       <td><%= issue["object_id"] %></td>
-      <td><%= issue["object_name"] %></td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
Fixes #3357

Les erreurs `InvalidCoordinates` et `MissingCoordinates` peuvent concerner stops OU shapes, adapte le template en conséquence.