### PR TITLE
DatasetsSwitchingClimateResilienceBillJob : conversion e-mail en Markdown

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/dataset_with_error_producer.html.md
+++ b/apps/transport/lib/transport_web/templates/email/dataset_with_error_producer.html.md
@@ -1,6 +1,6 @@
 Bonjour,
 
-Des erreurs bloquantes ont été détectées dans votre jeu de données <%= link_for_dataset(@dataset, :heex) %>. Ces erreurs empêchent la réutilisation de vos données.
+Des erreurs bloquantes ont été détectées dans votre jeu de données <%= link_for_dataset(@dataset) %>. Ces erreurs empêchent la réutilisation de vos données.
 
 Nous vous invitons à les corriger en vous appuyant sur les rapports de validation suivants :
 <%= for resource <- @resources do %>

--- a/apps/transport/lib/transport_web/templates/email/dataset_with_error_reuser.html.md
+++ b/apps/transport/lib/transport_web/templates/email/dataset_with_error_reuser.html.md
@@ -1,6 +1,6 @@
 Bonjour,
 
-Des erreurs bloquantes ont été détectées dans le jeu de données <%= link_for_dataset(@dataset, :heex) %> que vous réutilisez.
+Des erreurs bloquantes ont été détectées dans le jeu de données <%= link_for_dataset(@dataset) %> que vous réutilisez.
 
 <%= if @producer_warned do %>
 Le producteur de ces données a été informé de ces erreurs.

--- a/apps/transport/lib/transport_web/templates/email/datasets_climate_resilience_bill_inappropriate_licence.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/datasets_climate_resilience_bill_inappropriate_licence.html.heex
@@ -6,7 +6,7 @@
 
 <ul>
   <%= for dataset <- @datasets do %>
-    <li><%= raw(link_for_dataset(dataset, :heex)) %></li>
+    <li><%= raw(link_for_dataset(dataset)) %></li>
   <% end %>
 </ul>
 

--- a/apps/transport/lib/transport_web/templates/email/datasets_switching_climate_resilience_bill.html.md
+++ b/apps/transport/lib/transport_web/templates/email/datasets_switching_climate_resilience_bill.html.md
@@ -1,0 +1,17 @@
+Bonjour,
+
+<%= unless Enum.empty?(@datasets_now_climate_resilience) do %>
+Les jeux de données suivants font désormais l’objet d’une intégration obligatoire :
+<%= for dataset <- @datasets_now_climate_resilience do %>
+<%= link_for_dataset(dataset) %>
+<% end %>
+<% end %>
+
+<%= unless Enum.empty?(@datasets_previously_climate_resilience) do %>
+Les jeux de données suivants faisaient l’objet d’une intégration obligatoire et ne font plus l’objet de cette obligation :
+<%= for dataset <- @datasets_previously_climate_resilience do %>
+<%= link_for_dataset(dataset) %>
+<% end %>
+<% end %>
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -5,12 +5,12 @@ Vous gérez des données présentes sur transport.data.gouv.fr.
 ## Gérer vos notifications
 
 <%= if Enum.count(@datasets_subscribed) == 1 do %>
-Vous êtes susceptible de recevoir des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset(:heex) %>.
+Vous êtes susceptible de recevoir des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset() %>.
 <% else %>
 Vous êtes susceptible de recevoir des notifications pour les jeux de données suivants :
 <ul>
   <%= for dataset <- @datasets_subscribed do %>
-  <li><%= link_for_dataset(dataset, :heex) %></li>
+  <li><%= link_for_dataset(dataset) %></li>
   <% end %>
 </ul>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -5,12 +5,12 @@ Vous gérez des données présentes sur transport.data.gouv.fr.
 ## Recevoir des notifications
 
 <%= if Enum.count(@datasets) == 1 do %>
-Vous gérez le jeu de données <%= @datasets |> hd() |> link_for_dataset(:heex) %>.
+Vous gérez le jeu de données <%= @datasets |> hd() |> link_for_dataset() %>.
 <% else %>
 Vous gérez les jeux de données suivants :
 <ul>
   <%= for dataset <- @datasets do %>
-  <li><%= link_for_dataset(dataset, :heex) %></li>
+  <li><%= link_for_dataset(dataset) %></li>
   <% end %>
 </ul>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/email/resource_unavailable_producer.html.md
+++ b/apps/transport/lib/transport_web/templates/email/resource_unavailable_producer.html.md
@@ -1,6 +1,6 @@
 Bonjour,
 
