### PR TITLE
Affiche score de disponibilité

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -59,7 +59,7 @@ defmodule TransportWeb.DatasetController do
       )
       |> assign(:latest_resources_history_infos, DB.ResourceHistory.latest_dataset_resources_history_infos(dataset.id))
       |> assign(:notifications_sent, DB.Notification.recent_reasons_binned(dataset, days_notifications_sent()))
-      |> assign(:freshness_score, DB.DatasetScore.get_latest(dataset, :freshness))
+      |> assign(:dataset_scores, DB.DatasetScore.get_latest_scores(dataset, Ecto.Enum.values(DB.DatasetScore, :topic)))
       |> put_status(if dataset.is_active, do: :ok, else: :not_found)
       |> render("details.html")
     else

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -1,0 +1,24 @@
+<div :if={@dataset_scores != %{}} class="light-grey pt-6">
+  <% freshness_score = Map.get(@dataset_scores, :freshness) %>
+  <div>
+    <%= unless is_nil(freshness_score) do %>
+      Score fraicheur : <%= freshness_score.score %>
+      <span class="small">
+        <%= freshness_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
+      </span>
+    <% else %>
+      Pas de score fraicheur
+    <% end %>
+  </div>
+  <% availability_score = Map.get(@dataset_scores, :availability) %>
+  <div>
+    <%= unless is_nil(availability_score) do %>
+      Score de disponibilité : <%= availability_score.score %>
+      <span class="small">
+        <%= availability_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
+      </span>
+    <% else %>
+      Pas de score de disponibilité
+    <% end %>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -19,14 +19,7 @@
   <%= if admin?(assigns[:current_user]) do %>
     <i class="fa fa-external-link-alt"></i>
     <%= link("backoffice", to: backoffice_page_path(@conn, :edit, @dataset.id)) %>
-    <div class="light-grey pt-6">
-      <%= if not is_nil(@freshness_score) do %>
-        Score fraicheur : <%= @freshness_score.score %><br />
-        <%= @freshness_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(locale) %>
-      <% else %>
-        Pas de score fraicheur
-      <% end %>
-    </div>
+    <%= render("_dataset_scores.html", dataset_scores: @dataset_scores, locale: locale) %>
   <% end %>
 </div>
 <div class="dataset-page">

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -370,6 +370,32 @@ defmodule TransportWeb.DatasetControllerTest do
              |> Phoenix.HTML.safe_to_string()
   end
 
+  test "displays dataset scores for admins", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true)
+
+    insert(:dataset_score,
+      dataset: dataset,
+      timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour),
+      score: 0.55,
+      topic: :freshness
+    )
+
+    set_empty_mocks()
+
+    content =
+      conn
+      |> setup_admin_in_session()
+      |> get(dataset_path(conn, :details, dataset.slug))
+      |> html_response(200)
+
+    assert content =~ "Score fraicheur : 0.55"
+
+    # For someone who's not an admin
+    set_empty_mocks()
+    content = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
+    refute content =~ "Score fraicheur"
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")


### PR DESCRIPTION
- Affiche le score de disponibilité (introduit dans #3333) sur la page `dataset#details` pour les admins
- Ajoute les méthodes requises
- Couverture de tests adéquate

![image](https://github.com/etalab/transport-site/assets/295709/9361f1d3-5f5d-4ece-8eaf-f6d75e0bf2a9)

