### PR TITLE
Crontab Oban : vérifie que les modules existent

### DIFF
--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -70,7 +70,7 @@ defmodule DB.DataConversion do
     delete_data_conversions(conversions)
 
     %{"dataset_id" => dataset_id}
-    |> Transport.Jobs.DatasetGtfsToNetexConverterJob.new()
+    |> Transport.Jobs.DatasetGTFSToNeTExConverterJob.new()
     |> Oban.insert()
   end
 

--- a/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/gtfs_to_netex_converter_job.ex
@@ -1,4 +1,4 @@
-defmodule Transport.Jobs.GtfsToNetexConverterJob do
+defmodule Transport.Jobs.GTFSToNeTExConverterJob do
   @moduledoc """
   This will enqueue GTFS -> NeTEx conversion jobs for all GTFS resources found in ResourceHistory
   """
@@ -7,11 +7,11 @@ defmodule Transport.Jobs.GtfsToNetexConverterJob do
 
   @impl true
   def perform(%{}) do
-    GTFSGenericConverter.enqueue_all_conversion_jobs("NeTEx", Transport.Jobs.SingleGtfsToNetexConverterJob)
+    GTFSGenericConverter.enqueue_all_conversion_jobs("NeTEx", Transport.Jobs.SingleGTFSToNeTExConverterJob)
   end
 end
 
-defmodule Transport.Jobs.SingleGtfsToNetexConverterJob do
+defmodule Transport.Jobs.SingleGTFSToNeTExConverterJob do
   @moduledoc """
   Conversion Job of a GTFS to a NeTEx, saving the resulting file in S3
   """
@@ -31,7 +31,7 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJob do
   end
 end
 
-defmodule Transport.Jobs.DatasetGtfsToNetexConverterJob do
+defmodule Transport.Jobs.DatasetGTFSToNeTExConverterJob do
   @moduledoc """
   This will enqueue GTFS -> NeTEx conversions jobs for all GTFS resources linked to a dataset, but only for the most recent resource history
   """

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -151,7 +151,7 @@ defmodule DB.DataConversionTest do
 
     # list candidate resource history for future conversions
     resource_history_ids =
-      dataset.id |> Transport.Jobs.DatasetGtfsToNetexConverterJob.list_gtfs_last_resource_history() |> Enum.sort()
+      dataset.id |> Transport.Jobs.DatasetGTFSToNeTExConverterJob.list_gtfs_last_resource_history() |> Enum.sort()
 
     assert [resource_history_1.id, resource_history_2.id] == resource_history_ids
   end
@@ -180,7 +180,7 @@ defmodule DB.DataConversionTest do
 
     # new conversion is enqueued
     assert_enqueued(
-      worker: Transport.Jobs.DatasetGtfsToNetexConverterJob,
+      worker: Transport.Jobs.DatasetGTFSToNeTExConverterJob,
       args: %{"dataset_id" => dataset.id}
     )
   end

--- a/apps/transport/test/transport/jobs/single_gtfs_to_netex_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/single_gtfs_to_netex_converter_job_test.exs
@@ -1,9 +1,9 @@
-defmodule Transport.Jobs.SingleGtfsToNetexConverterJobTest do
+defmodule Transport.Jobs.SingleGTFSToNeTExConverterJobTest do
   use ExUnit.Case, async: true
   use Oban.Testing, repo: DB.Repo
   import DB.Factory
   import Mox
-  alias Transport.Jobs.SingleGtfsToNetexConverterJob
+  alias Transport.Jobs.SingleGTFSToNeTExConverterJob
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
@@ -19,7 +19,7 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJobTest do
 
     # no mox expectation set, and the test passes => conversion is properly skipped
     assert {:cancel, "Conversion is not needed"} ==
-             perform_job(SingleGtfsToNetexConverterJob, %{"resource_history_id" => resource_history_id})
+             perform_job(SingleGTFSToNeTExConverterJob, %{"resource_history_id" => resource_history_id})
   end
 
   test "launch a NeTEx conversion" do
@@ -66,7 +66,7 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJobTest do
 
     # job succeed
     assert :ok ==
-             perform_job(SingleGtfsToNetexConverterJob, %{"resource_history_id" => resource_history_id})
+             perform_job(SingleGTFSToNeTExConverterJob, %{"resource_history_id" => resource_history_id})
 
     # a data_conversion row is recorded ✌️‍
     assert %DB.DataConversion{payload: %{"filesize" => 41, "filename" => "conversions/gtfs-to-netex/fff.netex.zip"}} =
@@ -111,7 +111,7 @@ defmodule Transport.Jobs.SingleGtfsToNetexConverterJobTest do
       {:error, "conversion failed"}
     end)
 
-    assert {:cancel, _} = perform_job(SingleGtfsToNetexConverterJob, %{"resource_history_id" => resource_history_id})
+    assert {:cancel, _} = perform_job(SingleGTFSToNeTExConverterJob, %{"resource_history_id" => resource_history_id})
 
     # ResourceHistory's payload is updated with the error information
     expected_payload =


### PR DESCRIPTION
Répare un bug introduit dans #3549, un job a été renommé et ceci n'a pas été répliqué dans la configuration runtime de la crontab.

On obtient l'erreur suivante en production au boot.

```
2023-10-23T17:59:45+02:00 [os_mon] memory supervisor port (memsup): Erlang has closed
2023-10-23T17:59:45+02:00 (oban 2.15.4) lib/oban/config.ex:88: Oban.Config.new/1
2023-10-23T17:59:45+02:00 ** (ArgumentError) Transport.Jobs.GtfsToGeojsonConverterJob not found or can't be loaded
2023-10-23T17:59:45+02:00 (oban 2.15.4) lib/oban.ex:226: Oban.start_link/1
```

Je fais un fix rapide avec un check en utilisant [Code.ensure_compiled!](https://hexdocs.pm/elixir/Code.html#ensure_compiled!/1) mais je pense regarder un peu plus ensuite, voir demander conseil côté Oban.