### PR TITLE
Requêteur SIRI : décode response.body non utf-8

### DIFF
--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -27,6 +27,11 @@ defmodule Transport.Http.Utils do
 
   defp parse_charset([content_type]), do: parse_charset(content_type)
 
+  # Parse the content-type charset part and attempt to convert it to one of the two encodings we
+  # support at the moment (`:utf8` and `:latin1`), expressed as atoms expected by the Erlang-unicode module
+  # (see https://www.erlang.org/doc/man/unicode#type-encoding).
+  # 
+  # Keep the original value if no match is found.
   defp parse_charset(content_type) when is_binary(content_type) do
     case Plug.Conn.Utils.content_type(content_type) do
       {:ok, _, _, %{"charset" => charset}} ->

--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -28,6 +28,7 @@ defmodule Transport.Http.Utils do
   end
 
   defp parse_charset([content_type]), do: parse_charset(content_type)
+
   defp parse_charset(content_type) when is_binary(content_type) do
     case Plug.Conn.Utils.content_type(content_type) do
       {:ok, _, _, %{"charset" => charset}} ->
@@ -42,6 +43,7 @@ defmodule Transport.Http.Utils do
         nil
     end
   end
+
   defp parse_charset(_), do: nil
 
   # When the header isn't sent, the RFC spec says we should assume ISO-8859-1, but the default is

--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -6,14 +6,12 @@ defmodule Transport.Http.Utils do
 
   def location_header(headers), do: header_value(headers, "location")
 
-  @spec header_value(map(), binary()) :: binary() | nil
   def header_value(headers, header) do
     for {key, value} <- headers, String.downcase(key) == String.downcase(header) do
       value
     end
   end
 
