### PR TITLE
Validation TableSchema : remplacement du domaine

### DIFF
--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -25,7 +25,7 @@ defmodule Shared.Validation.TableSchemaValidator do
   @behaviour Shared.Validation.TableSchemaValidator.Wrapper
   @timeout 180_000
   @validata_web_url URI.parse("https://validata.fr/table-schema")
-  @validata_api_url URI.parse("https://validata-api.app.etalab.studio/validate")
+  @validata_api_url URI.parse("https://api.validata.etalab.studio/validate")
   # https://git.opendatafrance.net/validata/validata-core/-/blob/75ee5258010fc43b6a164122eff2579c2adc01a7/validata_core/helpers.py#L152
   @structure_tags ["#head", "#structure"]
 

--- a/apps/shared/test/validation/tableschema_validator_test.exs
+++ b/apps/shared/test/validation/tableschema_validator_test.exs
@@ -16,7 +16,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
       setup_schemas_response()
       schema_version = "0.2.2"
       query = URI.encode_query(%{schema: schema_url(@schema_name, schema_version), url: @url, header_case: "false"})
-      expected_url = "https://validata-api.app.etalab.studio/validate?#{query}"
+      expected_url = "https://api.validata.etalab.studio/validate?#{query}"
 
       assert validator_api_url(@schema_name, @url, schema_version) == expected_url
     end
@@ -24,7 +24,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
     test "with latest version" do
       setup_schemas_response()
       query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url, header_case: "false"})
-      expected_url = "https://validata-api.app.etalab.studio/validate?#{query}"
+      expected_url = "https://api.validata.etalab.studio/validate?#{query}"
 
       assert validator_api_url(@schema_name, @url) == expected_url
     end
@@ -167,7 +167,7 @@ defmodule Shared.Validation.TableSchemaValidatorTest do
 
   defp validata_response_with_body(body, status_code \\ 200) do
     query = URI.encode_query(%{schema: schema_url(@schema_name, "latest"), url: @url, header_case: "false"})
-    url = "https://validata-api.app.etalab.studio/validate?#{query}"
+    url = "https://api.validata.etalab.studio/validate?#{query}"
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn ^url, [] = _headers, [recv_timeout: 180_000] = _options ->


### PR DESCRIPTION
Fixes #3487

Le certificat du nom de domaine a expiré, on remplace le domaine pour Validata API.