### PR TITLE
Espace producteur : répare traduction FR

### DIFF
--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -202,5 +202,5 @@ msgstr "Modifier"
 #, elixir-autogen, elixir-format
 msgid "1 resource"
 msgid_plural "%{count} resources"
-msgstr[0] "1 ressources"
+msgstr[0] "1 ressource"
 msgstr[1] "%{count} ressources"


### PR DESCRIPTION
Un `s` qui n'est pas à sa place, introduit dans https://github.com/etalab/transport-site/pull/3504

Navré d'avoir laissé passé ça.