### PR TITLE
Dataset : suppression espaces pour custom_title

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -481,6 +481,7 @@ defmodule DB.Dataset do
       :custom_tags,
       :legal_owner_company_siren
     ])
+    |> update_change(:custom_title, &String.trim/1)
     |> cast_aom(params)
     |> cast_datagouv_zone(params, territory_name)
     |> cast_nation_dataset(params)

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -152,6 +152,16 @@ defmodule DB.DatasetDBTest do
                  "legal_owner_company_siren" => "552049447"
                })
     end
+
+    test "custom_title is trimmed" do
+      assert {:ok, %Ecto.Changeset{changes: %{custom_title: "Foo"}}} =
+               Dataset.changeset(%{
+                 "datagouv_id" => "1",
+                 "slug" => "slug",
+                 "national_dataset" => "true",
+                 "custom_title" => "  Foo "
+               })
+    end
   end
 
   describe "mobility-licence" do


### PR DESCRIPTION
J'ai remarqué que des espaces étaient souvent ajoutés en fin de valeur, rempli par notre équipe dans le backoffice.