### PR TITLE
Conversions NeTEx : changement de convertisseur par défaut

### DIFF
--- a/apps/transport/lib/converters/converter.ex
+++ b/apps/transport/lib/converters/converter.ex
@@ -2,7 +2,6 @@ defmodule Transport.Converters.Converter do
   @moduledoc """
   A behaviour for data converters, used only for GTFS files at the moment.
   """
-  @callback convert(binary(), binary()) :: :ok | {:error, any()}
   @callback converter() :: binary()
   @callback converter_version() :: binary()
 end

--- a/apps/transport/lib/converters/gtfs_to_netex_enroute.ex
+++ b/apps/transport/lib/converters/gtfs_to_netex_enroute.ex
@@ -4,6 +4,8 @@ defmodule Transport.Converters.GTFSToNeTExEnRoute do
   Documentation: https://documenter.getpostman.com/view/9203997/SzmfXwrp
   """
   require Logger
+  @behaviour Transport.Converters.Converter
+
   @base_url "https://chouette-convert.enroute.mobi/api/conversions"
 
   @doc """
@@ -65,6 +67,16 @@ defmodule Transport.Converters.GTFSToNeTExEnRoute do
     Req.get!(url, compressed: false, headers: auth_headers(), into: file_stream)
     :ok
   end
+
+  @impl Transport.Converters.Converter
+  def converter, do: "enroute/gtfs-to-netex"
+
+  @doc """
+  The EnRoute converter version. Not available yet.
+  https://enroute.atlassian.net/servicedesk/customer/portal/1/SUPPORT-1091
+  """
+  @impl Transport.Converters.Converter
+  def converter_version, do: "current"
 
   defp base_url do
     # Use Bypass with Req in the test environment, we need to change the base URL

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -23,6 +23,8 @@ defmodule DB.DataConversion do
   @doc """
   Finds the default converter to use for a target format.
 
+  iex> converter_to_use(:NeTEx)
+  "enroute/gtfs-to-netex"
   iex> Enum.each(Ecto.Enum.values(DB.DataConversion, :convert_to), & converter_to_use/1)
   :ok
   """
@@ -31,7 +33,7 @@ defmodule DB.DataConversion do
     Map.fetch!(
       %{
         "GeoJSON" => Transport.GTFSToGeoJSONConverter.converter(),
-        "NeTEx" => Transport.GTFSToNeTExHoveConverter.converter()
+        "NeTEx" => Transport.Converters.GTFSToNeTExEnRoute.converter()
       },
       to_string(convert_to)
     )

--- a/apps/transport/lib/jobs/conversions/gtfs_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_geojson_converter_job.ex
@@ -32,7 +32,6 @@ defmodule Transport.GTFSToGeoJSONConverter do
   """
   @behaviour Transport.Converters.Converter
 
-  @impl true
   def convert(gtfs_file_path, geojson_file_path) do
     binary_path = Path.join(Application.fetch_env!(:transport, :transport_tools_folder), "gtfs-geojson")
 

--- a/apps/transport/lib/jobs/conversions/gtfs_to_netex_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_netex_converter_job.ex
@@ -79,7 +79,6 @@ defmodule Transport.GTFSToNeTExHoveConverter do
   """
   @behaviour Transport.Converters.Converter
 
-  @impl true
   def convert(gtfs_file_path, netex_file_path) do
     binary_path = Path.join(Application.fetch_env!(:transport, :transport_tools_folder), "gtfs2netexfr")
     participant = Application.get_env(:transport, :domain_name)

--- a/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_netex_enroute_converter_job.ex
@@ -201,11 +201,6 @@ defmodule Transport.Jobs.GTFSToNeTExEnRouteConverterJob do
     System.tmp_dir!() |> Path.join("enroute_conversion_gtfs_netex_#{id}")
   end
 
-  def converter, do: "enroute/gtfs-to-netex"
-
-  @doc """
-  The EnRoute converter version. Not available yet.
-  https://enroute.atlassian.net/servicedesk/customer/portal/1/SUPPORT-1091
-  """
-  def converter_version, do: "current"
+  defdelegate converter, to: GTFSToNeTExEnRoute
+  defdelegate converter_version, to: GTFSToNeTExEnRoute
 end

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -131,6 +131,15 @@ defmodule DB.DataConversionTest do
         payload: %{filename: "filename"}
       )
 
+    _ignored_non_default_converter =
+      insert(:data_conversion,
+        convert_from: "GTFS",
+        convert_to: "NeTEx",
+        converter: "non-default-netex-converter",
+        resource_history_uuid: uuid_other,
+        payload: %{filename: "filename"}
+      )
+
     conversions =
       dataset.id
       |> DB.DataConversion.latest_data_conversions("NeTEx")

--- a/apps/transport/test/transport/jobs/conversions/gtfs_to_netex_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/gtfs_to_netex_converter_job_test.exs
@@ -43,7 +43,7 @@ defmodule Transport.Jobs.GTFSToNeTExConverterJobTest do
     insert(:data_conversion,
       convert_from: :GTFS,
       convert_to: :NeTEx,
-      converter: DB.DataConversion.converter_to_use(:NeTEx),
+      converter: "hove/transit_model",
       resource_history_uuid: uuid,
       payload: %{}
     )

--- a/apps/transport/test/transport/jobs/conversions/single_gtfs_to_netex_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/single_gtfs_to_netex_converter_job_test.exs
@@ -18,7 +18,7 @@ defmodule Transport.Jobs.SingleGTFSToNeTExHoveConverterJobTest do
       convert_from: :GTFS,
       convert_to: :NeTEx,
       resource_history_uuid: uuid,
-      converter: DB.DataConversion.converter_to_use(:NeTEx),
+      converter: "hove/transit_model",
       payload: %{}
     )
 
@@ -80,7 +80,7 @@ defmodule Transport.Jobs.SingleGTFSToNeTExHoveConverterJobTest do
              DB.Repo.get_by!(DB.DataConversion,
                convert_from: :GTFS,
                convert_to: :NeTEx,
-               converter: DB.DataConversion.converter_to_use(:NeTEx),
+               converter: "hove/transit_model",
                resource_history_uuid: uuid
              )
 
@@ -137,7 +137,6 @@ defmodule Transport.Jobs.SingleGTFSToNeTExHoveConverterJobTest do
       |> DB.Repo.get_by!(
         convert_from: :GTFS,
         convert_to: :NeTEx,
-        converter: DB.DataConversion.converter_to_use(:NeTEx),
         resource_history_uuid: uuid
       )
     end)


### PR DESCRIPTION
Utilise le convertisseur EnRoute comme convertisseur par défaut pour le format `NeTEx`.

Les conversions du stock passé est quasiment terminé (reste très peu d'anciens fichiers en cours de conversion) et le flux est bien converti au fur et à mesure.

```sql
select status, count(1)
from data_conversion dc
where dc.converter = 'enroute/gtfs-to-netex'
group by 1;
```

On pourra prochainement supprimer la conversion en parallèle qui est toujours effectuée avec Hove.