### PR TITLE
GBFS : ne pas stocker de metrics pour 404

### DIFF
--- a/apps/gbfs/test/gbfs/page_cache_test.exs
+++ b/apps/gbfs/test/gbfs/page_cache_test.exs
@@ -105,21 +105,6 @@ defmodule GBFS.PageCacheTest do
     {:telemetry_event, [:gbfs, :request, request_type], %{}, %{target: GBFS.Telemetry.target_for_network(network_name)}}
   end
 
-  defp setup_telemetry_handler do
-    events = Transport.Telemetry.gbfs_request_event_names()
-    events |> Enum.at(1) |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
-    test_pid = self()
-    # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
-    :telemetry.attach_many(
-      "test-handler-#{System.unique_integer()}",
-      events,
-      fn name, measurements, metadata, _ ->
-        send(test_pid, {:telemetry_event, name, measurements, metadata})
-      end,
-      nil
-    )
-  end
-
   # To be implemented later, but for now the error handling on that (Sentry etc)
   # is not clear (#1378)
   @tag :pending

--- a/apps/gbfs/test/support/app_config_helper.ex
+++ b/apps/gbfs/test/support/app_config_helper.ex
@@ -10,7 +10,7 @@ defmodule AppConfigHelper do
   end
 
   def setup_telemetry_handler do
-    events = Transport.Telemetry.gbfs_request_event_names()
+    events = Enum.map([:external, :internal], &[:gbfs, :request, &1])
     events |> Enum.at(1) |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
     test_pid = self()
     # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs

--- a/apps/gbfs/test/support/app_config_helper.ex
+++ b/apps/gbfs/test/support/app_config_helper.ex
@@ -3,17 +3,30 @@ defmodule AppConfigHelper do
   A way to temporarily change Application config. Make sure to only use this
   with "async: false" tests
   """
-  import ExUnit.Callbacks, only: [on_exit: 1]
-
-  def change_app_config_temporarily(config_name, config_key, value) do
-    old_value = Application.fetch_env!(config_name, config_key)
-    on_exit(fn -> Application.put_env(config_name, config_key, old_value) end)
-    Application.put_env(config_name, config_key, value)
-  end
-
   def enable_cache do
     change_app_config_temporarily(:gbfs, :disable_page_cache, false)
     # clear the cache since some element can still be there
-    on_exit(fn -> Cachex.clear(:gbfs) end)
+    ExUnit.Callbacks.on_exit(fn -> Cachex.clear(:gbfs) end)
+  end
+
+  def setup_telemetry_handler do
+    events = Transport.Telemetry.gbfs_request_event_names()
+    events |> Enum.at(1) |> :telemetry.list_handlers() |> Enum.map(& &1.id) |> Enum.each(&:telemetry.detach/1)
+    test_pid = self()
+    # inspired by https://github.com/dashbitco/broadway/blob/main/test/broadway_test.exs
+    :telemetry.attach_many(
+      "test-handler-#{System.unique_integer()}",
+      events,
+      fn name, measurements, metadata, _ ->
+        send(test_pid, {:telemetry_event, name, measurements, metadata})
+      end,
+      nil
+    )
+  end
+
+  defp change_app_config_temporarily(config_name, config_key, value) do
+    old_value = Application.fetch_env!(config_name, config_key)
+    ExUnit.Callbacks.on_exit(fn -> Application.put_env(config_name, config_key, old_value) end)
+    Application.put_env(config_name, config_key, value)
   end
 end

--- a/apps/transport/priv/repo/migrations/20230925124412_gbfs_metrics_remove_404_rows.exs
+++ b/apps/transport/priv/repo/migrations/20230925124412_gbfs_metrics_remove_404_rows.exs
@@ -1,0 +1,18 @@
+defmodule DB.Repo.Migrations.GbfsMetricsRemove404Rows do
+  use Ecto.Migration
+
+  def up do
+    # See https://github.com/etalab/transport-site/issues/3483
+    execute """
+    delete from metrics
+    where period >= '2023-09-15'::date and target in (
+      'gbfs:city_name_lowercase', 'gbfs:foo',
+      'gbfs:valence', 'gbfs:montpellier', 'gbfs:rouen', 'gbfs:marseille', 'gbfs:strasbourg'
+    )
+    """
+  end
+
+  def down do
+    IO.puts "no going back"
+  end
+end


### PR DESCRIPTION
Fixes #3483

Voir l'issue pour le détail du problème.

Cette PR :
- arrête d'utiliser le cache/envoyer des events telemetry pour la route "catch-all" de l'app GBFS
- supprime les `metrics` qui ont été enregistrées à tort

Il y a un petit peu de refactor dans les tests, étant donné que j'ai besoin de vérifier le bon fonctionnement du cache dans 2 fichiers maintenant.