### PR TITLE
Corrige liens HTML pour e-mail :expiration

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
+++ b/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
@@ -2,11 +2,11 @@ Bonjour,
 
 Une ressource associée au jeu de données <%= link_for_dataset(@dataset) %> <%= @delay_str %>.
 
-Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour. Pour cela, veuillez <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau">remplacer la ressource périmée par la nouvelle ressource</a>.
+Afin qu’il puisse continuer à être utilisé par les différents acteurs, il faut qu’il soit mis à jour. Pour cela, veuillez [remplacer la ressource périmée par la nouvelle ressource](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau).
 
 Veuillez également anticiper vos prochaines mises à jour, au moins 7 jours avant l’expiration de votre fichier.
 
 L’équipe transport.data.gouv.fr
 
 ---
-Retrouvez comment gérer ces notifications <a href="https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees">dans notre documentation</a>.
+Retrouvez comment gérer ces notifications [dans notre documentation](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees).

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -268,6 +268,9 @@ defmodule Transport.DataCheckerTest do
         assert html_body =~
                  ~s(Une ressource associée au jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a> expire demain.)
 
+        assert html_body =~
+                 ~s(<a href="https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau">remplacer la ressource périmée par la nouvelle ressource</a>)
+
         refute html_body =~ "notification automatique"
         refute html_body =~ "article 122"
         :ok

--- a/apps/transport/test/transport_web/views/no_html_in_markdown_templates.exs
+++ b/apps/transport/test/transport_web/views/no_html_in_markdown_templates.exs
@@ -1,0 +1,17 @@
+defmodule NoHTMLInMarkdownTemplatesTest do
+  @moduledoc """
+  Check that we do not use `<a href=""></a>` links in Markdown templates
+  """
+  use ExUnit.Case, async: true
+
+  test "Do not use HTML links in Markdown templates" do
+    md_files = "../../apps/transport/lib/transport_web/templates/**/*.html.md" |> Path.wildcard()
+
+    refute Enum.empty?(md_files)
+    assert md_files |> Enum.filter(&with_html_link?/1) |> Enum.empty?()
+  end
+
+  def with_html_link?(file) do
+    file |> File.read!() |> String.contains?("<a href=")
+  end
+end


### PR DESCRIPTION
Répare un bug introduit dans https://github.com/etalab/transport-site/pull/3409, qui tentait déjà de corriger un autre bug :grimacing:

Mon erreur était de mettre des liens en HTML dans un template Markdown `.html.md`. Le moteur de template a (trop sympa) transformé les `<a href="">` en `<a href=””>` (_smart quotes_) ce qui n'est plus du code HTML valide.

![image](https://github.com/etalab/transport-site/assets/295709/d3fe175a-96fd-46d5-8540-2994a69d255a)

Corrige ce bug et ajoute un test pour vérifier qu'on n'essaie pas de mettre des liens HTML dans du `*.html.md`