### PR TITLE
ObanLogger : email en cas d'erreur pour certains jobs

### DIFF
--- a/apps/transport/lib/jobs/database_backup_replication_job.ex
+++ b/apps/transport/lib/jobs/database_backup_replication_job.ex
@@ -6,7 +6,7 @@ defmodule Transport.Jobs.DatabaseBackupReplicationJob do
   This job checks that the dump is recent enough, not too large
   and that permissions are write-only for the destination.
   """
-  use Oban.Worker, max_attempts: 3
+  use Oban.Worker, max_attempts: 3, tags: [Transport.Jobs.ObanLogger.email_on_failure_tag()]
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do

--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -1,19 +1,38 @@
-defmodule Transport.ObanLogger do
+defmodule Transport.Jobs.ObanLogger do
   @moduledoc """
   Logs the Oban job exceptions as warnings
   """
   require Logger
+  @tag_email_on_failure "email_on_failure"
+
+  def email_on_failure_tag, do: @tag_email_on_failure
 
   def handle_event(
         [:oban, :job, :exception],
         %{duration: duration},
-        %{args: args, error: error, id: id, worker: worker},
+        %{args: args, error: error, id: id, worker: worker, job: %Oban.Job{tags: tags}} = meta,
         nil
       ) do
+    if email_on_failure_tag() in tags do
+      send_email_to_tech(meta)
+    end
+
     Logger.warning(
       "Job #{id} handled by #{worker} called with args #{inspect(args)} failed in #{duration}. Error: #{inspect(error)}"
     )
   end
 
   def setup, do: :telemetry.attach("oban-logger", [:oban, :job, :exception], &handle_event/4, nil)
+
+  defp send_email_to_tech(%{worker: worker}) do
+    Transport.EmailSender.impl().send_mail(
+      "transport.data.gouv.fr",
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :tech_email),
+      Application.get_env(:transport, :contact_email),
+      "Échec de job Oban : #{worker}",
+      "Un job Oban #{worker} vient d'échouer, il serait bien d'investiguer.",
+      ""
+    )
+  end
 end

--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -5,6 +5,13 @@ defmodule Transport.Jobs.ObanLogger do
   require Logger
   @tag_email_on_failure "email_on_failure"
 
+  @doc """
+  If you add this tag to an `Oban.Job`, if this job fails an email will be sent
+  to the tech team alias to warn about this failure.
+
+  ⚠️ Do not use this on a lot of jobs or jobs that are executed often, this is not a Sentry replacement! ⚠️
+  This should soon be replaced by a Sentry integration.
+  """
   def email_on_failure_tag, do: @tag_email_on_failure
 
   def handle_event(

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -47,7 +47,7 @@ defmodule Transport.Application do
       ## manually add a children supervisor that is not scheduled
       |> Kernel.++([{Task.Supervisor, name: ImportTaskSupervisor}])
 
-    :ok = Transport.ObanLogger.setup()
+    :ok = Transport.Jobs.ObanLogger.setup()
 
     :ok = Transport.Telemetry.setup()
 

--- a/apps/transport/test/transport/jobs/database_backup_replication_job_test.exs
+++ b/apps/transport/test/transport/jobs/database_backup_replication_job_test.exs
@@ -181,6 +181,11 @@ defmodule Transport.Test.Transport.Jobs.DatabaseBackupReplicationJobTest do
     assert :ok == perform_job(DatabaseBackupReplicationJob, %{})
   end
 
+  test "email on failure tag is set" do
+    expected_tag = Transport.Jobs.ObanLogger.email_on_failure_tag()
+    assert %Ecto.Changeset{params: %{"tags" => [^expected_tag]}} = DatabaseBackupReplicationJob.new(%{})
+  end
+
   defp config_is_destination?(%{bucket_name: bucket_name}), do: bucket_name == @destination_bucket_name
   defp config_is_source?(%{bucket_name: bucket_name}), do: bucket_name == @source_bucket_name
 end

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -18,7 +18,7 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
   test "sends an email on failure if the appropriate tag is set" do
     assert {:error, "failed"} == perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{}, tags: [])
 
-    # When the specific tag is sent, an email should be sent
+    # When the specific tag is set, an email should be sent
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
                              "contact@transport.beta.gouv.fr",

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -1,0 +1,41 @@
+defmodule Transport.Test.Transport.Jobs.ObanLoggerJobTag do
+  use Oban.Worker
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    {:error, "failed"}
+  end
+end
+
+defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
+  use ExUnit.Case, async: true
+  @moduletag :capture_log
+  use Oban.Testing, repo: DB.Repo
+  import Mox
+
+  setup :verify_on_exit!
+
+  test "sends an email on failure if the appropriate tag is set" do
+    assert {:error, "failed"} == perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{}, tags: [])
+
+    # When the specific tag is sent, an email should be sent
+    Transport.EmailSender.Mock
+    |> expect(:send_mail, fn "transport.data.gouv.fr",
+                             "contact@transport.beta.gouv.fr",
+                             "tech@transport.data.gouv.fr" = _to,
+                             "contact@transport.beta.gouv.fr",
+                             "Échec de job Oban : Transport.Test.Transport.Jobs.ObanLoggerJobTag" = _subject,
+                             plain_text_body,
+                             "" = _html_part ->
+      assert plain_text_body ==
+               "Un job Oban Transport.Test.Transport.Jobs.ObanLoggerJobTag vient d'échouer, il serait bien d'investiguer."
+
+      :ok
+    end)
+
+    assert {:error, "failed"} ==
+             perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{},
+               tags: [Transport.Jobs.ObanLogger.email_on_failure_tag()]
+             )
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -191,6 +191,7 @@ config :transport,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",
   contact_email: "contact@transport.beta.gouv.fr",
   bizdev_email: "deploiement@transport.beta.gouv.fr",
+  tech_email: "tech@transport.data.gouv.fr",
   security_email: "contact@transport.beta.gouv.fr",
   transport_tools_folder: Path.absname("transport-tools/")
 


### PR DESCRIPTION
Adapte le logger Oban pour permettre d'envoyer un e-mail à notre équipe tech en cas d'échec sur certains jobs.

Applique ce nouveau mécanisme à `DatabaseBackupReplicationJob`, job dont l'exécution est importante.