### PR TITLE
Script d'export des contacts

### DIFF
--- a/scripts/contacts/contact_export.exs
+++ b/scripts/contacts/contact_export.exs
@@ -1,0 +1,19 @@
+#! mix run
+
+import Ecto.Query
+
+# NOTE: for now, edit Transport.Vault and temporarily inject the production `CLOAK_KEY` value to decrypt email
+# NOTE: in `restore_db.sh`, make sure to uncomment `Truncating contact table` line when restoring a backup!
+
+# DB.Contact.__schema__(:fields)
+# |> IO.inspect(IEx.inspect_opts())
+
+rows =
+  from(DB.Contact)
+  |> select([c], map(c, [:id, :first_name, :last_name, :job_title, :organization, :email]))
+  |> order_by([{:asc, :id}])
+  |> DB.Repo.all()
+  |> CSV.encode(headers: true)
+  |> Enum.into([])
+
+File.write!("data.csv", rows)


### PR DESCRIPTION
Suite à une demande de @cyrilmorin, j'ai écrit un script qui permet d'exporter les contacts en CSV.

Je l'ai fait tourner: en local, avec une base restaurée. Petite subtilité il y a la clé Cloak (l'email est chiffré avec https://github.com/danielberkompas/cloak) à récupérer de la production aussi.

Dans une itération suivante, il sera préférable de faire tourner le tout en production directement, c'était du one-shot mais je ne voulais pas perdre le script pour autant.