### PR TITLE
AvailabilityChecker : accepte réponse 303 suite à GET pour SIRI

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -36,6 +36,13 @@ defmodule Transport.AvailabilityChecker do
       {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code in [401, 405] ->
         true
 
+      # Bug affecting Hackney (dependency of HTTPoison)
+      # 303 status codes on `GET` requests should be fine but they're returned as errors
+      # https://github.com/edgurgel/httpoison/issues/171#issuecomment-244029927
+      # https://github.com/etalab/transport-site/issues/3463
+      {:error, %HTTPoison.Error{reason: {:invalid_redirection, _}}} ->
+        true
+
       _ ->
         false
     end

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -53,6 +53,16 @@ defmodule Transport.AvailabilityCheckerTest do
       assert AvailabilityChecker.available?("SIRI", "url405")
       assert AvailabilityChecker.available?("SIRI Lite", "url405")
     end
+
+    test "303 response" do
+      # See https://github.com/edgurgel/httpoison/issues/171#issuecomment-244029927
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+        {:error, %HTTPoison.Error{reason: {:invalid_redirection, nil}}}
+      end)
+
+      assert AvailabilityChecker.available?("SIRI", "url303")
+    end
   end
 
   test "head NOT supported, fallback on stream method" do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3463

Voir le détail dans l'issue et l'approche suivie.

Ce fix est attendue par un client, [Twisto Caen la mer](https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri). [Voir Front](https://app.frontapp.com/open/msg_1qtpzxue?key=5oSuYWMp-F7u2impB_9lvmwnvMk6LD4c).