-  @spec reencode_body_to_utf8(binary(), map()) :: binary()
   @doc """
   Takes a response body and response headers and try to convert the body to UTF-8.
   It looks at the charset defined in the `content-type` header.

--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -2,10 +2,71 @@ defmodule Transport.Http.Utils do
   @moduledoc """
   Useful functions to work with http requests
   """
+  require Logger
 
-  def location_header(headers) do
-    for {key, value} <- headers, String.downcase(key) == "location" do
+  def location_header(headers), do: header_value(headers, "location")
+
+  @spec header_value(map(), binary()) :: binary() | nil
+  def header_value(headers, header) do
+    for {key, value} <- headers, String.downcase(key) == String.downcase(header) do
       value
     end
+  end
+
+  @spec reencode_body_to_utf8(binary(), map()) :: binary()
+  @doc """
+  Takes a response body and response headers and try to convert the body to UTF-8.
+  It looks at the charset defined in the `content-type` header.
+
+  Inspired by https://bernheisel.com/blog/httpoison-and-decompression
+  """
+  def reencode_body_to_utf8(body, headers) do
+    headers
+    |> header_value("content-type")
+    |> parse_charset()
+    |> reencode_body(body)
+  end
+
+  defp parse_charset([content_type]), do: parse_charset(content_type)
+  defp parse_charset(content_type) when is_binary(content_type) do
+    case Plug.Conn.Utils.content_type(content_type) do
+      {:ok, _, _, %{"charset" => charset}} ->
+        # Case insensitive and ignore dashes
+        cond do
+          charset =~ ~r/utf-?8/i -> :utf8
+          charset =~ ~r/iso-?8859-?1/i -> :latin1
+          true -> charset
+        end
+
+      _ ->
+        nil
+    end
+  end
+  defp parse_charset(_), do: nil
+
+  # When the header isn't sent, the RFC spec says we should assume ISO-8859-1, but the default is
+  # actually different per format, eg, XML should be assumed UTF-8. We're going to not re-encode
+  # if it's not sent and assume UTF-8. This should be safe for most cases.
+  defp reencode_body(nil, body), do: body
+  defp reencode_body(:utf8, body), do: body
+
+  defp reencode_body(:latin1, body) do
+    case :unicode.characters_to_binary(body, :latin1, :utf8) do
+      {:error, binary, rest} ->
+        Logger.error("Failed to re-encode text. BODY: #{inspect(binary)} REST: #{inspect(rest)}")
+        body
+
+      {:incomplete, reencoded_text, rest} ->
+        Logger.warning("Failed to re-encode entire text. Dropping characters: #{inspect(rest)}")
+        reencoded_text
+
+      reencoded_text ->
+        reencoded_text
+    end
+  end
+
+  defp reencode_body(other, body) do
+    Logger.error("Need to implement re-encoding support for: #{other}")
+    body
   end
 end

--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -71,7 +71,9 @@ defmodule Transport.Http.Utils do
   end
 
   defp reencode_body(other, body) do
-    Logger.error("Need to implement re-encoding support for: #{other}")
+    message = "Need to implement re-encoding support for: #{other}"
+    Logger.error(message)
+    Sentry.capture_message("#{inspect(__MODULE__)}: #{message}")
     body
   end
 end

--- a/apps/transport/lib/http/utils.ex
+++ b/apps/transport/lib/http/utils.ex
@@ -27,16 +27,17 @@ defmodule Transport.Http.Utils do
 
   defp parse_charset([content_type]), do: parse_charset(content_type)
 
-  # Parse the content-type charset part and attempt to convert it to one of the two encodings we
-  # support at the moment (`:utf8` and `:latin1`), expressed as atoms expected by the Erlang-unicode module
+  # Parse the content-type charset part and attempt to convert it
+  # to one of the two encodings we support at the moment (`:utf8` and `:latin1`),
+  # expressed as atoms expected by the Erlang's unicode module
   # (see https://www.erlang.org/doc/man/unicode#type-encoding).
-  # 
+  #
   # Keep the original value if no match is found.
   defp parse_charset(content_type) when is_binary(content_type) do
     case Plug.Conn.Utils.content_type(content_type) do
       {:ok, _, _, %{"charset" => charset}} ->
-        # Case insensitive and ignore dashes
         cond do
+          # Case insensitive and ignore dashes
           charset =~ ~r/utf-?8/i -> :utf8
           charset =~ ~r/iso-?8859-?1/i -> :latin1
           true -> charset
@@ -49,12 +50,14 @@ defmodule Transport.Http.Utils do
 
   defp parse_charset(_), do: nil
 
-  # When the header isn't sent, the RFC spec says we should assume ISO-8859-1, but the default is
-  # actually different per format, eg, XML should be assumed UTF-8. We're going to not re-encode
-  # if it's not sent and assume UTF-8. This should be safe for most cases.
+  # When the header isn't sent, the RFC spec says we should assume ISO-8859-1
+  # but the default is actually different per format, eg, XML should be assumed UTF-8.
+  # We're going to not re-encode if it's not sent and assume UTF-8.
+  # This should be safe for most cases.
   defp reencode_body(nil, body), do: body
   defp reencode_body(:utf8, body), do: body
 
+  # Reencode the body from Latin 1 to UTF-8
   defp reencode_body(:latin1, body) do
     case :unicode.characters_to_binary(body, :latin1, :utf8) do
       {:error, binary, rest} ->

--- a/apps/transport/lib/transport_web/live/siri_querier_live.ex
+++ b/apps/transport/lib/transport_web/live/siri_querier_live.ex
@@ -90,7 +90,8 @@ defmodule TransportWeb.Live.SIRIQuerierLive do
         {:ok, %HTTPoison.Response{} = response} ->
           # LiveView does not allow binary payloads. We can work-around that by using Base64, or using a custom channel.
           # Unzip and reencode the response body if needed.
-          # We do not make any attempt to modify the XML prolog (e.g. `<?xml version="1.0" encoding="UTF-8"?>`) to match the target encoding.
+          # We do not make any attempt to modify the XML prolog
+          # (e.g. `<?xml version="1.0" encoding="UTF-8"?>`) to match the target encoding.
           # If the prolog is sent on some payloads, we may need to "string replace"
           # that part too.
           headers = lowercase_headers(response.headers)

--- a/apps/transport/lib/transport_web/live/siri_querier_live.ex
+++ b/apps/transport/lib/transport_web/live/siri_querier_live.ex
@@ -89,7 +89,10 @@ defmodule TransportWeb.Live.SIRIQuerierLive do
            ) do
         {:ok, %HTTPoison.Response{} = response} ->
           # LiveView does not allow binary payloads. We can work-around that by using Base64, or using a custom channel.
-          # Unzip and reencode the response body if needed
+          # Unzip and reencode the response body if needed.
+          # We do not make any attempt to modify the XML prolog (e.g. `<?xml version="1.0" encoding="UTF-8"?>`) to match the target encoding.
+          # If the prolog is sent on some payloads, we may need to "string replace"
+          # that part too.
           headers = lowercase_headers(response.headers)
           response_body = response.body |> maybe_gunzip(headers) |> reencode_body_to_utf8(headers)
 

--- a/apps/transport/lib/transport_web/live/siri_querier_live.ex
+++ b/apps/transport/lib/transport_web/live/siri_querier_live.ex
@@ -1,6 +1,7 @@
 defmodule TransportWeb.Live.SIRIQuerierLive do
   use Phoenix.LiveView
   use Phoenix.HTML, only: [text_input: 2]
+  import Transport.Http.Utils, only: [reencode_body_to_utf8: 2]
   import TransportWeb.Gettext
   import TransportWeb.Router.Helpers, only: [live_path: 3, static_path: 2]
   import Unlock.GunzipTools, only: [maybe_gunzip: 2, lowercase_headers: 1]
@@ -88,8 +89,9 @@ defmodule TransportWeb.Live.SIRIQuerierLive do
            ) do
         {:ok, %HTTPoison.Response{} = response} ->
           # LiveView does not allow binary payloads. We can work-around that by using Base64, or using a custom channel.
-          # Make sure to unzip!
-          response_body = maybe_gunzip(response.body, lowercase_headers(response.headers))
+          # Unzip and reencode the response body if needed
+          headers = lowercase_headers(response.headers)
+          response_body = response.body |> maybe_gunzip(headers) |> reencode_body_to_utf8(headers)
 
           socket
           |> assign(%{

--- a/apps/transport/test/transport_web/controllers/siri_querier_test.exs
+++ b/apps/transport/test/transport_web/controllers/siri_querier_test.exs
@@ -123,8 +123,9 @@ defmodule TransportWeb.SIRIQuerierLiveTest do
     assert view |> element("#siri_response_error") |> render() =~ "Got an error"
 
     # re-encodes a latin1 body to UTF-8
+    # Express `£éduff` in latin1 as bytes first
     latin1 = <<163, 233, 100, 117, 102, 102>>
-    utf8 = "£éduff"
+    expected_utf8_conversion = "£éduff"
 
     Transport.HTTPoison.Mock
     |> expect(:post, fn ^endpoint_url, _body, [{"content-type", "text/xml"}], [recv_timeout: _] ->
@@ -139,7 +140,7 @@ defmodule TransportWeb.SIRIQuerierLiveTest do
     view |> element(~s{button[phx-click="execute_query"}) |> render_click()
 
     assert view |> element("#siri_response_wrapper") |> render() =~
-             ~s(<input type="hidden" value="#{utf8}" data-code="response_code_id")
+             ~s(<input type="hidden" value="#{expected_utf8_conversion}" data-code="response_code_id")
 
     refute view |> has_element?("#siri_response_error")
   end


### PR DESCRIPTION
Fixes #3469

Ajoute du code qui détecte le `charset` dans `content-type` et qui réencode vers de l'UTF-8 pour éviter les erreurs de rendering dans la LiveView.

Pour tester en local, avec le serveur de Toulon qui répond en `ISO-8859-1` : http://localhost:5000/tools/siri-querier?endpoint_url=https%3A%2F%2Fsaes.ratpdev.com%2Frdtpm&requestor_ref=OPENDATA&query_template=GetStopMonitoring&stop_ref=TOGR09