### PR TITLE
Trad EN validateur GTFS : enlève traduction FR

### DIFF
--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -169,4 +169,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Files in a subfolder"
-msgstr "Fichiers dans un sous-dossier"
+msgstr ""


### PR DESCRIPTION
Corrige une petite erreur de traduction ajoutée dans https://github.com/etalab/transport-site/pull/3595/files#diff-3ea1bdfeaea8fd0b507c47429ae38a45bec3aec648c440e189bed8794d0702b6

Une traduction FR est présente dans un fichier `EN` à tort.