### PR TITLE
Désactiver job quotidien Validata JSON

### DIFF
--- a/apps/transport/lib/jobs/resource_history_validata_json_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validata_json_job.ex
@@ -1,6 +1,9 @@
 defmodule Transport.Jobs.ResourceHistoryValidataJSONJob do
   @moduledoc """
   Validate a `DB.ResourceHistory` with Transport.Validators.ValidataJson and stores the result in the database.
+
+  ⚠️ This job is not executed at the moment.
+  https://github.com/etalab/transport-site/issues/3492
   """
   use Oban.Worker, max_attempts: 3, queue: :resource_validation, tags: ["validation"]
   alias Transport.Jobs.ResourceHistorySchemaValidation

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,8 +116,10 @@ oban_crontab_all_envs =
         {"0 7 * * *", Transport.Jobs.GTFSRTMultiValidationDispatcherJob},
         {"30 7 * * *", Transport.Jobs.GBFSMultiValidationDispatcherJob},
         {"45 */3 * * *", Transport.Jobs.ResourceHistoryJSONSchemaValidationJob},
-        # once a day for the moment, as we are just testing the tool
-        {"0 20 * * *", Transport.Jobs.ResourceHistoryValidataJSONJob},
+        # Validata JSON is not properly maintained/monitored.
+        # Disable it for now.
+        # https://github.com/etalab/transport-site/issues/3492
+        # {"0 20 * * *", Transport.Jobs.ResourceHistoryValidataJSONJob},
         {"15 */3 * * *", Transport.Jobs.ResourceHistoryTableSchemaValidationJob},
         {"5 6 * * *", Transport.Jobs.NewDatagouvDatasetsJob},
         {"0 6 * * *", Transport.Jobs.NewDatasetNotificationsJob},


### PR DESCRIPTION
Fixes #3492

Voir issue pour le détail.

Ceci ajoute des jobs dans Oban qui ne finissent jamais car le validateur n'effectue pas de validation, on poll l'API en attente d'un résultat qui n'arrive pas et le job finit par timeout. Ceci survient pour plusieurs centaines de ressources chaque jour.