### PR TITLE
Mise à jour de la base de données de communes (millésime 2023)

### DIFF
--- a/apps/transport/lib/mix/tasks/transport/import_communes.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_communes.ex
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
     changeset_change_keys = changeset.changes |> Map.keys()
 
     unless Enum.empty?(changeset_change_keys -- [:geom, :population]) do
-      Logger.info("Important changes for Insee #{changeset.data.insee}. #{readable_changeset(changeset)}")
+      Logger.info("Important changes for INSEE #{changeset.data.insee}. #{readable_changeset(changeset)}")
     end
 
     changeset |> Repo.insert_or_update!()
@@ -105,10 +105,7 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
     %{geom | srid: 4326}
   end
 
-  defp readable_changeset(changeset) do
-    changes = changeset.changes
-    data = changeset.data
-
+  defp readable_changeset(%Ecto.Changeset{changes: changes, data: data} = changeset) do
     changes
     |> Map.keys()
     |> Enum.map_join(" ; ", fn key -> "#{key}: #{Map.get(data, key)} => #{Map.get(changes, key)}" end)
@@ -122,7 +119,7 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
     # Gets a list of tuples describing regions from the database
     regions = regions_by_insee()
     region_insees = regions |> Map.keys()
-    # Gets a list of tuples describing communes GEOJSON from the network
+    # Gets a list of tuples describing communes GeoJSON from the network
     geojsons = geojson_by_insee()
     # Gets the official list of communes from the network and filter them to match database regions
     etalab_communes = load_etalab_communes(region_insees)
@@ -135,8 +132,8 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
     removed_communes = communes_insee |> MapSet.new() |> MapSet.difference(MapSet.new(etalab_insee)) |> Enum.into([])
     nb_removed = removed_communes |> Enum.count()
 
-    Logger.info("#{nb_new} new communes. Insee codes: #{Enum.join(new_communes, ", ")}")
-    Logger.info("#{nb_removed} communes should be removed. Insee codes: #{Enum.join(removed_communes, ", ")}")
+    Logger.info("#{nb_new} new communes. INSEE codes: #{Enum.join(new_communes, ", ")}")
+    Logger.info("#{nb_removed} communes should be removed. INSEE codes: #{Enum.join(removed_communes, ", ")}")
 
     Logger.info("Deleting removed communes…")
     Commune |> where([c], c.insee in ^removed_communes) |> Repo.delete_all()

--- a/apps/transport/lib/mix/tasks/transport/import_communes.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_communes.ex
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Transport.ImportCommunes do
     %{geom | srid: 4326}
   end
 
-  defp readable_changeset(%Ecto.Changeset{changes: changes, data: data} = changeset) do
+  defp readable_changeset(%Ecto.Changeset{changes: changes, data: data}) do
     changes
     |> Map.keys()
     |> Enum.map_join(" ; ", fn key -> "#{key}: #{Map.get(data, key)} => #{Map.get(changes, key)}" end)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -87,8 +87,7 @@ config :transport, :email_sender_impl, Transport.EmailSender.Dummy
 config :transport, Transport.Mailer, adapter: Swoosh.Adapters.Local
 
 # Uncomment if you want to disable all logs from the database
-# config :transport, DB.Repo,
-#  log: false
+# config :transport, DB.Repo, log: false
 
 extra_config_file = Path.join(__DIR__, "#{config_env()}.secret.exs")
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -86,6 +86,10 @@ config :transport, :email_sender_impl, Transport.EmailSender.Dummy
 # Add a dev.secret.exs to use a real email provider
 config :transport, Transport.Mailer, adapter: Swoosh.Adapters.Local
 
+# Uncomment if you want to disable all logs from the database
+# config :transport, DB.Repo,
+#  log: false
+
 extra_config_file = Path.join(__DIR__, "#{config_env()}.secret.exs")
 
 if File.exists?(extra_config_file) do


### PR DESCRIPTION
# Changements côté code

Le diff a l’air important parce que j’ai déplacé des fonctions pour les remettre dans l’ordre du script, mais en fait, comme changements, il n’y a pas grand chose :
- Passage de HTTPoison à Req. HTTPoison me crachait une erreur avec un simple `HTTPoison.get!`.
- Pas mal de commentaires pour comprendre le code (en fait, c’est ce qui m’a pris le plus de temps, comprendre ce qui était fait)
- Je retourne les clefs du changeset de chaque commune pour avoir une idée de ce qui est modifié – surtout de la géométrie, donc, mais quand même 22 changements de nom
- Et si un changeset change autre chose que la géométrie ou la population, j’outpute les changements dans les logs pour analyse.

# Analyse des changements côté données

