### PR TITLE
ObanLogger : envoi d'un e-mail uniquement lors du dernier essai

### DIFF
--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -17,10 +17,16 @@ defmodule Transport.Jobs.ObanLogger do
   def handle_event(
         [:oban, :job, :exception],
         %{duration: duration},
-        %{args: args, error: error, id: id, worker: worker, job: %Oban.Job{tags: tags}} = meta,
+        %{
+          args: args,
+          error: error,
+          id: id,
+          worker: worker,
+          job: %Oban.Job{tags: tags, attempt: attempt, max_attempts: max_attempts}
+        } = meta,
         nil
       ) do
-    if email_on_failure_tag() in tags do
+    if email_on_failure_tag() in tags and attempt == max_attempts do
       send_email_to_tech(meta)
     end
 

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -19,6 +19,16 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
     assert {:error, "failed"} == perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{}, tags: [])
 
     # When the specific tag is set, an email should be sent
+
+    # Should not be sent when not trying for the last time
+    assert {:error, "failed"} ==
+             perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{},
+               tags: [Transport.Jobs.ObanLogger.email_on_failure_tag()],
+               attempt: 1,
+               max_attempts: 2
+             )
+
+    # Should be sent when failing at the last attempt
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
                              "contact@transport.beta.gouv.fr",
@@ -35,7 +45,9 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
 
     assert {:error, "failed"} ==
              perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{},
-               tags: [Transport.Jobs.ObanLogger.email_on_failure_tag()]
+               tags: [Transport.Jobs.ObanLogger.email_on_failure_tag()],
+               attempt: 2,
+               max_attempts: 2
              )
   end
 end


### PR DESCRIPTION
Retravaille #3387

L'événement était déclenché dès lors que le job ne réussit pas. Le comportement souhaité est d'être prévenu en cas "d'échec fatal", après le dernier essai.