### PR TITLE
Hot-fix pour tenter d'éviter une partie des crashs mémoires du worker

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -22,6 +22,11 @@ defmodule Transport.Jobs.ResourceHistoryAndValidationDispatcherJob do
     :ok
   end
 
+  # A way to skip (via hardcoded configuration) the historization of a given dataset
+  def hotfix_skip_history(resource) do
+    resource.dataset_id in Application.fetch_env!(:transport, :skip_historize_dataset_ids)
+  end
+
   def resources_to_historise(resource_id \\ nil) do
     base_query =
       Resource.base_query()
@@ -38,6 +43,7 @@ defmodule Transport.Jobs.ResourceHistoryAndValidationDispatcherJob do
     |> Enum.reject(
       &(Resource.is_real_time?(&1) or Resource.is_documentation?(&1) or Dataset.should_skip_history?(&1.dataset))
     )
+    |> Enum.reject(&hotfix_skip_history(&1))
   end
 end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -123,7 +123,11 @@ config :transport,
   hasher_impl: Hasher,
   validator_selection: Transport.ValidatorsSelection.Impl,
   data_visualization: Transport.DataVisualization.Impl,
-  workflow_notifier: Transport.Jobs.Workflow.ObanNotifier
+  workflow_notifier: Transport.Jobs.Workflow.ObanNotifier,
+  # See `compare_http.exs` `show_large`, this is a hot-fix to avoid
+  # snapshotting very large resources, until we implement streaming
+  # See: http://transport.data.gouv.fr/datasets/641
+  skip_historize_dataset_ids: [641]
 
 # Datagouv IDs for national databases created automatically.
 # These are IDs used in staging, demo.data.gouv.fr

--- a/scripts/compare_http.exs
+++ b/scripts/compare_http.exs
@@ -193,7 +193,7 @@ defmodule Script do
   def show_large do
     task = fn resource ->
       {status_code, body} = Downloader.cached_get(:http_poison, resource.url, "resource_id=#{resource.id}")
-      {resource.dataset_id, body |> byte_size() |> Sizeable.filesize() , :crypto.hash(:sha256, body) |> Base.encode16()}
+      {resource.dataset_id, body |> byte_size(), :crypto.hash(:sha256, body) |> Base.encode16()}
     end
 
     Transport.Jobs.ResourceHistoryAndValidationDispatcherJob.resources_to_historise()
@@ -204,9 +204,9 @@ defmodule Script do
       timeout: :infinity
     )
     |> Enum.map(fn {:ok, x} -> x end)
-    |> Enum.filter(fn {_id, size} -> size > 100_000_000 end)
-    |> Enum.map(fn {id, s} -> id end)
-    |> Enum.uniq()
+    |> Enum.filter(fn {_id, size, hash} -> size > 100_000_000 end)
+    |> Enum.map(fn {id, s, hash} -> id end)
+    |> Enum.frequencies()
     |> Enum.each(&IO.inspect(&1))
   end
 end

--- a/scripts/compare_http.exs
+++ b/scripts/compare_http.exs
@@ -193,10 +193,11 @@ defmodule Script do
   def show_large do
     task = fn resource ->
       {status_code, body} = Downloader.cached_get(:http_poison, resource.url, "resource_id=#{resource.id}")
-      {resource.dataset_id, body |> byte_size()}
+      {resource.dataset_id, body |> byte_size() |> Sizeable.filesize() , :crypto.hash(:sha256, body) |> Base.encode16()}
     end
 
     Transport.Jobs.ResourceHistoryAndValidationDispatcherJob.resources_to_historise()
+    # |> Enum.filter(fn(x) -> x.dataset_id == 641 end)
     |> Task.async_stream(
       task,
       max_concurrency: 10,


### PR DESCRIPTION
Je reprends la suggestion de @AntoineAugusti de ne plus historiser ce dataset à l'aide de tags:
- #3526

mais je la la simplifie encore plus vu que c'est du hot-fix. Dans la présente PR, je hard-code en configuration l'id du dataset à ne pas historiser, et je modifie `ResourceHistoryJob` pour filtrer en fonction.

On va voir si cela suffit à nous acheter du temps en attendant de corriger le `ResourceHistoryJob` pour utiliser du streaming HTTP, voir:
- #3447
- https://github.com/etalab/transport-site/pull/3452
- https://github.com/etalab/transport-site/pull/3498
- https://github.com/etalab/transport-site/issues/3435

Si cela fonctionne, le worker devrait beaucoup moins rebooter.

Si cela ne suffit pas, il faudra regarder du côté du script qui fait le transfert de backup de BDD également!