Tl;dr : **on aurait dû retrouver 10 suppressions de communes et zéro nouvelles communes, d’après [le fichier de l’INSEE](https://www.insee.fr/fr/information/2549968)**, en raison des fusions avec intégration dans un code INSEE prexistant suivantes :
- 01039 Béon => fusionne dans 01138 Culoz-Béon, anciennement Culoz
- 02077 Berzy le Sec => fusionne dans 02564 Bernoy-le-Chateau, anciennement Noyant-et-Aconin
- 09255 Saint-Amans => Fusionne dans 09056 Bézac (pas de changement de nom)
- 16140 FontClaireau => Fusionne dans 16206 Mansle les Fontaines, anciennement Mansle
- 50015 Annoville => fusionne dans 50272 Tourneville sur Mer, anciennement Lingreville
- 51063 Binson-et-Orquigny et 51637 Villers-sous-Châtillon => fusionne dans 51457 Cœur de Vallée, anciennement Reuil
- 71492 Saint-Ythaire => fusionne dans 71042 Bonnay-Saint-Ythaire, anciennement Bonnay
- 85037 Breuil-Barret et 85053 La Chapelle-aux-Lys => fusionne dans 85289 Terval, anciennement La Tardière

**En pratique, on a 11 supressions de communes et 1 nouvelle commune**, la faute à la commune de[ Les Trois Lacs](https://fr.wikipedia.org/wiki/Les_Trois_Lacs), qui entraîne la création du code INSEE 27676 et la suppression du code 27058 (et bizarrement, le code 27647 aurait aussi dû disparaître mais nous ne l’avions pas en base de données). Ça aurait dû être effectif avec le batch 2021 d’après Wikipedia, or cette commune n’est pas dans le listing INSEE de l’année 2020. Ce qui s’est passé, mystère.

**On a aussi pas mal de changements de code d’arrondissement : 32.** L’essentiel c’est en Meurthe-et-Moselle, dans le coin de Nancy et Pont à Mousson. J’ai vérifié[ le code officiel de l’INSEE](https://www.insee.fr/fr/information/2549968), ça colle à la dernière version, donc tout va bien. En revanche je ne trouve pas de décret correspondant, je ne sais pas si c’est un rattrapage de données erronées ou un vrai changement administratif récent. Le seul décret qui correspont à un changement c’est celui pour la création de l’arrondissement de Saint-George en Guyane, code 9733 https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046493097?isSuggest=true

**Au total, en termes de changements, on a les stats suivantes :**
- Changement d’arrondissement INSEE : 32
- Changement de nom : 21 : 8 communes renommées suite à des fusions (voir plus haut) et 13 changements du genre rajouter ou retirer un « Le ».
- Changement de géométrie : 724 – attention, ce sont des stats pré-réctification par `ST_MakeValid(geom)`, donc il est possible que derrière ça retombe sur ses pattes avec la même géométrie qu’à l’origine.
- Population : 31890 communes
- SIREN : 9

(+ une nouvelle création de commune, les Trois Lacs, où du coup tous les attributs changent, d’où les stats dans les logs qui sont incrémentées de 1). 

Output avec un dump de BDD récent :

```
[info] 1 new communes. Insee codes: 27676
[info] 11 communes should be removed. Insee codes: 01039, 02077, 09255, 16140, 27058, 50015, 51063, 51637, 71492, 85037, 85053
[info] Deleting removed communes…
[info] Updating communes (including potentially incorrect geometry)…
[info] Important changes for Insee 01138. geom: SRID=4326;POLYGON((5.7599 45.8889,5.7747 45.8819,5.7861 45.8823,5.7934 45.8801,5.8065 45.8768,5.8152 45.8772,5.8088 45.8625,5.8075 45.8606,5.8034 45.8552,5.801 45.8457,5.7972 45.8311,5.7953 45.83,5.7889 45.8267,5.7878 45.8235,5.7874 45.8271,5.7797 45.8264,5.7792 45.8237,5.7768 45.8217,5.7743 45.822,5.7723 45.8237,5.7667 45.8243,5.7631 45.8249,5.7641 45.8345,5.7678 45.8461,5.7682 45.8483,5.7649 45.8526,5.7662 45.8533,5.7666 45.8602,5.7709 45.8657,5.7672 45.8688,5.7652 45.8724,5.7627 45.8741,5.761 45.8777,5.7593 45.8784,5.7579 45.8811,5.758 45.8852,5.7599 45.8889)) => SRID=4326;POLYGON((5.7599 45.8889,5.7747 45.8819,5.7861 45.8823,5.7934 45.8801,5.8065 45.8768,5.8152 45.8772,5.8088 45.8625,5.8075 45.8606,5.8034 45.8552,5.801 45.8457,5.7972 45.8311,5.7953 45.83,5.7889 45.8267,5.7878 45.8235,5.7874 45.8271,5.7797 45.8264,5.7792 45.8237,5.7768 45.8217,5.7743 45.822,5.7723 45.8237,5.7667 45.8243,5.7631 45.8249,5.7641 45.8345,5.7486 45.8354,5.7466 45.8365,5.7414 45.8435,5.736 45.8458,5.7321 45.8459,5.7281 45.8483,5.7301 45.851,5.7331 45.8521,5.734 45.8549,5.7404 45.8643,5.7427 45.8666,5.7401 45.8735,5.7423 45.8789,5.7469 45.8756,5.7498 45.8749,5.7502 45.8773,5.7532 45.8802,5.7579 45.8811,5.758 45.8852,5.7599 45.8889)) ; nom: Culoz => Culoz-Béon ; population: 3004 => 2987 ; siren: 210101382 => 200099406
[info] Important changes for Insee 02564. geom: SRID=4326;POLYGON((3.3318 49.3107,3.3268 49.3118,3.3228 49.3106,3.3263 49.3162,3.3244 49.3176,3.3204 49.3228,3.3187 49.3217,3.3156 49.3246,3.3194 49.3262,3.3177 49.3283,3.3227 49.3312,3.3292 49.3311,3.3271 49.3352,3.3285 49.338,3.3315 49.3388,3.333 49.342,3.3311 49.3446,3.3332 49.3466,3.3335 49.3487,3.3338 49.3496,3.3423 49.3495,3.3516 49.3438,3.3469 49.3402,3.3449 49.3366,3.3493 49.3307,3.345 49.3299,3.3453 49.3284,3.3359 49.328,3.3346 49.3236,3.3325 49.3231,3.33 49.3192,3.3334 49.3132,3.3318 49.3107)) => SRID=4326;POLYGON((3.3318 49.3107,3.3268 49.3118,3.3228 49.3106,3.3168 49.3109,3.3114 49.3149,3.302 49.3118,3.2985 49.3073,3.2958 49.3018,3.2941 49.3003,3.2885 49.2981,3.2745 49.2963,3.2673 49.2917,3.2636 49.2907,3.2639 49.294,3.2625 49.2961,3.2619 49.3012,3.2643 49.3016,3.2641 49.3048,3.2651 49.3068,3.278 49.3104,3.2731 49.3144,3.2799 49.3174,3.277 49.3199,3.2785 49.3262,3.2871 49.3258,3.2946 49.327,3.295 49.3298,3.2966 49.3324,3.3035 49.3349,3.3063 49.335,3.3126 49.3375,3.3188 49.3374,3.3207 49.3382,3.3196 49.3405,3.3223 49.3421,3.333 49.342,3.3311 49.3446,3.3332 49.3466,3.3335 49.3487,3.3338 49.3496,3.3423 49.3495,3.3516 49.3438,3.3469 49.3402,3.3449 49.3366,3.3493 49.3307,3.345 49.3299,3.3453 49.3284,3.3359 49.328,3.3346 49.3236,3.3325 49.3231,3.33 49.3192,3.3334 49.3132,3.3318 49.3107)) ; nom: Noyant-et-Aconin => Bernoy-le-Château ; population: 495 => 491 ; siren: 210205415 => 200098754
[info] Important changes for Insee 03223. nom: Saint-Christophe => Saint-Christophe-en-Bourbonnais ; population: 441 => 437
[info] Important changes for Insee 09056. geom: SRID=4326;POLYGON((1.5683 43.1411,1.5641 43.1435,1.5605 43.143,1.5562 43.1439,1.553 43.148,1.5531 43.1508,1.5514 43.1532,1.548 43.1546,1.5507 43.1592,1.5554 43.1602,1.5572 43.1616,1.5574 43.164,1.5633 43.1646,1.5734 43.1657,1.5829 43.1651,1.5941 43.1591,1.5942 43.151,1.5951 43.1485,1.5926 43.1435,1.5933 43.1419,1.5922 43.1387,1.589 43.1391,1.5868 43.1408,1.5841 43.1407,1.5748 43.1422,1.57 43.1399,1.5683 43.1411)) => SRID=4326;POLYGON((1.5683 43.1411,1.5641 43.1435,1.5605 43.143,1.5562 43.1439,1.553 43.148,1.5531 43.1508,1.5514 43.1532,1.548 43.1546,1.544 43.1489,1.5448 43.1451,1.541 43.1457,1.5363 43.1493,1.5347 43.1517,1.5348 43.1591,1.5399 43.1607,1.5453 43.1607,1.5498 43.1651,1.5491 43.1677,1.5495 43.1713,1.5524 43.1743,1.5568 43.171,1.5599 43.1701,1.5631 43.1666,1.5633 43.1646,1.5734 43.1657,1.5829 43.1651,1.5941 43.1591,1.5942 43.151,1.5951 43.1485,1.5926 43.1435,1.5933 43.1419,1.5922 43.1387,1.589 43.1391,1.5868 43.1408,1.5841 43.1407,1.5748 43.1422,1.57 43.1399,1.5683 43.1411)) ; population: 394 => 413 ; siren: 210900569 => 200099182
[info] Important changes for Insee 16206. geom: SRID=4326;POLYGON((0.1872 45.8776,0.1838 45.8735,0.1847 45.8679,0.1798 45.8662,0.179 45.8642,0.1716 45.8664,0.1699 45.8639,0.1653 45.8668,0.1615 45.8682,0.1603 45.8698,0.1565 45.8716,0.158 45.877,0.1588 45.8809,0.1634 45.8884,0.1694 45.8879,0.1713 45.8924,0.1745 45.8957,0.1756 45.8988,0.1778 45.8987,0.1782 45.8936,0.1793 45.8921,0.1894 45.8915,0.1888 45.89,0.1822 45.8803,0.1866 45.8792,0.1872 45.8776)) => SRID=4326;POLYGON((0.1872 45.8776,0.1838 45.8735,0.1847 45.8679,0.1798 45.8662,0.179 45.8642,0.1716 45.8664,0.1699 45.8639,0.1653 45.8668,0.1615 45.8682,0.1603 45.8698,0.1565 45.8716,0.158 45.877,0.1588 45.8809,0.1634 45.8884,0.1694 45.8879,0.1713 45.8924,0.1745 45.8957,0.1756 45.8988,0.1778 45.8987,0.1782 45.8936,0.1825 45.894,0.185 45.8973,0.1906 45.8987,0.189 45.9014,0.1879 45.9062,0.1896 45.9089,0.193 45.9099,0.1999 45.9093,0.1998 45.9063,0.2027 45.9041,0.2022 45.8996,0.2067 45.8979,0.2089 45.8948,0.2149 45.8961,0.2165 45.893,0.213 45.893,0.2072 45.891,0.2063 45.8895,0.2069 45.8867,0.2092 45.8829,0.2093 45.8798,0.2067 45.8762,0.1987 45.8769,0.1957 45.8782,0.191 45.8783,0.1872 45.8776)) ; nom: Mansle => Mansle-les-Fontaines ; population: 1692 => 1681 ; siren: 211602065 => 200099455
[info] Important changes for Insee 17132. nom: Cramchaban => Cram-Chaban ; population: 650 => 648
[info] Important changes for Insee . arrondissement_insee:  => 271 ; departement_insee:  => 27 ; geom:  => SRID=4326;POLYGON((1.2806 49.1747,1.2715 49.1784,1.2691 49.1825,1.2699 49.1877,1.2713 49.1904,1.2703 49.1934,1.27 49.2001,1.2691 49.2022,1.2662 49.2041,1.272 49.2057,1.2838 49.2129,1.293 49.2202,1.3022 49.2218,1.3091 49.2217,1.3091 49.2234,1.3165 49.2271,1.3186 49.2272,1.3282 49.2334,1.3349 49.2383,1.3447 49.2461,1.353 49.2497,1.3584 49.251,1.3639 49.2519,1.3687 49.2521,1.3758 49.2506,1.3818 49.2503,1.3902 49.2471,1.3935 49.2433,1.3972 49.2411,1.3989 49.2354,1.3965 49.2328,1.3954 49.2287,1.3907 49.224,1.3907 49.2212,1.3875 49.2193,1.3825 49.2166,1.3774 49.2121,1.3724 49.211,1.3716 49.2119,1.366 49.2097,1.3485 49.2041,1.3428 49.2012,1.3385 49.1978,1.3329 49.2001,1.3301 49.2003,1.3245 49.2028,1.3224 49.2052,1.318 49.2041,1.3167 49.2017,1.3089 49.1953,1.3083 49.1921,1.3048 49.1866,1.3049 49.1837,1.2982 49.179,1.2884 49.1782,1.2829 49.1763,1.2806 49.1747)) ; insee:  => 27676 ; nom:  => Les Trois Lacs ; population:  => 1759 ; region_id:  => 8 ; siren:  => 200063782
[info] Important changes for Insee 28012. nom: Commune nouvelle d'Arrou => Vald'Yerre ; population: 3653 => 3580
[info] Important changes for Insee 32289. nom: Montpézat => Montpezat ; population: 239 => 240
[info] Important changes for Insee 32465. nom: Villefranche => Villefranche-d'Astarac ; population: 123 => 138
[info] Important changes for Insee 33081. nom: Cadillac => Cadillac-sur-Garonne ; population: 2836 => 2846
[info] Important changes for Insee 38243. nom: Le Monestier-du-Percy => Monestier-du-Percy ; population: 250 => 247
[info] Important changes for Insee 38301. nom: Percy => Le Percy ; population: 175 => 172
[info] Important changes for Insee 44066. nom: Grandchamps-des-Fontaines => Grandchamp-des-Fontaines ; population: 6439 => 6606
[info] Important changes for Insee 45259. nom: Quiers-sur-Bézonde => Quiers-sur-Bezonde ; population: 1133 => 1128
[info] Important changes for Insee 50272. geom: SRID=4326;POLYGON((-1.5618 48.9516,-1.5472 48.9526,-1.5449 48.9521,-1.5333 48.9524,-1.5292 48.954,-1.5269 48.9525,-1.5205 48.9516,-1.5157 48.953,-1.508 48.9567,-1.5014 48.9556,-1.4995 48.9559,-1.4985 48.9526,-1.5044 48.9512,-1.5054 48.9492,-1.505 48.9436,-1.5025 48.941,-1.4977 48.939,-1.5011 48.9373,-1.5122 48.9329,-1.5129 48.9316,-1.5199 48.9308,-1.5212 48.9319,-1.5256 48.9297,-1.5299 48.9299,-1.5313 48.931,-1.5351 48.9309,-1.537 48.9327,-1.5397 48.9323,-1.5438 48.9321,-1.5436 48.9345,-1.5481 48.9399,-1.5513 48.9409,-1.5596 48.9387,-1.5624 48.9415,-1.5627 48.9443,-1.5618 48.9516)) => SRID=4326;POLYGON((-1.4995 48.9559,-1.4985 48.9526,-1.5044 48.9512,-1.5054 48.9492,-1.505 48.9436,-1.5025 48.941,-1.4977 48.939,-1.5011 48.9373,-1.5122 48.9329,-1.5129 48.9316,-1.5199 48.9308,-1.5212 48.9319,-1.5256 48.9297,-1.5299 48.9299,-1.5313 48.931,-1.5351 48.9309,-1.537 48.9327,-1.5397 48.9323,-1.5438 48.9321,-1.5436 48.9345,-1.5481 48.9399,-1.5513 48.9409,-1.5596 48.9387,-1.5624 48.9415,-1.5627 48.9443,-1.5618 48.9516,-1.5619 48.9684,-1.5482 48.9698,-1.5411 48.9687,-1.5335 48.9696,-1.5278 48.9686,-1.5245 48.9721,-1.52 48.9759,-1.5138 48.9754,-1.5042 48.9678,-1.5023 48.965,-1.5027 48.9634,-1.5001 48.9587,-1.4995 48.9559)) ; nom: Lingreville => Tourneville-sur-Mer ; population: 1019 => 1023 ; siren: 215002726 => 200098713
[info] Important changes for Insee 51457. geom: SRID=4326;POLYGON((3.818 49.0732,3.807 49.0765,3.8029 49.0764,3.8008 49.0787,3.7953 49.0828,3.7921 49.0831,3.7873 49.0825,3.7883 49.0868,3.7937 49.0872,3.797 49.0904,3.7963 49.0922,3.8049 49.09,3.8072 49.09,3.8138 49.0944,3.8204 49.1004,3.8249 49.099,3.828 49.1011,3.8292 49.0979,3.833 49.0962,3.8297 49.0934,3.8241 49.0921,3.8247 49.0891,3.8224 49.0801,3.8318 49.0788,3.8399 49.0769,3.8391 49.0756,3.8344 49.0755,3.8309 49.0738,3.8227 49.0724,3.818 49.0732)) => SRID=4326;POLYGON((3.818 49.0732,3.807 49.0765,3.8029 49.0764,3.8008 49.0787,3.7953 49.0828,3.7921 49.0831,3.7873 49.0825,3.7846 49.0831,3.7814 49.0823,3.779 49.0861,3.7776 49.0936,3.7743 49.0978,3.7818 49.0982,3.783 49.1007,3.7881 49.1054,3.7911 49.1066,3.8063 49.1099,3.8102 49.1115,3.8074 49.1143,3.8136 49.1165,3.8166 49.1147,3.8219 49.1131,3.8334 49.1109,3.8349 49.1096,3.8435 49.1055,3.8292 49.0979,3.833 49.0962,3.8297 49.0934,3.8241 49.0921,3.8247 49.0891,3.8224 49.0801,3.8318 49.0788,3.8399 49.0769,3.8391 49.0756,3.8344 49.0755,3.8309 49.0738,3.8227 49.0724,3.818 49.0732)) ; nom: Reuil => Cœur-de-la-Vallée ; population: 280 => 281 ; siren: 215104241 => 200098796
[info] Important changes for Insee 54112. arrondissement_insee: 541 => 544 ; population: 706 => 718
[info] Important changes for Insee 54144. arrondissement_insee: 543 => 542 ; population: 398 => 382
[info] Important changes for Insee 54145. arrondissement_insee: 542 => 543 ; population: 931 => 939
[info] Important changes for Insee 54153. arrondissement_insee: 541 => 544 ; population: 55 => 56
[info] Important changes for Insee 54193. arrondissement_insee: 543 => 544 ; geom: SRID=4326;POLYGON((5.9376 48.8933,5.9379 48.8943,5.9482 48.8987,5.949 48.9029,5.949 48.9082,5.9474 48.911,5.9484 48.9153,5.9499 48.9171,5.9541 48.9187,5.9571 48.9187,5.9633 48.9173,5.9677 48.9173,5.9826 48.9188,5.9861 48.9185,5.9885 48.9161,5.9865 48.9144,5.9888 48.9097,5.9909 48.9078,5.9864 48.906,5.9819 48.9063,5.9779 48.9041,5.9812 48.9021,5.9757 48.8999,5.973 48.8957,5.9534 48.893,5.9483 48.8917,5.9408 48.8885,5.9384 48.8894,5.9376 48.8933)) => SRID=4326;POLYGON((5.9376 48.8933,5.9379 48.8943,5.9482 48.8987,5.949 48.9029,5.949 48.9082,5.9474 48.911,5.9484 48.9153,5.9499 48.9171,5.9541 48.9187,5.9571 48.9187,5.9633 48.9173,5.9677 48.9173,5.9831 48.9188,5.9861 48.9185,5.9885 48.9161,5.9865 48.9144,5.9888 48.9097,5.9909 48.9078,5.9864 48.906,5.9819 48.9063,5.9779 48.9041,5.9812 48.9021,5.9757 48.8999,5.973 48.8957,5.9534 48.893,5.9483 48.8917,5.9408 48.8885,5.9384 48.8894,5.9376 48.8933)) ; population: 77 => 71
[info] Important changes for Insee 54225. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((5.9871 48.8326,5.981 48.8314,5.9683 48.8328,5.9674 48.8332,5.9693 48.835,5.9679 48.8363,5.9677 48.8417,5.9762 48.8503,5.9801 48.8523,5.9792 48.8581,5.9854 48.8581,5.9978 48.8509,5.9992 48.8492,6.0021 48.8469,6.0023 48.845,6.0064 48.8391,6.0003 48.8391,5.9974 48.8351,5.993 48.8326,5.9871 48.8326)) => SRID=4326;POLYGON((5.9683 48.8329,5.9675 48.8333,5.9677 48.8417,5.9762 48.8503,5.9801 48.8523,5.9792 48.8581,5.9854 48.8581,5.9978 48.8509,5.9992 48.8492,6.0021 48.8469,6.0023 48.845,6.0064 48.8391,6.0002 48.839,5.9974 48.8351,5.9953 48.8333,5.9921 48.8325,5.9871 48.8326,5.9807 48.8314,5.9683 48.8329)) ; population: 179 => 180
[info] Important changes for Insee 54239. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((6.0365 48.8436,6.0378 48.8419,6.0364 48.8389,6.0335 48.8397,6.0241 48.8374,6.0189 48.8371,6.0249 48.8301,6.0253 48.8272,6.021 48.8279,6.0151 48.8321,6.013 48.8317,6.0035 48.8338,6.0042 48.8364,6.0089 48.8379,6.0064 48.8391,6.0023 48.845,6.0021 48.8469,5.9992 48.8492,6.0012 48.8497,6.0039 48.848,6.0074 48.8473,6.0137 48.8496,6.0174 48.8564,6.0204 48.8556,6.0186 48.8512,6.0193 48.8499,6.0244 48.8502,6.028 48.848,6.0271 48.8452,6.0311 48.8434,6.0365 48.8436)) => SRID=4326;POLYGON((6.0365 48.8436,6.0378 48.8419,6.0364 48.8389,6.0335 48.8397,6.0241 48.8374,6.0189 48.8371,6.0249 48.8301,6.0253 48.8272,6.021 48.8279,6.0154 48.8321,6.0126 48.8318,6.0034 48.8339,6.0042 48.8364,6.0089 48.8379,6.0064 48.8391,6.0023 48.845,6.0021 48.8469,5.9992 48.8492,6.0012 48.8497,6.0039 48.848,6.0074 48.8473,6.0137 48.8496,6.0174 48.8564,6.0204 48.8556,6.0186 48.8512,6.0193 48.8499,6.0244 48.8502,6.028 48.848,6.0271 48.8452,6.0311 48.8434,6.0365 48.8436)) ; population: 137 => 141
[info] Important changes for Insee 54244. arrondissement_insee: 541 => 544 ; population: 111 => 110
[info] Important changes for Insee 54249. arrondissement_insee: 541 => 544 ; population: 254 => 253
[info] Important changes for Insee 54269. arrondissement_insee: 542 => 543 ; population: 360 => 345
[info] Important changes for Insee 54318. arrondissement_insee: 544 => 543 ; population: 5863 => 5749
[info] Important changes for Insee 54353. arrondissement_insee: 541 => 544 ; population: 922 => 901
[info] Important changes for Insee 54355. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((5.9666 48.8621,5.9651 48.8607,5.9668 48.8589,5.972 48.8604,5.9766 48.8576,5.9792 48.8581,5.9801 48.8523,5.9762 48.8503,5.9677 48.8417,5.9679 48.8363,5.9693 48.835,5.9674 48.8332,5.9602 48.8366,5.9579 48.833,5.9532 48.8319,5.9516 48.8289,5.9465 48.8288,5.9437 48.8274,5.9422 48.8333,5.935 48.8329,5.9291 48.8388,5.9275 48.8412,5.9179 48.848,5.9186 48.8498,5.9219 48.8512,5.9325 48.8456,5.9355 48.8515,5.9317 48.8526,5.9344 48.8543,5.9382 48.8552,5.9387 48.8572,5.9367 48.8615,5.9397 48.8646,5.947 48.8634,5.9518 48.8653,5.9544 48.8652,5.9638 48.869,5.9655 48.8684,5.9648 48.8633,5.9666 48.8621)) => SRID=4326;POLYGON((5.9666 48.8621,5.9651 48.8607,5.9668 48.8589,5.972 48.8604,5.9766 48.8576,5.9792 48.8581,5.9801 48.8523,5.9762 48.8503,5.9677 48.8417,5.9675 48.8333,5.96 48.8367,5.9578 48.8329,5.9539 48.8319,5.9518 48.8292,5.9463 48.8287,5.9437 48.8277,5.9422 48.8333,5.935 48.8329,5.9291 48.8388,5.9275 48.8412,5.9179 48.848,5.9186 48.8498,5.9219 48.8512,5.9325 48.8456,5.9355 48.8515,5.9317 48.8526,5.9344 48.8543,5.9382 48.8552,5.9387 48.8572,5.9367 48.8615,5.9397 48.8646,5.947 48.8634,5.9518 48.8653,5.9544 48.8652,5.9638 48.869,5.9655 48.8684,5.9648 48.8633,5.9666 48.8621)) ; population: 94 => 92
[info] Important changes for Insee 54410. arrondissement_insee: 541 => 544 ; population: 519 => 516
[info] Important changes for Insee 54435. arrondissement_insee: 543 => 544 ; population: 362 => 365
[info] Important changes for Insee 54441. arrondissement_insee: 541 => 544 ; population: 234 => 231
[info] Important changes for Insee 54460. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((5.9683 48.8328,5.981 48.8314,5.9871 48.8326,5.9887 48.8313,5.9901 48.8273,5.9917 48.8261,5.9915 48.8201,5.992 48.8158,5.9896 48.813,5.9948 48.8078,5.9953 48.8056,5.9824 48.802,5.9793 48.8004,5.9763 48.7973,5.9703 48.7983,5.9699 48.7974,5.9643 48.797,5.9671 48.7994,5.964 48.8023,5.9638 48.804,5.961 48.8073,5.9566 48.8094,5.9563 48.8111,5.9617 48.8127,5.96 48.8149,5.965 48.8172,5.9682 48.8194,5.9656 48.8209,5.967 48.8238,5.9695 48.8254,5.9709 48.8304,5.9683 48.8328)) => SRID=4326;POLYGON((5.9694 48.7976,5.9643 48.797,5.9671 48.7994,5.964 48.8023,5.9638 48.804,5.961 48.8073,5.9566 48.8094,5.9563 48.8111,5.9617 48.8127,5.9599 48.815,5.9683 48.8192,5.9656 48.8217,5.9696 48.8256,5.9714 48.8306,5.9683 48.8329,5.9807 48.8314,5.9871 48.8326,5.9887 48.8313,5.9901 48.8273,5.9917 48.8261,5.9915 48.8201,5.992 48.8158,5.9896 48.813,5.9948 48.8078,5.9953 48.8056,5.9812 48.8016,5.9761 48.7973,5.9703 48.7986,5.9694 48.7976)) ; population: 156 => 151
[info] Important changes for Insee 54463. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((6.0076 48.8044,6.0088 48.8032,6.0143 48.8017,6.0173 48.7999,6.0154 48.7974,6.0179 48.7962,6.0178 48.7902,6.0194 48.7886,6.0178 48.7837,6.0193 48.7797,6.0164 48.7792,6.0175 48.7771,6.017 48.7739,6.0118 48.7757,6.0102 48.7743,6.0059 48.7745,6.0012 48.773,5.9973 48.7704,5.9933 48.775,5.9874 48.7769,5.9803 48.7811,5.9742 48.7766,5.9651 48.7899,5.9614 48.7895,5.9699 48.7974,5.9703 48.7983,5.9763 48.7973,5.9793 48.8004,5.9824 48.802,5.9953 48.8056,5.9995 48.8061,6.0024 48.8037,6.0076 48.8044)) => SRID=4326;POLYGON((6.0076 48.8044,6.0088 48.8032,6.0143 48.8017,6.0173 48.7999,6.0154 48.7974,6.0179 48.7962,6.0178 48.7902,6.0194 48.7886,6.0178 48.7837,6.0193 48.7797,6.0164 48.7792,6.0175 48.7771,6.017 48.7739,6.0118 48.7757,6.0102 48.7743,6.0059 48.7745,6.0012 48.773,5.9973 48.7704,5.9933 48.775,5.9874 48.7769,5.9803 48.7811,5.9742 48.7766,5.9651 48.7899,5.9614 48.7895,5.9662 48.7939,5.9694 48.7976,5.9703 48.7986,5.9761 48.7973,5.9812 48.8016,5.9953 48.8056,5.9995 48.8061,6.0024 48.8037,6.0076 48.8044)) ; population: 235 => 229
[info] Important changes for Insee 54477. arrondissement_insee: 541 => 544
[info] Important changes for Insee 54505. arrondissement_insee: 544 => 543 ; population: 714 => 724
[info] Important changes for Insee 54509. arrondissement_insee: 542 => 543 ; population: 994 => 996
[info] Important changes for Insee 54511. arrondissement_insee: 541 => 544 ; population: 112 => 111
[info] Important changes for Insee 54535. arrondissement_insee: 541 => 544 ; population: 200 => 198
[info] Important changes for Insee 54570. arrondissement_insee: 541 => 544
[info] Important changes for Insee 54573. arrondissement_insee: 544 => 543 ; geom: SRID=4326;POLYGON((6.0253 48.8272,6.0252 48.8249,6.0235 48.8223,6.0275 48.8135,6.0272 48.8115,6.0152 48.8077,6.0131 48.806,6.0076 48.8044,6.0024 48.8037,5.9995 48.8061,5.9953 48.8056,5.9948 48.8078,5.9896 48.813,5.992 48.8158,5.9915 48.8201,5.9917 48.8261,5.9901 48.8273,5.9887 48.8313,5.9871 48.8326,5.993 48.8326,5.9974 48.8351,6.0003 48.8391,6.0064 48.8391,6.0089 48.8379,6.0042 48.8364,6.0035 48.8338,6.013 48.8317,6.0151 48.8321,6.021 48.8279,6.0253 48.8272)) => SRID=4326;POLYGON((6.0253 48.8272,6.0252 48.8249,6.0235 48.8223,6.0275 48.8135,6.0272 48.8115,6.0152 48.8077,6.0131 48.806,6.0076 48.8044,6.0024 48.8037,5.9995 48.8061,5.9953 48.8056,5.9948 48.8078,5.9896 48.813,5.992 48.8158,5.9915 48.8201,5.9917 48.8261,5.9901 48.8273,5.9887 48.8313,5.9871 48.8326,5.9921 48.8325,5.9953 48.8333,5.9974 48.8351,6.0002 48.839,6.0064 48.8391,6.0089 48.8379,6.0042 48.8364,6.0034 48.8339,6.0126 48.8318,6.0154 48.8321,6.021 48.8279,6.0253 48.8272)) ; population: 170 => 165
[info] Important changes for Insee 54593. arrondissement_insee: 541 => 544 ; population: 428 => 431
[info] Important changes for Insee 54599. arrondissement_insee: 541 => 544 ; population: 112 => 109
[info] Important changes for Insee 56262. nom: Bono => Le Bono ; population: 2533 => 2567
[info] Important changes for Insee 62588. nom: Montreuil => Montreuil-sur-Mer ; population: 1935 => 1913
[info] Important changes for Insee 63233. nom: Montaigut => Montaigut-en-Combraille ; population: 982 => 985
[info] Important changes for Insee 70017. arrondissement_insee: 701 => 702
[info] Important changes for Insee 71042. geom: SRID=4326;POLYGON((4.5924 46.5448,4.5922 46.5513,4.594 46.5509,4.5999 46.5502,4.6044 46.5525,4.6087 46.5514,4.6104 46.5551,4.613 46.5567,4.6148 46.561,4.6177 46.5623,4.6228 46.5604,4.6271 46.5608,4.6301 46.5598,4.6334 46.5626,4.6355 46.566,4.6357 46.5694,4.6427 46.5684,4.6464 46.5686,4.651 46.5665,4.6558 46.565,4.6582 46.5625,4.6571 46.5555,4.6561 46.5523,4.6566 46.5501,4.6533 46.547,4.6491 46.5445,4.6449 46.5468,4.6437 46.546,4.637 46.5464,4.6381 46.5413,4.6338 46.5404,4.6325 46.5379,4.6272 46.5363,4.6253 46.5337,4.6179 46.532,4.6142 46.5301,4.6116 46.5324,4.6112 46.534,4.6086 46.5361,4.6069 46.5353,4.6027 46.5355,4.5969 46.5375,4.591 46.5347,4.5883 46.5361,4.5926 46.5381,4.5908 46.542,4.5924 46.5448)) => SRID=4326;POLYGON((4.5924 46.5448,4.5922 46.5513,4.594 46.5509,4.5931 46.5553,4.5897 46.5544,4.5913 46.558,4.5858 46.5618,4.5816 46.5606,4.5793 46.5644,4.5759 46.5647,4.5766 46.5688,4.5797 46.5688,4.5834 46.5753,4.5853 46.5775,4.5919 46.5795,4.5938 46.5812,4.5938 46.584,4.5976 46.5848,4.5995 46.5866,4.6038 46.5882,4.6065 46.5861,4.6037 46.5824,4.609 46.5802,4.6111 46.5786,4.6179 46.5769,4.618 46.5751,4.6158 46.5728,4.62 46.5728,4.6206 46.5701,4.6241 46.5707,4.6266 46.5701,4.6357 46.5694,4.6427 46.5684,4.6464 46.5686,4.651 46.5665,4.6558 46.565,4.6582 46.5625,4.6571 46.5555,4.6561 46.5523,4.6566 46.5501,4.6533 46.547,4.6491 46.5445,4.6449 46.5468,4.6437 46.546,4.637 46.5464,4.6381 46.5413,4.6338 46.5404,4.6325 46.5379,4.6272 46.5363,4.6253 46.5337,4.6179 46.532,4.6142 46.5301,4.6116 46.5324,4.6112 46.534,4.6086 46.5361,4.6069 46.5353,4.6027 46.5355,4.5969 46.5375,4.591 46.5347,4.5883 46.5361,4.5926 46.5381,4.5908 46.542,4.5924 46.5448)) ; nom: Bonnay => Bonnay-Saint-Ythaire ; population: 318 => 312 ; siren: 217100429 => 200098622
[info] Important changes for Insee 81085. nom: Escroux => Lacapelle-Escroux ; population: 45 => 44
[info] Important changes for Insee 85289. geom: SRID=4326;POLYGON((-0.6842 46.664,-0.6849 46.6624,-0.6893 46.6616,-0.6911 46.6569,-0.6897 46.6522,-0.6934 46.6486,-0.7012 46.6451,-0.7055 46.6403,-0.7055 46.6393,-0.7106 46.6365,-0.7179 46.6395,-0.7209 46.6418,-0.7389 46.6522,-0.7413 46.6524,-0.7446 46.6563,-0.7479 46.6568,-0.7535 46.6589,-0.7582 46.6584,-0.7693 46.6562,-0.77 46.6566,-0.7689 46.6606,-0.7672 46.6621,-0.7676 46.6676,-0.7651 46.6704,-0.7632 46.6792,-0.7632 46.6818,-0.7591 46.6833,-0.7559 46.6827,-0.7537 46.6839,-0.7513 46.6868,-0.7472 46.6877,-0.7437 46.6875,-0.7414 46.6882,-0.7314 46.6866,-0.7326 46.6848,-0.726 46.6817,-0.721 46.6807,-0.7179 46.6808,-0.7156 46.6789,-0.713 46.6742,-0.7051 46.6722,-0.6985 46.6697,-0.6912 46.6685,-0.6874 46.6659,-0.6852 46.6661,-0.6842 46.664)) => SRID=4326;POLYGON((-0.7106 46.6365,-0.7179 46.6395,-0.7209 46.6418,-0.7389 46.6522,-0.7413 46.6524,-0.7446 46.6563,-0.7479 46.6568,-0.7535 46.6589,-0.7582 46.6584,-0.7693 46.6562,-0.77 46.6566,-0.7689 46.6606,-0.7672 46.6621,-0.7676 46.6676,-0.7651 46.6704,-0.7632 46.6792,-0.7632 46.6818,-0.7591 46.6833,-0.7559 46.6827,-0.7537 46.6839,-0.7513 46.6868,-0.7472 46.6877,-0.7437 46.6875,-0.7414 46.6882,-0.7314 46.6866,-0.7326 46.6848,-0.726 46.6817,-0.721 46.6807,-0.7179 46.6808,-0.7156 46.6789,-0.713 46.6742,-0.7051 46.6722,-0.6985 46.6697,-0.6912 46.6685,-0.6874 46.6659,-0.6852 46.6661,-0.6842 46.664,-0.6791 46.6656,-0.6753 46.6651,-0.6708 46.6662,-0.6709 46.6681,-0.6659 46.6725,-0.6622 46.674,-0.658 46.6768,-0.6519 46.6736,-0.6472 46.6705,-0.6417 46.6641,-0.637 46.6634,-0.6415 46.6602,-0.6453 46.6587,-0.6491 46.6562,-0.6483 46.6479,-0.649 46.6454,-0.6594 46.6402,-0.6597 46.6387,-0.6571 46.6342,-0.6534 46.6368,-0.6486 46.637,-0.6436 46.6383,-0.6349 46.6376,-0.6293 46.6346,-0.6237 46.6336,-0.6246 46.6305,-0.6191 46.6255,-0.615 46.6229,-0.6141 46.6205,-0.6167 46.6198,-0.6194 46.6154,-0.6231 46.6115,-0.6243 46.6062,-0.6269 46.6056,-0.6335 46.6057,-0.6366 46.6051,-0.6352 46.6093,-0.6394 46.6107,-0.6426 46.6091,-0.6456 46.6108,-0.6484 46.6155,-0.6499 46.6149,-0.6517 46.6099,-0.6574 46.6071,-0.6603 46.6089,-0.6641 46.6139,-0.6661 46.6181,-0.6648 46.6243,-0.6739 46.6274,-0.6761 46.6289,-0.6774 46.6315,-0.6915 46.634,-0.6938 46.633,-0.6997 46.6339,-0.7023 46.6316,-0.7133 46.631,-0.7106 46.6365)) ; nom: La Tardière => Terval ; population: 1327 => 1332 ; siren: 218502896 => 200099489
[info] Important changes for Insee 97301. arrondissement_insee: 9731 => 9733 ; geom: SRID=4326;MULTIPOLYGON(((-51.7476 4.4471,-51.802 4.4405,-51.8082 4.4407,-51.8109 4.4399,-51.8155 4.437,-51.8402 4.434,-51.8435 4.4334,-51.8538 4.4299,-51.8574 4.4276,-51.8584 4.4257,-51.8628 4.4217,-51.8612 4.4187,-51.8599 4.4138,-51.863 4.4082,-51.8624 4.3975,-51.8606 4.3716,-51.8602 4.3612,-51.8644 4.3557,-51.8659 4.3546,-51.87 4.3494,-51.8699 4.3456,-51.8683 4.3431,-51.8612 4.3402,-51.8594 4.334,-51.8582 4.3315,-51.8646 4.3097,-51.8562 4.2655,-51.8532 4.249,-51.8512 4.2448,-51.85 4.2406,-51.8515 4.2375,-51.8506 4.2322,-51.8516 4.2309,-51.8509 4.2219,-51.8511 4.2151,-51.8528 4.2118,-51.8514 4.2096,-51.8451 4.2071,-51.8427 4.2052,-51.8402 4.2053,-51.8378 4.2071,-51.8348 4.2066,-51.8326 4.2078,-51.8309 4.2073,-51.8296 4.2054,-51.8256 4.2045,-51.8228 4.2053,-51.8203 4.2035,-51.8174 4.1974,-51.8145 4.1963,-51.8114 4.1976,-51.8102 4.1966,-51.8094 4.1909,-51.8077 4.1872,-51.8066 4.1807,-51.8102 4.1766,-51.8136 4.1759,-51.815 4.1728,-51.8203 4.1707,-51.827 4.1719,-51.8304 4.1732,-51.8337 4.1719,-51.8349 4.1698,-51.8377 4.1674,-51.8368 4.1639,-51.8373 4.1596,-51.8405 4.1568,-51.8447 4.1557,-51.8475 4.1567,-51.8479 4.1588,-51.8475 4.1628,-51.8484 4.1636,-51.852 4.1614,-51.8558 4.1628,-51.8584 4.1629,-51.8599 4.1645,-51.8624 4.1636,-51.8657 4.1604,-51.868 4.1591,-51.872 4.1585,-51.8733 4.1591,-51.8755 4.1632,-51.8764 4.1635,-51.8809 4.1612,-51.8852 4.1621,-51.8901 4.1602,-51.8914 4.1585,-51.8954 4.1572,-51.8969 4.1528,-51.8956 4.1481,-51.8959 4.1425,-51.8964 4.1405,-51.8983 4.1381,-51.9001 4.1376,-51.9025 4.1388,-51.9048 4.1377,-51.9075 4.1321,-51.9102 4.1321,-51.9134 4.1282,-51.9183 4.1265,-51.9227 4.1269,-51.9271 4.129,-51.9266 4.1341,-51.9298 4.1353,-51.9317 4.1343,-51.9333 4.1349,-51.9367 4.1397,-51.9382 4.1442,-51.9423 4.1457,-51.9431 4.1482,-51.9501 4.1568,-51.9516 4.1574,-51.9551 4.1564,-51.9575 4.1542,-51.9607 4.1483,-51.965 4.1435,-51.9667 4.143,-51.969 4.147,-51.971 4.1478,-51.9739 4.1445,-51.9771 4.1426,-51.9794 4.1424,-51.9842 4.1434,-51.9864 4.1422,-51.9905 4.1336,-51.997 4.1331,-51.998 4.1319,-51.9985 4.1276,-52.001 4.1234,-51.9994 4.1209,-51.9997 4.1171,-52.0009 4.1144,-52.0032 4.1125,-52.0064 4.1115,-52.0099 4.1056,-52.0105 4.1006,-52.0095 4.0972,-52.0112 4.0947,-52.0104 4.0933,-52.0074 4.0944,-52.0037 4.095,-51.9994 4.0939,-51.9981 4.0917,-51.9934 4.0884,-51.9915 4.0876,-51.9908 4.0827,-51.9937 4.0776,-51.9955 4.076,-51.9947 4.0741,-51.9949 4.0704,-51.991 4.0691,-51.9901 4.0636,-51.988 4.062,-51.9862 4.0624,-51.9836 4.0646,-51.9823 4.0644,-51.9816 4.0619,-51.9794 4.0591,-51.9776 4.0587,-51.9778 4.0532,-51.976 4.0445,-51.9734 4.0375,-51.9718 4.0343,-51.9706 4.0296,-51.9715 4.0277,-51.971 4.0259,-51.9677 4.0228,-51.9665 4.0206,-51.9658 4.0119,-51.9638 4.0104,-51.9628 4.008,-51.963 4.0037,-51.969 4.0022,-51.9722 3.9982,-51.9763 3.9972,-51.9776 3.9955,-51.9814 3.9948,-51.9834 3.9956,-51.9871 3.9947,-51.9913 3.9951,-51.9945 3.9962,-51.996 3.9944,-51.9966 3.9905,-51.9999 3.9858,-52.0022 3.9883,-52.0038 3.9885,-52.0062 3.9864,-52.0087 3.9851,-52.0121 3.9817,-52.0129 3.9796,-52.0123 3.9776,-52.0092 3.9719,-52.0085 3.9678,-52.0089 3.9666,-52.0131 3.9696,-52.0144 3.9729,-52.0161 3.9733,-52.021 3.9694,-52.0235 3.9708,-52.0245 3.9733,-52.0269 3.9755,-52.0279 3.9776,-52.0303 3.98,-52.0302 3.983,-52.0313 3.9865,-52.0327 3.9884,-52.0351 3.989,-52.0377 3.9874,-52.0415 3.9832,-52.0428 3.9805,-52.049 3.9819,-52.054 3.9815,-52.0553 3.9797,-52.0548 3.9732,-52.0586 3.9705,-52.058 3.9683,-52.0594 3.9629,-52.0615 3.9624,-52.0635 3.966,-52.0656 3.9684,-52.0676 3.9684,-52.0681 3.964,-52.0699 3.9625,-52.0718 3.9628,-52.0733 3.9601,-52.079 3.9614,-52.0802 3.959,-52.08 3.9539,-52.078 3.9471,-52.0808 3.9425,-52.0837 3.9408,-52.083 3.9381,-52.0847 3.9377,-52.0871 3.9415,-52.0894 3.944,-52.0899 3.9459,-52.0894 3.9489,-52.0852 3.9545,-52.0884 3.9597,-52.0884 3.9654,-52.0897 3.9683,-52.0952 3.9715,-52.0985 3.9748,-52.1014 3.9754,-52.1034 3.9731,-52.1052 3.973,-52.1069 3.9746,-52.1087 3.9779,-52.111 3.9844,-52.1127 3.9861,-52.1158 3.9858,-52.1166 3.9911,-52.118 3.9953,-52.12 3.9977,-52.1223 3.9961,-52.1239 3.9923,-52.1256 3.9905,-52.1253 3.9874,-52.1268 3.9851,-52.1265 3.982,-52.1248 3.9802,-52.1252 3.9774,-52.1304 3.9751,-52.1304 3.9723,-52.134 3.9703,-52.1352 3.9662,-52.1336 3.9631,-52.1352 3.9599,-52.1348 3.9578,-52.1329 3.9537,-52.1334 3.9511,-52.1311 3.947,-52.1306 3.9451,-52.1324 3.9418,-52.1328 3.9394,-52.136 3.938,-52.1382 3.9395,-52.1402 3.9392,-52.1442 3.9371,-52.1495 3.9365,-52.1509 3.9352,-52.1518 3.9289,-52.15 3.9232,-52.1543 3.9227,-52.1552 3.9191,-52.1556 3.9152,-52.1554 3.9103,-52.1592 3.9086,-52.1613 3.9098,-52.1633 3.9073,-52.1636 3.8995,-52.1646 3.8985,-52.1699 3.8987,-52.1725 3.8977,-52.1743 3.896,-52.1778 3.8957,-52.1843 3.8926,-52.1875 3.8933,-52.1901 3.8927,-52.1957 3.8959,-52.197 3.8992,-52.1995 3.899,-52.2014 3.8938,-52.2043 3.8944,-52.2048 3.8988,-52.2065 3.9006,-52.2128 3.9034,-52.2144 3.9035,-52.2175 3.902,-52.2175 3.9003,-52.215 3.8955,-52.2168 3.891,-52.2136 3.8903,-52.2137 3.8877,-52.2162 3.8846,-52.2159 3.8823,-52.2178 3.8798,-52.2207 3.8771,-52.223 3.8784,-52.229 3.8743,-52.2316 3.8704,-52.2311 3.8656,-52.2317 3.8638,-52.2341 3.8623,-52.2344 3.8577,-52.2373 3.8554,-52.2377 3.8524,-52.2393 3.8522,-52.2409 3.8537,-52.2433 3.8531,-52.2444 3.8493,-52.2475 3.8486,-52.2538 3.8541,-52.2702 3.8214,-52.2818 3.8151,-52.2858 3.8185,-52.3111 3.8083,-52.3161 3.8135,-52.3318 3.8035,-52.3478 3.8108,-52.3509 3.8033,-52.3752 3.8084,-52.3792 3.7948,-52.3832 3.7891,-52.3868 3.7673,-52.3804 3.7598,-52.3881 3.7073,-52.3857 3.6898,-52.3883 3.6831,-52.395 3.6725,-52.4057 3.6673,-52.4103 3.6551,-52.4326 3.6492,-52.4467 3.6515,-52.4534 3.6492,-52.4624 3.6404,-52.4679 3.6439,-52.4787 3.6659,-52.4844 3.6402,-52.4882 3.631,-52.4931 3.618,-52.4907 3.5779,-52.5035 3.5425,-52.5183 3.5239,-52.5309 3.51,-52.5284 3.5027,-52.5207 3.5013,-52.5076 3.5051,-52.5013 3.5043,-52.4988 3.5002,-52.5011 3.4946,-52.5136 3.4873,-52.5348 3.4827,-52.5507 3.4782,-52.5542 3.4735,-52.5534 3.4626,-52.5463 3.4556,-52.5433 3.4476,-52.5449 3.4361,-52.5525 3.4146,-52.5539 3.3963,-52.5523 3.378,-52.5518 3.3636,-52.5579 3.3541,-52.6106 3.3389,-52.6208 3.3389,-52.6318 3.3411,-52.639 3.3357,-52.6405 3.3227,-52.634 3.2999,-52.6205 3.2788,-52.616 3.2755,-52.6086 3.277,-52.6056 3.2706,-52.6116 3.2623,-52.6256 3.2525,-52.6337 3.2398,-52.6501 3.2332,-52.6621 3.2221,-52.6724 3.2108,-52.6763 3.1999,-52.6812 3.1899,-52.6933 3.1925,-52.7001 3.1984,-52.7107 3.1992,-52.7231 3.1933,-52.7296 3.1951,-52.7384 3.2024,-52.7464 3.2065,-52.758 3.2068,-52.7639 3.2096,-52.7736 3.2274,-52.7723 3.2319,-52.7615 3.2439,-52.758 3.2557,-52.767 3.2674,-52.7881 3.2862,-52.8054 3.2953,-52.82 3.2986,-52.8285 3.2929,-52.8478 3.2732,-52.8577 3.2707,-52.8813 3.2749,-52.8926 3.2729,-52.9025 3.273,-52.9333 3.294,-52.9553 3.2957,-52.9779 3.3039,-52.9888 3.3043,-53.0008 3.3034,-53.0106 3.2997,-53.0178 3.2993,-53.0299 3.3051,-53.0365 3.305,-53.0464 3.2999,-53.0589 3.2998,-53.0648 3.298,-53.0699 3.2893,-53.0729 3.2784,-53.0655 3.2597,-53.0711 3.2426,-53.0803 3.2136,-53.0878 3.204,-53.0978 3.2053,-53.1014 3.2116,-53.1009 3.2299,-53.1039 3.2368,-53.1123 3.2502,-53.111 3.2636,-53.1182 3.2635,-53.1371 3.2702,-53.1457 3.2758,-53.171 3.3167,-53.1591 3.3341,-53.1533 3.3503,-53.1548 3.3616,-53.1615 3.3823,-53.162 3.3944,-53.1575 3.4069,-53.147 3.4144,-53.1343 3.423,-53.1251 3.4271,-53.1214 3.4342,-53.1275 3.4435,-53.1252 3.4501,-53.1265 3.4608,-53.1392 3.4717,-53.1429 3.4782,-53.138 3.4874,-53.1295 3.5018,-53.1285 3.5143,-53.1234 3.521,-53.1067 3.5332,-53.0984 3.5468,-53.0974 3.5641,-53.1027 3.5792,-53.1017 3.5869,-53.094 3.5937,-53.0862 3.6014,-53.0889 3.6094,-53.1001 3.6155,-53.1089 3.6135,-53.1159 3.6053,-53.122 3.601,-53.1341 3.6065,-53.1372 3.6134,-53.1298 3.6253,-53.1273 3.6352,-53.1337 3.6889,-53.1394 3.7019,-53.1633 3.7261,-53.1753 3.7427,-53.1786 3.7553,-53.1835 3.7619,-53.1977 3.7644,-53.2049 3.7694,-53.2112 3.7791,-53.2213 3.7915,-53.2284 3.8016,-53.2276 3.8099,-53.2155 3.813,-53.2052 3.8113,-53.1964 3.8164,-53.1941 3.8256,-53.1699 3.8497,-53.1608 3.8582, (truncated)
[info] Important changes for Insee 97308. arrondissement_insee: 9731 => 9733 ; population: 4245 => 4303
[info] Important changes for Insee 97314. arrondissement_insee: 9731 => 9733 ; geom: SRID=4326;POLYGON((-51.963 4.0037,-51.9628 4.008,-51.9638 4.0104,-51.9658 4.0119,-51.9665 4.0206,-51.9677 4.0228,-51.971 4.0259,-51.9715 4.0277,-51.9706 4.0296,-51.9718 4.0343,-51.9734 4.0375,-51.976 4.0445,-51.9778 4.0532,-51.9776 4.0587,-51.9794 4.0591,-51.9816 4.0619,-51.9823 4.0644,-51.9836 4.0646,-51.9862 4.0624,-51.988 4.062,-51.9901 4.0636,-51.991 4.0691,-51.9949 4.0704,-51.9947 4.0741,-51.9955 4.076,-51.9937 4.0776,-51.9908 4.0827,-51.9915 4.0876,-51.9934 4.0884,-51.9981 4.0917,-51.9994 4.0939,-52.0037 4.095,-52.0074 4.0944,-52.0104 4.0933,-52.0112 4.0947,-52.0095 4.0972,-52.0105 4.1006,-52.0099 4.1056,-52.0064 4.1115,-52.0032 4.1125,-52.0009 4.1144,-51.9997 4.1171,-51.9994 4.1209,-52.001 4.1234,-51.9985 4.1276,-51.998 4.1319,-51.997 4.1331,-51.9905 4.1336,-51.9864 4.1422,-51.9842 4.1434,-51.9794 4.1424,-51.9771 4.1426,-51.9739 4.1445,-51.971 4.1478,-51.969 4.147,-51.9667 4.143,-51.965 4.1435,-51.9607 4.1483,-51.9575 4.1542,-51.9551 4.1564,-51.9516 4.1574,-51.9501 4.1568,-51.9431 4.1482,-51.9423 4.1457,-51.9382 4.1442,-51.9367 4.1397,-51.9333 4.1349,-51.9317 4.1343,-51.9298 4.1353,-51.9266 4.1341,-51.9271 4.129,-51.9227 4.1269,-51.9183 4.1265,-51.9134 4.1282,-51.9102 4.1321,-51.9075 4.1321,-51.9048 4.1377,-51.9025 4.1388,-51.9001 4.1376,-51.8983 4.1381,-51.8964 4.1405,-51.8959 4.1425,-51.8956 4.1481,-51.8969 4.1528,-51.8954 4.1572,-51.8914 4.1585,-51.8901 4.1602,-51.8852 4.1621,-51.8809 4.1612,-51.8764 4.1635,-51.8755 4.1632,-51.8733 4.1591,-51.872 4.1585,-51.868 4.1591,-51.8657 4.1604,-51.8624 4.1636,-51.8599 4.1645,-51.8584 4.1629,-51.8558 4.1628,-51.852 4.1614,-51.8484 4.1636,-51.8475 4.1628,-51.8479 4.1588,-51.8475 4.1567,-51.8447 4.1557,-51.8405 4.1568,-51.8373 4.1596,-51.8368 4.1639,-51.8377 4.1674,-51.8349 4.1698,-51.8337 4.1719,-51.8304 4.1732,-51.827 4.1719,-51.8203 4.1707,-51.815 4.1728,-51.8136 4.1759,-51.8102 4.1766,-51.8066 4.1807,-51.8077 4.1872,-51.8094 4.1909,-51.8102 4.1966,-51.8114 4.1976,-51.8145 4.1963,-51.8174 4.1974,-51.8203 4.2035,-51.8228 4.2053,-51.8256 4.2045,-51.8296 4.2054,-51.8309 4.2073,-51.8326 4.2078,-51.8348 4.2066,-51.8378 4.2071,-51.8402 4.2053,-51.8427 4.2052,-51.8451 4.2071,-51.8514 4.2096,-51.8528 4.2118,-51.8511 4.2151,-51.8509 4.2219,-51.8516 4.2309,-51.8506 4.2322,-51.8515 4.2375,-51.85 4.2406,-51.8512 4.2448,-51.8532 4.249,-51.8562 4.2655,-51.8646 4.3097,-51.8582 4.3315,-51.8594 4.334,-51.8612 4.3402,-51.8683 4.3431,-51.8699 4.3456,-51.87 4.3494,-51.8659 4.3546,-51.8644 4.3557,-51.8602 4.3612,-51.8606 4.3716,-51.8624 4.3975,-51.863 4.4082,-51.8599 4.4138,-51.8612 4.4187,-51.8628 4.4217,-51.8584 4.4257,-51.8574 4.4276,-51.8538 4.4299,-51.8435 4.4334,-51.8402 4.434,-51.8155 4.437,-51.8109 4.4399,-51.8082 4.4407,-51.802 4.4405,-51.7476 4.4471,-51.7482 4.4432,-51.7474 4.4418,-51.7476 4.4389,-51.7521 4.4377,-51.7529 4.4343,-51.7518 4.4292,-51.7548 4.4251,-51.7533 4.4226,-51.7524 4.4182,-51.7504 4.4193,-51.749 4.4169,-51.7465 4.416,-51.7423 4.4126,-51.74 4.4095,-51.7404 4.4072,-51.7378 4.4046,-51.7358 4.4045,-51.7308 4.4009,-51.7272 4.3977,-51.7243 4.3969,-51.72 4.3941,-51.7145 4.3921,-51.7108 4.3878,-51.7045 4.3899,-51.7027 4.3899,-51.7013 4.3936,-51.6996 4.3961,-51.6951 4.3949,-51.6922 4.3951,-51.6912 4.3932,-51.6914 4.3898,-51.693 4.3854,-51.6918 4.3834,-51.6935 4.3822,-51.6959 4.3834,-51.6985 4.3832,-51.7017 4.3816,-51.7054 4.3784,-51.7077 4.3756,-51.7091 4.3703,-51.7112 4.3648,-51.7134 4.3641,-51.714 4.362,-51.7159 4.3607,-51.7181 4.3572,-51.7193 4.3517,-51.7192 4.3489,-51.7182 4.3453,-51.7184 4.3404,-51.7164 4.3303,-51.7146 4.3264,-51.7137 4.3225,-51.7105 4.3124,-51.7085 4.3101,-51.7072 4.305,-51.7031 4.2971,-51.7 4.2929,-51.6985 4.29,-51.6962 4.2882,-51.692 4.2821,-51.689 4.2764,-51.6839 4.2713,-51.6803 4.2696,-51.6777 4.267,-51.6794 4.2659,-51.68 4.2612,-51.6759 4.2538,-51.6715 4.2495,-51.6672 4.2472,-51.6642 4.247,-51.6622 4.244,-51.661 4.2439,-51.6591 4.2385,-51.6597 4.2373,-51.6575 4.2348,-51.6574 4.2331,-51.6609 4.2266,-51.6594 4.2259,-51.6556 4.2262,-51.6511 4.2236,-51.6452 4.2177,-51.6444 4.2161,-51.6408 4.2128,-51.6826 4.1559,-51.6953 4.1389,-51.7018 4.1344,-51.7035 4.1354,-51.7055 4.135,-51.707 4.1331,-51.7098 4.1313,-51.7099 4.13,-51.7051 4.1279,-51.704 4.1253,-51.7045 4.1212,-51.706 4.1195,-51.7095 4.1174,-51.7128 4.1144,-51.7148 4.1109,-51.715 4.1061,-51.713 4.1046,-51.7023 4.1045,-51.6984 4.1034,-51.6952 4.1011,-51.694 4.098,-51.6934 4.0946,-51.6936 4.0903,-51.6965 4.0818,-51.6995 4.0779,-51.7067 4.0744,-51.7142 4.072,-51.7188 4.0709,-51.7218 4.0696,-51.7263 4.0646,-51.7288 4.061,-51.7326 4.0599,-51.737 4.0578,-51.7397 4.0534,-51.7502 4.0527,-51.7521 4.0496,-51.7511 4.0482,-51.7526 4.0433,-51.7546 4.0421,-51.7575 4.0428,-51.7623 4.0401,-51.7709 4.0421,-51.7739 4.0449,-51.7772 4.0435,-51.7822 4.0422,-51.7861 4.0425,-51.788 4.041,-51.7875 4.0371,-51.7903 4.0334,-51.7935 4.0315,-51.7941 4.0298,-51.7919 4.0277,-51.7906 4.0233,-51.7915 4.02,-51.7914 4.0174,-51.7943 4.0146,-51.7916 4.0118,-51.7893 4.0119,-51.789 4.0094,-51.7863 4.0096,-51.783 4.0075,-51.7819 4.003,-51.7853 4.0014,-51.7876 4.0013,-51.7902 4.0025,-51.7941 4.0009,-51.795 3.997,-51.7971 3.9967,-51.7976 3.9931,-51.8015 3.9922,-51.8035 3.9906,-51.8066 3.9894,-51.8077 3.9869,-51.8117 3.9872,-51.8136 3.9893,-51.8162 3.9897,-51.8164 3.9927,-51.818 3.9935,-51.8203 3.9926,-51.8215 3.99,-51.8245 3.9897,-51.8282 3.9933,-51.8308 3.9928,-51.832 3.9898,-51.8337 3.9893,-51.836 3.9912,-51.8374 3.9897,-51.8459 3.9888,-51.8471 3.9908,-51.8492 3.9894,-51.8527 3.9896,-51.8531 3.9861,-51.8553 3.9817,-51.854 3.9801,-51.8547 3.9765,-51.8562 3.9762,-51.8589 3.9798,-51.8616 3.9777,-51.8621 3.9747,-51.8635 3.974,-51.8676 3.9781,-51.8733 3.9761,-51.8749 3.9777,-51.8761 3.9805,-51.8801 3.982,-51.882 3.9809,-51.8832 3.9824,-51.8856 3.9818,-51.8876 3.9841,-51.89 3.9857,-51.8908 3.9893,-51.8935 3.9902,-51.8967 3.9903,-51.9002 3.9887,-51.9042 3.9895,-51.9103 3.9924,-51.9113 3.9955,-51.9133 3.9978,-51.9154 3.9991,-51.9207 3.9995,-51.9229 4.0025,-51.9284 4.002,-51.9308 4.0034,-51.9328 4.0015,-51.9341 3.9964,-51.9386 3.9969,-51.9375 4.0001,-51.9385 4.0048,-51.9399 4.005,-51.9428 4.0026,-51.9432 3.9988,-51.9441 3.9975,-51.9478 3.9973,-51.9502 3.9996,-51.9532 3.9991,-51.9557 4.0022,-51.9582 4.0039,-51.9615 4.0031,-51.963 4.0037)) => SRID=4326;POLYGON((-51.963 4.0037,-51.9628 4.008,-51.9638 4.0104,-51.9658 4.0119,-51.9665 4.0206,-51.9677 4.0228,-51.971 4.0259,-51.9715 4.0277,-51.9706 4.0296,-51.9718 4.0343,-51.9734 4.0375,-51.976 4.0445,-51.9778 4.0532,-51.9776 4.0587,-51.9794 4.0591,-51.9816 4.0619,-51.9823 4.0644,-51.9836 4.0646,-51.9862 4.0624,-51.988 4.062,-51.9901 4.0636,-51.991 4.0691,-51.9949 4.0704,-51.9947 4.0741,-51.9955 4.076,-51.9937 4.0776,-51.9908 4.0827,-51.9915 4.0876,-51.9934 4.0884,-51.9981 4.0917,-51.9994 4.0939,-52.0037 4.095,-52.0074 4.0944,-52.0104 4.0933,-52.0112 4.0947,-52.0095 4.0972,-52.0105 4.1006,-52.0099 4.1056,-52.0064 4.1115,-52.0032 4.1125,-52.0009 4.1144,-51.9997 4.1171,-51.9994 4.1209,-52.001 4.1234,-51.9985 4.1276,-51.998 4.1319,-51.997 4.1331,-51.9905 4.1336,-51.9864 4.1422,-51.9842 4.1434,-51.9794 4.1424,-51.9771 4.1426,-51.9739 4.1445,-51.971 4.1478,-51.969 4.147,-51.9667 4.143,-51.965 4.1435,-51.9607 4.1483,-51.9575 4.1542,-51.9551 4.1564,-51.9516 4.1574,-51.9501 4.1568,-51.9431 4.1482,-51.9423 4.1457,-51.9382 4.1442,-51.9367 4.1397,-51.9333 4.1349,-51.9317 4.1343,-51.9298 4.1353,-51.9266 4.1341,-51.9271 4.129,-51.9227 4.1269,-51.9183 4.1265,-51.9134 4.1282,-51.9102 4.1321,-51.9075 4.1321,-51.9048 4.1377,-51.9025 4.1388,-51.9001 4.1376,-51.8983 4.1381,-51.8964 4.1405,-51.8959 4.1425,-51.8956 4.1481,-51.8969 4.1528,-51.8954 4.1572,-51.8914 4.1585,-51.8901 4.1602,-51.8852 4.1621,-51.8809 4.1612,-51.8764 4.1635,-51.8755 4.1632,-51.8733 4.1591,-51.872 4.1585,-51.868 4.1591,-51.8657 4.1604,-51.8624 4.1636,-51.8599 4.1645,-51.8584 4.1629,-51.8558 4.1628,-51.852 4.1614,-51.8484 4.1636,-51.8475 4.1628,-51.8479 4.1588,-51.8475 4.1567,-51.8447 4.1557,-51.8405 4.1568,-51.8373 4.1596,-51.8368 4.1639,-51.8377 4.1674,-51.8349 4.1698,-51.8337 4.1719,-51.8304 (truncated)
[info] Important changes for Insee 97356. arrondissement_insee: 9731 => 9733 ; population: 1864 => 1894
[info] Important changes for Insee 98818. siren: 200012508 => 
[info] Finished. Count of changes: %{arrondissement_insee: 33, departement_insee: 1, geom: 725, insee: 1, nom: 22, population: 31890, region_id: 1, siren: 10}
[info] Ensure valid geometries and rectify if needed.
[info] Enabling trigger and refreshing views.
```
