### PR TITLE
Détecte et ne valide pas les fichiers GTFS Flex

### DIFF
--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -48,7 +48,7 @@ defmodule DB.ResourceHistory do
     |> limit(1)
   end
 
-  @spec latest_resource_history(DB.Resource.t()) :: DB.ResourceHistory.t() | nil
+  @spec latest_resource_history(DB.Resource.t() | integer()) :: DB.ResourceHistory.t() | nil
   def latest_resource_history(%DB.Resource{id: id}), do: latest_resource_history(id)
 
   def latest_resource_history(resource_id) do

--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -87,7 +87,15 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
     :ok
   end
 
-  defp validate(resource_history, validator, force_validation) do
+  defp validate(%DB.ResourceHistory{} = resource_history, validator, force_validation) do
+    if DB.ResourceHistory.is_gtfs_flex?(resource_history) do
+      {:discard, "ResourceHistory##{resource_history.id} is a GTFS Flex, we do not validate it"}
+    else
+      run_validation(resource_history, validator, force_validation)
+    end
+  end
+
+  defp run_validation(%DB.ResourceHistory{} = resource_history, validator, force_validation) do
     case DB.MultiValidation.resource_history_latest_validation(resource_history.id, validator) do
       nil ->
         :ok = validator.validate_and_save(resource_history)
@@ -100,7 +108,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
           DB.Repo.delete(latest_validation)
           :ok
         else
-          {:cancel, "resource history #{resource_history.id} is already validated by #{Atom.to_string(validator)}"}
+          {:cancel, "ResourceHistory##{resource_history.id} is already validated by #{Atom.to_string(validator)}"}
         end
     end
   end

--- a/apps/transport/lib/jobs/resource_history_validation_job.ex
+++ b/apps/transport/lib/jobs/resource_history_validation_job.ex
@@ -89,7 +89,7 @@ defmodule Transport.Jobs.ResourceHistoryValidationJob do
 
   defp validate(%DB.ResourceHistory{} = resource_history, validator, force_validation) do
     if DB.ResourceHistory.is_gtfs_flex?(resource_history) do
-      {:discard, "ResourceHistory##{resource_history.id} is a GTFS Flex, we do not validate it"}
+      {:discard, "ResourceHistory##{resource_history.id} is a GTFS-Flex, we do not validate it"}
     else
       run_validation(resource_history, validator, force_validation)
     end

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.ResourceController do
         :uptime_per_day,
         DB.ResourceUnavailability.uptime_per_day(resource, availability_number_days())
       )
-      |> assign(:resource_history_infos, DB.ResourceHistory.latest_resource_history_infos(id))
+      |> assign(:resource_history, DB.ResourceHistory.latest_resource_history(id))
       |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
       |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
       |> assign(:latest_validations_details, latest_validations_details(resource))

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -46,7 +46,7 @@
         ) %>
       <% end %>
 
-      <%= if geojson_with_viz?(@resource, @resource_history_infos) do %>
+      <%= if geojson_with_viz?(@resource, @resource_history) do %>
         <h2 class="mt-48" id="visualization"><%= dgettext("validations", "Visualization") %></h2>
         <div class="panel no-padding">
           <div id="resource-geojson-info" class="p-24"></div>
@@ -58,8 +58,8 @@
               GenericGeojsonMap(
                 'resource-geojson',
                 'resource-geojson-info',
-                "<%= @resource_history_infos.url %>",
-                "<%= @resource_history_infos.filesize %>",
+                "<%= Map.fetch!(@resource_history.payload, "url") %>",
+                "<%= Map.fetch!(@resource_history.payload, "filesize") %>",
                 "<%= dgettext("validations", "Visualization is quite big") %>",
                 "<%= dgettext("validations", "Show anyway") %>"
                 )

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -84,7 +84,10 @@
       <h2 id="validation-report" class="mt-48"><%= dgettext("validations", "Validation report") %></h2>
       <div class="panel" id="issues">
         <p :if={is_gtfs_flex} class="notification">
-          <%= dgettext("validations", "This file is a GTFS Flex. We are not able to validate it for now.") %>
+          <%= dgettext(
+            "validations",
+            "This file contains the GTFS-Flex extension. We are not able to validate it for now."
+          ) %>
         </p>
         <%= if not is_gtfs_flex and is_nil(@validation_summary) do %>
           <%= dgettext("validations", "No validation available") %>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -1,3 +1,4 @@
+<% is_gtfs_flex = not is_nil(@resource_history) and DB.ResourceHistory.is_gtfs_flex?(@resource_history) %>
 <section>
   <% associated_geojson = get_associated_geojson(@related_files) %>
   <% associated_netex = get_associated_netex(@related_files) %>
