### PR TITLE
DataConversion : gère plusieurs convertisseurs

### DIFF
--- a/apps/transport/lib/converters/converter.ex
+++ b/apps/transport/lib/converters/converter.ex
@@ -1,0 +1,8 @@
+defmodule Transport.Converters.Converter do
+  @moduledoc """
+  A behaviour for data converters, used only for GTFS files at the moment.
+  """
+  @callback convert(binary(), binary()) :: :ok | {:error, any()}
+  @callback converter() :: binary()
+  @callback converter_version() :: binary()
+end

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -31,7 +31,7 @@ defmodule DB.DataConversion do
     Map.fetch!(
       %{
         "GeoJSON" => Transport.GTFSToGeoJSONConverter.converter(),
-        "NeTEx" => Transport.GtfsToNeTExConverter.converter()
+        "NeTEx" => Transport.GTFSToNeTExConverter.converter()
       },
       to_string(convert_to)
     )

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -47,7 +47,7 @@ defmodule DB.DataConversion do
       on: fragment("(?->>'uuid')::uuid = ?", rh.payload, dc.resource_history_uuid),
       as: :data_conversion
     )
-    |> where([data_conversion: dc], dc.convert_from = :GTFS and dc.convert_to in ^convert_tos)
+    |> where([data_conversion: dc], dc.convert_from == :GTFS and dc.convert_to in ^convert_tos)
     |> where([data_conversion: dc], dc.status == :success and dc.converter in ^converters)
   end
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -221,6 +221,8 @@ defmodule DB.Resource do
   def get_related_conversion_info(nil, _), do: nil
 
   def get_related_conversion_info(resource_id, format) do
+    converter = DB.DataConversion.converter_to_use(format)
+
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
       as: :dc,
@@ -231,7 +233,11 @@ defmodule DB.Resource do
       filesize: fragment("(? ->> 'filesize')::int", dc.payload),
       resource_history_last_up_to_date_at: rh.last_up_to_date_at
     })
-    |> where([rh, dc], rh.resource_id == ^resource_id and dc.convert_to == ^format)
+    |> where(
+      [rh, dc],
+      rh.resource_id == ^resource_id and dc.convert_to == ^format and dc.status == :success and
+        dc.converter == ^converter
+    )
     |> order_by([rh, _], desc: rh.inserted_at)
     |> limit(1)
     |> DB.Repo.one()

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -220,6 +220,7 @@ defmodule DB.Resource do
           | nil
   def get_related_conversion_info(nil, _), do: nil
 
+  @spec get_related_conversion_info(integer(), :NeTEx | :GeoJSON) :: DB.ResourceHistory.t() | nil
   def get_related_conversion_info(resource_id, format) do
     converter = DB.DataConversion.converter_to_use(format)
 

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -215,12 +215,11 @@ defmodule DB.Resource do
   def get_related_geojson_info(resource_id), do: get_related_conversion_info(resource_id, :GeoJSON)
   def get_related_netex_info(resource_id), do: get_related_conversion_info(resource_id, :NeTEx)
 
-  @spec get_related_conversion_info(integer() | nil, atom()) ::
+  @spec get_related_conversion_info(integer() | nil, :NeTEx | :GeoJSON) ::
           %{url: binary(), stable_url: binary(), filesize: binary(), resource_history_last_up_to_date_at: DateTime.t()}
           | nil
   def get_related_conversion_info(nil, _), do: nil
 
-  @spec get_related_conversion_info(integer(), :NeTEx | :GeoJSON) :: DB.ResourceHistory.t() | nil
   def get_related_conversion_info(resource_id, format) do
     converter = DB.DataConversion.converter_to_use(format)
 

