### PR TITLE
Pas de possibilité de réponse pour discussions fermées

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
@@ -31,7 +31,7 @@
       </div>
     <% end %>
 
-    <div :if={@current_user} class="discussion-form">
+    <div :if={not is_nil(@current_user) and is_nil(@discussion["closed"])} class="discussion-form">
       <a href={"#reply-#{@discussion["id"]}"}>
         <%= dgettext("page-dataset-details", "Respond") %>
       </a>


### PR DESCRIPTION
N'affiche pas le bouton "Répondre" pour les discussions qui sont fermées sur data.gouv.fr, actuellement visible ([voir ici](https://transport.data.gouv.fr/datasets/gtfs-noirmoutier-gratibus-ete-2023#dataset-discussions)).

Il me semble qu'il y a d'ailleurs un bug où on peut ajouter un commentaire lorsqu'une discussion est fermée https://github.com/etalab/data.gouv.fr/issues/1139