### PR TITLE
Transport.SIRI : ajout RequestExtension aux requêtes

### DIFF
--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -1,4 +1,6 @@
-# Ref: http://www.normes-donnees-tc.org/wp-content/uploads/2021/09/BNTRA-CN03-GT7_NF-Profil-SIRI-FR_v1.2_20210308.pdf
+# Links:
+# - http://www.normes-donnees-tc.org/wp-content/uploads/2021/09/BNTRA-CN03-GT7_NF-Profil-SIRI-FR_v1.2_20210308.pdf
+# - https://github.com/SIRI-CEN/SIRI
 defmodule Transport.SIRI do
   @moduledoc """
   A module to build SIRI queries.
@@ -20,6 +22,8 @@ defmodule Transport.SIRI do
     ~S(<?xml version="1.0" encoding="UTF-8"?>)
   end
 
+  def request_extension, do: empty_element("RequestExtension", [])
+
   def check_status(timestamp, requestor_ref, message_identifier) do
     doc =
       element("S:Envelope", @top_level_namespaces, [
@@ -29,7 +33,8 @@ defmodule Transport.SIRI do
               element("siri:RequestTimestamp", [], timestamp),
               element("siri:RequestorRef", [], requestor_ref),
               element("siri:MessageIdentifier", [], message_identifier)
-            ])
+            ]),
+            request_extension()
           ])
         ])
       ])
@@ -46,7 +51,8 @@ defmodule Transport.SIRI do
               element("siri:RequestTimestamp", [], timestamp),
               element("siri:RequestorRef", [], requestor_ref),
               element("siri:MessageIdentifier", [], message_identifier)
-            ])
+            ]),
+            request_extension()
           ])
         ])
       ])
@@ -63,7 +69,8 @@ defmodule Transport.SIRI do
               element("siri:RequestTimestamp", [], timestamp),
               element("siri:RequestorRef", [], requestor_ref),
               element("siri:MessageIdentifier", [], message_identifier)
-            ])
+            ]),
+            request_extension()
           ])
         ])
       ])
@@ -110,7 +117,8 @@ defmodule Transport.SIRI do
                 element("siri:MessageIdentifier", [], message_identifier)
               ]
               |> append_if_not_nil(line_refs_element(line_refs))
-            )
+            ),
+            request_extension()
           ])
         ])
       ])
@@ -137,7 +145,8 @@ defmodule Transport.SIRI do
                 element("siri:MonitoringRef", [], stop_ref),
                 element("siri:StopVisitTypes", [], "all")
               ]
-            )
+            ),
+            request_extension()
           ])
         ])
       ])
@@ -162,7 +171,8 @@ defmodule Transport.SIRI do
                 element("siri:RequestTimestamp", [], timestamp),
                 element("siri:MessageIdentifier", [], message_identifier)
               ]
-            )
+            ),
+            request_extension()
           ])
         ])
       ])

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -44,6 +44,7 @@ defmodule Transport.SIRITest do
             <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
             <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
           </Request>
+          <RequestExtension/>
         </sw:CheckStatus>
       </S:Body>
     </S:Envelope>
@@ -68,6 +69,7 @@ defmodule Transport.SIRITest do
             <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
             <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
           </Request>
+          <RequestExtension/>
         </sw:LinesDiscovery>
       </S:Body>
     </S:Envelope>
@@ -92,6 +94,7 @@ defmodule Transport.SIRITest do
             <siri:RequestorRef>#{requestor_ref}</siri:RequestorRef>
             <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
           </Request>
+          <RequestExtension/>
         </sw:StopPointsDiscovery>
       </S:Body>
     </S:Envelope>
@@ -126,6 +129,7 @@ defmodule Transport.SIRITest do
                 <siri:LineRef>#{line_002}</siri:LineRef>
               </siri:Lines>
             </Request>
+            <RequestExtension/>
         </sw:GetEstimatedTimetable>
       </S:Body>
     </S:Envelope>
@@ -156,6 +160,7 @@ defmodule Transport.SIRITest do
               <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
               <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
             </Request>
+            <RequestExtension/>
         </sw:GetEstimatedTimetable>
       </S:Body>
     </S:Envelope>
@@ -184,6 +189,7 @@ defmodule Transport.SIRITest do
           <siri:RequestTimestamp>#{timestamp}</siri:RequestTimestamp>
           <siri:MessageIdentifier>#{message_identifier}</siri:MessageIdentifier>
         </Request>
+        <RequestExtension/>
       </sw:GetGeneralMessage>
     </S:Body>
     </S:Envelope>
@@ -215,6 +221,7 @@ defmodule Transport.SIRITest do
           <siri:MonitoringRef>#{stop_ref}</siri:MonitoringRef>
           <siri:StopVisitTypes>all</siri:StopVisitTypes>
         </Request>
+        <RequestExtension/>
       </sw:GetStopMonitoring>
     </S:Body>
     </S:Envelope>


### PR DESCRIPTION
En lien avec
- #3462

Cette issue met en évidence que l'on ne respecte pas le XSD de SIRI, l'ajout de `<RequestExtension/>` est attendu dans les différentes requêtes, ce qui est fait dans cette PR.

J'ai pu tester en local ensuite que le requêteur web fonctionnait avec le réseau de Toulon.