### PR TITLE
Corrige valeurs de metrics.target pour certains GBFS

### DIFF
--- a/apps/transport/priv/repo/migrations/20230913130308_metrics_gbfs_target_name.exs
+++ b/apps/transport/priv/repo/migrations/20230913130308_metrics_gbfs_target_name.exs
@@ -1,0 +1,12 @@
+defmodule DB.Repo.Migrations.MetricsGBFSTargetName do
+  use Ecto.Migration
+
+  def up do
+    # See https://github.com/etalab/transport-site/issues/3458
+    execute "update metrics set target = replace(target, '/', '') where target like 'gbfs:%/'"
+  end
+
+  def down do
+    IO.puts("no going back")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3458

Une migration changeant le nom des mauvaises valeurs des événements devrait être suffisant.

En plusieurs étapes :
- correction du nom de l'événement innaproprié pour avoir le bon nom (`gbfs:besancon/` vers `gbfs:besancon`)
- https://github.com/etalab/transport-site/blob/e25f9c70641063a5152201fdef87ce60fa97c395/apps/transport/lib/jobs/archive_metrics_job.ex#L81, `Transport.Jobs.ArchiveMetricsJob` est en charge de consolider les metrics au bout d'un moment (90 jours) qui se base sur des doublons de date/event/target (qui vont être présents étant donné qu'on va avoir changé la valeur de `target`).

On aura donc une correction automatique au bout d'un minimum de 90 jours. L'issue indiquant qu'on a quelques lignes mauvaises dès le `2022-12-21`, on devrait pouvoir vérifier rapidement que la correction est bonne.