@@ -82,9 +83,13 @@
       <% end %>
       <h2 id="validation-report" class="mt-48"><%= dgettext("validations", "Validation report") %></h2>
       <div class="panel" id="issues">
-        <%= unless @validation_summary do %>
+        <p :if={is_gtfs_flex} class="notification">
+          <%= dgettext("validations", "This file is a GTFS Flex. We are not able to validate it for now.") %>
+        </p>
+        <%= if not is_gtfs_flex and is_nil(@validation_summary) do %>
           <%= dgettext("validations", "No validation available") %>
-        <% else %>
+        <% end %>
+        <%= unless is_nil(@validation_summary) do %>
           <%= if @issues.total_entries == 0 do %>
             <%= dgettext("validations", "No validation error") %>.
           <% else %>

--- a/apps/transport/lib/transport_web/templates/validation/show.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.heex
@@ -53,7 +53,10 @@
             <h2><%= dgettext("validations", "Nice work, there are no issues!") %></h2>
           <% end %>
           <p class="notification">
-            <%= dgettext("validations", "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions.") %>
+            <%= dgettext(
+              "validations",
+              "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+            ) %>
           </p>
         </div>
       </div>

--- a/apps/transport/lib/transport_web/templates/validation/show.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show.html.heex
@@ -52,6 +52,9 @@
           <% else %>
             <h2><%= dgettext("validations", "Nice work, there are no issues!") %></h2>
           <% end %>
+          <p class="notification">
+            <%= dgettext("validations", "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions.") %>
+          </p>
         </div>
       </div>
     </div>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -194,7 +194,9 @@ defmodule TransportWeb.ResourceView do
     live_path(conn, TransportWeb.Live.OnDemandValidationSelectLive, type: type)
   end
 
-  def geojson_with_viz?(%{format: "geojson"}, %{url: url, filesize: filesize})
+  def geojson_with_viz?(%DB.Resource{format: "geojson"}, %DB.ResourceHistory{
+        payload: %{"url" => url, "filesize" => filesize}
+      })
       when not is_nil(filesize) and not is_nil(url),
       do: true
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -410,9 +410,9 @@ msgid "analyzing found differences..."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This file is a GTFS Flex. We are not able to validate it for now."
+msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -408,3 +408,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "analyzing found differences..."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This file is a GTFS Flex. We are not able to validate it for now."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -410,9 +410,9 @@ msgid "analyzing found differences..."
 msgstr "analyse des différences trouvées..."
 
 #, elixir-autogen, elixir-format
-msgid "This file is a GTFS Flex. We are not able to validate it for now."
-msgstr "Ce fichier est un fichier GTFS Flex. Nous ne sommes pas en mesure de le valider pour le moment."
-
-#, elixir-autogen, elixir-format
 msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
 msgstr "Veuillez noter que notre validateur GTFS n'est pas en mesure de valider les extensions Flex et Fares v2 pour le moment."
+
+#, elixir-autogen, elixir-format
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
+msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -408,3 +408,11 @@ msgstr "Les shapes présentes dans le GTFS ont été ignorées, certaines règle
 #, elixir-autogen, elixir-format
 msgid "analyzing found differences..."
 msgstr "analyse des différences trouvées..."
+
+#, elixir-autogen, elixir-format
+msgid "This file is a GTFS Flex. We are not able to validate it for now."
+msgstr "Ce fichier est un fichier GTFS Flex. Nous ne sommes pas en mesure de le valider pour le moment."
+
+#, elixir-autogen, elixir-format
+msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+msgstr "Veuillez noter que notre validateur GTFS n'est pas en mesure de valider les extensions Flex et Fares v2 pour le moment."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -409,9 +409,9 @@ msgid "analyzing found differences..."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This file is a GTFS Flex. We are not able to validate it for now."
+msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
 msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -407,3 +407,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "analyzing found differences..."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This file is a GTFS Flex. We are not able to validate it for now."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
+msgstr ""

--- a/apps/transport/test/db/resource_history_test.exs
+++ b/apps/transport/test/db/resource_history_test.exs
@@ -8,6 +8,8 @@ defmodule DB.ResourceHistoryTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
+  doctest DB.ResourceHistory, import: true
+
   test "test fetch latest resource history payload for a resource" do
     now = DateTime.utc_now()
     past = now |> DateTime.add(-3 * 60)
@@ -26,29 +28,7 @@ defmodule DB.ResourceHistoryTest do
       payload: %{"permanent_url" => url = "url"}
     })
 
