### PR TITLE
Gère DB.DatasetScore.score nil pour affichage

### DIFF
--- a/apps/transport/lib/db/dataset_score.ex
+++ b/apps/transport/lib/db/dataset_score.ex
@@ -80,4 +80,14 @@ defmodule DB.DatasetScore do
     |> order_by([dataset_score: ds], asc: ds.timestamp, asc: ds.topic)
     |> DB.Repo.all()
   end
+
+  @doc """
+  iex> score_for_humans(%DB.DatasetScore{score: nil})
+  nil
+  iex> score_for_humans(%DB.DatasetScore{score: 0.123})
+  0.12
+  """
+  @spec score_for_humans(__MODULE__.t()) :: nil | float()
+  def score_for_humans(%__MODULE__{score: nil}), do: nil
+  def score_for_humans(%__MODULE__{score: score}), do: Float.round(score, 2)
 end

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -81,8 +81,10 @@ defmodule TransportWeb.DatasetController do
     [width: "container", height: 250]
     |> VegaLite.new()
     |> VegaLite.data_from_values(
-      Enum.map(data, fn %DB.DatasetScore{} = ds ->
-        %{"topic" => ds.topic, "score" => ds.score |> Float.round(2), "date" => ds.timestamp |> DateTime.to_date()}
+      data
+      |> Enum.reject(&match?(%DB.DatasetScore{score: nil}, &1))
+      |> Enum.map(fn %DB.DatasetScore{topic: topic, timestamp: timestamp} = ds ->
+        %{"topic" => topic, "score" => DB.DatasetScore.score_for_humans(ds), "date" => timestamp |> DateTime.to_date()}
       end)
     )
     |> VegaLite.mark(:line, interpolate: "step-before", tooltip: true, strokeWidth: 3)

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -2,7 +2,7 @@
   <% freshness_score = Map.get(@dataset_scores, :freshness) %>
   <div>
     <%= unless is_nil(freshness_score) do %>
-      Score fraicheur : <%= freshness_score.score |> Float.round(2) %>
+      Score fraicheur : <%= DB.DatasetScore.score_for_humans(freshness_score) %>
       <span class="small">
         <%= freshness_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
       </span>
@@ -13,7 +13,7 @@
   <% availability_score = Map.get(@dataset_scores, :availability) %>
   <div>
     <%= unless is_nil(availability_score) do %>
-      Score de disponibilité : <%= availability_score.score |> Float.round(2) %>
+      Score de disponibilité : <%= DB.DatasetScore.score_for_humans(availability_score) %>
       <span class="small">
         <%= availability_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
       </span>

--- a/apps/transport/test/db/dataset_score_test.exs
+++ b/apps/transport/test/db/dataset_score_test.exs
@@ -6,6 +6,8 @@ defmodule DB.DatasetScoreTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
+  doctest DB.DatasetScore, import: true
+
   describe "save dataset score" do
     test "some fields are mandatory" do
       changeset = %DB.DatasetScore{} |> DB.DatasetScore.changeset(%{})

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -380,6 +380,18 @@ defmodule TransportWeb.DatasetControllerTest do
       topic: :freshness
     )
 
+    insert(:dataset_score,
+      dataset: dataset,
+      timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour),
+      score: nil,
+      topic: :availability
+    )
+
+    assert %{
+             availability: %DB.DatasetScore{topic: :availability, score: nil},
+             freshness: %DB.DatasetScore{topic: :freshness, score: 0.549}
+           } = dataset |> DB.DatasetScore.get_latest_scores(Ecto.Enum.values(DB.DatasetScore, :topic))
+
     set_empty_mocks()
 
     content =
@@ -389,8 +401,20 @@ defmodule TransportWeb.DatasetControllerTest do
       |> html_response(200)
 
     assert content =~ "Score fraicheur : 0.55"
+    assert content =~ "Score de disponibilité : \n"
+  end
 
-    # For someone who's not an admin
+  test "does not display scores for non admins", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true)
+
+    insert(:dataset_score,
+      dataset: dataset,
+      timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour),
+      score: 1,
+      topic: :freshness
+    )
+
+    refute dataset |> DB.DatasetScore.get_latest_scores([:freshness]) |> Enum.empty?()
     set_empty_mocks()
     content = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
     refute content =~ "Score fraicheur"


### PR DESCRIPTION
#3382 n'était pas aussi anecdotique que ça, ça engendre des 500 quand `score: nil`.

J'améliore le code et ajoute pas mal de tests.

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/4382715635/)