--- a/apps/transport/lib/jobs/gtfs_generic_converter.ex
+++ b/apps/transport/lib/jobs/gtfs_generic_converter.ex
@@ -129,6 +129,9 @@ defmodule Transport.Jobs.GTFSGenericConverter do
           %DataConversion{
             convert_from: :GTFS,
             convert_to: String.to_existing_atom(format),
+            status: :success,
+            converter: converter_module.converter(),
+            converter_version: converter_module.converter_version(),
             resource_history_uuid: resource_uuid,
             payload: %{
               filename: conversion_file_name,

--- a/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
@@ -44,5 +44,5 @@ defmodule Transport.GTFSToGeoJSONConverter do
   def converter, do: "rust-transit/gtfs-to-geojson"
 
   @impl true
-  def converter_version, do: "9ca9a25b895ba1b2fdf4d04e92895afec52d0608"
+  def converter_version, do: "0.3.1"
 end

--- a/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
@@ -28,7 +28,9 @@ defmodule Transport.GtfsToGeojsonConverter do
   @moduledoc """
   Given a GTFS file path, create from the file the corresponding geojson with the stops and line shapes if available.
   """
-  @spec convert(binary(), binary()) :: :ok | {:error, any()}
+  @behaviour Transport.Converters.Converter
+
+  @impl true
   def convert(gtfs_file_path, geojson_file_path) do
     binary_path = Path.join(Application.fetch_env!(:transport, :transport_tools_folder), "gtfs-geojson")
 
@@ -37,4 +39,10 @@ defmodule Transport.GtfsToGeojsonConverter do
       {:error, e} -> {:error, e}
     end
   end
+
+  @impl true
+  def converter, do: "rust-transit/gtfs-to-geojson"
+
+  @impl true
+  def converter_version, do: "9ca9a25b895ba1b2fdf4d04e92895afec52d0608"
 end

--- a/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_geojson_converter_job.ex
@@ -1,4 +1,4 @@
-defmodule Transport.Jobs.GtfsToGeojsonConverterJob do
+defmodule Transport.Jobs.GTFSToGeoJSONConverterJob do
   @moduledoc """
   This will enqueue GTFS -> GeoJSON conversion jobs for all GTFS resources found in ResourceHistory
   """
@@ -7,11 +7,11 @@ defmodule Transport.Jobs.GtfsToGeojsonConverterJob do
 
   @impl true
   def perform(%{}) do
-    GTFSGenericConverter.enqueue_all_conversion_jobs("GeoJSON", Transport.Jobs.SingleGtfsToGeojsonConverterJob)
+    GTFSGenericConverter.enqueue_all_conversion_jobs("GeoJSON", Transport.Jobs.SingleGTFSToGeoJSONConverterJob)
   end
 end
 
-defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJob do
+defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJob do
   @moduledoc """
   Conversion Job of a GTFS to a GeoJSON, saving the resulting file in S3
   """
@@ -20,11 +20,11 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJob do
 
   @impl true
   def perform(%{args: %{"resource_history_id" => resource_history_id}}) do
-    GTFSGenericConverter.perform_single_conversion_job(resource_history_id, "GeoJSON", Transport.GtfsToGeojsonConverter)
+    GTFSGenericConverter.perform_single_conversion_job(resource_history_id, "GeoJSON", Transport.GTFSToGeoJSONConverter)
   end
 end
 
-defmodule Transport.GtfsToGeojsonConverter do
+defmodule Transport.GTFSToGeoJSONConverter do
   @moduledoc """
   Given a GTFS file path, create from the file the corresponding geojson with the stops and line shapes if available.
   """

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -63,7 +63,9 @@ defmodule Transport.GtfsToNeTExConverter do
   @moduledoc """
   Given a GTFS file path, convert it to NeTEx.
   """
-  @spec convert(binary(), binary()) :: :ok | {:error, any()}
+  @behaviour Transport.Converters.Converter
+
+  @impl true
   def convert(gtfs_file_path, netex_file_path) do
     binary_path = Path.join(Application.fetch_env!(:transport, :transport_tools_folder), "gtfs2netexfr")
     participant = Application.get_env(:transport, :domain_name)
@@ -76,4 +78,10 @@ defmodule Transport.GtfsToNeTExConverter do
       {:error, e} -> {:error, e}
     end
   end
+
+  @impl true
+  def converter, do: "hove/transit_model"
+
+  @impl true
+  def converter_version, do: "0.55.0"
 end

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -20,7 +20,7 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJob do
 
   @impl true
   def perform(%{args: %{"resource_history_id" => resource_history_id}}) do
-    GTFSGenericConverter.perform_single_conversion_job(resource_history_id, "NeTEx", Transport.GtfsToNeTExConverter)
+    GTFSGenericConverter.perform_single_conversion_job(resource_history_id, "NeTEx", Transport.GTFSToNeTExConverter)
   end
 
   @impl true
@@ -44,7 +44,7 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
     dataset_id
     |> list_gtfs_last_resource_history()
     |> Enum.each(fn rh_id ->
-      GTFSGenericConverter.perform_single_conversion_job(rh_id, "NeTEx", Transport.GtfsToNeTExConverter)
+      GTFSGenericConverter.perform_single_conversion_job(rh_id, "NeTEx", Transport.GTFSToNeTExConverter)
     end)
   end
 
@@ -59,7 +59,7 @@ defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
   end
 end
 
-defmodule Transport.GtfsToNeTExConverter do
+defmodule Transport.GTFSToNeTExConverter do
   @moduledoc """
   Given a GTFS file path, convert it to NeTEx.
   """

--- a/apps/transport/priv/repo/migrations/20231019121309_data_conversion_add_columns.exs
+++ b/apps/transport/priv/repo/migrations/20231019121309_data_conversion_add_columns.exs
@@ -14,7 +14,7 @@ defmodule DB.Repo.Migrations.DataConversionAddColumns do
     # https://github.com/etalab/transport-tools/blob/278f66679537981176f414de8027a86b1b0808ba/Dockerfile#L38
     execute "update data_conversion set converter = 'hove/transit_model', converter_version = '0.55.0' where convert_to = 'NeTEx' and convert_from = 'GTFS'"
     # https://github.com/etalab/transport-tools/blob/278f66679537981176f414de8027a86b1b0808ba/Dockerfile#L8
-    execute "update data_conversion set converter = 'rust-transit/gtfs-to-geojson', converter_version = '9ca9a25b895ba1b2fdf4d04e92895afec52d0608' where convert_to = 'GeoJSON' and convert_from = 'GTFS'"
+    execute "update data_conversion set converter = 'rust-transit/gtfs-to-geojson', converter_version = '0.3.1' where convert_to = 'GeoJSON' and convert_from = 'GTFS'"
 
     alter table("data_conversion") do
       modify :status, :varchar, null: false, from: {:string, null: true}

--- a/apps/transport/priv/repo/migrations/20231019121309_data_conversion_add_columns.exs
+++ b/apps/transport/priv/repo/migrations/20231019121309_data_conversion_add_columns.exs
@@ -11,7 +11,9 @@ defmodule DB.Repo.Migrations.DataConversionAddColumns do
     drop unique_index("data_conversion", [:convert_from, :convert_to, :resource_history_uuid])
 
     execute "update data_conversion set status = 'success'"
+    # https://github.com/etalab/transport-tools/blob/278f66679537981176f414de8027a86b1b0808ba/Dockerfile#L38
     execute "update data_conversion set converter = 'hove/transit_model', converter_version = '0.55.0' where convert_to = 'NeTEx' and convert_from = 'GTFS'"
+    # https://github.com/etalab/transport-tools/blob/278f66679537981176f414de8027a86b1b0808ba/Dockerfile#L8
     execute "update data_conversion set converter = 'rust-transit/gtfs-to-geojson', converter_version = '9ca9a25b895ba1b2fdf4d04e92895afec52d0608' where convert_to = 'GeoJSON' and convert_from = 'GTFS'"
 
     alter table("data_conversion") do

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -133,7 +133,7 @@ defmodule DB.DataConversionTest do
 
     conversions =
       dataset.id
-      |> DB.DataConversion.last_data_conversions("NeTEx")
+      |> DB.DataConversion.latest_data_conversions("NeTEx")
       |> Enum.sort_by(fn %{data_conversion_id: dc_id} -> dc_id end, :asc)
 
     assert [

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -7,6 +7,8 @@ defmodule DB.DataConversionTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
+  doctest DB.DataConversion, import: true
+
   test "constraints on data_conversion table" do
     assert %{id: _data_conversion_id} =
              insert(:data_conversion,
@@ -71,6 +73,7 @@ defmodule DB.DataConversionTest do
     insert(:data_conversion,
       convert_from: "GTFS",
       convert_to: "NeTEx",
+      converter: DB.DataConversion.converter_to_use("NeTEx"),
       resource_history_uuid: uuid_old,
       payload: %{filename: "filename_old"}
     )
@@ -83,6 +86,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "NeTEx",
+        converter: DB.DataConversion.converter_to_use("NeTEx"),
         resource_history_uuid: uuid,
         payload: %{filename: "filename"}
       )
@@ -91,6 +95,7 @@ defmodule DB.DataConversionTest do
     insert(:data_conversion,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
+      converter: DB.DataConversion.converter_to_use("GeoJSON"),
       resource_history_uuid: uuid,
       payload: %{filename: "filename_bad_format"}
     )
@@ -105,6 +110,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "NeTEx",
+        converter: DB.DataConversion.converter_to_use("NeTEx"),
         resource_history_uuid: uuid_2,
         payload: %{filename: "filename_2"}
       )
@@ -120,6 +126,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "NeTEx",
+        converter: DB.DataConversion.converter_to_use("NeTEx"),
         resource_history_uuid: uuid_other,
         payload: %{filename: "filename"}
       )
@@ -159,6 +166,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "NeTEx",
+        converter: DB.DataConversion.converter_to_use("NeTEx"),
         resource_history_uuid: uuid,
         payload: %{filename: filename = "filepath/filename"}
       )
