### PR TITLE
ResourceUnavailableJob : teste 1 fois URL finale

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -310,6 +310,8 @@ defmodule Transport.ImportData do
          # For ODS gtfs as csv we do not have a 'latest' field
          # (the 'latest' field is the stable data.gouv.fr url)
          "latest_url" => resource["latest"] || resource["url"],
+         # GOTCHA: `filetype` is set to `file` for exports coming from ODS
+         # https://github.com/opendatateam/udata-ods/issues/250
          "filetype" => resource["filetype"],
          "type" => resource["type"],
          "id" => existing_resource[:id],


### PR DESCRIPTION
En lien avec 
- #3463
- https://github.com/opendatateam/udata-ods/issues/250

Concerne principalement l'URL SIRI de [Twisto Caen](https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri). Pour ce cas, l'URL donnée par l'API ODS v1 (et donc qui remonte dans l'API data.gouv.fr) est `https://twisto.opendatasoft.com/api/datasets/1.0/fichier-gtfs-du-reseau-twisto/alternative_exports/https_api_okina_fr_gateway_cae_realtime_anshar_ws_services` qui répond une 303.

Côté transport.data.gouv.fr, on souhaite avoir l'URL finale (ce qu'attend le producteur, son industriel et le réutilisateur).

Plusieurs possibilités :
- attendre une évolution sur le moissonneur ODS côté data.gouv.fr
- adapter notre code d'import `ImportData` pour transformer les données là
- adapter le job qui vérifie la disponibilité des ressources

J'ai choisi la dernière option, tout en sachant que ce n'est pas viable dans le temps. Des évolutions vont avoir lieu sur le moissonneur ou notre code d'import, on pourra revoir.