### PR TITLE
E-mails : passage à @transport.data.gouv.fr

### DIFF
--- a/apps/shared/test/validation/gbfs_validator_test.exs
+++ b/apps/shared/test/validation/gbfs_validator_test.exs
@@ -16,7 +16,7 @@ defmodule GBFSValidatorTest do
 
       assert [
                {"content-type", "application/json"},
-               {"user-agent", "contact@transport.beta.gouv.fr"}
+               {"user-agent", "contact@transport.data.gouv.fr"}
              ] == headers
 
       assert String.starts_with?(url, "https://gbfs-validator.netlify.app")

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -27,8 +27,8 @@ defmodule Transport.DataCheckerTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
-        assert from_email == "contact@transport.beta.gouv.fr"
-        assert to_email == "deploiement@transport.beta.gouv.fr"
+        assert from_email == "contact@transport.data.gouv.fr"
+        assert to_email == "deploiement@transport.data.gouv.fr"
         assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données disparus sont réapparus sur data.gouv.fr/
         :ok
@@ -101,8 +101,8 @@ defmodule Transport.DataCheckerTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
-        assert from_email == "contact@transport.beta.gouv.fr"
-        assert to_email == "deploiement@transport.beta.gouv.fr"
+        assert from_email == "contact@transport.data.gouv.fr"
+        assert to_email == "deploiement@transport.data.gouv.fr"
         assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données ont disparus de data.gouv.fr/
         :ok
@@ -139,8 +139,8 @@ defmodule Transport.DataCheckerTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name, from_email, to_email, _reply_to, subject, body, _html_body ->
-        assert from_email == "contact@transport.beta.gouv.fr"
-        assert to_email == "deploiement@transport.beta.gouv.fr"
+        assert from_email == "contact@transport.data.gouv.fr"
+        assert to_email == "deploiement@transport.data.gouv.fr"
         assert subject == "Jeux de données supprimés ou archivés"
         assert body =~ ~r/Certains jeux de données sont indiqués comme archivés/
         :ok
@@ -242,8 +242,8 @@ defmodule Transport.DataCheckerTest do
       # a first mail to our team
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name,
-                               "contact@transport.beta.gouv.fr" = _from_email,
-                               "deploiement@transport.beta.gouv.fr" = _to_email,
+                               "contact@transport.data.gouv.fr" = _from_email,
+                               "deploiement@transport.data.gouv.fr" = _to_email,
                                _reply_to,
                                "Jeux de données arrivant à expiration" = _subject,
                                body,
@@ -259,7 +259,7 @@ defmodule Transport.DataCheckerTest do
       # a second mail to the email address in the notifications config
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name,
-                               "contact@transport.beta.gouv.fr" = _from_email,
+                               "contact@transport.data.gouv.fr" = _from_email,
                                ^producer_email = _to_email,
                                _reply_to,
                                "Jeu de données arrivant à expiration" = _subject,
@@ -305,9 +305,9 @@ defmodule Transport.DataCheckerTest do
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Jeu de données arrivant à expiration" = _subject,
                              "" = _plain_text_body,
                              html_part ->
@@ -343,9 +343,9 @@ defmodule Transport.DataCheckerTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn "transport.data.gouv.fr",
-                               "contact@transport.beta.gouv.fr",
+                               "contact@transport.data.gouv.fr",
                                ^email = _to,
-                               "contact@transport.beta.gouv.fr",
+                               "contact@transport.data.gouv.fr",
                                "Nouveaux jeux de données référencés" = _subject,
                                plain_text_body,
                                "" = _html_part ->

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -461,9 +461,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn "transport.data.gouv.fr" = _display_name,
-                               "contact@transport.beta.gouv.fr" = _from,
-                               "deploiement@transport.beta.gouv.fr" = _to,
-                               "contact@transport.beta.gouv.fr" = _reply_to,
+                               "contact@transport.data.gouv.fr" = _from,
+                               "deploiement@transport.data.gouv.fr" = _to,
+                               "contact@transport.data.gouv.fr" = _reply_to,
                                "[OK] Rapport de consolidation de la BNLC" = _subject,
                                "",
                                html_part ->