@@ -169,6 +177,7 @@ defmodule DB.DataConversionTest do
 
     # data conversion has been deleted
     assert_raise Ecto.NoResultsError, fn -> DB.DataConversion |> DB.Repo.get!(data_conversion.id) end
+
     # new conversion is enqueued
     assert_enqueued(
       worker: Transport.Jobs.DatasetGtfsToNetexConverterJob,

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -392,6 +392,7 @@ defmodule DB.DatasetDBTest do
       resource_history_uuid: uuid1,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
+      converter: DB.DataConversion.converter_to_use("GeoJSON"),
       payload: %{"permanent_url" => "url1", "filesize" => 21}
     )
 
@@ -399,6 +400,7 @@ defmodule DB.DatasetDBTest do
       resource_history_uuid: uuid1,
       convert_from: "GTFS",
       convert_to: "NeTEx",
+      converter: DB.DataConversion.converter_to_use("NeTEx"),
       payload: %{"permanent_url" => "url11", "filesize" => 42}
     )
 
@@ -406,7 +408,18 @@ defmodule DB.DatasetDBTest do
       resource_history_uuid: uuid2,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
+      converter: DB.DataConversion.converter_to_use("GeoJSON"),
       payload: %{"permanent_url" => "url2", "filesize" => 76}
+    )
+
+    # Should be ignored, status is `pending`
+    insert(:data_conversion,
+      resource_history_uuid: uuid2,
+      convert_from: "GTFS",
+      convert_to: "NeTEx",
+      converter: DB.DataConversion.converter_to_use("NeTEx"),
+      status: :pending,
+      payload: %{"permanent_url" => "url21", "filesize" => 43}
     )
 
     dataset = DB.Dataset |> preload(:resources) |> DB.Repo.get(dataset_id)

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -42,7 +42,7 @@ defmodule DB.ResourceTest do
     insert_geojson_data_conversion(uuid3, "url3", 10)
 
     data_conversion_pending =
