### PR TITLE
Ajout test liens valides pour la documentation

### DIFF
--- a/apps/transport/test/documentation_links_test.exs
+++ b/apps/transport/test/documentation_links_test.exs
@@ -21,6 +21,6 @@ defmodule Transport.DocumentationLinksTest do
         end
       end)
 
-    assert [] == failures, "Unexpected status codes for: #{Enum.map_join(failures, ", ", &elem(&1, 1))}"
+    assert [] == failures, "Unexpected status codes for:\n#{Enum.map_join(failures, "\n", &elem(&1, 1))}"
   end
 end

--- a/apps/transport/test/documentation_links_test.exs
+++ b/apps/transport/test/documentation_links_test.exs
@@ -1,0 +1,26 @@
+defmodule Transport.DocumentationLinksTest do
+  use ExUnit.Case, async: true
+  @moduletag :documentation_links
+  @documentation_domain "doc.transport.data.gouv.fr"
+
+  test "documentation links are valid" do
+    regexp = ~r/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/
+    {output, 0} = System.shell("grep -r #{@documentation_domain} ../../apps/transport/lib")
+
+    failures =
+      regexp
+      |> Regex.scan(output)
+      |> Enum.filter(fn [url | _] -> String.contains?(url, @documentation_domain) end)
+      |> Enum.map(fn [url | _] -> url |> URI.parse() |> Map.replace!(:fragment, nil) |> URI.to_string() end)
+      |> Enum.uniq()
+      |> Enum.map(fn url -> {HTTPoison.head(url), url} end)
+      |> Enum.reject(fn {response, _} ->
+        case response do
+          {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in [200, 302] -> true
+          _ -> false
+        end
+      end)
+
+    assert [] == failures, "Unexpected status codes for: #{Enum.map_join(failures, ", ", &elem(&1, 1))}"
+  end
+end

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -1,7 +1,7 @@
 exclude = [:pending]
 # NOTE: the CI variable is defined by CircleCI (and oftent by CI providers) here:
 # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-extra_exclude = if System.get_env("CI") == "true", do: [], else: [:transport_tools]
+extra_exclude = if System.get_env("CI") == "true", do: [], else: [:transport_tools, :documentation_links]
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)
 

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -1,7 +1,16 @@
 exclude = [:pending]
 # NOTE: the CI variable is defined by CircleCI (and oftent by CI providers) here:
 # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-extra_exclude = if System.get_env("CI") == "true", do: [], else: [:transport_tools, :documentation_links]
+extra_exclude =
+  if System.get_env("CI") == "true" do
+    # Run :documentation_links only on Mondays
+    case Date.utc_today() |> Date.day_of_week() do
+      1 -> []
+      _ -> [:documentation_links]
+    end
+  else
+    [:transport_tools, :documentation_links]
+  end
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)
 


### PR DESCRIPTION
Ajoute un test à notre suite, qui ne sera exécuté qu'en CI. J'ai repris une bonne partie du code dans https://github.com/etalab/transport-site/issues/2579#issuecomment-1667451745, merci @thbar !

C'est l'occasion de voir quelques surprises :grimacing: