### PR TITLE
Backoffice dataset form : gère cas où org est nil

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -169,6 +169,7 @@ defmodule TransportWeb.Backoffice.PageController do
     |> assign(:notifications_last_nb_days, notifications_last_nb_days())
     |> assign(:resources_with_history, DB.Dataset.last_resource_history(dataset_id))
     |> assign(:contacts_datalist, contacts_datalist())
+    |> assign(:contacts_in_org, contacts_in_org(conn.assigns[:dataset]))
     |> assign(
       :import_logs,
       LogsImport
@@ -178,6 +179,12 @@ defmodule TransportWeb.Backoffice.PageController do
     )
     |> render("form_dataset.html")
   end
+
+  defp contacts_in_org(%DB.Dataset{organization_object: organization_object}) do
+    Enum.sort_by(organization_object.contacts, &DB.Contact.display_name/1)
+  end
+
+  defp contacts_in_org(_), do: []
 
   defp contacts_datalist do
     DB.Contact.base_query()

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -4,7 +4,6 @@
   ) %>
 
   <%= unless is_nil(@dataset) do %>
-    <% contacts_in_org = Enum.sort_by(@dataset.organization_object.contacts, &DB.Contact.display_name/1) %>
     <div class="is-centered mt-48">
       <%= dgettext("backoffice", "Other actions on the dataset") %>
     </div>
@@ -84,12 +83,12 @@
               <i class="fas fa-external-link"></i> Créer un contact
             </a>
           </div>
-          <div :if={Enum.count(contacts_in_org) > 0}>
+          <div :if={Enum.count(@contacts_in_org) > 0}>
             <p>
               Contacts dans l'organisation s'étant déjà connectés au PAN
             </p>
             <ul>
-              <%= for contact <- contacts_in_org do %>
+              <%= for contact <- @contacts_in_org do %>
                 <% onclick_fn = ~s{getElementById("contact_id").value =} <> to_string(contact.id) %>
                 <li class="pb-6">
                   <a href={backoffice_contact_path(@conn, :edit, contact.id)} target="_blank">


### PR DESCRIPTION
Un problème similaire à ce qui était arrivé dans #3559.

Impossible d'avoir une liste de contacts pour un JDD quand le dataset n'a pas d'organisation attribuée (ie publié par un utilisateur et non une org, très rare et on essaie d'y mettre fin).