### PR TITLE
Buckets Scaleway : ajuste lifecycle rules

### DIFF
--- a/docs/scaleway/README.md
+++ b/docs/scaleway/README.md
@@ -1,0 +1,37 @@
+# Scaleway bucket configurations
+
+We use Scaleway for database backups replication.
+
+This folder holds configuration for:
+- bucket policies (permissions)
+- bucket lifecycles (how long to keep uploaded files, when to delete temporary files)
+
+## Scaleway documentation links
+
+- [Using bucket policies](https://www.scaleway.com/en/docs/storage/object/api-cli/using-bucket-policies/)
+- [Managing the lifecycle of objects](https://www.scaleway.com/en/docs/storage/object/api-cli/lifecycle-rules-api/)
+
+[See the GitHub issue comment](https://github.com/etalab/transport-site/issues/1548#issuecomment-1083189225) explaining what has been implemented.
+
+## Seeing / applying configuration
+
+At the moment **these configuration are NOT automatically applied** through CI or something else. You'll need to run CLI commands.
+
+Grab Scaleway credentials from our password manager solution first and [install the AWS CLI](https://www.scaleway.com/en/docs/storage/object/api-cli/object-storage-aws-cli/).
+
+### CLI commands related to lifecycles
+```
+# See the lifecycle configuration
+aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api get-bucket-lifecycle-configuration --bucket transport-staging-backups
+aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api get-bucket-lifecycle-configuration --bucket transport-prod-backups
+# Apply a lifecycle configuration to a bucket
+aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api put-bucket-lifecycle-configuration --lifecycle-configuration file:///Users/antoineaugusti/Documents/transport-site/docs/scaleway/bucket_lifecycle_configuration_production.json --bucket transport-prod-backups
+
+### CLI commands related to bucket policies
+```
+# See a bucket policy configuration
+aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api get-bucket-policy --bucket transport-prod-backups 
+
+# Apply a bucket policy configuration to a bucket
+aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api put-bucket-policy --bucket transport-prod-backups --policy file://docs/scaleway/bucket_policy_production.json
+```

--- a/docs/scaleway/bucket_lifecycle_configuration_production.json
+++ b/docs/scaleway/bucket_lifecycle_configuration_production.json
@@ -1,14 +1,24 @@
 {
    "Rules":[
       {
-         "Expiration":{
-            "Days":90
-         },
          "ID":"delete-after-90-days",
+         "Status":"Enabled",
          "Filter":{
             "Prefix":""
          },
-         "Status":"Enabled"
+         "Expiration":{
+            "Days":90
+         }
+      },
+      {
+         "ID":"Remove uncompleted uploads",
+         "Status":"Enabled",
+         "Filter":{
+            "Prefix":""
+         },
+         "AbortIncompleteMultipartUpload":{
+            "DaysAfterInitiation":1
+         }
       }
    ]
 }

--- a/docs/scaleway/bucket_lifecycle_configuration_staging.json
+++ b/docs/scaleway/bucket_lifecycle_configuration_staging.json
@@ -1,14 +1,24 @@
 {
    "Rules":[
       {
-         "Expiration":{
-            "Days":30
-         },
          "ID":"delete-after-30-days",
+         "Status":"Enabled",
          "Filter":{
             "Prefix":""
          },
-         "Status":"Enabled"
+         "Expiration":{
+            "Days":30
+         }
+      },
+      {
+         "ID":"Remove uncompleted uploads",
+         "Status":"Enabled",
+         "Filter":{
+            "Prefix":""
+         },
+         "AbortIncompleteMultipartUpload":{
+            "DaysAfterInitiation":1
+         }
       }
    ]
 }


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3406

- Adapte les lifecycle rules de nos 2 buckets contenant une réplication de nos sauvegardes de bases de données afin de supprimer les uploads incomplets au bout d'1 jour. J'ai suivi [la configuration](https://www.scaleway.com/en/docs/storage/object/api-cli/lifecycle-rules-api/#setting-rules-for-incomplete-multipart-uploads).
- Ajoute un README de documentation générale présentant le contenu de ce dossier

## Changements de configuration

Ceci a déjà été appliqué en staging et production, exemple de commande

```
aws --endpoint-url "https://s3.fr-par.scw.cloud" --region fr-par s3api put-bucket-lifecycle-configuration --lifecycle-configuration file://$(pwd)/docs/scaleway/bucket_lifecycle_configuration_production.json --bucket transport-prod-backups
```

J'ai vérifié ensuite la bonne conf avec `get-bucket-lifecycle-configuration` et via l'UI.

![image](https://github.com/etalab/transport-site/assets/295709/4e557801-ca5c-4c7e-975f-50c3a4706602)

J'ai trouvé l'interface confusante, [j'ai ouvert un ticket](https://console.scaleway.com/support/tickets/500AX000001ywHxYAI).