### PR TITLE
Mise à jour liens documentation

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -235,7 +235,9 @@ defmodule TransportWeb.Router do
     end
 
     # old static pages that have been moved to doc.transport
-    get("/faq", Redirect, external: "https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites")
+    get("/faq", Redirect,
+      external: "https://doc.transport.data.gouv.fr/le-point-d-acces-national/generalites/le-point-dacces-national"
+    )
 
     get("/guide", Redirect,
       external:
@@ -252,7 +254,7 @@ defmodule TransportWeb.Router do
         "https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/conditions-dutilisation-des-donnees/licence-odbl"
     )
 
-    get("/budget", Redirect, external: "https://doc.transport.data.gouv.fr/guide-du-pan/budget")
+    get("/budget", Redirect, external: "https://doc.transport.data.gouv.fr/le-point-d-acces-national/generalites/budget")
 
     # old static pages that have been moved to blog.transport
     get("/blog/2019_04_26_interview_my_bus", Redirect,

--- a/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_community_resources.html.heex
@@ -18,7 +18,7 @@
         "Reusers can share in this section edits made on resources%{odbl_text}. <a href=\"%{datagouv_link}\" target=\"_blank\">Publish your own ressource</a> on data.gouv.fr or <a href=\"%{doc_link}\" target=\"_blank\">browse our documentation.</a>",
         datagouv_link: publish_community_resource_url(@dataset),
         doc_link:
-          "https://doc.transport.data.gouv.fr/reutilisateurs/utilisation-par-les-reutilisateurs-de-donnees/repartager-les-modifications-apportees-a-une-ressource",
+          "https://doc.transport.data.gouv.fr/administration-des-donnees/reutilisation-des-donnees/procedures-de-repartage-des-donnees",
         odbl_text: odbl_text
       )
       |> raw() %>

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -31,7 +31,8 @@
         dgettext(
           "page-dataset-details",
           ~s(If you are a data producer, you can <a href="%{url}" target="_blank">manage how you receive these notifications</a> from your Producer section.),
-          url: "https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications"
+          url:
+            "https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications"
         )
       ) %>
     </p>

--- a/apps/transport/lib/transport_web/templates/email/dataset_now_on_nap.html.md
+++ b/apps/transport/lib/transport_web/templates/email/dataset_now_on_nap.html.md
@@ -1,8 +1,8 @@
 Bonjour,
 
-Votre jeu de données [<%= @dataset_custom_title %>](<%= @dataset_url %>) a bien été référencé sur le [Point d'Accès National aux données de transport, transport.data.gouv.fr](https://doc.transport.data.gouv.fr/guide-du-pan).
+Votre jeu de données [<%= @dataset_custom_title %>](<%= @dataset_url %>) a bien été référencé sur le [Point d'Accès National aux données de transport, transport.data.gouv.fr](https://doc.transport.data.gouv.fr/le-point-d-acces-national/generalites/le-point-dacces-national).
 
-Pour gérer la qualité de vos données : [les mettre à jour](https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees), vous [inscrire à des notifications](https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications) etc. nous vous encourageons à passer par l'[espace producteur du PAN](https://transport.data.gouv.fr/espace_producteur).
+Pour gérer la qualité de vos données : [les mettre à jour](https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees), vous [inscrire à des notifications](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications) etc. nous vous encourageons à passer par l'[espace producteur du PAN](https://transport.data.gouv.fr/espace_producteur).
 
 Si vous avez des questions, n'hésitez pas à contacter notre équipe à l'adresse : <%= @contact_email_address %>.
 

--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -15,7 +15,7 @@ Vous êtes susceptible de recevoir des notifications pour les jeux de données s
 </ul>
 <% end %>
 
-Les notifications facilitent la gestion de vos données. Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications#les-differents-types-de-notifications).
+Les notifications facilitent la gestion de vos données. Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications#les-differents-types-de-notifications).
 
 Vous pouvez gérer ces notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>).
 
@@ -25,7 +25,7 @@ Vous pouvez gérer ces notifications depuis [votre espace producteur du Point d'
 Les autres personnes inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
 <% end %>
 
-Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/producteurs/comment-et-pourquoi-les-producteurs-de-donnees-utilisent-ils-le-pan/creer-une-organisation-sur-data.gouv.fr). Chacune de ces personnes peut paramétrer des notifications depuis leur espace producteur.
+Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/creer-un-compte-utilisateur-sur-data.gouv.fr). Chacune de ces personnes peut paramétrer des notifications depuis leur espace producteur.
 
 Nous restons disponible pour vous accompagner si besoin.
 

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -15,7 +15,7 @@ Vous gérez les jeux de données suivants :
 </ul>
 <% end %>
 
-Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>). Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications#les-differents-types-de-notifications).
+Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>). Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications).
 
 ## Gérer les membres de vos organisations
 

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -15,7 +15,7 @@ Vous gérez les jeux de données suivants :
 </ul>
 <% end %>
 
-Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>). Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sinscrire-aux-notifications#les-differents-types-de-notifications).
+Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>). Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications#les-differents-types-de-notifications).
 
 ## Gérer les membres de vos organisations
 
@@ -23,7 +23,7 @@ Pour vous faciliter la gestion de ces données, vous pouvez activer des notifica
 Les autres personnes pouvant s'inscrire à ces notifications et s'étant déjà connecté sont : <%= @contacts_in_orgs %>.
 <% end %>
 
-Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si certaines personnes ne font plus partie de votre organisation, vous pouvez supprimer leur accès depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/producteurs/comment-et-pourquoi-les-producteurs-de-donnees-utilisent-ils-le-pan/creer-une-organisation-sur-data.gouv.fr).
+Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si certaines personnes ne font plus partie de votre organisation, vous pouvez supprimer leur accès depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/creer-un-compte-utilisateur-sur-data.gouv.fr).
 
 Chacune de ces personnes peut paramétrer des notifications depuis leur espace producteur.
 

--- a/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_footer.html.heex
@@ -45,13 +45,19 @@
         </li>
       <% end %>
       <li>
-        <a class="footer__link" target="_blank" href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/">API</a>
+        <a
+          class="footer__link"
+          target="_blank"
+          href="https://doc.transport.data.gouv.fr/administration-des-donnees/outils/api"
+        >
+          API
+        </a>
       </li>
       <li>
         <a
           class="footer__link"
           target="_blank"
-          href="https://doc.transport.data.gouv.fr/foire-aux-questions-1/generalites"
+          href="https://doc.transport.data.gouv.fr/le-point-d-acces-national/generalites/le-point-dacces-national"
         >
           FAQ
         </a>

--- a/apps/transport/lib/transport_web/templates/notification/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/notification/index.html.heex
@@ -14,7 +14,7 @@
             "espace-producteurs",
             ~s[<a href="%{doc_url}" target="_blank">Learn more</a> about how notifications work and when they are sent.],
             doc_url:
-              "https://doc.transport.data.gouv.fr/producteurs/gerer-la-qualite-des-donnees/sabonner-aux-notifications"
+              "https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications"
           )
         ) %>
       </p>

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -33,7 +33,7 @@
               </a>
             </div>
             <div class="search-method">
-              <a href="https://doc.transport.data.gouv.fr/reutilisateurs/apis/">
+              <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/outils/api">
                 <img src={static_path(@conn, "/images/icons/api.png")} alt="API" />
                 <%= dgettext("page-index", "Use our APIs") %>
               </a>
@@ -187,7 +187,7 @@
     <p class="text-center">
       <%= dgettext("page-index", "reusers list description") %>
       <%= link(dgettext("page-index", "Learn more"),
-        to: "https://doc.transport.data.gouv.fr/reutilisateurs/outils-pour-les-reutilisateurs"
+        to: "https://doc.transport.data.gouv.fr/administration-des-donnees/outils"
       ) %>.
     </p>
   </div>

--- a/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
@@ -122,7 +122,7 @@
             ) %>
           </div>
           <div class="pt-12">
-            <a href="https://doc.transport.data.gouv.fr/presentation-et-mode-demploi-du-pan/cadre-juridique-harmonise">
+            <a href="https://doc.transport.data.gouv.fr/le-point-d-acces-national/cadre-juridique">
               <%= dgettext("page-producteurs", "Read here a summary of those obligations") %>
             </a>
           </div>

--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -170,7 +170,7 @@
               Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.
             </p>
             <p>
-              Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/outils/validateurs#validateur-de-fichiers-gtfs">documentation</a>.
+              Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/outils/validateurs">documentation</a>.
             </p>
           </div>
           <div class="tile">

--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -170,7 +170,7 @@
               Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.
             </p>
             <p>
-              Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/reutilisateurs/qualite-de-donnee#validateur-de-fichiers-gtfs">documentation</a>.
+              Retrouvez plus d'informations sur ces outils dans la <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/outils/validateurs#validateur-de-fichiers-gtfs">documentation</a>.
             </p>
           </div>
           <div class="tile">


### PR DESCRIPTION
Remplace les liens avec ceux indiqués dans https://github.com/etalab/transport-site/issues/2579#issuecomment-1669710754

`mix test apps/transport/test --only documentation_links` passe sur ma machine ensuite