### PR TITLE
DocumentationLinksTest : facilite le debug

### DIFF
--- a/apps/transport/test/documentation_links_test.exs
+++ b/apps/transport/test/documentation_links_test.exs
@@ -4,23 +4,39 @@ defmodule Transport.DocumentationLinksTest do
   @documentation_domain "doc.transport.data.gouv.fr"
 
   test "documentation links are valid" do
+    urls = documentation_urls()
+
+    refute Enum.empty?(urls), "We should find #{@documentation_domain} URLs in our codebase"
+
+    failures =
+      urls
+      |> Enum.map(fn url ->
+        case HTTPoison.head(url) do
+          {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in [200, 302] -> :success
+          response -> {:error, url, response}
+        end
+      end)
+      |> Enum.reject(&(&1 == :success))
+
+    message = """
+    Unexpected HTTP responses for:
+    #{failures |> Enum.map_join("\n - ", fn {:error, url, _response} -> url end)}
+
+    Debug:
+    #{inspect(failures)}
+    """
+
+    assert Enum.empty?(failures), message
+  end
+
+  defp documentation_urls do
     regexp = ~r/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/
     {output, 0} = System.shell("grep -r #{@documentation_domain} ../../apps/transport/lib")
 
-    failures =
-      regexp
-      |> Regex.scan(output)
-      |> Enum.filter(fn [url | _] -> String.contains?(url, @documentation_domain) end)
-      |> Enum.map(fn [url | _] -> url |> URI.parse() |> Map.replace!(:fragment, nil) |> URI.to_string() end)
-      |> Enum.uniq()
-      |> Enum.map(fn url -> {HTTPoison.head(url), url} end)
-      |> Enum.reject(fn {response, _} ->
-        case response do
-          {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in [200, 302] -> true
-          _ -> false
-        end
-      end)
-
-    assert [] == failures, "Unexpected status codes for:\n#{Enum.map_join(failures, "\n", &elem(&1, 1))}"
+    regexp
+    |> Regex.scan(output)
+    |> Enum.filter(fn [url | _] -> String.contains?(url, @documentation_domain) end)
+    |> Enum.map(fn [url | _] -> url |> URI.parse() |> Map.replace!(:fragment, nil) |> URI.to_string() end)
+    |> Enum.uniq()
   end
 end


### PR DESCRIPTION
Nous [avons constaté](https://mattermost.incubateur.net/betagouv/pl/s88dq6fan3rw7dok6z1kwag87c) que ces tests ont fail plusieurs fois aujourd'hui en CI et l'output des tests ne permet pas de savoir la cause du problème.

Cette PR ajoute plus de détails pour comprendre le problème, qui n'a pas été reproduit localement.