### PR TITLE
AOMs : pas d'espaces pour les départements

### DIFF
--- a/apps/transport/lib/transport/import_aom.ex
+++ b/apps/transport/lib/transport/import_aom.ex
@@ -58,15 +58,15 @@ defmodule Transport.ImportAOMs do
      Ecto.Changeset.change(aom, %{
        composition_res_id: external_id,
        insee_commune_principale: insee,
-       departement: line["Dep"],
-       siren: line["N° SIREN"],
+       departement: line["Dep"] |> String.trim(),
+       siren: line["N° SIREN"] |> String.trim(),
        nom: nom,
        forme_juridique: normalize_forme(line["Forme juridique"]),
        nombre_communes: to_int(line["Nombre de communes du RT"]),
        population_municipale: to_int(line["Population municipale 2018"]),
        population_totale: to_int(line["Population totale 2018"]),
-       surface: line["Surface (km²)"],
-       commentaire: line["Commentaire"],
+       surface: line["Surface (km²)"] |> String.trim(),
+       commentaire: line["Commentaire"] |> String.trim(),
        region: new_region
      })}
   end

--- a/apps/transport/priv/repo/migrations/20230828142610_aom_trim_departement.exs
+++ b/apps/transport/priv/repo/migrations/20230828142610_aom_trim_departement.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.AomTrimDepartement do
+  use Ecto.Migration
+
+  def up do
+    execute "update aom set departement = trim(departement)"
+  end
+
+  def down do
+    IO.puts("No going back")
+  end
+end


### PR DESCRIPTION
Fixes #3423

- migration de BDD pour supprimer les espaces dans `aom.departement`
- modification du code d'import pour `trim` plusieurs champs (pas vu d'autres écarts)