### PR TITLE
Dataset : permet d'ignorer historisation avec un tag

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -1014,13 +1014,16 @@ defmodule DB.Dataset do
 
   @doc """
   Should this dataset not be historicized?
+
+  iex> should_skip_history?(%DB.Dataset{type: "road-data"})
+  true
+  iex> should_skip_history?(%DB.Dataset{type: "public-transit"})
+  false
+  iex> should_skip_history?(%DB.Dataset{type: "public-transit", custom_tags: ["skip_history", "foo"]})
+  true
   """
-  def should_skip_history?(%__MODULE__{slug: slug, type: type}) do
-    type in ["bike-scooter-sharing", "car-motorbike-sharing", "road-data"] or
-      slug in [
-        "prix-des-carburants-en-france-flux-instantane",
-        "prix-des-carburants-en-france-flux-quotidien"
-      ]
+  def should_skip_history?(%__MODULE__{type: type} = dataset) do
+    type in ["bike-scooter-sharing", "car-motorbike-sharing", "road-data"] or has_custom_tag?(dataset, "skip_history")
   end
 
   def has_licence_ouverte?(%__MODULE__{licence: licence}), do: licence in @licences_ouvertes

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -22,11 +22,6 @@ defmodule Transport.Jobs.ResourceHistoryAndValidationDispatcherJob do
     :ok
   end
 
-  # A way to skip (via hardcoded configuration) the historization of a given dataset
-  def hotfix_skip_history(resource) do
-    resource.dataset_id in Application.fetch_env!(:transport, :skip_historize_dataset_ids)
-  end
-
   def resources_to_historise(resource_id \\ nil) do
     base_query =
       Resource.base_query()
@@ -41,10 +36,7 @@ defmodule Transport.Jobs.ResourceHistoryAndValidationDispatcherJob do
     query
     |> Repo.all()
     |> Enum.reject(
-      &(Resource.is_real_time?(&1) or
-          Resource.is_documentation?(&1) or
-          Dataset.should_skip_history?(&1.dataset) or
-          hotfix_skip_history(&1))
+      &(Resource.is_real_time?(&1) or Resource.is_documentation?(&1) or Dataset.should_skip_history?(&1.dataset))
     )
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -46,7 +46,8 @@ defmodule TransportWeb.CustomTagsLive do
           "Ce jeu de données est soumis à l'obligation de réutilisation selon l'article 122 de la loi climat et résilience"
       },
       %{name: "requestor_ref:<valeur>", doc: "Renseigne le requestor_ref des ressources SIRI pour ce jeu de données"},
-      %{name: "saisonnier", doc: "Indique sur la page du JDD que ce jeu de données n'opère qu'une partie de l'année"}
+      %{name: "saisonnier", doc: "Indique sur la page du JDD que ce jeu de données n'opère qu'une partie de l'année"},
+      %{name: "skip_history", doc: "Désactive l'historisation des ressources pour ce jeu de données"}
     ]
   end
 

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -566,14 +566,9 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
     insert(:resource,
       url: "https://example.com/file",
-      dataset:
-        insert(:dataset,
-          is_active: true,
-          type: "charging-stations",
-          slug: "prix-des-carburants-en-france-flux-quotidien"
-        ),
+      dataset: insert(:dataset, is_active: true, type: "charging-stations", custom_tags: ["skip_history"]),
       format: "GTFS",
-      title: "Ignored because the dataset slug is skipped",
+      title: "Ignored because it has the `skip_history` custom tag",
       datagouv_id: "9",
       is_community_resource: false
     )

--- a/config/config.exs
+++ b/config/config.exs
@@ -123,11 +123,7 @@ config :transport,
   hasher_impl: Hasher,
   validator_selection: Transport.ValidatorsSelection.Impl,
   data_visualization: Transport.DataVisualization.Impl,
-  workflow_notifier: Transport.Jobs.Workflow.ObanNotifier,
-  # See `compare_http.exs` `show_large`, this is a hot-fix to avoid
-  # snapshotting very large resources, until we implement streaming
-  # See: http://transport.data.gouv.fr/datasets/641
-  skip_historize_dataset_ids: [641]
+  workflow_notifier: Transport.Jobs.Workflow.ObanNotifier
 
 # Datagouv IDs for national databases created automatically.
 # These are IDs used in staging, demo.data.gouv.fr


### PR DESCRIPTION
#3527 a montré tout son intérêt en production en permettant d'éviter des reboots. Cette PR est un refactor pour conserver le mécanisme et le solidifier (les tags sont gardés tous les jours dans `DatasetHistory` et il y avait des slugs de JDD qui étaient indiqués en dur).

J'ai ajouté les tags `skip_history` sur les JDD des prix de carburant en production déjà.