### PR TITLE
AvailabilityChecker : accepte uniquement statut 200

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -50,7 +50,9 @@ defmodule Transport.AvailabilityChecker do
 
   def available?(format, url, false) when is_binary(url) do
     case http_client().head(url, [], follow_redirect: true) do
-      {:ok, %Response{status_code: code}} when code >= 200 and code < 300 ->
+      # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses
+      # Other 2xx status codes don't seem appropriate here
+      {:ok, %Response{status_code: 200}} ->
         true
 
       {:ok, %Response{status_code: code}} when code in [401, 403, 405] ->


### PR DESCRIPTION
Fixes #3612

Retravaille `AvailabilityChecker` pour ne plus accepter des statuts HTTP `2xx` mais uniquement `200` pour la plupart des ressources.

Je me demandais s'il fallait accepter du `204 No Content` pour des ressources GTFS-RT mais il ne me semble pas avoir vu des serveurs répondre ceci, ce n'est pas indiqué dans la spec/best practices.

Ne change pas le fonctionnement du reste de ce module
- SIRI/SIRI Lite est traité à part (401 et 405 sont valides)
- teste `HEAD` et fallback en `GET` si non supporté