### PR TITLE
Backoffice : corrige contacts_in_orgs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -180,11 +180,11 @@ defmodule TransportWeb.Backoffice.PageController do
     |> render("form_dataset.html")
   end
 
-  defp contacts_in_org(%DB.Dataset{organization_object: organization_object}) do
+  def contacts_in_org(%DB.Dataset{organization_object: %DB.Organization{} = organization_object}) do
     Enum.sort_by(organization_object.contacts, &DB.Contact.display_name/1)
   end
 
-  defp contacts_in_org(_), do: []
+  def contacts_in_org(_), do: []
 
   defp contacts_datalist do
     DB.Contact.base_query()

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -268,7 +268,14 @@ defmodule DB.Factory do
   end
 
   def organization_factory do
-    %DB.Organization{id: Ecto.UUID.generate()}
+    %DB.Organization{
+      id: Ecto.UUID.generate(),
+      badges: [],
+      logo: "https://example.com/#{Ecto.UUID.generate()}.small.png",
+      logo_thumbnail: "https://example.com/#{Ecto.UUID.generate()}.small.png",
+      name: sequence(:name, fn i -> "organization_name_#{i}" end),
+      slug: sequence(:slug, fn i -> "organization_slug_#{i}" end)
+    }
   end
 
   def insert_contact(%{} = args \\ %{}) do

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -153,6 +153,26 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
            ]
   end
 
+  describe "contacts_in_org" do
+    test "org is not set" do
+      dataset = insert(:dataset, organization_id: nil)
+      assert [] == PageController.contacts_in_org(dataset |> DB.Repo.preload(organization_object: :contacts))
+    end
+
+    test "dataset is nil" do
+      assert [] == PageController.contacts_in_org(nil)
+    end
+
+    test "with contacts" do
+      organization = insert(:organization)
+      dataset = insert(:dataset, organization_id: organization.id)
+      %DB.Contact{id: contact_id} = insert_contact(%{organizations: [organization |> Map.from_struct()]})
+
+      assert [%DB.Contact{id: ^contact_id}] =
+               PageController.contacts_in_org(dataset |> DB.Repo.preload(organization_object: :contacts))
+    end
+  end
+
   defp insert_notification_at_datetime(%{} = args, %DateTime{} = datetime) do
     args
     |> insert_notification()


### PR DESCRIPTION
Suite de #3614. J'avais oublié un pattern matching pour éviter `org = nil` 🙄.

J'en profite pour ajouter des tests, bien nécessaires.

Navré.