### PR TITLE
Hot-fix - passage du TTL de cache de la home-page à 15 minutes

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -16,7 +16,11 @@ defmodule TransportWeb.PageController do
   end
 
   defp home_index_stats do
-    Transport.Cache.API.fetch("home-index-stats", fn -> compute_home_index_stats() end)
+    # with HOTFIX for https://github.com/etalab/transport-site/issues/3609
+    # combined with the fact our HTTP monitor checks the url every minute, should
+    # allow regular traffic for most users
+    temporary_ttl = :timer.minutes(15)
+    Transport.Cache.API.fetch("home-index-stats", fn -> compute_home_index_stats() end, temporary_ttl)
   end
 
   defp put_breaking_news(conn, %{level: level, msg: msg}) do


### PR DESCRIPTION
Voir:
- #3609

Testé en dév via le backoffice:

<img width="800" alt="CleanShot 2023-11-17 at 16 16 45@2x" src="https://github.com/etalab/transport-site/assets/10141/e42534ea-1d65-4b59-acd7-99ca07e475f5">

