### PR TITLE
Validateur GTFS : message quand fichiers dans un sous-dossier

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_subfolder_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_subfolder_issue.html.heex
@@ -1,0 +1,4 @@
+<p>
+  <% folder = @issues |> hd() |> Map.fetch!("object_id") %>
+  <%= dgettext("validations-explanations", "SubFolder", folder: folder) %>
+</p>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -42,7 +42,8 @@ defmodule TransportWeb.ResourceView do
         "UnusedShapeId" => "_unused_shape_issue.html",
         "InvalidShapeId" => "_invalid_shape_id_issue.html",
         "MissingId" => "_missing_id_issue.html",
-        "MissingName" => "_missing_name_issue.html"
+        "MissingName" => "_missing_name_issue.html",
+        "SubFolder" => "_subfolder_issue.html"
       },
       issue_type(issues.entries),
       "_generic_issue.html"

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -223,7 +223,8 @@ defmodule Transport.Validators.GTFSTransport do
       "InvalidStopParent" => dgettext("gtfs-transport-validator", "Invalid stop parent"),
       "IdNotAscii" => dgettext("gtfs-transport-validator", "ID is not ASCII-encoded"),
       "InvalidShapeId" => dgettext("gtfs-transport-validator", "Invalid shape ID"),
-      "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID")
+      "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID"),
+      "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder")
     }
 
   @spec is_gtfs_outdated(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -166,3 +166,7 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Duplicate stop sequence"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Files in a subfolder"
+msgstr "Fichiers dans un sous-dossier"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -122,3 +122,7 @@ msgstr "Some stops within a trip have the same stop sequence value."
 #, elixir-autogen, elixir-format
 msgid "Related stops"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "SubFolder"
+msgstr ".txt files are in subfolder (%{folder}). Files must reside at the root level directly, not in a subfolder."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -166,3 +166,7 @@ msgstr "Shape ID inutilisé"
 #, elixir-autogen, elixir-format
 msgid "Duplicate stop sequence"
 msgstr "Doublon de stop_sequence dans un trajet"
+
+#, elixir-autogen, elixir-format
+msgid "Files in a subfolder"
+msgstr "Fichiers dans un sous-dossier"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -122,3 +122,7 @@ msgstr "Certains arrêts dans un même trajet ont la même valeur de stop_sequen
 #, elixir-autogen, elixir-format
 msgid "Related stops"
 msgstr "Arrêts associés"
+
+#, elixir-autogen, elixir-format
+msgid "SubFolder"
+msgstr "Les fichiers .txt sont dans un sous-dossier (%{folder}). Les fichiers doivent être à la racine de l'archive ZIP et non dans un sous-dossier."

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -165,3 +165,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Duplicate stop sequence"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Files in a subfolder"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -121,3 +121,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Related stops"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "SubFolder"
+msgstr ""


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3540. Similaire à la PR de ce matin #3593 qui ajoute la gestion d'une autre nouvelle erreur.

Prend en compte la nouvelle erreur ajoutée dans https://github.com/etalab/transport-validator/pull/176, `SubFolder`. Ajoute une vue et des messages pertinents pour cette erreur.