### PR TITLE
Adapte CSP pour style sur Vega Embed

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -30,6 +30,10 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
   true
   """
   def csp_headers(app_env, nonce) do
+    # https://github.com/vega/vega-embed/issues/1214#issuecomment-1670812445
+    vega_hash_values =
+      "'sha256-9uoGUaZm3j6W7+Fh2wfvjI8P7zXcclRw5tVUu3qKZa0=' 'sha256-MmUum7+PiN7Rz79EUMm0OmUFWjCx6NZ97rdjoIbTnAg='"
+
     csp_content =
       case app_env do
         :production ->
@@ -40,7 +44,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net;
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
           frame-src https://www.dailymotion.com/;
-          style-src 'self' 'nonce-#{nonce}';
+          style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
           report-uri #{Application.fetch_env!(:sentry, :csp_url)}
           """
 
@@ -53,7 +57,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
             img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net;
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
             frame-src https://www.dailymotion.com/;
-            style-src 'self' 'nonce-#{nonce}';
+            style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
             report-uri #{Application.fetch_env!(:sentry, :csp_url)}
           """
 

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores_chart.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores_chart.html.heex
@@ -4,7 +4,7 @@
     <div id="vega-vis"></div>
     <p class="small">Ceci est visible uniquement par les membres de transport.data.gouv.fr.</p>
     <script src={static_path(@conn, "/js/vega.js")} nonce={@conn.assigns[:csp_nonce_value]} />
-    <script>
+    <script nonce={@conn.assigns[:csp_nonce_value]}>
       const spec = <%= raw Jason.encode!(@scores_chart) %>;
       window.vegaEmbed("#vega-vis", spec, {renderer: "svg"});
     </script>


### PR DESCRIPTION
#3375 n'était pas suffisant, j'adopte une des solutions proposée dans https://github.com/vega/vega-embed/issues/1214#issuecomment-1670812445. Peut-être qu'on pourra spécifier le `nonce` dans Vega Embed plus tard.