### PR TITLE
Ne pas proposer de conversion NeTEx quand une ressource existe

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -47,7 +47,12 @@ defmodule TransportWeb.CustomTagsLive do
       },
       %{name: "requestor_ref:<valeur>", doc: "Renseigne le requestor_ref des ressources SIRI pour ce jeu de données"},
       %{name: "saisonnier", doc: "Indique sur la page du JDD que ce jeu de données n'opère qu'une partie de l'année"},
-      %{name: "skip_history", doc: "Désactive l'historisation des ressources pour ce jeu de données"}
+      %{name: "skip_history", doc: "Désactive l'historisation des ressources pour ce jeu de données"},
+      %{
+        name: "keep_netex_conversions",
+        doc:
+          "Conserve les conversions NeTEx automatiques pour ce jeu de données, même s'il contient des ressources NeTEx"
+      }
     ]
   end
 


### PR DESCRIPTION
Fixes #3490

Adapte `DB.Dataset.get_resources_related_files` pour ne pas renvoyer une conversion NeTEx quand une ressource NeTEx est déjà présente dans le JDD.

L'ajout notable est la méthode `DB.Dataset.target_conversion_formats` qui détermine les formats de conversion que l'on souhaite.

Démo : pour le JDD IC SNCF on ne propose plus de conversion NeTEx pour leur GTFS.

![image](https://github.com/etalab/transport-site/assets/295709/d7eafa68-93bc-4369-8b66-7ef45bb0f359)

## Notes

- J'ai fait en sorte qu'on puisse conserver les conversions NeTEx automatiques si on met un tag `keep_netex_conversions` dans le backoffice (pour certains cas bizarres).
- `get_resources_related_files` est utilisé par l'UI (`dataset#details`) et l'API `/api/datasets/:id`, c'est donc bien répercuté aux 2 endroits
- on continuera à convertir automatiquement ces GTFS, on se contente uniquement de ne pas exposer ces conversions