### PR TITLE
Ajuste délai minimum entre 2 notifications : 7 jours

### DIFF
--- a/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
+++ b/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
@@ -13,7 +13,7 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   use Oban.Worker, max_attempts: 3, tags: ["notifications"]
   import Ecto.Query
 
-  @nb_days_before_sending_notification_again 15
+  @nb_days_before_sending_notification_again 7
   @notification_reason :dataset_with_error
   @enabled_validators [
     Transport.Validators.GTFSTransport,
@@ -64,7 +64,7 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     save_notification(dataset, email)
   end
 
-  defp notifications_sent_recently(%DB.Dataset{id: dataset_id}) do
+  def notifications_sent_recently(%DB.Dataset{id: dataset_id}) do
     datetime_limit = DateTime.utc_now() |> DateTime.add(-@nb_days_before_sending_notification_again, :day)
 
     DB.Notification

--- a/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
@@ -4,7 +4,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
   currently unavailable for at least 6 hours.
 
   Notifications are sent at the dataset level and are sent again no sooner than
-  15 days apart (to avoid potential spamming).
+  7 days apart (to avoid potential spamming).
 
   This job should be scheduled every 30 minutes because it looks at unavailabilities
   that are ongoing since [6h00 ; 6h30].
@@ -13,7 +13,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
   import Ecto.Query
 
   @hours_consecutive_downtime 6
-  @nb_days_before_sending_notification_again 15
+  @nb_days_before_sending_notification_again 7
   @notification_reason :resource_unavailable
 
   @impl Oban.Worker
@@ -67,7 +67,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     save_notification(dataset, email)
   end
 
-  defp notifications_sent_recently(%DB.Dataset{id: dataset_id}) do
+  def notifications_sent_recently(%DB.Dataset{id: dataset_id}) do
     datetime_limit = DateTime.utc_now() |> DateTime.add(-@nb_days_before_sending_notification_again, :day)
 
     DB.Notification

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -239,9 +239,12 @@ defmodule DB.Factory do
   end
 
   def insert_notification(args) do
-    %DB.Notification{}
-    |> DB.Notification.changeset(args)
-    |> DB.Repo.insert!()
+    notification = %DB.Notification{} |> DB.Notification.changeset(args) |> DB.Repo.insert!()
+
+    case Map.get(args, :inserted_at) do
+      nil -> notification
+      %DateTime{} = dt -> notification |> Ecto.Changeset.change(%{inserted_at: dt}) |> DB.Repo.update!()
+    end
   end
 
   def notification_subscription_factory do


### PR DESCRIPTION
Ajuste le délai d'envoi minimum pour un jeu de données : on passe de 15 jours à 7 jours.

Ceci s'applique aux motifs :
- erreurs sur un JDD (erreur + fatal pour GTFS)
- ressource indisponible pendant au moins 6h consécutives

ces 2 événements sont assez rares et importants, ne pas envoyer un e-mail parce que c'est déjà survenu au cours des 15 derniers jours parait un peu trop.