### PR TITLE
subfolder_issue : les issues sont en Scrivener

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_subfolder_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_subfolder_issue.html.heex
@@ -1,4 +1,4 @@
 <p>
-  <% folder = @issues |> hd() |> Map.fetch!("object_id") %>
+  <% %Scrivener.Page{entries: [%{"object_id" => folder, "issue_type" => "SubFolder"}]} = @issues %>
   <%= dgettext("validations-explanations", "SubFolder", folder: folder) %>
 </p>


### PR DESCRIPTION
Revoit ce qui a été fait dans https://github.com/etalab/transport-site/pull/3595

En réalité la structure que l'on a n'est pas une liste mais dans [une structure `Scrivener.Page`](https://hexdocs.pm/scrivener/Scrivener.Page.html). J'ai été induit en erreur car on a des boucles `for issue <- @issues` qui [utilise `entries` en fait](https://github.com/drewolson/scrivener/blob/09ab5c2b2b474bd1dca71723274b674a1f1805f3/lib/scrivener/page.ex#L31)

![image](https://github.com/etalab/transport-site/assets/295709/0d83278f-e121-4f2c-b636-0d148acf572f)

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/4629310368/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream&stream_index=2)
