### PR TITLE
Répare discussions repliées

### DIFF
--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -89,8 +89,10 @@ defmodule TransportWeb.DiscussionsLive do
   def discussion_should_be_closed?(%{"closed" => closed}) when not is_nil(closed), do: true
 
   def discussion_should_be_closed?(%{"discussion" => comment_list}) do
-    {:ok, latest_comment_datetime, 0} = List.first(comment_list)["posted_on"] |> DateTime.from_iso8601()
-    DateTime.utc_now() |> Timex.shift(months: -2) |> DateTime.compare(latest_comment_datetime) == :gt
+    comment_datetime_list = comment_list |> Enum.map(fn comment -> DateTime.from_iso8601(comment["posted_on"]) |> elem(1) end)
+    latest_comment_datetime = comment_datetime_list |> Enum.max(DateTime)
+    two_months_ago = DateTime.utc_now() |> Timex.shift(months: -2)
+    DateTime.compare(two_months_ago, latest_comment_datetime) == :gt
   end
 end
 

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -89,8 +89,12 @@ defmodule TransportWeb.DiscussionsLive do
   def discussion_should_be_closed?(%{"closed" => closed}) when not is_nil(closed), do: true
 
   def discussion_should_be_closed?(%{"discussion" => comment_list}) do
-    comment_datetime_list = comment_list |> Enum.map(fn comment -> DateTime.from_iso8601(comment["posted_on"]) |> elem(1) end)
-    latest_comment_datetime = comment_datetime_list |> Enum.max(DateTime)
+    latest_comment_datetime =
+      comment_list
+      |> Enum.map(&DateTime.from_iso8601(&1["posted_on"]))
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.max(DateTime)
+
     two_months_ago = DateTime.utc_now() |> Timex.shift(months: -2)
     DateTime.compare(two_months_ago, latest_comment_datetime) == :gt
   end

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -92,7 +92,7 @@ defmodule TransportWeb.DiscussionsLive do
     latest_comment_datetime =
       comment_list
       |> Enum.map(fn comment ->
-        { :ok, comment_datetime, 0} = DateTime.from_iso8601(comment["posted_on"])
+        {:ok, comment_datetime, 0} = DateTime.from_iso8601(comment["posted_on"])
         comment_datetime
       end)
       |> Enum.max(DateTime)

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -91,8 +91,10 @@ defmodule TransportWeb.DiscussionsLive do
   def discussion_should_be_closed?(%{"discussion" => comment_list}) do
     latest_comment_datetime =
       comment_list
-      |> Enum.map(&DateTime.from_iso8601(&1["posted_on"]))
-      |> Enum.map(&elem(&1, 1))
+      |> Enum.map(fn comment ->
+        { :ok, comment_datetime, 0} = DateTime.from_iso8601(comment["posted_on"])
+        comment_datetime
+      end)
       |> Enum.max(DateTime)
 
     two_months_ago = DateTime.utc_now() |> Timex.shift(months: -2)


### PR DESCRIPTION
fixes #3436 

Plutôt que prendre l’ordre des commentaires dans le retour API pour connaître le dernier commentaire, on s’appuie sur les dates de publication.