-Les ressources <%= @resource_titles %> dans votre jeu de données <%= link_for_dataset(@dataset, :heex) %> ne sont plus disponibles au téléchargement depuis plus de <%= @hours_consecutive_downtime %>h.
+Les ressources <%= @resource_titles %> dans votre jeu de données <%= link_for_dataset(@dataset) %> ne sont plus disponibles au téléchargement depuis plus de <%= @hours_consecutive_downtime %>h.
 
 <%= if @deleted_recreated_on_datagouv do %>
 Il semble que vous ayez supprimé et créé une nouvelle ressource. Lors de la mise à jour de vos données, remplacez plutôt le fichier au sein de la ressource existante. Retrouvez la procédure pas à pas [sur notre documentation](https://doc.transport.data.gouv.fr/producteurs/mettre-a-jour-des-donnees).

--- a/apps/transport/lib/transport_web/templates/email/resource_unavailable_reuser.html.md
+++ b/apps/transport/lib/transport_web/templates/email/resource_unavailable_reuser.html.md
@@ -1,6 +1,6 @@
 Bonjour,
 
-Les ressources <%= @resource_titles %> du jeu de données <%= link_for_dataset(@dataset, :heex) %> que vous réutilisez ne sont plus disponibles au téléchargement depuis plus de <%= @hours_consecutive_downtime %>h.
+Les ressources <%= @resource_titles %> du jeu de données <%= link_for_dataset(@dataset) %> que vous réutilisez ne sont plus disponibles au téléchargement depuis plus de <%= @hours_consecutive_downtime %>h.
 
 <%= if @producer_warned do %>
 Le producteur de ces données a été informé de cette indisponibilité.

--- a/apps/transport/lib/transport_web/templates/email/resources_changed.html.md
+++ b/apps/transport/lib/transport_web/templates/email/resources_changed.html.md
@@ -1,5 +1,5 @@
 Bonjour,
 
-Les ressources du jeu de données <%= link_for_dataset(@dataset, :heex) %> viennent d'être modifiées (ajout/suppression de ressources ou modification d'URLs de téléchargement).
+Les ressources du jeu de données <%= link_for_dataset(@dataset) %> viennent d'être modifiées (ajout/suppression de ressources ou modification d'URLs de téléchargement).
 
 L’équipe du PAN

--- a/apps/transport/lib/transport_web/views/email_view.ex
+++ b/apps/transport/lib/transport_web/views/email_view.ex
@@ -1,13 +1,9 @@
 defmodule TransportWeb.EmailView do
   use TransportWeb, :view
 
-  def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}, mode) when mode in [:heex, :markdown] do
+  def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}) do
     url = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
-
-    case mode do
-      :markdown -> "[#{custom_title}](#{url})"
-      :heex -> link(custom_title, to: url)
-    end
+    link(custom_title, to: url)
   end
 
   def link_for_resource(%DB.Resource{id: id, title: title}) do

--- a/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
@@ -132,15 +132,13 @@ defmodule Transport.Test.Transport.Jobs.DatasetsSwitchingClimateResilienceBillJo
                              ^email,
                              "contact@transport.beta.gouv.fr",
                              "Loi climat et résilience : suivi des jeux de données" = _subject,
-                             plain_text_body,
-                             "" = _html_part ->
-      assert plain_text_body =~ ~r/^Bonjour/
+                             "" = _plain_text,
+                             html ->
+      assert html =~
+               ~s(Les jeux de données suivants font désormais l’objet d’une intégration obligatoire :\n\n<a href="http://127.0.0.1:5100/datasets/#{d1.slug}">#{d1.custom_title}</a>)
 
-      assert plain_text_body =~
-               "Les jeux de données suivants font désormais l'objet d'une intégration obligatoire :\n* #{d1.custom_title} - (Transport public collectif - horaires théoriques) - http://127.0.0.1:5100/datasets/#{d1.slug}"
-
-      assert plain_text_body =~
-               "Les jeux de données suivants faisaient l'objet d'une intégration obligatoire et ne font plus l'objet de cette obligation :\n* #{d2.custom_title} - (Transport public collectif - horaires théoriques) - http://127.0.0.1:5100/datasets/#{d2.slug}"
+      assert html =~
+               ~s(Les jeux de données suivants faisaient l’objet d’une intégration obligatoire et ne font plus l’objet de cette obligation :\n\n<a href="http://127.0.0.1:5100/datasets/#{d2.slug}">#{d2.custom_title}</a>)
 
       :ok
     end)


### PR DESCRIPTION
Convertit une notification envoyée (JDD qui deviennent soumis à l'article 122 ou qui ne le sont plus) au format Markdown pour une meilleure expérience pour les destinataires.