### PR TITLE
Résolution de l’erreur 500 sur /explore/gtfs-stops/data

### DIFF
--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -32,22 +32,23 @@ defmodule TransportWeb.ExploreController do
 
   @max_points 20_000
 
-  def gtfs_stops_data(conn, params) do
+  def gtfs_stops_data(
+        conn,
+        %{
+          "south" => south,
+          "east" => east,
+          "west" => west,
+          "north" => north,
+          "width_pixels" => width,
+          "height_pixels" => height,
+          "zoom_level" => zoom_level
+        } = _params
+      ) do
     if national_map_disabled?() do
       conn
       |> put_status(503)
       |> json(%{error: "temporarily unavailable"})
     else
-      %{
-        "south" => south,
-        "east" => east,
-        "west" => west,
-        "north" => north,
-        "width_pixels" => width,
-        "height_pixels" => height,
-        "zoom_level" => zoom_level
-      } = params
-
       {south, ""} = Float.parse(south)
       {east, ""} = Float.parse(east)
       {west, ""} = Float.parse(west)
@@ -83,5 +84,11 @@ defmodule TransportWeb.ExploreController do
         )
       end
     end
+  end
+
+  def gtfs_stops_data(conn, _params) do
+    conn
+    |> put_status(422)
+    |> json(%{error: "incorrect parameters"})
   end
 end

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -57,7 +57,6 @@ defmodule TransportWeb.ExploreControllerTest do
     conn = conn |> get("/explore/gtfs-stops-data")
     json = json_response(conn, 422)
     assert json["error"] == "incorrect parameters"
-    # assert json["type"] == "FeatureCollection"
   end
 
   test "GET /explore/gtfs-stops-data with parameters", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -52,4 +52,28 @@ defmodule TransportWeb.ExploreControllerTest do
     assert title == "Carte consolidée des arrêts GTFS (beta)"
     assert html =~ "<h2>Carte consolidée des arrêts GTFS (beta)</h2>"
   end
+
+  test "GET /explore/gtfs-stops-data without parameters", %{conn: conn} do
+    conn = conn |> get("/explore/gtfs-stops-data")
+    json = json_response(conn, 422)
+    assert json["error"] == "incorrect parameters"
+    # assert json["type"] == "FeatureCollection"
+  end
+
+  test "GET /explore/gtfs-stops-data with parameters", %{conn: conn} do
+    conn =
+      conn
+      |> get("/explore/gtfs-stops-data", %{
+        "south" => "48.8",
+        "east" => "2.4",
+        "west" => "2.2",
+        "north" => "48.9",
+        "width_pixels" => "1000",
+        "height_pixels" => "1000",
+        "zoom_level" => "12"
+      })
+
+    json = json_response(conn, 200)
+    assert json["data"]["type"] == "FeatureCollection"
+  end
 end


### PR DESCRIPTION
Voir https://transport-data-gouv-fr.sentry.io/issues/4207628748