### PR TITLE
PeriodicReminders : évite de programmer des doublons

### DIFF
--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -16,7 +16,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
   @notification_reason DB.NotificationSubscription.reason(:periodic_reminder_producers)
 
   use Oban.Worker,
-    unique: [period: 60 * 60 * 60 * @min_days_before_sending_again],
+    unique: [period: 60 * 60 * 24 * @min_days_before_sending_again],
     max_attempts: 3,
     tags: ["notifications"]
 

--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -75,7 +75,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
 
       subscribed_as_producer?(contact) or org_has_published_dataset?
     end)
-    |> Enum.uniq()
+    |> Enum.uniq_by(& &1.id)
   end
 
   defp schedule_jobs(contacts, %DateTime{} = scheduled_at) do

--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -11,11 +11,16 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
   Emails may be sent over multiple days if we have a large number to send, to
   avoid going over daily quotas and to spread the support load.
   """
-  use Oban.Worker, max_attempts: 3, tags: ["notifications"]
-  import Ecto.Query
-
+  @min_days_before_sending_again 90
   @max_emails_per_day 100
   @notification_reason DB.NotificationSubscription.reason(:periodic_reminder_producers)
+
+  use Oban.Worker,
+    unique: [period: 60 * 60 * 60 * @min_days_before_sending_again],
+    max_attempts: 3,
+    tags: ["notifications"]
+
+  import Ecto.Query
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args, inserted_at: %DateTime{} = inserted_at}) when args == %{} or is_nil(args) do
@@ -70,6 +75,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
 
       subscribed_as_producer?(contact) or org_has_published_dataset?
     end)
+    |> Enum.uniq()
   end
 
   defp schedule_jobs(contacts, %DateTime{} = scheduled_at) do
@@ -89,7 +95,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
   end
 
   def sent_mail_recently?(%DB.Contact{email: email}) do
-    dt_limit = DateTime.utc_now() |> DateTime.add(-90, :day)
+    dt_limit = DateTime.utc_now() |> DateTime.add(-@min_days_before_sending_again, :day)
 
     DB.Notification
     |> where([n], n.email_hash == ^email and n.reason == ^@notification_reason and n.inserted_at >= ^dt_limit)

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -21,6 +21,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
 
     test "enqueues jobs for each contact" do
       dataset = insert(:dataset, organization_id: org_id = Ecto.UUID.generate())
+      insert(:dataset, organization_id: publisher_org_id = Ecto.UUID.generate())
       # Contact should be kept: it doesn't have orgs set but it's subscribed as a producer
       %DB.Contact{id: contact_id_without_org} = insert_contact()
 
@@ -41,11 +42,15 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
         contact: insert_contact()
       )
 
-      # Contact should be kept: no subscriptions but member of an org with published datasets
+      # Contact should be kept: no subscriptions but member of orgs
+      # with published datasets.
+      # A single job should be enqueued even if the contact is a member
+      # of multiple orgs with published datasets.
       %DB.Contact{id: contact_id_with_org} =
         insert_contact(%{
           organizations: [
-            sample_org(%{"id" => org_id})
+            sample_org(%{"id" => org_id}),
+            sample_org(%{"id" => publisher_org_id})
           ]
         })
 


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3583

Évite de sélectionner plusieurs fois un contact qui est éligible à cet envoi.

Un double fix
- `Enum.uniq()` en sélectionnant les contacts (suffisant pour corriger le problème)
- Ajout d'un [`unique`](https://hexdocs.pm/oban/Oban.html#module-unique-jobs) au job