### PR TITLE
Calcule et stocke un score de conformité

### DIFF
--- a/apps/transport/lib/db/dataset_score.ex
+++ b/apps/transport/lib/db/dataset_score.ex
@@ -9,7 +9,7 @@ defmodule DB.DatasetScore do
 
   typed_schema "dataset_score" do
     belongs_to(:dataset, DB.Dataset)
-    field(:topic, Ecto.Enum, values: [:freshness, :availability])
+    field(:topic, Ecto.Enum, values: [:freshness, :availability, :compliance])
     field(:score, :float)
     field(:timestamp, :utc_datetime_usec)
     field(:details, :map)

--- a/apps/transport/lib/jobs/dataset_quality_score.ex
+++ b/apps/transport/lib/jobs/dataset_quality_score.ex
@@ -30,6 +30,7 @@ defmodule Transport.Jobs.DatasetQualityScore do
   def perform(%Oban.Job{args: %{"dataset_id" => dataset_id}}) do
     Transport.Jobs.DatasetFreshnessScore.save_freshness_score(dataset_id)
     Transport.Jobs.DatasetAvailabilityScore.save_availability_score(dataset_id)
+    Transport.Jobs.DatasetComplianceScore.save_compliance_score(dataset_id)
     :ok
   end
 
@@ -63,12 +64,23 @@ defmodule Transport.Jobs.DatasetQualityScore do
   @doc """
   Exponential smoothing. See https://en.wikipedia.org/wiki/Exponential_smoothing
 
-  iex> exp_smoothing(0.5, 1)
+  iex> exp_smoothing(0.5, 1, :freshness)
   0.55
+  iex> exp_smoothing(0.5, 1, 0.9)
+  0.55
+  iex> exp_smoothing(0.5, 1, :compliance)
+  0.525
   """
-  @spec exp_smoothing(float, float) :: float
-  def exp_smoothing(previous_score, today_score) do
-    alpha = 0.9
+  @spec exp_smoothing(float(), float(), atom() | float()) :: float()
+  def exp_smoothing(previous_score, today_score, :compliance) do
+    exp_smoothing(previous_score, today_score, 0.95)
+  end
+
+  def exp_smoothing(previous_score, today_score, topic) when topic in [:freshness, :availability] do
+    exp_smoothing(previous_score, today_score, 0.9)
+  end
+
+  def exp_smoothing(previous_score, today_score, alpha) do
     alpha * previous_score + (1.0 - alpha) * today_score
   end
 
@@ -146,7 +158,7 @@ defmodule Transport.Jobs.DatasetQualityScore do
     computed_score =
       case last_score = last_dataset_score(dataset_id, topic) do
         %{score: previous_score} when is_float(previous_score) ->
-          exp_smoothing(previous_score, today_score)
+          exp_smoothing(previous_score, today_score, topic)
 
         _ ->
           today_score
@@ -164,10 +176,62 @@ defmodule Transport.Jobs.DatasetQualityScore do
     Map.fetch!(
       %{
         availability: &Transport.Jobs.DatasetAvailabilityScore.current_dataset_availability/1,
-        freshness: &Transport.Jobs.DatasetFreshnessScore.current_dataset_freshness/1
+        freshness: &Transport.Jobs.DatasetFreshnessScore.current_dataset_freshness/1,
+        compliance: &Transport.Jobs.DatasetComplianceScore.current_dataset_compliance/1
       },
       topic
     )