@@ -660,9 +660,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn "transport.data.gouv.fr" = _display_name,
-                               "contact@transport.beta.gouv.fr" = _from,
-                               "deploiement@transport.beta.gouv.fr" = _to,
-                               "contact@transport.beta.gouv.fr" = _reply_to,
+                               "contact@transport.data.gouv.fr" = _from,
+                               "deploiement@transport.data.gouv.fr" = _to,
+                               "contact@transport.data.gouv.fr" = _reply_to,
                                "[ERREUR] Rapport de consolidation de la BNLC" = _subject,
                                "",
                                html_part ->

--- a/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
@@ -37,9 +37,9 @@ defmodule Transport.Test.Transport.Jobs.DatasetNowOnNAPNotificationJobTest do
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Votre jeu de données a été référencé sur transport.data.gouv.fr",
                              "",
                              html_content ->

--- a/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
@@ -24,9 +24,9 @@ defmodule Transport.Test.Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenc
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
-                             "deploiement@transport.beta.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
+                             "deploiement@transport.data.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Jeux de données article 122 avec licence inappropriée",
                              "",
                              html_content ->

--- a/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
@@ -128,9 +128,9 @@ defmodule Transport.Test.Transport.Jobs.DatasetsSwitchingClimateResilienceBillJo
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Loi climat et résilience : suivi des jeux de données" = _subject,
                              "" = _plain_text,
                              html ->

--- a/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
@@ -58,9 +58,9 @@ defmodule Transport.Test.Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNot
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
+                             "contact@transport.data.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Jeux de données GTFS-RT sans ressources liées" = _subject,
                              plain_text_body,
                              "" = _html_part ->

--- a/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
@@ -131,9 +131,9 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "foo@example.com" = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              "",
                              html ->
@@ -153,9 +153,9 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^reuser_email,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              "",
                              html ->
