### PR TITLE
BlockUserAgent : ne crashe pas quand pas de user-agent

### DIFF
--- a/apps/transport/test/transport_web/plugs/block_user_agent_test.exs
+++ b/apps/transport/test/transport_web/plugs/block_user_agent_test.exs
@@ -14,6 +14,8 @@ defmodule TransportWeb.Plugs.BlockUserAgentTest do
     end)
   end
 
+  doctest TransportWeb.Plugs.BlockUserAgent, import: true
+
   describe "init" do
     test "with strings" do
       assert [block_user_agent_keywords: [], log_user_agent: true] ==
@@ -73,6 +75,14 @@ defmodule TransportWeb.Plugs.BlockUserAgentTest do
         |> text_response(401)
 
       assert text == "Unauthorized"
+    end
+
+    test "does not crash when user-agent is not set", %{conn: conn} do
+      assert [] == get_req_header(conn, "user-agent")
+
+      assert %Plug.Conn{halted: false} =
+               conn
+               |> TransportWeb.Plugs.BlockUserAgent.call(log_user_agent: true, block_user_agent_keywords: [])
     end
   end
 end


### PR DESCRIPTION
Suite de #3572 #3574

Voir [Sentry](https://transport-data-gouv-fr.sentry.io/issues/4586926444/?referrer=alert_email&alert_type=email&alert_timestamp=1698686327344&alert_rule_id=12100279&notification_uuid=a1521a84-9ba9-4cb2-b06a-5e8d7316b6f4&environment=prod)

Gère le cas où la requête HTTP ne contient pas de header `user-agent`, on autorise ceci pour le moment.