-      insert_geojson_data_conversion(uuid4, "url4", 10, DB.DataConversion.converter_to_use("GeoJSON"), "pending")
+      insert_geojson_data_conversion(uuid4, "url4", 10, DB.DataConversion.converter_to_use("GeoJSON"), :pending)
 
     assert %{url: "url2", filesize: 12, resource_history_last_up_to_date_at: _} =
              Resource.get_related_geojson_info(resource_id_1)
@@ -68,18 +68,12 @@ defmodule DB.ResourceTest do
     })
   end
 
-  defp insert_geojson_data_conversion(
-         uuid,
-         permanent_url,
-         filesize,
-         converter \\ "rust-transit/gtfs-to-geojson",
-         status \\ "success"
-       ) do
+  defp insert_geojson_data_conversion(uuid, permanent_url, filesize, converter \\ nil, status \\ :success) do
     insert(:data_conversion, %{
       resource_history_uuid: uuid,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
-      converter: converter,
+      converter: converter || DB.DataConversion.converter_to_use("GeoJSON"),
       status: status,
       payload: %{permanent_url: permanent_url, filesize: filesize}
     })

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -63,7 +63,11 @@ defmodule DB.Factory do
   end
 
   def data_conversion_factory do
-    %DB.DataConversion{}
+    %DB.DataConversion{
+      status: "success",
+      converter: "my_converter",
+      converter_version: Ecto.UUID.generate()
+    }
   end
 
   def resource_unavailability_factory do

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -64,7 +64,7 @@ defmodule DB.Factory do
 
   def data_conversion_factory do
     %DB.DataConversion{
-      status: "success",
+      status: :success,
       converter: "my_converter",
       converter_version: Ecto.UUID.generate()
     }