@@ -171,9 +171,9 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "bar@example.com" = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              "",
                              html ->

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -120,8 +120,8 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
       Transport.EmailSender.Mock
       |> expect(:send_mail, fn _from_name,
-                               "contact@transport.beta.gouv.fr" = _from_email,
-                               "deploiement@transport.beta.gouv.fr" = _to_email,
+                               "contact@transport.data.gouv.fr" = _from_email,
+                               "deploiement@transport.data.gouv.fr" = _to_email,
                                _reply_to,
                                "Nouveaux jeux de données à référencer - data.gouv.fr" = _subject,
                                body,

--- a/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
@@ -28,9 +28,9 @@ defmodule Transport.Test.Transport.Jobs.NewDatasetNotificationsJobTest do
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Nouveaux jeux de données référencés" = _subject,
                              plain_text_body,
                              "" = _html_part ->

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -31,9 +31,9 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
     # Should be sent when failing at the last attempt
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "tech@transport.data.gouv.fr" = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "Échec de job Oban : Transport.Test.Transport.Jobs.ObanLoggerJobTag" = _subject,
                              plain_text_body,
                              "" = _html_part ->

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -202,9 +202,9 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              "",
                              html ->
@@ -249,9 +249,9 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^email = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              "",
                              html ->

--- a/apps/transport/test/transport/jobs/resource_unavailable_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_notification_job_test.exs
@@ -137,9 +137,9 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableNotificationJobTest d
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "foo@example.com" = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              _plain_text_body,
                              html_part ->
@@ -156,9 +156,9 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableNotificationJobTest d
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              ^reuser_email = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              _plain_text_body,
                              html_part ->
@@ -174,9 +174,9 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableNotificationJobTest d
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              "bar@example.com" = _to,
-                             "contact@transport.beta.gouv.fr",
+                             "contact@transport.data.gouv.fr",
                              subject,
                              _plain_text_body,
                              html_part ->

--- a/apps/transport/test/transport/jobs/resources_changed_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/resources_changed_notification_job_test.exs
@@ -157,9 +157,9 @@ defmodule Transport.Test.Transport.Jobs.ResourcesChangedNotificationJobTest do
 
     assert_email_sent(fn %Swoosh.Email{} = sent ->
       assert %Swoosh.Email{
-               from: {"transport.data.gouv.fr", "contact@transport.beta.gouv.fr"},
+               from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
                to: [{"", ^email}],
-               reply_to: {"", "contact@transport.beta.gouv.fr"},
+               reply_to: {"", "contact@transport.data.gouv.fr"},
                subject: "Super JDD : ressources modifiées",
                text_body: nil,
                html_body: html_body

--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -23,8 +23,8 @@ defmodule TransportWeb.ContactControllerTest do
     |> refute
 
     assert_email_sent(
-      from: {"PAN, Formulaire Contact", "contact@transport.beta.gouv.fr"},
-      to: "contact@transport.beta.gouv.fr",
+      from: {"PAN, Formulaire Contact", "contact@transport.data.gouv.fr"},
+      to: "contact@transport.data.gouv.fr",
       subject: "dataset",
       text_body: "where is my dataset?",
       html_body: nil,

--- a/apps/transport/test/transport_web/live_views/feedback_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/feedback_live_test.exs
@@ -53,13 +53,13 @@ defmodule TransportWeb.FeedbackLiveTest do
     |> assert
 
     assert_email_sent(
-      from: {"Formulaire feedback", "contact@transport.beta.gouv.fr"},
-      to: "contact@transport.beta.gouv.fr",
+      from: {"Formulaire feedback", "contact@transport.data.gouv.fr"},
+      to: "contact@transport.data.gouv.fr",
       subject: "Nouvel avis pour on-demand-validation : j’aime",
       text_body:
         "Vous avez un nouvel avis sur le PAN.\nFonctionnalité : on-demand-validation\nNotation : j’aime\nAdresse e-mail : \n\nExplication : so useful for my GTFS files\n",
       html_body: nil,
-      reply_to: "contact@transport.beta.gouv.fr"
+      reply_to: "contact@transport.data.gouv.fr"
     )
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -192,10 +192,10 @@ config :transport,
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",
-  contact_email: "contact@transport.beta.gouv.fr",
-  bizdev_email: "deploiement@transport.beta.gouv.fr",
+  contact_email: "contact@transport.data.gouv.fr",
+  bizdev_email: "deploiement@transport.data.gouv.fr",
   tech_email: "tech@transport.data.gouv.fr",
-  security_email: "contact@transport.beta.gouv.fr",
+  security_email: "contact@transport.data.gouv.fr",
   transport_tools_folder: Path.absname("transport-tools/")
 
 # For now, never send session data (containing sensitive data in our case) nor params,


### PR DESCRIPTION
Passe les adresses `@transport.beta.gouv.fr` en `@transport.data.gouv.fr`.

Ceci impacte :
- l'envoi des e-mails transactionnels (notifications et formulaire de contact)
- ce qui est affiché sur notre site web quand on indique notre adresse de contact
- restera à effectuer des changements sur notre documentation à terme cc @etalab/transport-bizdev 

Côté Front les e-mails envoyés à ces adresses [arrivent dans la même boite](https://app.frontapp.com/settings/tim:7861846/channels).

Le faible volume d'envoi d'e-mails (< 200 / semaine) fait qu'on devrait pouvoir changer de domaine sans faire ceci graduellement en étalant sur plusieurs jours. On gardera un oeil attentif côté Mailjet tout de même évidemment.

Je n'ai pas fait de changement de configuration sur Mailjet/AlwaysData/Front. Tout était déjà configuré de manière adéquate.

## Configuration Mailjet

Les 2 domaines sont bien validés et la configuration est correcte pour SPF et DKIM.

![image](https://github.com/etalab/transport-site/assets/295709/6a0dcf57-7a6c-4a8e-815e-ed6bac90477c)
![Screenshot 2023-10-20 at 12 15 50](https://github.com/etalab/transport-site/assets/295709/f3408bfb-4d05-4436-9b8f-3c89de680206)

```
$ dig transport.data.gouv.fr in txt +short 
"v=spf1 include:spf.mailjet.com include:_spf.alwaysdata.com include:_spf.scw-tem.cloud ?all"
"google-site-verification=2ynzGMtND4Fvl3yI4AaWnX7Okiin_uGWxxMOW3n-xw8"

$ dig mailjet._domainkey.transport.data.gouv.fr. in txt +short
"k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAnmSyschvS3oUNBYDmz3lrDH3DXrJ97REbHpwiCbkjkCTXSDcwBD3rACSqacyF7pt7KEqn5b9tZKA+o2v2scf2EVaLNIOvKKBYSwhQ8ifyvDeSInWSWs9LmvGScF5VUCymuLqKe2d8UH7OkZnvfqeC8dl5AV7LKFKNv1i4OWhQQIDAQAB"
```

J'ai envoyé un e-mail à la main à moi-même depuis `prod-worker` avec succès.