### PR TITLE
Dataset#details : info lorsqu'un JDD est saisonnier

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -1028,12 +1028,18 @@ defmodule DB.Dataset do
   @doc """
   iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: ["licence-osm"]})
   false
-  iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: nil})
-  false
   iex> display_climate_resilience_bill_badge?(%__MODULE__{custom_tags: ["loi-climat-resilience", "foo"]})
   true
   """
-  def climate_resilience_bill?(%__MODULE__{custom_tags: custom_tags}) do
-    "loi-climat-resilience" in (custom_tags || [])
-  end
+  def climate_resilience_bill?(%__MODULE__{} = dataset), do: has_custom_tag?(dataset, "loi-climat-resilience")
+
+  @doc """
+  iex> has_custom_tag?(%__MODULE__{custom_tags: ["foo"]}, "foo")
+  true
+  iex> has_custom_tag?(%__MODULE__{custom_tags: ["foo"]}, "bar")
+  false
+  iex> has_custom_tag?(%__MODULE__{custom_tags: nil}, "bar")
+  false
+  """
+  def has_custom_tag?(%__MODULE__{custom_tags: custom_tags}, tag_name), do: tag_name in (custom_tags || [])
 end

--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -45,7 +45,8 @@ defmodule TransportWeb.CustomTagsLive do
         doc:
           "Ce jeu de données est soumis à l'obligation de réutilisation selon l'article 122 de la loi climat et résilience"
       },
-      %{name: "requestor_ref:<valeur>", doc: "Renseigne le requestor_ref des ressources SIRI pour ce jeu de données"}
+      %{name: "requestor_ref:<valeur>", doc: "Renseigne le requestor_ref des ressources SIRI pour ce jeu de données"},
+      %{name: "saisonnier", doc: "Indique sur la page du JDD que ce jeu de données n'opère qu'une partie de l'année"}
     ]
   end
 

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -75,6 +75,12 @@
   </div>
   <div class="dataset-infos">
     <section>
+      <p :if={seasonal_warning?(@dataset)} class="notification">
+        ℹ️ <%= dgettext(
+          "page-dataset-details",
+          "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+        ) %>
+      </p>
       <div class="panel">
         <%= description(@dataset) %>
       </div>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -356,10 +356,8 @@ defmodule TransportWeb.DatasetView do
   def licence_url(_), do: nil
 
   @spec description(Dataset.t() | Resource.t()) :: Phoenix.HTML.safe()
-  def description(instance) do
-    instance.description
-    |> markdown_to_safe_html!()
-  end
+  def description(%Dataset{description: description}), do: description |> markdown_to_safe_html!()
+  def description(%Resource{description: description}), do: description |> markdown_to_safe_html!()
 
   def markdown_to_safe_html!(md), do: MarkdownHandler.markdown_to_safe_html!(md)
 
@@ -522,8 +520,8 @@ defmodule TransportWeb.DatasetView do
   iex> display_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: [], custom_tags: nil})
   false
   """
-  def display_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: tags, custom_tags: custom_tags}) do
-    "openstreetmap" in tags or "licence-osm" in (custom_tags || [])
+  def display_odbl_osm_conditions?(%Dataset{licence: "odc-odbl", tags: tags} = dataset) do
+    "openstreetmap" in tags or Dataset.has_custom_tag?(dataset, "licence-osm")
   end
 
   def display_odbl_osm_conditions?(%Dataset{}), do: false
@@ -534,4 +532,12 @@ defmodule TransportWeb.DatasetView do
   end
 
   def related_gtfs_resource(%Resource{}), do: nil
+
+  @doc """
+  iex> seasonal_warning?(%DB.Dataset{custom_tags: ["saisonnier", "foo"]})
+  true
+  iex> seasonal_warning?(%DB.Dataset{custom_tags: ["foo"]})
+  false
+  """
+  def seasonal_warning?(%Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -605,3 +605,7 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Dataset scores"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -605,3 +605,7 @@ msgstr "chargement des discussions..."
 #, elixir-autogen, elixir-format
 msgid "Dataset scores"
 msgstr "Scores du jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+msgstr "Le service de transport de ce jeu de donnée ne fonctionne pas toute l'année et les ressources associées peuvent être périmées selon la période de l'année. Nous vous invitons à contacter le producteur via les discussions pour plus d'information."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -605,3 +605,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dataset scores"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -447,6 +447,22 @@ defmodule TransportWeb.DatasetControllerTest do
     end
   end
 
+  test "a banner is displayed for a seasonal dataset", %{conn: conn} do
+    dataset = insert(:dataset, is_active: true, custom_tags: ["saisonnier", "foo"])
+    set_empty_mocks()
+
+    assert TransportWeb.DatasetView.seasonal_warning?(dataset)
+
+    [{"p", [{"class", "notification"}], [content]}] =
+      conn
+      |> get(dataset_path(conn, :details, dataset.slug))
+      |> html_response(200)
+      |> Floki.parse_document!()
+      |> Floki.find(".notification")
+
+    assert content =~ "Le service de transport de ce jeu de donnée ne fonctionne pas toute l'année"
+  end
+
   test "gtfs-rt entities" do
     dataset = %{id: dataset_id} = insert(:dataset, type: "public-transit")
     %{id: resource_id_1} = insert(:resource, dataset_id: dataset_id, format: "gtfs-rt")


### PR DESCRIPTION
Fixes #3457

Ajoute une bannière d'information sur `dataset#details` lorsqu'un JDD est indiqué comme saisonnier par notre équipe depuis le backoffice. Cette bannière est affichée tout le temps (ie quand c'est "à jour" ou "périmé").