--- a/apps/transport/test/transport/jobs/gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/gtfs_to_geojson_converter_job_test.exs
@@ -1,10 +1,10 @@
-defmodule Transport.Jobs.GtfsToGeojsonConverterJobTest do
+defmodule Transport.Jobs.GTFSToGeoJSONConverterJobTest do
   use ExUnit.Case, async: true
   use Oban.Testing, repo: DB.Repo
   import DB.Factory
   import Mox
 
-  alias Transport.Jobs.{GtfsToGeojsonConverterJob, SingleGtfsToGeojsonConverterJob}
+  alias Transport.Jobs.{GTFSToGeoJSONConverterJob, SingleGTFSToGeoJSONConverterJob}
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
@@ -41,9 +41,9 @@ defmodule Transport.Jobs.GtfsToGeojsonConverterJobTest do
 
     insert(:data_conversion, convert_from: "GTFS", convert_to: "GeoJSON", resource_history_uuid: uuid, payload: %{})
 
-    :ok = perform_job(GtfsToGeojsonConverterJob, %{})
+    :ok = perform_job(GTFSToGeoJSONConverterJob, %{})
 
     assert [%Oban.Job{args: %{"resource_history_id" => ^resource_history_id}}] =
-             all_enqueued(worker: SingleGtfsToGeojsonConverterJob)
+             all_enqueued(worker: SingleGTFSToGeoJSONConverterJob)
   end
 end

--- a/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/single_gtfs_to_geojson_converter_job_test.exs
@@ -1,9 +1,9 @@
-defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
+defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJobTest do
   use ExUnit.Case, async: true
   use Oban.Testing, repo: DB.Repo
   import DB.Factory
   import Mox
-  alias Transport.Jobs.SingleGtfsToGeojsonConverterJob
+  alias Transport.Jobs.SingleGTFSToGeoJSONConverterJob
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
@@ -19,7 +19,7 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
 
     # no mox expectation set, and the test passes => conversion is properly skipped
     assert {:cancel, "Conversion is not needed"} ==
-             perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
+             perform_job(SingleGTFSToGeoJSONConverterJob, %{"resource_history_id" => resource_history_id})
   end
 
   test "existing conversion" do
@@ -30,7 +30,7 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
 
     # no mox expectation set, and the test passes => conversion is properly skipped
     assert {:cancel, "Conversion is not needed"} ==
-             perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
+             perform_job(SingleGTFSToGeoJSONConverterJob, %{"resource_history_id" => resource_history_id})
   end
 
   test "launch a conversion" do
@@ -60,7 +60,7 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
 
     # job succeed
     assert :ok ==
-             perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
+             perform_job(SingleGTFSToGeoJSONConverterJob, %{"resource_history_id" => resource_history_id})
 
     # a data_conversion row is recorded ✌️‍
     assert %DB.DataConversion{payload: %{"filesize" => 23, "filename" => "conversions/gtfs-to-geojson/fff.geojson"}} =
@@ -96,7 +96,7 @@ defmodule Transport.Jobs.SingleGtfsToGeojsonConverterJobTest do
       {:error, "conversion failed"}
     end)
 
-    assert {:cancel, _} = perform_job(SingleGtfsToGeojsonConverterJob, %{"resource_history_id" => resource_history_id})
+    assert {:cancel, _} = perform_job(SingleGTFSToGeoJSONConverterJob, %{"resource_history_id" => resource_history_id})
 
     # ResourceHistory's payload is updated with the error information
     expected_payload =

