### PR TITLE
ImportData : adapte lecture des zones datagouv

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -235,33 +235,31 @@ defmodule Transport.ImportData do
   end
 
   @spec read_datagouv_zone(map()) :: [binary()]
-  defp read_datagouv_zone(%{
-         "features" => [
-           %{
-             "properties" => %{
-               "level" => "fr:commune",
-               "keys" => %{
-                 "insee" => insee
-               }
-             }
-           }
-           | _
-         ]
-       }) do
+  def read_datagouv_zone(%{
+        "features" => [
+          %{
+            "properties" => %{
+              "level" => "fr:commune",
+              "code" => insee
+            }
+          }
+          | _
+        ]
+      }) do
     [insee]
   end
 
-  defp read_datagouv_zone(%{
-         "features" => [
-           %{
-             "properties" => %{
-               "level" => "fr:epci",
-               "code" => code
-             }
-           }
-           | _
-         ]
-       }) do
+  def read_datagouv_zone(%{
+        "features" => [
+          %{
+            "properties" => %{
+              "level" => "fr:epci",
+              "code" => code
+            }
+          }
+          | _
+        ]
+      }) do
     # For the EPCI we get the list of cities contained by the EPCI
     EPCI
     |> Repo.get_by(code: code)
@@ -275,12 +273,12 @@ defmodule Transport.ImportData do
     end
   end
 
-  defp read_datagouv_zone(%{"features" => [%{"id" => id} | _]}) do
+  def read_datagouv_zone(%{"features" => [%{"id" => id} | _]}) do
     Logger.info("For the moment we can only handle cities, we cannot handle the zone #{id}")
     []
   end
 
-  defp read_datagouv_zone(z) do
+  def read_datagouv_zone(z) do
     Logger.info("invalid format we cannot handle the zone #{inspect(z)}")
     []
   end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -106,6 +106,10 @@ defmodule DB.Factory do
     }
   end
 
+  def epci_factory do
+    %DB.EPCI{}
+  end
+
   def data_import_factory do
     %DB.DataImport{}
   end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -361,4 +361,46 @@ defmodule Transport.ImportDataTest do
     assert [%{"format" => "gtfs", "type" => "main"}, %{"format" => "svg", "type" => "documentation"}] ==
              ImportData.get_valid_resources(resources, "public-transit")
   end
+
+  describe "read_datagouv_zone" do
+    test "for a commune" do
+      # Example: https://www.data.gouv.fr/api/1/spatial/zones/fr:commune:38185/
+      assert ["38185"] ==
+               ImportData.read_datagouv_zone(%{
+                 "features" => [
+                   %{
+                     "id" => "fr:commune:38185",
+                     "properties" => %{
+                       "code" => "38185",
+                       "level" => "fr:commune",
+                       "name" => "Grenoble",
+                       "slug" => "Grenoble",
+                       "uri" => "http://id.insee.fr/geo/commune/f71595ba-1957-416a-83c2-c7f677a91ca4"
+                     }
+                   }
+                 ]
+               })
+    end
+
+    test "for an EPCI" do
+      commune = insert(:commune)
+      epci = insert(:epci, code: "242320109", nom: "Le Pays Dunois", communes_insee: [commune.insee])
+      # Example: https://www.data.gouv.fr/api/1/spatial/zones/fr:epci:242320109/
+      assert [commune.insee] ==
+               ImportData.read_datagouv_zone(%{
+                 "features" => [
+                   %{
+                     "id" => "fr:epci:#{epci.code}",
+                     "properties" => %{
+                       "code" => epci.code,
+                       "level" => "fr:epci",
+                       "name" => epci.nom,
+                       "slug" => "Le-Pays-Dunois",
+                       "uri" => "http://id.insee.fr/geo/intercommunalite/882b7908-51cf-401d-b0db-ae6ad708b670"
+                     }
+                   }
+                 ]
+               })
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3657, voir le détail du problème là-bas.

Le retour de l'API data.gouv.fr a changé [pour une commune](https://www.data.gouv.fr/api/1/spatial/zones/fr:commune:38185/), il n'y a plus la clé `keys` mais on retrouve le même format que pour les EPCI avec la clé `code` qui contient le code INSEE.

Ajoute des tests pour cette méthode, qui n'était pas couverte auparavant.