### PR TITLE
Désactive les métriques associés à Oban

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -206,6 +206,9 @@ config :appsignal, :config,
   # we use a plug which sets the namespace as ignore programmatically
   # and here declare that the corresponding requests should be ignored
   ignore_namespaces: ["ignore"],
+  # would generate too much noise for now, shutting it down
+  instrument_oban: false,
+  report_oban_errors: false,
   # but this is not always enough:
   ignore_actions: [
     # without this action, requests will be counted twice


### PR DESCRIPTION
Je fais cela pour permettre d'activer AppSignal sur les workers, sans que la consommation explose.