### PR TITLE
ConversionController : répare test instable

### DIFF
--- a/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
@@ -7,6 +7,7 @@ defmodule TransportWeb.ConversionControllerTest do
   setup do
     setup_telemetry_handler()
     # See https://elixirforum.com/t/dbconnection-ownershiperror-cannot-find-ownership-process-for-pid-0-xxx-0/41373/3
+    # and https://github.com/etalab/transport-site/issues/3434
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(DB.Repo)
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
   end
@@ -65,7 +66,8 @@ defmodule TransportWeb.ConversionControllerTest do
       assert_received {:telemetry_event, [:conversions, :get, :GeoJSON], %{}, %{target: ^target}}
 
       # Need to wait a few milliseconds because the real telemetry handler
-      # writes rows in the database asynchronously
+      # writes rows in the database asynchronously.
+      # NOTE: to be improved in the future
       Process.sleep(100)
 
       assert [%DB.Metrics{target: ^target, event: "conversions:get:GeoJSON", period: ^period, count: 1}] =

--- a/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
@@ -6,7 +6,9 @@ defmodule TransportWeb.ConversionControllerTest do
 
   setup do
     setup_telemetry_handler()
-    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+    # See https://elixirforum.com/t/dbconnection-ownershiperror-cannot-find-ownership-process-for-pid-0-xxx-0/41373/3
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(DB.Repo)
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
   end
 
   describe "get" do
@@ -64,7 +66,7 @@ defmodule TransportWeb.ConversionControllerTest do
 
       # Need to wait a few milliseconds because the real telemetry handler
       # writes rows in the database asynchronously
-      Process.sleep(50)
+      Process.sleep(100)
 
       assert [%DB.Metrics{target: ^target, event: "conversions:get:GeoJSON", period: ^period, count: 1}] =
                DB.Metrics |> DB.Repo.all()


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3434 (or at least attempts to).

- je tente de démarrer Ecto avec un owner clair
- j'attends plus longtemps avant de requêter en base, on pouvait voir avant qu'on avait un array vide alors qu'on attendait une ligne dans `metrics`

@thbar si tu vois une meilleure manière. Je n'arrive pas à répliquer à 100% en local.

```
mix test apps/transport/test --seed 317213
````

passe chez moi alors que ça a [fail ce matin en CI](https://app.circleci.com/pipelines/github/etalab/transport-site/8419/workflows/d6e9736a-50bb-4815-9df0-95df44f47cbb/jobs/41633) avec ce seed.