### PR TITLE
Consolidation BNLC : téléchargement du fichier consolidé dans e-mail interne

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -25,6 +25,17 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   @type dataset_not_found_error :: %{error: :dataset_not_found, dataset_slug: binary()}
 
   @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"action" => "delete_s3_file", "filename" => filename}}) do
+    if filename |> String.starts_with?("bnlc") do
+      Transport.S3.delete_object!(:on_demand_validation, filename)
+      Logger.info("Deleted #{filename} on S3")
+      :ok
+    else
+      {:discard, "Cannot delete file, unexpected filename: #{inspect(filename)}"}
+    end
+  end
+
+  @impl Oban.Worker
   def perform(%Oban.Job{}) do
     consolidate()
   end
@@ -48,7 +59,9 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
       Logger.info("Sending the email recap")
 
-      send_email_recap(%{
+      upload_temporary_file()
+      |> schedule_deletion()
+      |> send_email_recap(%{
         dataset_errors: dataset_errors,
         validation_errors: validation_errors,
         download_errors: download_errors
@@ -58,13 +71,32 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
     end
   end
 
-  @spec send_email_recap(consolidation_errors()) :: {:ok, any()} | {:error, any()}
-  def send_email_recap(%{} = errors) do
+  defp upload_temporary_file do
+    content = File.read!(@bnlc_path)
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_string() |> String.replace(" ", "_")
+    filename = "bnlc-#{now}.csv"
+    Transport.S3.upload_to_s3!(:on_demand_validation, content, filename)
+    filename
+  end
+
+  defp schedule_deletion(filename) do
+    # Delete temporary file in 4 weeks from S3
+    %{action: "delete_s3_file", filename: filename}
+    |> new(schedule_in: {4, :weeks})
+    |> Oban.insert!()
+
+    filename
+  end
+
+  @spec send_email_recap(binary(), consolidation_errors()) :: {:ok, any()} | {:error, any()}
+  def send_email_recap(filename, %{} = errors) do
     body =
       case format_errors(errors) do
         nil -> "✅ La consolidation s'est déroulée sans erreurs"
         txt when is_binary(txt) -> txt
       end
+
+    file_url = Transport.S3.permanent_url(:on_demand_validation, filename)
 
     Transport.EmailSender.impl().send_mail(
       "transport.data.gouv.fr",
@@ -73,7 +105,11 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
       Application.get_env(:transport, :contact_email),
       "Rapport de consolidation de la BNLC",
       "",
-      body
+      """
+      #{body}
+
+      🔗 <a href="#{file_url}">Fichier consolidé</a>
+      """
     )
   end
 

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -483,7 +483,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
               %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
             ] = all_enqueued()
 
-      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7*4
+      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7 * 4
       assert filename =~ ~r"^bnlc-.*\.csv$"
 
       # CSV content is fine
@@ -679,7 +679,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
               %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
             ] = all_enqueued()
 
-      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7*4
+      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7 * 4
       assert filename =~ ~r"^bnlc-.*\.csv$"
 
       assert """

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -480,8 +480,12 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       # A job has been enqueued and scheduled to delete the temporary file stored in the bucket
       assert [
-              %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
-            ] = all_enqueued()
+               %Oban.Job{
+                 worker: "Transport.Jobs.ConsolidateBNLCJob",
+                 args: %{"action" => "delete_s3_file", "filename" => filename},
+                 scheduled_at: scheduled_at
+               }
+             ] = all_enqueued()
 
       assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7 * 4
       assert filename =~ ~r"^bnlc-.*\.csv$"
@@ -676,8 +680,12 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       # A job has been enqueued and scheduled to delete the temporary file stored in the bucket
       assert [
-              %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
-            ] = all_enqueued()
+               %Oban.Job{
+                 worker: "Transport.Jobs.ConsolidateBNLCJob",
+                 args: %{"action" => "delete_s3_file", "filename" => filename},
+                 scheduled_at: scheduled_at
+               }
+             ] = all_enqueued()
 
       assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7 * 4
       assert filename =~ ~r"^bnlc-.*\.csv$"

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -447,6 +447,18 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
         end
       )
 
+      Transport.ExAWS.Mock
+      |> expect(:request!, fn %ExAws.Operation.S3{} = operation ->
+        assert %ExAws.Operation.S3{
+                 bucket: "transport-data-gouv-fr-on-demand-validation-test",
+                 path: path,
+                 http_method: :put,
+                 service: :s3
+               } = operation
+
+        assert path =~ ~r"^bnlc-.*\.csv$"
+      end)
+
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn "transport.data.gouv.fr" = _display_name,
                                "contact@transport.beta.gouv.fr" = _from,
@@ -455,12 +467,26 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                                "Rapport de consolidation de la BNLC" = _subject,
                                "",
                                html_part ->
-        assert html_part == "✅ La consolidation s'est déroulée sans erreurs"
+        assert html_part =~ ~r"^✅ La consolidation s'est déroulée sans erreurs"
+
+        # Make sure a link is there
+        assert html_part =~
+                 ~r{🔗 <a href="https://transport-data-gouv-fr-on-demand-validation-test.cellar-c2.services.clever-cloud.com/bnlc-.*\.csv">Fichier consolidé</a>}
+
         :ok
       end)
 
       assert :ok == perform_job(ConsolidateBNLCJob, %{})
 
+      # A job has been enqueued and scheduled to delete the temporary file stored in the bucket
+      assert [
+              %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
+            ] = all_enqueued()
+
+      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7*4
+      assert filename =~ ~r"^bnlc-.*\.csv$"
+
+      # CSV content is fine
       assert """
              foo,bar,baz\r
              I,Love,CSV\r
@@ -640,11 +666,21 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                  ~s{<h2>Ressources non valides par rapport au schéma etalab/schema-lieux-covoiturage</h2>\nRessource `Bar CSV` (<a href="https://data.gouv.fr/bar">Bar JDD</a>)}
 
         # Make sure a link is there
+        assert html_part =~
+                 ~r{🔗 <a href="https://transport-data-gouv-fr-on-demand-validation-test.cellar-c2.services.clever-cloud.com/bnlc-.*\.csv">Fichier consolidé</a>}
 
         :ok
       end)
 
       assert :ok == perform_job(ConsolidateBNLCJob, %{})
+
+      # A job has been enqueued and scheduled to delete the temporary file stored in the bucket
+      assert [
+              %Oban.Job{worker: "Transport.Jobs.ConsolidateBNLCJob", args: %{"action" => "delete_s3_file", "filename" => filename}, scheduled_at: scheduled_at}
+            ] = all_enqueued()
+
+      assert DateTime.diff(scheduled_at, DateTime.utc_now(), :day) == 7*4
+      assert filename =~ ~r"^bnlc-.*\.csv$"
 
       assert """
              foo,bar,baz\r


### PR DESCRIPTION
En lien avec #3419

Adapte le job de consolidation de la BNLC (qui est toujours en cours de développement, usage interne uniquement, sans impact en prod/remplacement de fichiers sur data.gouv.fr).

- Ajoute un lien de téléchargement du fichier consolidé dans l'e-mail de rapport qui est généré, envoyé aux bizdevs
- Ce fichier consolidé est mis sur notre S3 bucket temporaire (le même que validation à la demande) et supprimé au bout de 4 semaines

J'ai suivi cette approche pour ne pas avoir à envoyer de pièce jointe dans des e-mails.