+  end
+end
+
+defmodule Transport.Jobs.DatasetComplianceScore do
+  @moduledoc """
+  Methods specific to the compliance component of a dataset score.
+  """
+  import Ecto.Query
+  import Transport.Jobs.DatasetQualityScore
+
+  @validators [
+    Transport.Validators.GTFSTransport,
+    Transport.Validators.TableSchema,
+    Transport.Validators.EXJSONSchema,
+    Transport.Validators.GBFSValidator
+  ]
+
+  @doc """
+  Computes and saves a compliance score for a dataset.
+  """
+  def save_compliance_score(dataset_id) do
+    save_dataset_score(dataset_id, :compliance)
+  end
+
+  @spec current_dataset_compliance(integer()) :: %{score: float | nil, details: map()}
+  def current_dataset_compliance(dataset_id) do
+    validation_details =
+      dataset_id
+      |> DB.MultiValidation.dataset_latest_validation(@validators)
+      |> Enum.reject(fn {_resource_id, [multi_validation]} -> is_nil(multi_validation) end)
+
+    current_dataset_infos = Enum.map(validation_details, &resource_compliance(&1))
+    score = current_dataset_infos |> Enum.map(fn %{compliance: compliance} -> compliance end) |> average()
+
+    %{score: score, details: %{resources: current_dataset_infos}}
+  end
+
+  @spec resource_compliance({integer(), [DB.MultiValidation.t()]}) :: %{
+          :compliance => float(),
+          :resource_id => integer(),
+          :raw_measure => map()
+        }
+  # Works for TableSchema + JSON Schema and GBFS
+  def resource_compliance({resource_id, [%DB.MultiValidation{result: %{"has_errors" => has_errors} = result}]}) do
+    compliance = if has_errors, do: 0.0, else: 1.0
+    %{compliance: compliance, resource_id: resource_id, raw_measure: result}
+  end
+
+  def resource_compliance({resource_id, [%DB.MultiValidation{max_error: max_error}]}) do
+    compliance = if max_error in ["Fatal", "Error"], do: 0.0, else: 1.0
+    %{compliance: compliance, resource_id: resource_id, raw_measure: %{"max_error" => max_error}}
   end
 end
 
@@ -186,7 +250,7 @@ defmodule Transport.Jobs.DatasetAvailabilityScore do
   - for each resource, give it a score based on its availability over the last 24 hours
   - we compute an average of those scores to get a score at the dataset level
    - that score is averaged with the dataset's last computed score, using exponential smoothing
-  (see the function `exp_smoothing/1` below). This allows a score to reflect not only the current
+  (see the function `exp_smoothing/3`). This allows a score to reflect not only the current
   dataset situation but also past situations.
 
   If any resource as an availability score of 0 (under 95% of availability over the last 24 hours),
@@ -291,7 +355,7 @@ defmodule Transport.Jobs.DatasetFreshnessScore do
   - for each resource, give it a score
   - we compute an average of those scores to get a score at the dataset level
   - that score is averaged with the dataset's last computed score, using exponential smoothing
-  (see the function `exp_smoothing/1`). This allows a score to reflect not only the current
+  (see the function `exp_smoothing/3`). This allows a score to reflect not only the current
   dataset situation but also past situations. Typically, a dataset that had outdated resources
   for the past year, but only up-to-date resources today is expected to have a low freshness score.
   The interest of exponential smoothing is to give past scores an increasingly small weight as time

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -1,25 +1,21 @@
 <div :if={@dataset_scores != %{}} class="light-grey pt-6">
-  <% freshness_score = Map.get(@dataset_scores, :freshness) %>
+  <% components = [
+    {:freshness, "fraicheur"},
+    {:availability, "disponibilité"},
+    {:compliance, "conformité"}
+  ] %>
+  <%= for {topic, description} <- components do %>
   <div>
-    <%= unless is_nil(freshness_score) do %>
-      Score fraicheur : <%= DB.DatasetScore.score_for_humans(freshness_score) %>
+    <% score = Map.get(@dataset_scores, topic) %>
+    <%= unless is_nil(score) do %>
+      Score <%= description %> : <%= DB.DatasetScore.score_for_humans(score) %>
       <span class="small">
-        <%= freshness_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
+        <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
       </span>
     <% else %>
-      Pas de score fraicheur
+      Pas de score <%= description %>
     <% end %>
   </div>
