### PR TITLE
SessionController : filtre les organisations

### DIFF
--- a/apps/transport/test/transport_web/controllers/session_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/session_controller_test.exs
@@ -76,6 +76,14 @@ defmodule TransportWeb.SessionControllerTest do
     assert_in_delta last_login_at |> DateTime.to_unix(), DateTime.utc_now() |> DateTime.to_unix(), 1
   end
 
+  test "save_current_user", %{conn: conn} do
+    pan_org = %{"slug" => "equipe-transport-data-gouv-fr", "name" => "PAN"}
+    user_params = %{"foo" => "bar", "organizations" => [%{"slug" => "foo"}, pan_org]}
+
+    assert %{"foo" => "bar", "organizations" => [pan_org]} ==
+             conn |> init_test_session(%{}) |> save_current_user(user_params) |> get_session(:current_user)
+  end
+
   test "GET /login/callback and redirection to /datasets", %{conn: conn} do
     conn =
       conn


### PR DESCRIPTION
Fixes #3367

N'enregistre pas toutes les organisations dans le cookie de session, les utilisateurs avec trop d'organisations ont alors un cookie trop gros.

Les organisations ne sont pas récupérées directement en lisant la session plus, on repasse par l'API data.gouv.fr pour l'utilisateur en cas de besoin.