### PR TITLE
DatasetQualityScore : corrige bug de calcul de score avec nil

### DIFF
--- a/apps/transport/lib/jobs/dataset_quality_score.ex
+++ b/apps/transport/lib/jobs/dataset_quality_score.ex
@@ -156,7 +156,7 @@ defmodule Transport.Jobs.DatasetQualityScore do
 
     computed_score =
       case last_score = last_dataset_score(dataset_id, topic) do
-        %{score: previous_score} when is_float(previous_score) ->
+        %{score: previous_score} when is_float(previous_score) and is_float(today_score) ->
           exp_smoothing(previous_score, today_score, topic)
 
         _ ->


### PR DESCRIPTION
Fixes #3626, voir l'issue pour le détail du problème.

J'ai découpé mes commits pour ajouter un test qui échoue puis le corriger.

Cette exception est visiblement actuellement en prod pour [le JDD Vélib](https://transport.data.gouv.fr/datasets/508) et dans [le dashboard des jobs](https://transport.data.gouv.fr/backoffice/jobs?worker=DatasetQualityScore).