### PR TITLE
ImportData: changement format pour SIRI et SIRI Lite

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -397,7 +397,7 @@ defmodule Transport.ImportData do
         true -> []
       end
 
-    resources |> Enum.map(fn r -> %{r | "format" => "netex"} end)
+    resources |> Enum.map(fn r -> %{r | "format" => "NeTEx"} end)
   end
 
   @spec get_valid_gtfs_rt_resources([map()]) :: [map()]
@@ -413,14 +413,18 @@ defmodule Transport.ImportData do
   end
 
   @doc """
-    iex> get_valid_siri_resources([%{"format" => "siri", id: 1}, %{"format" => "xxx", id: 2}])
-    [%{"format" => "siri", id: 1}]
+  iex> get_valid_siri_resources([%{"format" => "siri", "id" => 1}, %{"format" => "xxx", "id" => 2}])
+  [%{"format" => "SIRI", "id" => 1}]
   """
   @spec get_valid_siri_resources([map()]) :: [map()]
-  def get_valid_siri_resources(resources), do: Enum.filter(resources, &is_siri?/1)
+  def get_valid_siri_resources(resources) do
+    resources |> Enum.filter(&is_siri?/1) |> Enum.map(fn r -> %{r | "format" => "SIRI"} end)
+  end
 
   @spec get_valid_siri_lite_resources([map()]) :: [map()]
-  def get_valid_siri_lite_resources(resources), do: Enum.filter(resources, &is_siri_lite?/1)
+  def get_valid_siri_lite_resources(resources) do
+    resources |> Enum.filter(&is_siri_lite?/1) |> Enum.map(fn r -> %{r | "format" => "SIRI Lite"} end)
+  end
 
   @spec get_community_resources(map()) :: [map()]
   def get_community_resources(%{"id" => datagouv_id}) do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -343,9 +343,9 @@ defmodule Transport.ImportDataTest do
     assert valid_resources |> Enum.frequencies_by(fn %{"format" => f} -> f end) == %{
              "gtfs" => 1,
              "gtfs-rt" => 1,
-             "netex" => 1,
-             "siri" => 1,
-             "siri lite" => 1
+             "NeTEx" => 1,
+             "SIRI" => 1,
+             "SIRI Lite" => 1
            }
   end
 


### PR DESCRIPTION
Suite de #3415

La détection SIRI / SIRI Lite était ok, mais plus loin dans le process d'import, `formated_format` se base uniquement sur le format pour garder en SIRI :cry: (`is_siri?(format) -> "SIRI"`).

Fait comme pour le NeTEx, change le format lorsqu'on a bien détecté que c'était une ressource NeTEx. Ce n'était pas si bête que ça.

Bref, encore une suite de PRs qui montre que `Transport.ImportData` est fragile et mérite un refactor pour assurer plus de sécurité/stabilité.