### PR TITLE
Notifications : ajuste le contenu du rappel périodique des notifs aux producteurs

### DIFF
--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -111,8 +111,6 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
       |> Enum.filter(&DB.Dataset.is_active?/1)
       |> Enum.sort_by(fn %DB.Dataset{custom_title: custom_title} -> custom_title end)
 
-    contacts_in_orgs = contact |> other_contacts_in_orgs()
-
     Transport.EmailSender.impl().send_mail(
       "transport.data.gouv.fr",
       Application.get_env(:transport, :contact_email),
@@ -120,12 +118,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
       Application.get_env(:transport, :contact_email),
       "Notifications pour vos données sur transport.data.gouv.fr",
       "",
-      Phoenix.View.render_to_string(TransportWeb.EmailView, "producer_without_subscriptions.html", %{
-        manage_organization_url: contact |> manage_organization_url(),
-        datasets: datasets,
-        contacts_in_orgs: Enum.map_join(contacts_in_orgs, ", ", &DB.Contact.display_name/1),
-        has_other_contacts: not Enum.empty?(contacts_in_orgs)
-      })
+      Phoenix.View.render_to_string(TransportWeb.EmailView, "producer_without_subscriptions.html", %{datasets: datasets})
     )
 
     DB.Notification.insert!(@notification_reason, contact.email)
