### PR TITLE
Requêteur SIRI : ajuste requête EstimatedTimetable

### DIFF
--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -81,11 +81,11 @@ defmodule Transport.SIRI do
   def line_refs_element([] = _line_refs), do: nil
 
   def line_refs_element(line_refs) do
-    line_refs = Enum.map(line_refs, &element("siri:LineRef", [], &1))
-
-    element("siri:Lines", [], [
-      element("siri:LineDirection", [], line_refs)
-    ])
+    element("siri:Lines", [], Enum.map(line_refs, fn line_ref ->
+      element("siri:LineDirection", [], [
+        element("siri:LineRef", [], line_ref)
+      ])
+    end))
   end
 
   def append_if_not_nil(list, nil), do: list

--- a/apps/transport/lib/siri_queries.ex
+++ b/apps/transport/lib/siri_queries.ex
@@ -81,11 +81,15 @@ defmodule Transport.SIRI do
   def line_refs_element([] = _line_refs), do: nil
 
   def line_refs_element(line_refs) do
-    element("siri:Lines", [], Enum.map(line_refs, fn line_ref ->
-      element("siri:LineDirection", [], [
-        element("siri:LineRef", [], line_ref)
-      ])
-    end))
+    element(
+      "siri:Lines",
+      [],
+      Enum.map(line_refs, fn line_ref ->
+        element("siri:LineDirection", [], [
+          element("siri:LineRef", [], line_ref)
+        ])
+      end)
+    )
   end
 
   def append_if_not_nil(list, nil), do: list

--- a/apps/transport/test/transport/siri_queries_test.exs
+++ b/apps/transport/test/transport/siri_queries_test.exs
@@ -127,6 +127,8 @@ defmodule Transport.SIRITest do
               <siri:Lines>
                 <siri:LineDirection>
                   <siri:LineRef>#{line_001}</siri:LineRef>
+                </siri:LineDirection>
+                <siri:LineDirection>
                   <siri:LineRef>#{line_002}</siri:LineRef>
                 </siri:LineDirection>
               </siri:Lines>


### PR DESCRIPTION
Corrige #3508

Les `LineRef` doivent être dans un `LineDirection` à chaque fois. Pas plusieurs `LineRef` dans un bloc `LineDirection`.

https://github.com/etalab/transport-normes/issues/38#issuecomment-1748903936