### PR TITLE
GTFSToNeTExEnRouteConverterJob : pas de module attribute dans doctest

### DIFF
--- a/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
@@ -170,13 +170,15 @@ defmodule Transport.Jobs.GTFSToNeTExEnRouteConverterJob do
   30
   iex> next_polling_attempt_seconds(500)
   30
-  iex> Enum.each(1..@max_attempts, &next_polling_attempt_seconds/1)
+  iex> Enum.each(1..max_polling_attempts(), &next_polling_attempt_seconds/1)
   :ok
   """
   def next_polling_attempt_seconds(current_attempt) when current_attempt < 12, do: 10
 
   def next_polling_attempt_seconds(current_attempt) when current_attempt >= 12 and current_attempt < @max_attempts,
     do: 30
+
+  def max_polling_attempts, do: @max_attempts
 
   def conversion_exists?(%DB.ResourceHistory{payload: %{"uuid" => rh_uuid}}) do
     converter = converter()

--- a/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
@@ -170,7 +170,7 @@ defmodule Transport.Jobs.GTFSToNeTExEnRouteConverterJob do
   30
   iex> next_polling_attempt_seconds(500)
   30
-  iex> Enum.each(1..max_polling_attempts(), &next_polling_attempt_seconds/1)
+  iex> Enum.each(1..max_polling_attempts() - 1, &next_polling_attempt_seconds/1)
   :ok
   """
   def next_polling_attempt_seconds(current_attempt) when current_attempt < 12, do: 10


### PR DESCRIPTION
#3588 ne passe pas en CI, mais passait bien en local avec `mix test apps/transport/test/transport/jobs/conversions/gtfs_to_netex_converter_job_test.exs` ! J'avais un doute de pouvoir utiliser un module attribute dans un doctest, c'est de toute évidence une mauvaise idée.