### PR TITLE
Event tracking Matomo : répare listener

### DIFF
--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -42,10 +42,12 @@ liveSocket.connect()
 
 // Track analytics events for DOM elements by a `data-tracking-category`.
 // The event will be recorded on a click event
+// See https://matomo.org/faq/reports/implement-event-tracking-with-matomo/#how-to-set-up-matomo-event-tracking-with-javascript
 document.querySelectorAll('[data-tracking-category]').forEach(el => {
     el.addEventListener('click', function (event) {
-        const name = event.dataset.trackingName || ''
-        window._paq.push(['trackEvent', event.dataset.trackingCategory, event.dataset.trackingAction, name])
+        const target = event.target
+        const name = target.dataset.trackingName || ''
+        window._paq.push(['trackEvent', target.dataset.trackingCategory, target.dataset.trackingAction, name])
     })
 })
 

--- a/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
@@ -21,13 +21,12 @@ resource_id = Map.fetch!(@conn.params, "resource_id") %>
         >
           <%= dgettext("resource", "Delete the resource") %>
         </button>
-        <a href={resource_path(@conn, :form, dataset_id, resource_id)}>
-          <button
-            class="button-outline primary"
-            type="button"
-            data-tracking-category="espace_producteur"
-            data-tracking-action="abort_delete_update_resource"
-          >
+        <a
+          href={resource_path(@conn, :form, dataset_id, resource_id)}
+          data-tracking-category="espace_producteur"
+          data-tracking-action="abort_delete_update_resource"
+        >
+          <button class="button-outline primary" type="button">
             <%= dgettext("resource", "Update the resource") %>
           </button>
         </a>


### PR DESCRIPTION
Répare code introduit dans #3504

Il y avait vraiment peu de code JavaScript mais c'était suffisant pour faire une erreur. Ça m'apprendra à faire des tests plus poussés en local. Un event ne donne pas la `target` directement donc `event.dataset` est `undefined` et le listener avait une erreur. Faut activer Matomo en local, [c'est désactivé d'habitude](https://github.com/etalab/transport-site/blob/99a2bb63d21a01a7b33b73f5f2dfc3b020fd5e14/apps/transport/lib/transport_web/templates/layout/app.html.heex#L30-L39).

L'event est bien envoyé ensuite, vérifié en local.

![image](https://github.com/etalab/transport-site/assets/295709/c3700824-5042-47ba-b7f0-58ba00bf2f60)

Je déplace en plus des balises de tracking car c'était mis sur un `<button>`, sur le `<a>` englobant c'est plus approprié.