### PR TITLE
BlockUserAgent : permet d'utiliser les envs au runtime

### DIFF
--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -40,14 +40,11 @@ defmodule TransportWeb.Endpoint do
 
   plug(Plug.RequestId)
   plug(RemoteIp, headers: ["x-forwarded-for"])
-
-  plug(TransportWeb.Plugs.BlockUserAgent,
-    log_user_agent: System.get_env("LOG_USER_AGENT", "false"),
-    block_user_agent_keywords: System.get_env("BLOCK_USER_AGENT_KEYWORDS", "")
-  )
-
+  # Can be configured with env variables:
+  # - LOG_USER_AGENT
+  # - BLOCK_USER_AGENT_KEYWORDS
+  plug(TransportWeb.Plugs.BlockUserAgent, :use_env_variables)
   plug(Plug.Logger)
-
   plug(PhoenixDDoS)
 
   plug(Plug.Parsers,

--- a/apps/transport/test/transport_web/routing/canonical_host_redirect_test.exs
+++ b/apps/transport/test/transport_web/routing/canonical_host_redirect_test.exs
@@ -1,12 +1,10 @@
 defmodule TransportWeb.CanonicalRoutingTest do
-  # we used shared sandbox
-  use ExUnit.Case, async: true
+  use TransportWeb.ConnCase, async: true
   import Phoenix.ConnTest
-  @endpoint TransportWeb.Endpoint
 
-  test "redirects browser calls to canonical browser for GET queries" do
+  test "redirects browser calls to canonical browser for GET queries", %{conn: conn} do
     conn =
-      build_conn()
+      conn
       |> Map.put(:host, "www.another.domain.com")
       |> get(path = "/something?with=query&params=1")
 

--- a/apps/transport/test/transport_web/routing/proxy_routing_test.exs
+++ b/apps/transport/test/transport_web/routing/proxy_routing_test.exs
@@ -1,12 +1,10 @@
 defmodule TransportWeb.ProxyRoutingTest do
-  # we used shared sandbox
-  use ExUnit.Case, async: true
+  use TransportWeb.ConnCase, async: true
   import Phoenix.ConnTest
-  @endpoint TransportWeb.Endpoint
 
-  test "accepts proxy. subdomain calls and delegates them to unlock" do
+  test "accepts proxy. subdomain calls and delegates them to unlock", %{conn: conn} do
     conn =
-      build_conn()
+      conn
       |> Map.put(:host, "proxy.example.com")
       |> get("/")
 


### PR DESCRIPTION
Retravaille https://github.com/etalab/transport-site/pull/3572 pour pouvoir configurer le Plug au runtime et permettre de changer les options avec seulement un reboot et non une compilation.

[Voir Mattermost](https://mattermost.incubateur.net/betagouv/pl/xh4kcfmr93fot8hgyw5mfseufa)