### PR TITLE
Ajout Plug pour logger et bloquer user-agent

### DIFF
--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -39,13 +39,14 @@ defmodule TransportWeb.Endpoint do
   )
 
   plug(Plug.RequestId)
-  plug(Plug.Logger)
   plug(RemoteIp, headers: ["x-forwarded-for"])
 
   plug(TransportWeb.Plugs.BlockUserAgent,
     log_user_agent: System.get_env("LOG_USER_AGENT", "false"),
     block_user_agent_keywords: System.get_env("BLOCK_USER_AGENT_KEYWORDS", "")
   )
+
+  plug(Plug.Logger)
 
   plug(PhoenixDDoS)
 

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -40,6 +40,14 @@ defmodule TransportWeb.Endpoint do
 
   plug(Plug.RequestId)
   plug(Plug.Logger)
+  plug(RemoteIp, headers: ["x-forwarded-for"])
+
+  plug(TransportWeb.Plugs.BlockUserAgent,
+    log_user_agent: System.get_env("LOG_USER_AGENT", "false"),
+    block_user_agent_keywords: System.get_env("BLOCK_USER_AGENT_KEYWORDS", "")
+  )
+
+  plug(PhoenixDDoS)
 
   plug(Plug.Parsers,
     parsers: [:urlencoded, :json, :multipart],

--- a/apps/transport/lib/transport_web/plugs/block_user_agent.ex
+++ b/apps/transport/lib/transport_web/plugs/block_user_agent.ex
@@ -1,0 +1,56 @@
+defmodule TransportWeb.Plugs.BlockUserAgent do
+  @moduledoc """
+  A Plug to:
+  - log the User-Agent making an HTTP request
+  - block HTTP requests when certain keywords are found in the User-Agent HTTP header
+
+  Options:
+  - log_user_agent: boolean or string
+  - block_user_agent_keywords: list of keywords or string that will be split on `|`
+  """
+  require Logger
+  import Plug.Conn
+  @behaviour Plug
+
+  @impl true
+  def init(log_user_agent: log_user_agent, block_user_agent_keywords: block_user_agent_keywords)
+      when is_binary(log_user_agent) and is_binary(log_user_agent) do
+    keywords = if block_user_agent_keywords == "", do: [], else: block_user_agent_keywords |> String.split("|")
+
+    init(
+      log_user_agent: log_user_agent == "true",
+      block_user_agent_keywords: keywords
+    )
+  end
+
+  def init(options) do
+    Keyword.validate!(options, log_user_agent: false, block_user_agent_keywords: [])
+  end
+
+  @impl true
+  def call(%Plug.Conn{request_path: request_path} = conn, options) do
+    if Keyword.fetch!(options, :log_user_agent) do
+      [user_agent] = get_req_header(conn, "user-agent")
+      Logger.info("Handling request #{request_path} by user-agent: #{user_agent}")
+    end
+
+    maybe_block_request(conn, Keyword.fetch!(options, :block_user_agent_keywords))
+  end
+
+  defp maybe_block_request(%Plug.Conn{} = conn, [] = _block_keywords), do: conn
+
+  defp maybe_block_request(%Plug.Conn{request_path: request_path} = conn, keywords) do
+    [user_agent] = get_req_header(conn, "user-agent")
+
+    if user_agent == "" or String.contains?(user_agent, keywords) do
+      Logger.info("Blocked request #{request_path} by user-agent: #{user_agent}")
+
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(401, "Unauthorized")
+      |> halt()
+    else
+      conn
+    end
+  end
+end

--- a/apps/transport/lib/transport_web/plugs/block_user_agent.ex
+++ b/apps/transport/lib/transport_web/plugs/block_user_agent.ex
@@ -14,7 +14,7 @@ defmodule TransportWeb.Plugs.BlockUserAgent do
 
   @impl true
   def init(log_user_agent: log_user_agent, block_user_agent_keywords: block_user_agent_keywords)
-      when is_binary(log_user_agent) and is_binary(log_user_agent) do
+      when is_binary(log_user_agent) and is_binary(block_user_agent_keywords) do
     keywords = if block_user_agent_keywords == "", do: [], else: block_user_agent_keywords |> String.split("|")
 
     init(

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -10,15 +10,6 @@ defmodule TransportWeb.Router do
 
   pipeline :browser_no_csp do
     plug(:canonical_host)
-
-    plug(RemoteIp, headers: ["x-forwarded-for"])
-
-    plug(TransportWeb.Plugs.BlockUserAgent,
-      log_user_agent: System.get_env("LOG_USER_AGENT", "false"),
-      block_user_agent_keywords: System.get_env("BLOCK_USER_AGENT_KEYWORDS", "")
-    )
-
-    plug(PhoenixDDoS)
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_live_flash)

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -12,6 +12,12 @@ defmodule TransportWeb.Router do
     plug(:canonical_host)
 
     plug(RemoteIp, headers: ["x-forwarded-for"])
+
+    plug(TransportWeb.Plugs.BlockUserAgent,
+      log_user_agent: System.get_env("LOG_USER_AGENT", "false"),
+      block_user_agent_keywords: System.get_env("BLOCK_USER_AGENT_KEYWORDS", "")
+    )
+
     plug(PhoenixDDoS)
     plug(:accepts, ["html"])
     plug(:fetch_session)

--- a/apps/transport/test/transport_web/plugs/block_user_agent_test.exs
+++ b/apps/transport/test/transport_web/plugs/block_user_agent_test.exs
@@ -1,0 +1,37 @@
+defmodule TransportWeb.Plugs.BlockUserAgentTest do
+  use TransportWeb.ConnCase, async: true
+
+  describe "init" do
+    test "with strings" do
+      assert [block_user_agent_keywords: [], log_user_agent: true] ==
+               TransportWeb.Plugs.BlockUserAgent.init(log_user_agent: "true", block_user_agent_keywords: "")
+
+      assert [block_user_agent_keywords: ["foo", "bar"], log_user_agent: false] ==
+               TransportWeb.Plugs.BlockUserAgent.init(log_user_agent: "", block_user_agent_keywords: "foo|bar")
+    end
+
+    test "with keywords" do
+      assert [log_user_agent: false, block_user_agent_keywords: ["foo", "bar"]] =
+               TransportWeb.Plugs.BlockUserAgent.init(block_user_agent_keywords: ["foo", "bar"], log_user_agent: false)
+    end
+  end
+
+  describe "call" do
+    test "blocks the request if the user-agent matches", %{conn: conn} do
+      text =
+        conn
+        |> Plug.Conn.put_req_header("user-agent", "Mozilla FooBar")
+        |> TransportWeb.Plugs.BlockUserAgent.call(log_user_agent: false, block_user_agent_keywords: ["FooBar"])
+        |> text_response(401)
+
+      assert text == "Unauthorized"
+    end
+
+    test "does nothing if the user-agent does not match", %{conn: conn} do
+      assert %Plug.Conn{halted: false} =
+               conn
+               |> Plug.Conn.put_req_header("user-agent", "Mozilla FooBar")
+               |> TransportWeb.Plugs.BlockUserAgent.call(log_user_agent: false, block_user_agent_keywords: ["nope"])
+    end
+  end
+end

--- a/apps/transport/test/transport_web/routing/canonical_host_redirect_test.exs
+++ b/apps/transport/test/transport_web/routing/canonical_host_redirect_test.exs
@@ -4,10 +4,6 @@ defmodule TransportWeb.CanonicalRoutingTest do
   import Phoenix.ConnTest
   @endpoint TransportWeb.Endpoint
 
-  setup do
-    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
-  end
-
   test "redirects browser calls to canonical browser for GET queries" do
     conn =
       build_conn()

--- a/config/config.exs
+++ b/config/config.exs
@@ -76,7 +76,10 @@ config :logger,
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  # :remote_ip is set by the dependency `remote_ip`
+  # `:http_*` are set by TransportWeb.Plugs.BlockUserAgent only
+  # when LOG_USER_AGENT=true
+  metadata: [:request_id, :remote_ip, :http_method, :http_path, :http_user_agent]
 
 config :scrivener_html,
   routes_helper: TransportWeb.Router.Helpers


### PR DESCRIPTION
Cette PR ajoute un plug permettant de :
- logger path et user-agent associé quand on le souhaite
- bloquer des requêtes sur `transport_web` avec une liste de mots clés

Ceci est configurable par variables d'environnement, de manière à pouvoir faire évoluer ceci rapidement
- `LOG_USER_AGENT`
- `BLOCK_USER_AGENT_KEYWORDS`, une liste de mots clés à séparer avec des pipes `|`