-  <% availability_score = Map.get(@dataset_scores, :availability) %>
-  <div>
-    <%= unless is_nil(availability_score) do %>
-      Score de disponibilité : <%= DB.DatasetScore.score_for_humans(availability_score) %>
-      <span class="small">
-        <%= availability_score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
-      </span>
-    <% else %>
-      Pas de score de disponibilité
-    <% end %>
-  </div>
+  <% end %>
   <a href="#scores-chart">Voir plus</a>
 </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -5,17 +5,17 @@
     {:compliance, "conformité"}
   ] %>
   <%= for {topic, description} <- components do %>
-  <div>
-    <% score = Map.get(@dataset_scores, topic) %>
-    <%= unless is_nil(score) do %>
-      Score <%= description %> : <%= DB.DatasetScore.score_for_humans(score) %>
-      <span class="small">
-        <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
-      </span>
-    <% else %>
-      Pas de score <%= description %>
-    <% end %>
-  </div>
+    <div>
+      <% score = Map.get(@dataset_scores, topic) %>
+      <%= unless is_nil(score) do %>
+        Score <%= description %> : <%= DB.DatasetScore.score_for_humans(score) %>
+        <span class="small">
+          <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
+        </span>
+      <% else %>
+        Pas de score <%= description %>
+      <% end %>
+    </div>
   <% end %>
   <a href="#scores-chart">Voir plus</a>
 </div>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -13,7 +13,7 @@
           <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
         </span>
       <% else %>
-        Pas de score <%= description %>
+        Pas de score de <%= description %>
       <% end %>
     </div>
   <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -8,7 +8,7 @@
     <div>
       <% score = Map.get(@dataset_scores, topic) %>
       <%= unless is_nil(score) do %>
-        Score de <%= description %>: <%= DB.DatasetScore.score_for_humans(score) %>
+        Score de <%= description %> : <%= DB.DatasetScore.score_for_humans(score) %>
         <span class="small">
           <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
         </span>

--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores.html.heex
@@ -8,7 +8,7 @@
     <div>
       <% score = Map.get(@dataset_scores, topic) %>
       <%= unless is_nil(score) do %>
-        Score <%= description %> : <%= DB.DatasetScore.score_for_humans(score) %>
+        Score de <%= description %>: <%= DB.DatasetScore.score_for_humans(score) %>
         <span class="small">
           <%= score.timestamp |> Shared.DateTimeDisplay.format_datetime_to_paris(@locale) %>
         </span>

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -409,9 +409,9 @@ defmodule TransportWeb.DatasetControllerTest do
       |> get(dataset_path(conn, :details, dataset.slug))
       |> html_response(200)
 
-    assert content =~ "Score de fraicheur : 0.55"
-    assert content =~ "Score de conformité : 0.8"
-    assert content =~ "Score de disponibilité : \n"
+    assert content =~ "Score de fraicheur : 0.55"
+    assert content =~ "Score de conformité : 0.8"
+    assert content =~ "Score de disponibilité : \n"
   end
 
   test "does not display scores for non admins", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -409,9 +409,9 @@ defmodule TransportWeb.DatasetControllerTest do
       |> get(dataset_path(conn, :details, dataset.slug))
       |> html_response(200)
 
-    assert content =~ "Score fraicheur : 0.55"
-    assert content =~ "Score conformité : 0.8"
-    assert content =~ "Score disponibilité : \n"
+    assert content =~ "Score de fraicheur : 0.55"
+    assert content =~ "Score de conformité : 0.8"
+    assert content =~ "Score de disponibilité : \n"
   end
 
   test "does not display scores for non admins", %{conn: conn} do
@@ -427,7 +427,7 @@ defmodule TransportWeb.DatasetControllerTest do
     refute dataset |> DB.DatasetScore.get_latest_scores([:freshness]) |> Enum.empty?()
     set_empty_mocks()
     content = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
