### PR TITLE
DB.Metrics.requests_over_last_days : mise à jour du namespace

### DIFF
--- a/apps/transport/lib/db/metrics.ex
+++ b/apps/transport/lib/db/metrics.ex
@@ -21,12 +21,7 @@ defmodule DB.Metrics do
   number of days.
   """
   def requests_over_last_days(%DB.Resource{} = resource, days) when is_integer(days) and days > 0 do
-    namespace =
-      cond do
-        DB.Resource.is_gtfs_rt?(resource) -> "proxy"
-        DB.Resource.is_gbfs?(resource) -> "gbfs"
-      end
-
+    namespace = DB.Resource.proxy_namespace(resource)
     date_from = %{DateTime.utc_now() | hour: 0, minute: 0, second: 0} |> DateTime.add(-days, :day)
     target = Enum.join([namespace, DB.Resource.proxy_slug(resource)], ":")
     external_event = Enum.join([namespace, "request", "external"], ":")

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -359,4 +359,16 @@ defmodule DB.Resource do
       nil
     end
   end
+
+  @doc """
+  The proxy namespace for a resource. Defined in other Umbrella apps (`gbfs` and `unlock`).
+  Used in `metrics.target` and `metrics.event`.
+
+  iex> proxy_namespace(%DB.Resource{url: "https://transport.data.gouv.fr/gbfs/cergy-pontoise/gbfs.json", format: "gbfs"})
+  "gbfs"
+  iex> proxy_namespace(%DB.Resource{url: "https://proxy.transport.data.gouv.fr/resource/axeo-guingamp-gtfs-rt-vehicle-position", format: "gtfs-rt"})
+  "proxy"
+  """
+  def proxy_namespace(%__MODULE__{format: "gbfs"}), do: "gbfs"
+  def proxy_namespace(%__MODULE__{}), do: "proxy"
 end


### PR DESCRIPTION
Un oubli dans #3601, le namespace associé à une ressource dans les metrics avait une dépendance sur GBFS / GTFS-RT.