### PR TITLE
BO : consolidation BNLC à blanc

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -25,8 +25,9 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   @type dataset_not_found_error :: %{error: :dataset_not_found, dataset_slug: binary()}
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
+  def perform(%Oban.Job{id: job_id}) do
     consolidate()
+    Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
   end
 
   @spec consolidate() :: :ok | {:discard, binary()}
@@ -53,8 +54,6 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
         validation_errors: validation_errors,
         download_errors: download_errors
       })
-
-      :ok
     end
   end
 

--- a/apps/transport/lib/transport_web/live/start_consolidate_bnlc_view.ex
+++ b/apps/transport/lib/transport_web/live/start_consolidate_bnlc_view.ex
@@ -1,0 +1,82 @@
+defmodule TransportWeb.Live.SendConsolidateBNLCView do
+  # Very similar to `TransportWeb.Live.SendNowOnNAPNotificationView`
+  use Phoenix.LiveView
+  @button_disabled [:dispatched, :sent]
+
+  def render(assigns) do
+    ~H"""
+    <button class={@button_class} phx-click="dispatch_job" disabled={@button_disabled}>
+      <%= @button_text %>
+    </button>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, socket |> assign_step(:first)}
+  end
+
+  def handle_event("dispatch_job", _value, socket) do
+    send(self(), :dispatch)
+    {:noreply, socket}
+  end
+
+  def handle_info(:dispatch, socket) do
+    new_socket =
+      case %{} |> Transport.Jobs.ConsolidateBNLCJob.new() |> Oban.insert() do
+        {:ok, %Oban.Job{id: job_id}} ->
+          send(self(), {:wait_for_completion, job_id})
+          assign_step(socket, :dispatched)
+      end
+
+    {:noreply, new_socket}
+  end
+
+  def handle_info({:wait_for_completion, job_id}, socket) do
+    :ok = Oban.Notifier.listen([:gossip])
+
+    new_socket =
+      receive do
+        {:notification, :gossip, %{"complete" => ^job_id}} ->
+          socket |> assign_step(:sent)
+      end
+
+    Oban.Notifier.unlisten([:gossip])
+    Process.send_after(self(), :reset, :timer.seconds(60))
+    {:noreply, new_socket}
+  end
+
+  def handle_info(:reset, socket) do
+    {:noreply, socket |> assign_step(:first)}
+  end
+
+  defp assign_step(socket, step) do
+    assign(
+      socket,
+      button_text: button_texts(step),
+      button_class: button_classes(step),
+      button_disabled: step in @button_disabled
+    )
+  end
+
+  defp button_texts(step) do
+    Map.get(
+      %{
+        sent: "Rapport disponible par e-mail",
+        dispatched: "Consolidation en cours"
+      },
+      step,
+      "Consolider à blanc"
+    )
+  end
+
+  defp button_classes(step) do
+    Map.get(
+      %{
+        sent: "button success",
+        dispatched: "button button-outlined secondary"
+      },
+      step,
+      "button"
+    )
+  end
+end

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -82,6 +82,11 @@
     </a>
   </div>
 
+  <h2>Consolidation BNLC</h2>
+  <div>
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView, []) %>
+  </div>
+
   <h2><%= dgettext("backoffice", "Validations") %></h2>
   <div>
     <%= form_for @conn, backoffice_dataset_path(@conn, :force_validate_gtfs_transport), [class: "no-margin"], fn _f -> %>


### PR DESCRIPTION
En lien avec #3419

Ajoute un bouton dans le backoffice permettant de lancer une "consolidation à blanc de la BNLC" (ie le faire juste pour nous, envoyer ceci par e-mail avec un rapport, voir PR #3478).

C'est une LiveView, pas trop compliquée, qui ajoute un job Oban et qui suit son avancement. Déjà fait ailleurs, je reprends du code.