@@ -142,7 +135,6 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
       "Rappel : vos notifications pour vos données sur transport.data.gouv.fr",
       "",
       Phoenix.View.render_to_string(TransportWeb.EmailView, "producer_with_subscriptions.html", %{
-        manage_organization_url: contact |> manage_organization_url(),
         datasets_subscribed: contact |> datasets_subscribed_as_producer(),
         has_other_producers_subscribers: not Enum.empty?(other_producers_subscribers),
         other_producers_subscribers: Enum.map_join(other_producers_subscribers, ", ", &DB.Contact.display_name/1)
@@ -152,14 +144,6 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
     DB.Notification.insert!(@notification_reason, contact.email)
   end
 
-  def manage_organization_url(%DB.Contact{organizations: [%DB.Organization{id: org_id}]}) do
-    Application.fetch_env!(:transport, :datagouvfr_site) <> "/fr/admin/organization/#{org_id}/"
-  end
-
-  def manage_organization_url(%DB.Contact{}) do
-    Application.fetch_env!(:transport, :datagouvfr_site) <> "/fr/admin/"
-  end
-
   @spec datasets_subscribed_as_producer(DB.Contact.t()) :: [DB.Dataset.t()]
   def datasets_subscribed_as_producer(%DB.Contact{notification_subscriptions: subscriptions}) do
     subscriptions
@@ -167,17 +151,6 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
     |> Enum.map(& &1.dataset)
     |> Enum.uniq()
     |> Enum.sort_by(& &1.custom_title)
-  end
-
-  @spec other_contacts_in_orgs(DB.Contact.t()) :: [DB.Contact.t()]
-  def other_contacts_in_orgs(%DB.Contact{id: contact_id} = contact) do
-    contact
-    |> DB.Repo.preload(organizations: [:contacts])
-    |> Map.fetch!(:organizations)
-    |> Enum.flat_map(& &1.contacts)
-    |> Enum.uniq()
-    |> Enum.reject(&match?(%DB.Contact{id: ^contact_id}, &1))
-    |> Enum.sort_by(&DB.Contact.display_name/1)
   end
 
   @spec subscribed_as_producer?(DB.Contact.t()) :: boolean()

--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -1,13 +1,9 @@
 Bonjour,
 
-Vous gérez des données présentes sur transport.data.gouv.fr.
-
-## Gérer vos notifications
-
 <%= if Enum.count(@datasets_subscribed) == 1 do %>
-Vous êtes susceptible de recevoir des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset() %>.
+Vous êtes inscrit à des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset() %>.
 <% else %>
-Vous êtes susceptible de recevoir des notifications pour les jeux de données suivants :
+Vous êtes inscrit à des notifications concernant les jeux de données suivants :
 <ul>
   <%= for dataset <- @datasets_subscribed do %>
   <li><%= link_for_dataset(dataset) %></li>
@@ -15,20 +11,14 @@ Vous êtes susceptible de recevoir des notifications pour les jeux de données s
 </ul>
 <% end %>
 
-Les notifications facilitent la gestion de vos données. Elles vous permettront d’être averti de l’expiration de vos ressources, des erreurs qu’elles peuvent contenir et de leur potentielle indisponibilité.
-
-Vous pouvez gérer ces notifications depuis [votre espace producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) du Point d’Accès National.
-
-## Gérer les membres de votre organisation
-
-L’administrateur de votre organisation peut ajouter, modifier ou supprimer les différents membres depuis [votre espace d’administration data.gouv.fr](<%= @manage_organization_url %>).
+Les notifications vous permettent d’être alerté en cas d’expiration, d’indisponibilité et d’erreurs de vos données. Rendez-vous sur votre [Espace Producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) pour les gérer de manière autonome.
 
 <%= if @has_other_producers_subscribers do %>
 Les autres personnes inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
 <% end %>
 
-Chaque utilisateur peut paramétrer ses propres notifications depuis son espace producteur du PAN.
-
 Nous restons disponibles pour vous accompagner si besoin.
 
-À bientôt !
+À bientôt,
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -1,13 +1,9 @@
 Bonjour,
 
-Vous gérez des données présentes sur transport.data.gouv.fr.
-
-## Recevoir des notifications
-
 <%= if Enum.count(@datasets) == 1 do %>
-Vous gérez le jeu de données <%= @datasets |> hd() |> link_for_dataset() %>.
+Le saviez-vous ? Il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <%= @datasets |> hd() |> link_for_dataset() %>.
 <% else %>
-Vous gérez les jeux de données suivants :
+Le saviez-vous ? Il est possible de vous inscrire à des notifications concernant les jeux de données que vous gérez sur transport.data.gouv.fr :
 <ul>
   <%= for dataset <- @datasets do %>
   <li><%= link_for_dataset(dataset) %></li>
@@ -15,18 +11,12 @@ Vous gérez les jeux de données suivants :
 </ul>
 <% end %>
 
-Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications depuis [votre espace producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) du Point d’Accès National. Elles vous permettront d’être averti de l’expiration de vos ressources, des erreurs qu’elles peuvent contenir et de leur potentielle indisponibilité.
+Les notifications vous permettent d’être alerté en cas d’expiration, d’indisponibilité et d’erreurs de vos données.
 
-## Gérer les membres de votre organisation
-
-L’administrateur de votre organisation peut ajouter, modifier ou supprimer les différents membres depuis [votre espace d’administration data.gouv.fr](<%= @manage_organization_url %>).
-
-<%= if @has_other_contacts do %>
-Les autres personnes pouvant s’inscrire à ces notifications et s’étant déjà connectées sont : <%= @contacts_in_orgs %>.
-<% end %>
-
-Chaque utilisateur peut paramétrer ses propres notifications depuis son espace producteur du PAN.
+Pour vous inscrire, rien de plus simple : rendez-vous sur votre [Espace Producteur](<%= TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur) %>) dans le menu “Recevoir des notifications”.
 
 Nous restons disponibles pour vous accompagner si besoin.
 
-À bientôt !
+À bientôt,
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -104,28 +104,6 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
            |> PeriodicReminderProducersNotificationJob.subscribed_as_producer?()
   end
 
-  test "other_contacts_in_orgs" do
-    org_id = Ecto.UUID.generate()
-
-    contact =
-      insert_contact(%{
-        organizations: [
-          sample_org(%{"id" => org_id}),
-          sample_org()
-        ]
-      })
-
-    %DB.Contact{id: other_contact_id} =
-      insert_contact(%{
-        organizations: [
-          sample_org(%{"id" => org_id})
-        ]
-      })
-
-    assert [%DB.Contact{id: ^other_contact_id}] =
-             PeriodicReminderProducersNotificationJob.other_contacts_in_orgs(contact)
-  end
-
   test "other_producers_subscribers" do
     producer_1 = insert_contact()
     %DB.Contact{id: producer_2_id} = producer_2 = insert_contact()
@@ -216,7 +194,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       assert subject == "Rappel : vos notifications pour vos données sur transport.data.gouv.fr"
 
       assert html =~
-               ~s(Vous êtes susceptible de recevoir des notifications pour le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
+               ~s(Vous êtes inscrit à des notifications pour le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
 
       assert html =~ "Les autres personnes inscrites à ces notifications sont : Marina Loiseau."
     end)
@@ -237,15 +215,6 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
         ]
       })
 
