### PR TITLE
Gérer l’affichage des discussions pour les datasets qui n’ont pas d’organisation

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/organization.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/organization.ex
@@ -22,7 +22,12 @@ defmodule Datagouvfr.Client.Organization do
   Call to GET /api/1/organizations/:id/
   """
   @impl true
-  def get(id, opts \\ []) do
+  def get(id, opts \\ [])
+
+  # This case is defined because some datasets don’t have an organization and we may call this function with nil for discussions
+  def get(nil, _opts), do: {:error, %{}}
+
+  def get(id, opts) do
     opts = Keyword.validate!(opts, restrict_fields: false)
     headers = if opts[:restrict_fields], do: [{"x-fields", "{logo_thumbnail,members{user{id}}}"}], else: []
 

--- a/apps/datagouvfr/lib/datagouvfr/client/organization.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/organization.ex
@@ -24,7 +24,8 @@ defmodule Datagouvfr.Client.Organization do
   @impl true
   def get(id, opts \\ [])
 
-  # This case is defined because some datasets don’t have an organization and we may call this function with nil for discussions
+  # This case is defined because some datasets don’t have an organization
+  # and we may call this function with nil for discussions
   def get(nil, _opts), do: {:error, %{}}
 
   def get(id, opts) do


### PR DESCRIPTION
Résout l’erreur Sentry https://transport-data-gouv-fr.sentry.io/issues/4558606484 qui survient quand on essaye d’accéder à une page d’un dataset qui n’appartient à aucune organisation. On tente alors, pour afficher les discussions, d’accéder via le client API data.gouv, à l’organisation, ce qui provoque une erreur puisque l’identifiant d’organisation fourni au client est `nil`. 

J’ai choisi la solution «simple» : gérer le cas dans le client data.gouv, mais en réalité on ne devrait même pas l’appeler. Dites-moi si vous pensez qu’il faudrait plutôt gérer ça dans discussions_live.ex – en fait, on a déjà un `case`, je voulais pas rajouter un `cond` par dessus.