### PR TITLE
Validation TableSchema : ignore casse des headers

### DIFF
--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -48,9 +48,9 @@ defmodule Shared.Validation.TableSchemaValidator do
 
     schema_url = schema_url(schema_name, schema_version || "latest")
 
-    # See https://go.validata.fr/api/v1/apidocs
+    # See https://api.validata.etalab.studio/apidocs
     @validata_api_url
-    |> Map.put(:query, URI.encode_query(%{schema: schema_url, url: url}))
+    |> Map.put(:query, URI.encode_query(%{schema: schema_url, url: url, header_case: "false"}))
     |> URI.to_string()
   end
 

--- a/apps/shared/test/validation/tableschema_validator_test.exs
+++ b/apps/shared/test/validation/tableschema_validator_test.exs
@@ -15,7 +15,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
     test "with a specific schema version" do
       setup_schemas_response()
       schema_version = "0.2.2"
-      query = URI.encode_query(%{schema: schema_url(@schema_name, schema_version), url: @url})
+      query = URI.encode_query(%{schema: schema_url(@schema_name, schema_version), url: @url, header_case: "false"})
       expected_url = "https://validata-api.app.etalab.studio/validate?#{query}"
 
       assert validator_api_url(@schema_name, @url, schema_version) == expected_url
@@ -23,7 +23,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
 
     test "with latest version" do
       setup_schemas_response()
-      query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url})
+      query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url, header_case: "false"})
       expected_url = "https://validata-api.app.etalab.studio/validate?#{query}"
 
       assert validator_api_url(@schema_name, @url) == expected_url
@@ -166,7 +166,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
   defp read_json(filename), do: File.read!("#{__DIR__}/../fixtures/#{filename}")
 
   defp validata_response_with_body(body, status_code \\ 200) do
-    query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url})
+    query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url, header_case: "false"})
     url = "https://validata-api.app.etalab.studio/validate?#{query}"
 
     Transport.HTTPoison.Mock


### PR DESCRIPTION
Voir [Désactiver la sensibilité à la casse dans l'en-tête](https://git.opendatafrance.net/validata/validata-core/-/issues/25) côté Validata.

Désactive la sensibilité à la casse des en-têtes pour la validation des schémas TableSchema, pour se conformer à ce que constatent les producteurs sur publier.etalab.studio et sur l'interface web de Validata.