-    insert_contact(%{
-      first_name: "Marina",
-      last_name: "Loiseau",
-      organizations: [
-        sample_org(%{"id" => org_id}),
-        sample_org()
-      ]
-    })
-
     dataset = insert(:dataset, custom_title: "Super JDD", organization_id: org_id)
 
     refute contact
@@ -263,12 +232,10 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       assert subject == "Notifications pour vos données sur transport.data.gouv.fr"
 
       assert html =~
-               ~s(Vous gérez le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
-
-      assert html =~ "Pour vous faciliter la gestion de ces données, vous pouvez activer des notifications"
+               ~s(Il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
 
       assert html =~
-               "Les autres personnes pouvant s’inscrire à ces notifications et s’étant déjà connectées sont : Marina Loiseau."
+               ~s(Pour vous inscrire, rien de plus simple : rendez-vous sur votre <a href="http://127.0.0.1:5100/espace_producteur">Espace Producteur</a>)
     end)
 
     assert :ok == perform_job(PeriodicReminderProducersNotificationJob, %{"contact_id" => contact.id})
@@ -286,27 +253,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
              perform_job(PeriodicReminderProducersNotificationJob, %{"contact_id" => contact.id})
   end
 
-  describe "manage_organization_url" do
-    test "single org" do
-      org_id = Ecto.UUID.generate()
-      contact = %{organizations: [sample_org(%{"id" => org_id})]} |> insert_contact() |> DB.Repo.preload(:organizations)
-      assert 1 == contact.organizations |> Enum.count()
-
-      assert "https://demo.data.gouv.fr/fr/admin/organization/#{org_id}/" ==
-               contact |> PeriodicReminderProducersNotificationJob.manage_organization_url()
-    end
-
-    test "multiple orgs" do
-      contact = %{organizations: [sample_org(), sample_org()]} |> insert_contact() |> DB.Repo.preload(:organizations)
-
-      assert 2 == contact.organizations |> Enum.count()
-
-      assert "https://demo.data.gouv.fr/fr/admin/" ==
-               contact |> PeriodicReminderProducersNotificationJob.manage_organization_url()
-    end
-  end
-
-  defp sample_org(%{} = args \\ %{}) do
+  defp sample_org(%{} = args) do
     Map.merge(
       %{
         "acronym" => nil,


### PR DESCRIPTION
Fixes #3567

Gère les 2 derniers templates à traiter pour la revue du contenu des notifications https://github.com/etalab/transport-site/issues/3567#issuecomment-1833475278, les rappels périodiques envoyés aux producteurs faisant la promotion des notifications.

Les modifications de contenu ont été effectuées suite [aux consignes données](https://www.notion.so/Gestion-des-notifications-externes-3e43125a9e6c41309fa72082c2008945) par @ChristinaLaumond. Le contenu est simplifié en enlevant le bloc sur la partie gestion des membres de l’organisation pour ne pas complexifier le message. Les méthodes inutilisées sont supprimées.