### PR TITLE
Mise à jour taille max backup de base de données

### DIFF
--- a/apps/transport/lib/jobs/database_backup_replication_job.ex
+++ b/apps/transport/lib/jobs/database_backup_replication_job.ex
@@ -83,7 +83,7 @@ defmodule Transport.Jobs.DatabaseBackupReplicationJob do
     {size, ""} = Integer.parse(size_str)
 
     if size > max_size_threshold() do
-      raise "Latest database dump is larger than 1 gigabytes #{inspect(dump)}"
+      raise "Latest database dump is larger than 10 gigabytes #{inspect(dump)}"
     end
 
     dump
@@ -99,7 +99,7 @@ defmodule Transport.Jobs.DatabaseBackupReplicationJob do
     dump
   end
 
-  def max_size_threshold, do: gigabytes(1)
+  def max_size_threshold, do: gigabytes(10)
   def recent_enough_threshold, do: hours_in_seconds(12)
 
   defp upload_filename(%{key: key}) do

--- a/apps/transport/test/transport/jobs/database_backup_replication_job_test.exs
+++ b/apps/transport/test/transport/jobs/database_backup_replication_job_test.exs
@@ -15,13 +15,13 @@ defmodule Transport.Test.Transport.Jobs.DatabaseBackupReplicationJobTest do
   end
 
   test "check_dump_not_too_large!" do
-    assert DatabaseBackupReplicationJob.max_size_threshold() == DatabaseBackupReplicationJob.gigabytes(1)
+    assert DatabaseBackupReplicationJob.max_size_threshold() == DatabaseBackupReplicationJob.gigabytes(10)
     DatabaseBackupReplicationJob.check_dump_not_too_large!(%{size: "1"})
 
-    oversize = DatabaseBackupReplicationJob.gigabytes(5)
+    oversize = DatabaseBackupReplicationJob.gigabytes(11)
     assert oversize > DatabaseBackupReplicationJob.max_size_threshold()
 
-    assert_raise RuntimeError, ~r'^Latest database dump is larger than 1 gigabytes', fn ->
+    assert_raise RuntimeError, ~r'^Latest database dump is larger than 10 gigabytes', fn ->
       DatabaseBackupReplicationJob.check_dump_not_too_large!(%{size: oversize |> round() |> to_string()})
     end
   end


### PR DESCRIPTION
Détecté suite à [ce ticket dans Front](https://app.frontapp.com/open/msg_1qn80tue?key=8gPjICa3JQ_nqAm9uaJweY-Vv_czc0xg)

On dépasse ce jour la taille de 1 GB pour le backup de notre base de données en production.

Le code actuel lève une erreur dans ce cas (l'objectif était de nous alerter sur un dump potentiellement faux/nous inviter à revoir notre stratégie).

Comme on est OK avec la croissance de la taille de ce fichier, adapte la taille max à 10 GB.