### PR TITLE
Exemple de script qui fait du streaming direct vers le disque

### DIFF
--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -89,8 +89,16 @@ defmodule TransportWeb.DiscussionsLive do
   def discussion_should_be_closed?(%{"closed" => closed}) when not is_nil(closed), do: true
 
   def discussion_should_be_closed?(%{"discussion" => comment_list}) do
-    {:ok, latest_comment_datetime, 0} = List.first(comment_list)["posted_on"] |> DateTime.from_iso8601()
-    DateTime.utc_now() |> Timex.shift(months: -2) |> DateTime.compare(latest_comment_datetime) == :gt
+    latest_comment_datetime =
+      comment_list
+      |> Enum.map(fn comment ->
+        {:ok, comment_datetime, 0} = DateTime.from_iso8601(comment["posted_on"])
+        comment_datetime
+      end)
+      |> Enum.max(DateTime)
+
+    two_months_ago = DateTime.utc_now() |> Timex.shift(months: -2)
+    DateTime.compare(two_months_ago, latest_comment_datetime) == :gt
   end
 end
 

--- a/scripts/req_stream.exs
+++ b/scripts/req_stream.exs
@@ -10,12 +10,13 @@ url = large_file_url
 
 # Download file to disk via an IO.Stream
 file = File.stream!("test.data", [:write])
+
 try do
   # NOTE: decode_body is apparently disabled on response streaming
   # https://hexdocs.pm/req/Req.Steps.html#decode_body/1
   response = Req.get!(url, into: file)
   # :body is just a ref to the File.Stream
-  IO.inspect(response, IEx.inspect_opts)
+  IO.inspect(response, IEx.inspect_opts())
 after
   :ok = File.close(file)
 end

--- a/scripts/req_stream.exs
+++ b/scripts/req_stream.exs
@@ -1,0 +1,17 @@
+Mix.install([
+  {:req, "~> 0.4.0"}
+])
+
+_large_file_url = "https://www.data.gouv.fr/fr/datasets/r/c83ba91e-2cd1-40f7-a632-eb0a76d83c49"
+small_file_url = "https://httpbin.org/range/100000"
+
+url = _large_file_url
+
+# downloading directly to disk
+file = File.stream!("test.data", [:write])
+response = Req.get!(large_file_url, into: file)
+File.close(file)
+# the body is not here (well it is, but as a stream)
+IO.inspect(response, IEx.inspect_opts)
+
+IO.puts "ok"

--- a/scripts/req_stream.exs
+++ b/scripts/req_stream.exs
@@ -2,16 +2,20 @@ Mix.install([
   {:req, "~> 0.4.0"}
 ])
 
-_large_file_url = "https://www.data.gouv.fr/fr/datasets/r/c83ba91e-2cd1-40f7-a632-eb0a76d83c49"
-small_file_url = "https://httpbin.org/range/100000"
+large_file_url = "https://www.data.gouv.fr/fr/datasets/r/c83ba91e-2cd1-40f7-a632-eb0a76d83c49"
+# small_file_url = "https://httpbin.org/range/100000"
 
-url = _large_file_url
+url = large_file_url
+# url = small_file_url
 
-# downloading directly to disk
+# Download file to disk via an IO.Stream
 file = File.stream!("test.data", [:write])
-response = Req.get!(large_file_url, into: file)
-File.close(file)
-# the body is not here (well it is, but as a stream)
-IO.inspect(response, IEx.inspect_opts)
-
-IO.puts "ok"
+try do
+  # NOTE: decode_body is apparently disabled on response streaming
+  # https://hexdocs.pm/req/Req.Steps.html#decode_body/1
+  response = Req.get!(url, into: file)
+  # :body is just a ref to the File.Stream
+  IO.inspect(response, IEx.inspect_opts)
+after
+  :ok = File.close(file)
+end


### PR DESCRIPTION
Pour en discuter entre dévs:
- #3446 
- #3447

J'ai fait un test de streaming avec Req, ça fonctionne pas mal. Ca pose des questions sur est-ce qu'on décode ou pas le body, compression etc.

J'ai pensé notamment à ces bouts de code:

https://github.com/etalab/transport-site/blob/2ccb1ed1e58e5c4889d28453f285dc434fd49110/apps/transport/lib/jobs/resource_history_job.ex#L245-L250

Le body est conservé en RAM car il est ensuite passé comme argument à l'upload S3:

https://github.com/etalab/transport-site/blob/2ccb1ed1e58e5c4889d28453f285dc434fd49110/apps/transport/lib/jobs/resource_history_job.ex#L140

Qui actuellement ne fait pas de streaming:

https://github.com/etalab/transport-site/blob/2ccb1ed1e58e5c4889d28453f285dc434fd49110/apps/transport/lib/S3/s3.ex#L35-L46

Mais cela est supporté:

https://github.com/ex-aws/ex_aws_s3#higher-level-operations

Bref - à discuter, ça lance la balle, et ça permettra de réduire l'usage mémoire de façon intéressante a priori.