### PR TITLE
LiveView : ne pas passer locale

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/_dataset.html.heex
@@ -45,9 +45,7 @@
     <% end %>
   </td>
   <td class="bo_action_button">
-    <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView,
-      session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
-    ) %>
+    <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView, session: %{"dataset_id" => @dataset.id}) %>
   </td>
   <td class="bo_action_button">
     <%= form_for @conn, backoffice_page_path(@conn, :edit, @dataset.id), [nodiv: true, method: "get"], fn _ -> %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -15,9 +15,7 @@
       </div>
 
       <div>
-        <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView,
-          session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
-        ) %>
+        <%= live_render(@conn, TransportWeb.Live.ValidateDatasetView, session: %{"dataset_id" => @dataset.id}) %>
       </div>
 
       <div>
@@ -27,9 +25,7 @@
       </div>
 
       <div :if={@dataset.type == "public-transit"}>
-        <%= live_render(@conn, TransportWeb.Live.ForceNeTExConversion,
-          session: %{"dataset_id" => @dataset.id, "locale" => get_session(@conn, :locale)}
-        ) %>
+        <%= live_render(@conn, TransportWeb.Live.ForceNeTExConversion, session: %{"dataset_id" => @dataset.id}) %>
       </div>
     </div>
 
@@ -154,7 +150,6 @@
         <%= live_render(@conn, TransportWeb.Live.SendNowOnNAPNotificationView,
           session: %{
             "dataset_id" => @dataset.id,
-            "locale" => get_session(@conn, :locale),
             "sent_reasons" =>
               @notifications_sent |> Enum.map(fn {{reason, _datetime}, _emails} -> reason end) |> Enum.uniq()
           }


### PR DESCRIPTION
Ne passer pas `locale` dans la session du `mount/3` des LiveViews, ceci est déjà présent dans la session générale de l'application.

https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-life-cycle

> When LiveView is first rendered, the mount/3 callback is invoked with the current params, the current session and the LiveView socket.