### PR TITLE
Validateur GTFS : ajout nouvelle erreur DuplicateStopSequence

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_duplicate_stop_sequence_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_duplicate_stop_sequence_issue.html.heex
@@ -1,0 +1,21 @@
+<p>
+  <%= dgettext("validations-explanations", "Impacted file:") %> <tt>stop_times.txt</tt>
+</p>
+<p>
+  <%= dgettext("validations-explanations", "DuplicateStopSequence") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Trip ID") %></th>
+    <th><%= dgettext("validations-explanations", "Related stops") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_id"] %></td>
+      <td>
+        <ul><%= format_related_objects(issue["related_objects"]) %></ul>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -29,6 +29,7 @@ defmodule TransportWeb.ResourceView do
       %{
         "UnloadableModel" => "_unloadable_model_issue.html",
         "DuplicateStops" => "_duplicate_stops_issue.html",
+        "DuplicateStopSequence" => "_duplicate_stop_sequence_issue.html",
         "ExtraFile" => "_extra_file_issue.html",
         "MissingFile" => "_missing_file_issue.html",
         "NullDuration" => "_speed_issue.html",

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -206,6 +206,7 @@ defmodule Transport.Validators.GTFSTransport do
       "InvalidUrl" => dgettext("gtfs-transport-validator", "Invalid url"),
       "InvalidTimezone" => dgettext("gtfs-transport-validator", "Invalid timezone"),
       "DuplicateStops" => dgettext("gtfs-transport-validator", "Duplicate stops"),
+      "DuplicateStopSequence" => dgettext("gtfs-transport-validator", "Duplicate stop sequence"),
       "MissingPrice" => dgettext("gtfs-transport-validator", "Missing price"),
       "InvalidCurrency" => dgettext("gtfs-transport-validator", "Invalid currency"),
       "InvalidTransfers" => dgettext("gtfs-transport-validator", "Invalid transfers"),

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -162,3 +162,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unused shape ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Duplicate stop sequence"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -114,3 +114,11 @@ msgstr "Object type"
 #, elixir-autogen, elixir-format
 msgid "Object ID"
 msgstr "Object ID"
+
+#, elixir-autogen, elixir-format
+msgid "DuplicateStopSequence"
+msgstr "Some stops within a trip have the same stop sequence value."
+
+#, elixir-autogen, elixir-format
+msgid "Related stops"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -162,3 +162,7 @@ msgstr "Shape ID invalide"
 #, elixir-autogen, elixir-format
 msgid "Unused shape ID"
 msgstr "Shape ID inutilisé"
+
+#, elixir-autogen, elixir-format
+msgid "Duplicate stop sequence"
+msgstr "Doublon de stop_sequence dans un trajet"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -114,3 +114,11 @@ msgstr "Type d'objet"
 #, elixir-autogen, elixir-format
 msgid "Object ID"
 msgstr "Identifiant de l’objet"
+
+#, elixir-autogen, elixir-format
+msgid "DuplicateStopSequence"
+msgstr "Certains arrêts dans un même trajet ont la même valeur de stop_sequence."
+
+#, elixir-autogen, elixir-format
+msgid "Related stops"
+msgstr "Arrêts associés"

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -161,3 +161,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unused shape ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Duplicate stop sequence"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -113,3 +113,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Object ID"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "DuplicateStopSequence"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Related stops"
+msgstr ""


### PR DESCRIPTION
Ajout de traductions et d'un template pour une nouvelle règle dans le validateur GTFS : vérification de la clé primaire (`trip_id`, `stop_sequence`) dans `stop_times.txt`.

Voir https://github.com/etalab/transport-validator/pull/174