### PR TITLE
Backoffice : répare 500 sur dataset#new

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -1,10 +1,10 @@
-<% contacts_in_org = Enum.sort_by(@dataset.organization_object.contacts, &DB.Contact.display_name/1) %>
 <div class="pt-48">
   <%= live_render(@conn, TransportWeb.EditDatasetLive,
     session: %{"dataset" => @dataset, "dataset_types" => @dataset_types, "regions" => @regions}
   ) %>
 
   <%= unless is_nil(@dataset) do %>
+    <% contacts_in_org = Enum.sort_by(@dataset.organization_object.contacts, &DB.Contact.display_name/1) %>
     <div class="is-centered mt-48">
       <%= dgettext("backoffice", "Other actions on the dataset") %>
     </div>

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -53,6 +53,13 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     assert [] == PageController.dataset_with_resource_under_90_availability()
   end
 
+  test "can load the dataset#new page", %{conn: conn} do
+    conn
+    |> setup_admin_in_session()
+    |> get(Routes.backoffice_page_path(conn, :new))
+    |> html_response(200)
+  end
+
   test "outdated datasets filter", %{conn: conn} do
     insert_outdated_resource_and_friends(custom_title: "un dataset outdated")
     insert_up_to_date_resource_and_friends(custom_title: "un dataset bien à jour")


### PR DESCRIPTION
Répare un bug introduit dans #3525, il y a 2 semaines !?! 🤔

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/4570684508/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream&stream_index=1)

```
lib/transport_web/templates/backoffice/page/form_dataset.html.heex in anonymous fn/2 in TransportWeb.Backoffice.PageView."form_dataset.html"/1 at line 1
lib/phoenix_live_view/engine.ex in Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/1 at line 137
lib/phoenix_live_view/engine.ex in Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/3 at line 153
lib/phoenix/controller.ex in Phoenix.Controller.render_and_send/4 at line 772
lib/transport_web/controllers/backoffice/page_controller.ex in TransportWeb.Backoffice.PageController.action/2 at line 1
lib/transport_web/controllers/backoffice/page_controller.ex in TransportWeb.Backoffice.PageController.phoenix_controller_pipeline/2 at line 1
lib/phoenix/router.ex in Phoenix.Router.__call__/2 at line 354
lib/transport_web/router.ex in TransportWeb.Router.call/2 at line 1
```

Le fix est simple, j'en profite pour ajouter un simple test vérifiant qu'on peut charger la page de référencement d'un JDD depuis le BO (regrettable que ça n'existait pas encore).