### PR TITLE
Correction configuration consolidation BNLC runtime

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -225,15 +225,16 @@ if config_env() == :prod do
     # published by us on data.gouv.fr.
     # Overrides values set in `config.exs`
     config :transport,
-      consolidation: %{
-        zfe: %{
-          dataset_id: "625438b890bf88454b283a55",
-          resource_ids: %{
-            "voies" => "3a5d0c66-aef9-4d68-841f-4fe81c9de980",
-            "aires" => "673a16bf-49ec-4645-9da2-cf975d0aa0ea"
+      consolidation:
+        Map.merge(Application.fetch_env!(:transport, :consolidation), %{
+          zfe: %{
+            dataset_id: "625438b890bf88454b283a55",
+            resource_ids: %{
+              "voies" => "3a5d0c66-aef9-4d68-841f-4fe81c9de980",
+              "aires" => "673a16bf-49ec-4645-9da2-cf975d0aa0ea"
+            }
           }
-        }
-      }
+        })
 
     config :transport, Transport.Mailer,
       adapter: Swoosh.Adapters.Mailjet,


### PR DESCRIPTION
En voulant nettoyer `configs.exs` et `runtime.exs` https://github.com/etalab/transport-site/pull/3607#discussion_r1398959374 j'ai cassé des choses.

`runtime.exs` écrasait complètement la clé de consolidation et il manquait en conséquence `bnlc`. Le job crashait en production.

```
** (KeyError) key :bnlc not found in: %{
  zfe: %{
    dataset_id: \\\"625438b890bf88454b283a55\\\",
    resource_ids: %{
      \\\"aires\\\" => \\\"673a16bf-49ec-4645-9da2-cf975d0aa0ea\\\",
      \\\"voies\\\" => \\\"3a5d0c66-aef9-4d68-841f-4fe81c9de980\\\"
    }
  }
  }
:erlang.map_get(:bnlc, %{zfe: %{dataset_id: \\\"625438b890bf88454b283a55\\\", resource_ids: %{\\\"aires\\\" => \\\"673a16bf-49ec-4645-9da2-cf975d0aa0ea\\\", \\\"voies\\\" => \\\"3a5d0c66-aef9-4d68-841f-4fe81c9de980\\\"}}})
(transport 0.0.1) lib/jobs/consolidate_bnlc_job.ex:548: Transport.Jobs.ConsolidateBNLCJob.consolidation_configuration/0
(transport 0.0.1) lib/jobs/consolidate_bnlc_job.ex:116: Transport.Jobs.ConsolidateBNLCJob.replace_file_on_datagouv/0
(transport 0.0.1) lib/jobs/consolidate_bnlc_job.ex:69: Transport.Jobs.ConsolidateBNLCJob.perform/1
(oban 2.16.2) lib/oban/queue/executor.ex:129: Oban.Queue.Executor.perform/1
(oban 2.16.2) lib/oban/queue/executor.ex:74: Oban.Queue.Executor.call/1
(elixir 1.15.5) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
(elixir 1.15.5) lib/task/supervised.ex:36: Task.Supervised.reply/4
```