### PR TITLE
ResourceUnavailableJob : permet d'ignorer certaines ressources

### DIFF
--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -52,6 +52,13 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
   require Logger
   alias DB.{Repo, Resource, ResourceUnavailability}
 
+  # Set this env variable to a list of `resource.id`s (comma separated) to bypass
+  # `AvailabilityChecker.available?`. This is *not* something that should be used
+  # for too long or for too many resources.
+  # Example values: `42,1337`
+  # https://github.com/etalab/transport-site/issues/3470
+  @bypass_ids_env_name "BYPASS_RESOURCE_AVAILABILITY_RESOURCE_IDS"
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"resource_id" => resource_id}}) do
     Logger.info("Running ResourceUnavailableJob for #{resource_id}")
@@ -68,14 +75,23 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
     {true, resource}
   end
 
-  defp check_availability({:updated, status_code, %Resource{format: format, url: url} = resource})
+  defp check_availability({:updated, status_code, %Resource{url: url} = resource})
        when status_code != 200 do
-    {Transport.AvailabilityChecker.Wrapper.available?(format, url), resource}
+    perform_check(resource, url)
   end
 
-  defp check_availability({:no_op, %Resource{format: format} = resource}) do
-    check_url = Resource.download_url(resource)
-    {Transport.AvailabilityChecker.Wrapper.available?(format, check_url), resource}
+  defp check_availability({:no_op, %Resource{} = resource}) do
+    perform_check(resource, Resource.download_url(resource))
+  end
+
+  defp perform_check(%Resource{id: resource_id, format: format} = resource, check_url) do
+    bypass_resource_ids = @bypass_ids_env_name |> System.get_env("") |> String.split(",")
+
+    if to_string(resource_id) in bypass_resource_ids do
+      {true, resource}
+    else
+      {Transport.AvailabilityChecker.Wrapper.available?(format, check_url), resource}
+    end
   end
 
   # GOTCHA: `filetype` is set to `"file"` for exports coming from ODS

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -88,6 +88,7 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
     bypass_resource_ids = @bypass_ids_env_name |> System.get_env("") |> String.split(",")
 
     if to_string(resource_id) in bypass_resource_ids do
+      Logger.info("is_available=true for resource##{resource_id} because the check is bypassed")
       {true, resource}
     else
       {Transport.AvailabilityChecker.Wrapper.available?(format, check_url), resource}

--- a/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
@@ -209,6 +209,34 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
              ] = all_enqueued(worker: Transport.Jobs.Workflow)
     end
 
+    test "does not perform a real availability check if the resource is bypassed" do
+      url = "https://example.com/stop-monitoring"
+
+      resource =
+        insert(:resource,
+          url: url,
+          latest_url: latest_url = url,
+          filetype: "file",
+          is_available: true,
+          format: "SIRI",
+          datagouv_id: Ecto.UUID.generate()
+        )
+
+      System.put_env("BYPASS_RESOURCE_AVAILABILITY_RESOURCE_IDS", "#{resource.id},42")
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn ^latest_url ->
+        {:ok, %HTTPoison.Response{status_code: 405}}
+      end)
+
+      # `Transport.AvailabilityChecker.Mock` is not called
+
+      assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
+
+      assert 0 == count_resource_unavailabilities()
+      assert %DB.Resource{is_available: true} = Repo.reload(resource)
+    end
+
     test "performs a GET request and allows a 401 response for a SIRI resource" do
       resource =
         insert(:resource,


### PR DESCRIPTION
Issue liée https://github.com/etalab/transport-site/issues/3470
Suite de #3466

La précédente PR ne règle pas totalement le problème : on a bien la logique de "follow" pour garder l'URL finale dans notre base de données mais le check ne réussit pas. L'URL finale renvoie une 405 en réponse à une requête HTTP `GET`, ce qui n'est pas bon dans le code existant. Ce serait ok selon `Transport.AvailabilityChecker.available?` (car ressource au format SIRI) mais impossible de déléguer la tâche à cette classe à cause du rate limiting en place (1 req/sec). On consomme ceci en faisant du "follow" puis avec un appel `Transport.AvailabilityChecker.available?`.

Je me résigne à ajouter une variable d'env temporaire permettant de bypass le check de disponibilité pour certaines ressources étant donné que :
- ceci concerne 1 seule ressource sur le PAN
- des "clients" attendent la résolution (Keolis Caen + Okina)
- le problème va être différent dans quelques semaines car il survient à cause de bugs ailleurs (HTTPoison + udata-ods)

J'ai déjà renseigné [la variable d'env en prod](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/applications/app_ddc3cfae-0131-427f-9bec-5ff2f054b896/variables) avec la valeur attendue, ie

```
BYPASS_RESOURCE_AVAILABILITY_RESOURCE_IDS=81282
```
[Ressource concernée](https://transport.data.gouv.fr/resources/81282)