### PR TITLE
AddSeeMore : tracking JS au clic

### DIFF
--- a/apps/transport/client/javascripts/utils.js
+++ b/apps/transport/client/javascripts/utils.js
@@ -1,4 +1,4 @@
-const addSeeMore = function (maxHeight, querySelector, seeMoreText, seeLessText) {
+const addSeeMore = function (maxHeight, querySelector, seeMoreText, seeLessText, featureName) {
     document.querySelectorAll(querySelector).forEach(
         function (div) {
             div.style.maxHeight = maxHeight
@@ -16,6 +16,7 @@ const addSeeMore = function (maxHeight, querySelector, seeMoreText, seeLessText)
                         if (div.style.maxHeight !== '100%') {
                             div.style.maxHeight = '100%'
                             linkDisplayMore.innerHTML = seeLessText
+                            window._paq.push(['trackEvent', 'see_more', featureName, querySelector])
                         } else {
                             div.style.maxHeight = maxHeight
                             linkDisplayMore.innerHTML = seeMoreText

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -14,7 +14,8 @@ defmodule TransportWeb.DiscussionsLive do
             "0px",
             "#comments-discussion-" + id,
             "<%= dgettext("page-dataset-details", "Display more") %>",
-            "<%= dgettext("page-dataset-details", "Display less") %>"
+            "<%= dgettext("page-dataset-details", "Display less") %>",
+            "discussion"
           )
         )
       })

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_resources_history.html.heex
@@ -70,7 +70,8 @@
     addSeeMore("280px",
       "#backed-up-resources-see-more-wrapper",
       "<%= dgettext("page-dataset-details", "Display more") %>",
-      "<%= dgettext("page-dataset-details", "Display less") %>"
+      "<%= dgettext("page-dataset-details", "Display less") %>",
+      "resource_history"
     )
   })
 </script>

--- a/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_notifications_sent.html.heex
@@ -44,7 +44,8 @@
     addSeeMore("15em",
       "#notifications-sent-content",
       "<%= dgettext("page-dataset-details", "Display more") %>",
-      "<%= dgettext("page-dataset-details", "Display less") %>"
+      "<%= dgettext("page-dataset-details", "Display less") %>",
+      "notifications_sent"
     )
   })
 </script>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -147,7 +147,8 @@
     addSeeMore("5em",
       ".networks-start-end",
       "<%= dgettext("page-dataset-details", "Display more") %>",
-      "<%= dgettext("page-dataset-details", "Display less") %>"
+      "<%= dgettext("page-dataset-details", "Display less") %>",
+      "gtfs_dates_per_network"
     )
   })
 </script>


### PR DESCRIPTION
Similaire à ce qui a été fait dans #3343

On a ajouté à plusieurs endroits récemment des éléments d'interface pour déplier/replier. Le code de tracking permettra de voir à quel point ceci est utilisé, en groupant par fonctionnalité : ressources historisées / commentaires / notifications envoyées etc.