### PR TITLE
Consolidation BNLC : adapter sujet e-mail selon statut

### DIFF
--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -464,7 +464,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                                "contact@transport.beta.gouv.fr" = _from,
                                "deploiement@transport.beta.gouv.fr" = _to,
                                "contact@transport.beta.gouv.fr" = _reply_to,
-                               "Rapport de consolidation de la BNLC" = _subject,
+                               "[OK] Rapport de consolidation de la BNLC" = _subject,
                                "",
                                html_part ->
         assert html_part =~ ~r"^✅ La consolidation s'est déroulée sans erreurs"
@@ -663,7 +663,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                                "contact@transport.beta.gouv.fr" = _from,
                                "deploiement@transport.beta.gouv.fr" = _to,
                                "contact@transport.beta.gouv.fr" = _reply_to,
-                               "Rapport de consolidation de la BNLC" = _subject,
+                               "[ERREUR] Rapport de consolidation de la BNLC" = _subject,
                                "",
                                html_part ->
         assert html_part =~


### PR DESCRIPTION
Fixes #3505

- Ajuste le sujet de l'e-mail de rapport en fonction de la présence d'erreurs ou pas
- Ajouter une ligne vide avant le lien vers le fichier à télécharger