--- a/apps/transport/test/transport/jobs/transport_tools_test.exs
+++ b/apps/transport/test/transport/jobs/transport_tools_test.exs
@@ -13,7 +13,7 @@ defmodule TransportWeb.TransportToolsTest do
     # See https://github.com/etalab/transport-site/issues/1820
     @tag :transport_tools
     test "check the GeoJSON conversion binary is accessible" do
-      {:error, msg} = Transport.GtfsToGeojsonConverter.convert("", "")
+      {:error, msg} = Transport.GTFSToGeoJSONConverter.convert("", "")
 
       # this is the error msg we would get if the binary file was not found
       assert msg != "rambo exited with 0"
@@ -22,7 +22,7 @@ defmodule TransportWeb.TransportToolsTest do
     @tag :transport_tools
     test "we can convert a gtfs to GeoJSON" do
       geojson_file = "test.geojson"
-      :ok = Transport.GtfsToGeojsonConverter.convert("#{__DIR__}/../../fixture/files/gtfs.zip", geojson_file)
+      :ok = Transport.GTFSToGeoJSONConverter.convert("#{__DIR__}/../../fixture/files/gtfs.zip", geojson_file)
       assert geojson_file |> File.read!() |> String.contains?("FeatureCollection")
       File.rm!(geojson_file)
     end

--- a/apps/transport/test/transport/jobs/transport_tools_test.exs
+++ b/apps/transport/test/transport/jobs/transport_tools_test.exs
@@ -30,7 +30,7 @@ defmodule TransportWeb.TransportToolsTest do
     @tag :transport_tools
     test "we can convert a gtfs to NeTEx" do
       netex_dir = "test_netex"
-      :ok = Transport.GtfsToNeTExConverter.convert("#{__DIR__}/../../fixture/files/gtfs.zip", netex_dir)
+      :ok = Transport.GTFSToNeTExConverter.convert("#{__DIR__}/../../fixture/files/gtfs.zip", netex_dir)
       assert File.dir?(netex_dir)
       File.rm_rf!(netex_dir)
     end

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -410,6 +410,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
       resource_history_uuid: uuid1,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
+      converter: DB.DataConversion.converter_to_use("GeoJSON"),
       payload: %{"permanent_url" => "https://example.com/url1", "filesize" => filesize = 43}
     )
 

--- a/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
@@ -42,6 +42,7 @@ defmodule TransportWeb.ConversionControllerTest do
         resource_history_uuid: uuid1,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
+        converter: DB.DataConversion.converter_to_use("GeoJSON"),
         payload: %{"permanent_url" => permanent_url = "https://example.com/url1", "filesize" => 42}
       )
 

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -59,6 +59,7 @@ defmodule TransportWeb.DatasetControllerTest do
       resource_history_uuid: uuid,
       convert_from: "GTFS",
       convert_to: "NeTEx",
+      converter: DB.DataConversion.converter_to_use("NeTEx"),
       payload: %{"permanent_url" => conversion_url = "https://super-cellar-url.com/netex"}
     )
 

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -96,6 +96,7 @@ defmodule TransportWeb.ResourceControllerTest do
       resource_history_uuid: uuid,
       convert_from: "GTFS",
       convert_to: "NeTEx",
+      converter: DB.DataConversion.converter_to_use("NeTEx"),
       payload: %{"permanent_url" => permanent_url = "https://super-cellar-url.com/netex"}
     )
 


### PR DESCRIPTION
Suivre la vision générale dans https://github.com/etalab/transport-site/issues/3427.

Cette PR permet d'avoir plusieurs convertisseurs pour les conversions de données (cas d'usage actuel GTFS vers GeoJSON et NeTEx). On a besoin de ce changement pour pouvoir convertir en NeTEx avec notre convertisseur actuel et celui d'EnRoute.

Ajoute 3 colonnes dans `data_conversion` :
- suivre l'avancement de la conversion. On va changer d'état pour EnRoute au fur et à mesure mais pour les convertisseurs actuels l'insertion se fera uniquement quand la conversion est terminée, donc `status = success`
- le nom du convertisseur
- sa version

c'est similaire à ce qu'il y a dans `multi_validation`.

Adapte le code existant pour s'assurer qu'on utilise uniquement des conversions terminées et avec un convertisseur spécifique (là on prend le convertisseur par défaut, étant donné qu'il n'y a pas de conversion NeTEx EnRoute pour le moment).