### PR TITLE
CustomTagsInput : ne pas lowercase un tag requestor_ref

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -77,7 +77,14 @@ defmodule TransportWeb.CustomTagsLive do
   end
 
   def handle_event("add_tag", %{"key" => "Enter", "value" => tag}, socket) do
-    clean_tag = tag |> String.downcase() |> String.trim()
+    # Do not lowercase a tag for a SIRI requestor_ref
+    clean_tag =
+      if String.starts_with?(tag, "requestor_ref:") do
+        tag |> String.trim()
+      else
+        tag |> String.downcase() |> String.trim()
+      end
+
     custom_tags = (socket.assigns.custom_tags ++ [clean_tag]) |> Enum.uniq()
     socket = socket |> clear_input() |> assign(:custom_tags, custom_tags)
 

--- a/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
@@ -33,5 +33,13 @@ defmodule TransportWeb.CustomTagsLiveTest do
 
     assert rendered_view =~ "excellent"
     refute rendered_view =~ "excellent   "
+
+    # Does not lowercase tags for SIRI requestor refs
+    rendered_view =
+      view
+      |> element("#custom_tag")
+      |> render_keydown(%{"key" => "Enter", "value" => "requestor_ref:OPENDATA"})
+
+    assert rendered_view =~ "requestor_ref:OPENDATA"
   end
 end


### PR DESCRIPTION
Mauvaise nouvelle, certains systèmes demandent un requestor ref SIRI en majuscules.

On peut les renseigner à l'aide d'un tag dans notre backoffice https://github.com/etalab/transport-site/pull/3291 mais notre système lowercase chaque tag.

Cette PR ne lowercase pas automatiquement un tag de requestor ref SIRI.