### PR TITLE
Backoffice BNLC : ajoute bouton pour remplacer sur datagouv

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -95,7 +95,30 @@
 
   <h2>Consolidation BNLC</h2>
   <div>
-    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView, []) %>
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView,
+      session: %{
+        "button_texts" => %{
+          sent: "Rapport disponible par e-mail",
+          dispatched: "Consolidation en cours",
+          default: "🧪 Consolider à blanc"
+        },
+        "button_default_class" => "button",
+        "job_args" => %{}
+      }
+    ) %>
+  </div>
+  <div>
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView,
+      session: %{
+        "button_texts" => %{
+          sent: "Fichier mis à jour et rapport envoyé",
+          dispatched: "Consolidation en cours",
+          default: "📥 Consolider et remplacer sur data.gouv.fr"
+        },
+        "button_default_class" => "button warning-light",
+        "job_args" => %{"action" => "datagouv_update"}
+      }
+    ) %>
   </div>
 
   <h2><%= dgettext("backoffice", "Validations") %></h2>


### PR DESCRIPTION
En lien avec #3419

Ajoute un bouton pour lancer la consolidation de la BNLC et remplacer la ressource sur data.gouv.fr, en plus du bouton existant pour consolider à blanc (consolider et envoyer un rapport, sans remplacer).

Il est préférable que #3607 soit mergée avant mais ce n'est pas grave. Si ce n'est pas le cas, les 2 boutons feront une consolidation à blanc.