### PR TITLE
Améliore contenu du rappel périodique aux producteurs

### DIFF
--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -115,6 +115,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
       "Notifications pour vos données sur transport.data.gouv.fr",
       "",
       Phoenix.View.render_to_string(TransportWeb.EmailView, "producer_without_subscriptions.html", %{
+        manage_organization_url: contact |> manage_organization_url(),
         datasets: datasets,
         contacts_in_orgs: Enum.map_join(contacts_in_orgs, ", ", &DB.Contact.display_name/1),
         has_other_contacts: not Enum.empty?(contacts_in_orgs)
@@ -135,6 +136,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
       "Rappel : vos notifications pour vos données sur transport.data.gouv.fr",
       "",
       Phoenix.View.render_to_string(TransportWeb.EmailView, "producer_with_subscriptions.html", %{
+        manage_organization_url: contact |> manage_organization_url(),
         datasets_subscribed: contact |> datasets_subscribed_as_producer(),
         has_other_producers_subscribers: not Enum.empty?(other_producers_subscribers),
         other_producers_subscribers: Enum.map_join(other_producers_subscribers, ", ", &DB.Contact.display_name/1)
@@ -142,6 +144,14 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
     )
 
     DB.Notification.insert!(@notification_reason, contact.email)
+  end
+
+  def manage_organization_url(%DB.Contact{organizations: organizations}) when length(organizations) == 1 do
+    "https://www.data.gouv.fr/fr/admin/organization/#{organizations |> hd() |> Map.fetch!(:id)}/"
+  end
+
+  def manage_organization_url(%DB.Contact{}) do
+    "https://www.data.gouv.fr/fr/admin/"
   end
 
   @spec datasets_subscribed_as_producer(DB.Contact.t()) :: [DB.Dataset.t()]

--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -15,18 +15,20 @@ Vous êtes susceptible de recevoir des notifications pour les jeux de données s
 </ul>
 <% end %>
 
-Les notifications facilitent la gestion de vos données. Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications#les-differents-types-de-notifications).
+Les notifications facilitent la gestion de vos données. Elles vous permettront d’être averti de l’expiration de vos ressources, des erreurs qu’elles peuvent contenir et de leur potentielle indisponibilité.
 
-Vous pouvez gérer ces notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>).
+Vous pouvez gérer ces notifications depuis [votre espace producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) du Point d’accès national.
 
-## Gérer les membres de vos organisations
+## Gérer les membres de votre organisation
+
+L’administrateur de votre organisation peut ajouter, modifier ou supprimer les différents membres depuis [votre espace d’administration data.gouv.fr](<%= @manage_organization_url %>).
 
 <%= if @has_other_producers_subscribers do %>
 Les autres personnes inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
 <% end %>
 
-Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/creer-un-compte-utilisateur-sur-data.gouv.fr). Chacune de ces personnes peut paramétrer des notifications depuis leur espace producteur.
+Chaque utilisateur peut paramétrer ses propres notifications depuis son espace producteur du PAN.
 
-Nous restons disponible pour vous accompagner si besoin.
+Nous restons disponibles pour vous accompagner si besoin.
 
-Bien à vous,
+À bientôt !

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -15,18 +15,18 @@ Vous gérez les jeux de données suivants :
 </ul>
 <% end %>
 
-Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur du Point d'accès national](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>). Elles vous permettront d'être averti de l'[expiration de vos ressources, des erreurs qu'elles peuvent contenir et de leur potentielle indisponibilité](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/gerer-la-qualite-des-donnees#sinscrire-aux-notifications).
+Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) du Point d’accès national. Elles vous permettront d’être averti de l’expiration de vos ressources, des erreurs qu’elles peuvent contenir et de leur potentielle indisponibilité.
 
-## Gérer les membres de vos organisations
+## Gérer les membres de votre organisation
+
+L’administrateur de votre organisation peut ajouter, modifier ou supprimer les différents membres depuis [votre espace d’administration data.gouv.fr](<%= @manage_organization_url %>).
 
 <%= if @has_other_contacts do %>
-Les autres personnes pouvant s'inscrire à ces notifications et s'étant déjà connecté sont : <%= @contacts_in_orgs %>.
+Les autres personnes pouvant s’inscrire à ces notifications et s’étant déjà connectés sont : <%= @contacts_in_orgs %>.
 <% end %>
 
-Vous pouvez gérer les membres de vos organisations depuis data.gouv.fr. Si certaines personnes ne font plus partie de votre organisation, vous pouvez supprimer leur accès depuis data.gouv.fr. Si d'autres personnes administrent vos données, elles peuvent [rejoindre votre organisation sur data.gouv.fr](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/creer-un-compte-utilisateur-sur-data.gouv.fr).
+Chaque utilisateur peut paramétrer ses propres notifications depuis son espace producteur du PAN.
 
-Chacune de ces personnes peut paramétrer des notifications depuis leur espace producteur.
+Nous restons disponibles pour vous accompagner si besoin.
 
-Nous restons disponible pour vous accompagner si besoin.
-
-Bien à vous,
+À bientôt !

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -252,7 +252,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       assert html =~ "Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications"
 
       assert html =~
-               "Les autres personnes pouvant s’inscrire à ces notifications et s’étant déjà connecté sont : Marina Loiseau."
+               "Les autres personnes pouvant s’inscrire à ces notifications et s’étant déjà connectés sont : Marina Loiseau."
     end)
 
     assert :ok == perform_job(PeriodicReminderProducersNotificationJob, %{"contact_id" => contact.id})
@@ -268,6 +268,26 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
 
     assert {:discard, "Mail has already been sent recently"} ==
              perform_job(PeriodicReminderProducersNotificationJob, %{"contact_id" => contact.id})
+  end
+
+  describe "manage_organization_url" do
+    test "single org" do
+      org_id = Ecto.UUID.generate()
+      contact = %{organizations: [sample_org(%{"id" => org_id})]} |> insert_contact() |> DB.Repo.preload(:organizations)
+      assert 1 == contact.organizations |> Enum.count()
+
+      assert "https://www.data.gouv.fr/fr/admin/organization/#{org_id}/" ==
+               contact |> PeriodicReminderProducersNotificationJob.manage_organization_url()
+    end
+
+    test "multiple orgs" do
+      contact = %{organizations: [sample_org(), sample_org()]} |> insert_contact() |> DB.Repo.preload(:organizations)
+
+      assert 2 == contact.organizations |> Enum.count()
+
+      assert "https://www.data.gouv.fr/fr/admin/" ==
+               contact |> PeriodicReminderProducersNotificationJob.manage_organization_url()
+    end
   end
 
   defp sample_org(%{} = args \\ %{}) do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3414

Prend en compte les commentaires apportés par @cyrilmorin sur le contenu de ces e-mails qui seront envoyés pour la première fois début octobre.