-    refute content =~ "Score fraicheur"
+    refute content =~ "Score de fraicheur"
   end
 
   describe "scores_chart" do

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -383,6 +383,13 @@ defmodule TransportWeb.DatasetControllerTest do
 
     insert(:dataset_score,
       dataset: dataset,
+      timestamp: DateTime.utc_now() |> DateTime.add(-3, :hour),
+      score: 0.8,
+      topic: :compliance
+    )
+
+    insert(:dataset_score,
+      dataset: dataset,
       timestamp: DateTime.utc_now() |> DateTime.add(-1, :hour),
       score: nil,
       topic: :availability
@@ -390,7 +397,8 @@ defmodule TransportWeb.DatasetControllerTest do
 
     assert %{
              availability: %DB.DatasetScore{topic: :availability, score: nil},
-             freshness: %DB.DatasetScore{topic: :freshness, score: 0.549}
+             freshness: %DB.DatasetScore{topic: :freshness, score: 0.549},
+             compliance: %DB.DatasetScore{topic: :compliance, score: 0.8}
            } = dataset |> DB.DatasetScore.get_latest_scores(Ecto.Enum.values(DB.DatasetScore, :topic))
 
     set_empty_mocks()
@@ -402,7 +410,8 @@ defmodule TransportWeb.DatasetControllerTest do
       |> html_response(200)
 
     assert content =~ "Score fraicheur : 0.55"
-    assert content =~ "Score de disponibilité : \n"
+    assert content =~ "Score conformité : 0.8"
+    assert content =~ "Score disponibilité : \n"
   end
 
   test "does not display scores for non admins", %{conn: conn} do


### PR DESCRIPTION
Fixes #3579

PR précédente faisant quelque chose de similaire #3333

Calcule et stocke un nouveau score d'un JDD, le score de conformité.

## Périmètre du score

- concerne les ressources qui sont actuellement validées (GTFS, GBFS et ressources avec un schéma associé)
  - ignore les ressources GTFS-RT (pour le moment !)
  - pour GTFS ne s'intéresser qu'aux erreurs de type `Error` et `Fatal` (comme ce qui est fait pour la notification d'erreurs de validation)
- le score vaut 0 (si au moins une erreur en GBFS/schémas et si `max_error` est `Error` ou `Fatal` en GTFS) ou 1 sinon
- Le score vaut `nil` si le JDD ne contient aucune ressource pour laquelle on peut attribuer un score
- pour un JDD, faire la moyenne des scores des ressources prises en compte

## Impact sur l'UI

Rien de visible pour les utilisateurs finaux.

Le nouveau score de conformité sera affiché pour les admins en haut du JDD et sur le graphique des scores en bas de page d'un JDD (3 topics maintenant).

![image](https://github.com/etalab/transport-site/assets/295709/fe571c29-e671-4a62-9bcc-ba9b079772fe)

1 seul point visible (du jour) car pas de données anciennes en local mais la série est bien OK

![image](https://github.com/etalab/transport-site/assets/295709/7b6386d2-134a-46ab-adce-9278356f36ea)

## Tests en local

En complément des tests écrits, j'ai calculé ces scores en local.

```iex
$ WORKER=1 iex -S mix
iex> Transport.Jobs.DatasetQualityScoreDispatcher.new(%{}) |> Oban.insert()
```

### Complétude du calcul

```sql
select ds.topic, count(1)
from dataset_score ds
where ds.timestamp::date = '2023-11-23'
group by 1;
```

donne le résultat attendu

|topic|count|
| --- | --- |
|   availability   |   488   |
|   compliance   |   488   |
|   freshness   |   488   |

### Rapidité d'exécution

Le calcul de l'ensemble des scores (tous les topics, pour ce jour) a pris 1mn20s 

```sql
select max(ds.timestamp) - min(ds.timestamp)
from dataset_score ds
where ds.timestamp::date = '2023-11-23'
```

### Cohérence des valeurs

J'ai exécuté la requête suivante, regardé la cohérence des scores et confirmé en regardant certaines pages de JDD que le score et les métadonnées étaient bonnes.

```sql
select *
from dataset_score
where topic = 'compliance'
```