### PR TITLE
Abonnements aux JDD : répare next_page

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
@@ -123,7 +123,7 @@ defmodule Datagouvfr.Client.Datasets do
   """
   @spec get_followers(String.t()) :: {atom, map}
   def get_followers(dataset_id) do
-    [@endpoint, dataset_id, "followers"]
+    [@endpoint, dataset_id, "followers", "?page_size=100"]
     |> Path.join()
     |> API.get()
   end
@@ -159,7 +159,7 @@ defmodule Datagouvfr.Client.Datasets do
     Enum.any?(
       followers,
       &(&1["follower"]["id"] == user_id)
-    ) or is_user_in_followers?(page[~c"next_page"], user_id, conn)
+    ) or is_user_in_followers?(page["next_page"], user_id, conn)
   end
 
   defp is_user_in_followers?(page_url, user_id, conn) when is_binary(page_url) do


### PR DESCRIPTION
Fixes #3431

## Évaluation de la volumétrie

Je cherche à identifier la fréquence où on va devoir paginer, aller chercher sur une page suivante pour avoir l'info "est-ce que l'utilisateur suit ce JDD".

J'ai parcouru l'API de data.gouv.fr pour tout notre catalogue avec

```
curl -s https://www.data.gouv.fr/api/1/datasets/5f727b957ba624d0618021e6/ | jq ".metrics.followers"
```

et je trouve une écrasante majorité de 0, 1, 2. 98% en-dessous de 10.

Max :
- 63 pour la BAN
- 50 pour IRVE

J'en déduis qu'en mettant un `page_size` "élevé", autour de 100, on ne va jamais paginer actuellement et on est pas trop mals pour le futur.

J'ai vérifié qu'en mettant un `page_size` élevé la réponse n'était pas trop lente.

![image](https://github.com/etalab/transport-site/assets/295709/cc7964fa-cf43-4ae6-9916-91560b04b49b)



## Améliorer le code

Je ne pense pas que ce soit utile maintenant, l'usage est faible : proposer de s'abonner sur la page d'un JDD chez nous. On envoie cette info via l'API de data.gouv.fr. La feature est très peu développée là-bas https://github.com/etalab/data.gouv.fr/issues/394#issuecomment-1542155529, il me semble que le seul effet est de recevoir les nouvelles discussions par e-mail. 

Ça pourrait évoluer à l'avenir.

J'ai testé le bon fonctionnement en local avec démo (s'abonner/changement d'état du bouton/se désabonner).