### PR TITLE
Télécharger export général des ressources avec URL privée

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -361,9 +361,8 @@ defmodule TransportWeb.Router do
   defp check_export_secret_key(%Plug.Conn{params: params} = conn, _) do
     export_key_value = Map.get(params, "export_key", "")
     expected_value = Application.fetch_env!(:transport, :export_secret_key)
-    key_matches = Plug.Crypto.secure_compare(export_key_value, expected_value)
 
-    if expected_value not in [nil, ""] and key_matches do
+    if Plug.Crypto.secure_compare(export_key_value, expected_value) do
       conn
     else
       conn

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -43,6 +43,10 @@ defmodule TransportWeb.Router do
     plug(:transport_data_gouv_member)
   end
 
+  pipeline :backoffice_csv_export do
+    plug(:check_export_secret_key)
+  end
+
   scope "/", OpenApiSpex.Plug do
     pipe_through(:browser_no_csp)
 
@@ -208,6 +212,10 @@ defmodule TransportWeb.Router do
 
       get("/breaking_news", BreakingNewsController, :index)
       post("/breaking_news", BreakingNewsController, :update_breaking_news)
+    end
+
+    scope "/backoffice", Backoffice, as: :backoffice do
+      pipe_through([:backoffice_csv_export])
       get("/download_resources_csv", PageController, :download_resources_csv)
     end
 
@@ -349,7 +357,23 @@ defmodule TransportWeb.Router do
     |> Enum.any?(fn org -> org["slug"] == "equipe-transport-data-gouv-fr" end)
   end
 
-  defp transport_data_gouv_member(conn, _) do
+  # Check that a secret key is passed in the URL in the `export_key` query parameter
+  defp check_export_secret_key(%Plug.Conn{params: params} = conn, _) do
+    export_key_value = Map.get(params, "export_key", "")
+    expected_value = Application.fetch_env!(:transport, :export_secret_key)
+    key_matches = Plug.Crypto.secure_compare(export_key_value, expected_value)
+
+    if expected_value not in [nil, ""] and key_matches do
+      conn
+    else
+      conn
+      |> put_flash(:error, dgettext("alert", "You need to be a member of the transport.data.gouv.fr team."))
+      |> redirect(to: Helpers.page_path(conn, :login, redirect_path: current_path(conn)))
+      |> halt()
+    end
+  end
+
+  defp transport_data_gouv_member(%Plug.Conn{} = conn, _) do
     if is_transport_data_gouv_member?(conn.assigns[:current_user]) do
       conn
     else

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -77,7 +77,15 @@
 
   <h2>Exports</h2>
   <div>
-    <a class="button" href={backoffice_page_path(@conn, :download_resources_csv)} title="Export CSV des ressources">
+    <a
+      class="button"
+      href={
+        backoffice_page_path(@conn, :download_resources_csv, %{
+          "export_key" => Application.fetch_env!(:transport, :export_secret_key)
+        })
+      }
+      title="Export CSV des ressources"
+    >
       🗳 Export des ressources
     </a>
   </div>

--- a/config/config.exs
+++ b/config/config.exs
@@ -186,6 +186,7 @@ config :gettext, :default_locale, "fr"
 
 config :transport,
   domain_name: System.get_env("DOMAIN_NAME", "transport.data.gouv.fr"),
+  export_secret_key: System.get_env("EXPORT_SECRET_KEY"),
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -57,7 +57,8 @@ config :transport, TransportWeb.Endpoint,
   live_view: [
     # NOTE: unsure if this is actually great to reuse the same value
     signing_salt: secret_key_base
-  ]
+  ],
+  export_secret_key: System.get_env("EXPORT_SECRET_KEY", "TwqrkD06AWp1uKGcBTck")
 
 datagouvfr_site = "https://demo.data.gouv.fr"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -47,7 +47,8 @@ config :transport,
     on_demand_validation: "on-demand-validation-test",
     gtfs_diff: "gtfs-diff-test"
   },
-  workflow_notifier: Transport.Jobs.Workflow.ProcessNotifier
+  workflow_notifier: Transport.Jobs.Workflow.ProcessNotifier,
+  export_secret_key: "fake_export_secret_key"
 
 config :ex_aws,
   cellar_organisation_id: "fake-cellar_organisation_id"
@@ -120,11 +121,11 @@ config(
   siri_query_generator_impl: Transport.SIRIQueryGenerator.Mock
 )
 
-# The Swoosh test adapter works a bit like an embryo of Mox. 
+# The Swoosh test adapter works a bit like an embryo of Mox.
 # See: https://github.com/swoosh/swoosh/blob/main/lib/swoosh/adapters/test.ex
 #
 # It won't be as flexible in all situations (see https://github.com/swoosh/swoosh/issues/66).
-# 
+#
 # If this causes issues, we will have instead to create
 # a behaviour/wrapper around `Transport.Mailer`
 config :transport, Transport.Mailer, adapter: Swoosh.Adapters.Test


### PR DESCRIPTION
Fixes #3522

Permet de télécharger "l'export général des ressources" proposé depuis notre backoffice aux membres du PAN depuis une URL incluant un token unique, pour pouvoir donner accès à ceci à des partenaires.

J'ai déjà renseigné la variable d'env `EXPORT_SECRET_KEY` chez Clever Cloud.