-    assert %{"permanent_url" => ^url} = latest_resource_history_payload(resource_id_2)
-  end
-
-  test "test fetch latest resource history infos for a resource" do
-    now = DateTime.utc_now()
-    past = now |> DateTime.add(-3 * 60)
-    pastpast = now |> DateTime.add(-6 * 60)
-
-    %{id: resource_id} = insert(:resource)
-    insert(:resource_history, %{resource_id: resource_id, inserted_at: pastpast})
-
-    insert(:resource_history, %{
-      resource_id: resource_id,
-      inserted_at: past,
-      payload: %{"permanent_url" => url = "url", "filesize" => size = 10}
-    })
-
-    assert %{url: url, filesize: size} == latest_resource_history_infos(resource_id)
-
-    # new resource history, no filesize
-    insert(:resource_history, %{resource_id: resource_id, inserted_at: now, payload: %{"permanent_url" => url}})
-
-    assert is_nil(latest_resource_history_infos(resource_id))
+    assert %DB.ResourceHistory{payload: %{"permanent_url" => ^url}} = latest_resource_history(resource_id_2)
   end
 
   test "test fetch latest resource history infos for a dataset" do

--- a/apps/transport/test/transport/jobs/resource_history_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_validation_job_test.exs
@@ -134,6 +134,19 @@ defmodule Transport.Jobs.ResourceHistoryValidationJobTest do
     assert_received :validate!
   end
 
+  test "do not validate a GTFS Flex" do
+    rh = insert(:resource_history, payload: %{"format" => "GTFS", "filenames" => ["locations.geojson", "stops.txt"]})
+
+    assert DB.ResourceHistory.is_gtfs_flex?(rh)
+
+    assert {:discard, "ResourceHistory##{rh.id} is a GTFS Flex, we do not validate it"} ==
+             Transport.Jobs.ResourceHistoryValidationJob
+             |> perform_job(%{
+               "resource_history_id" => rh.id,
+               "validator" => Transport.Validators.Dummy |> to_string()
+             })
+  end
+
   test "all validations for one resource history" do
     %{id: resource_history_id} = resource_history = insert(:resource_history, %{payload: %{"format" => "GTFS"}})
 

--- a/apps/transport/test/transport/jobs/resource_history_validation_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_validation_job_test.exs
@@ -134,12 +134,12 @@ defmodule Transport.Jobs.ResourceHistoryValidationJobTest do
     assert_received :validate!
   end
 
-  test "do not validate a GTFS Flex" do
+  test "do not validate a GTFS-Flex" do
     rh = insert(:resource_history, payload: %{"format" => "GTFS", "filenames" => ["locations.geojson", "stops.txt"]})
 
     assert DB.ResourceHistory.is_gtfs_flex?(rh)
 
-    assert {:discard, "ResourceHistory##{rh.id} is a GTFS Flex, we do not validate it"} ==
+    assert {:discard, "ResourceHistory##{rh.id} is a GTFS-Flex, we do not validate it"} ==
              Transport.Jobs.ResourceHistoryValidationJob
              |> perform_job(%{
                "resource_history_id" => rh.id,


### PR DESCRIPTION
Fixes #3058, voir [ce qui est prévu](https://github.com/etalab/transport-site/issues/3058#issuecomment-1768355590).

Cette PR :
- permet de détecter qu'une `ResourceHistory` est un fichier GTFS Flex (en détectant la présence de fichiers caractéristiques)
- de ne pas valider un GTFS avec notre validateur GTFS (de manière à ne pas afficher des erreurs erronnées)
- afficher la page de détails d'une ressource GTFS Flex qu'on a bien détecté que c'était un GTFS Flex mais qu'on ne sait pas encore le valider
- indique sur la validation à la demande GTFS qu'on ne sait pas valider les extensions Flex et Fares v2

![image](https://github.com/etalab/transport-site/assets/295709/b024c3b2-e9fd-4ada-a32e-657f45f63ca0)
![image](https://github.com/etalab/transport-site/assets/295709/ec8b4978-a88b-4792-a3ce-da0c5ee414f2)
![image](https://github.com/etalab/transport-site/assets/295709/bc9f00d9-7c23-4cab-906f-2d816d883e2a)

Pour les devs : 
- pour le déploiement il faudra supprimer la validation existante de l'unique GTFS Flex en base de données
- les validations concernant des GTFS Flex seront bien lancées dans un job en cas de changement de fichier mais le job finira immédiatement par un `:cancel` et donc ne sera jamais enregistré en base
- ce ne sera pas validé non plus en "validation forcée" au clic depuis le backoffice
