### PR TITLE
Amélioration du readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ You can install this 2 different ways:
 ## Manual installation <a name="manual_install"></a>
 
   * Make sure you have **Elixir**, **Node**, **Yarn** and **Docker** installed and up-to-date
-    * **Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects. The project needs at least **Elixir** 1.8 and **Erlang** 21.0
+    * **Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects. The project needs at least **Elixir** 1.8 and **Erlang** 21.0 See below if you wish to install the right tooling versions through ASDF
   * Install Elixir dependencies with `mix deps.get`
   * Install Node.js dependencies with `mix yarn install`
+
+  ### Erlang, Elixir, NodeJS and Yarn installation through ASDF
 
 If you wish to use `asdf` (recommended), make sure to install the correct plugins:
 
@@ -31,8 +33,13 @@ If you wish to use `asdf` (recommended), make sure to install the correct plugin
 * `asdf plugin-add elixir` (https://github.com/asdf-vm/asdf-elixir)
 * `asdf plugin-add nodejs` (https://github.com/asdf-vm/asdf-nodejs)
 
-Installation can then be done with:
+Installation for Erlang, Elixir and NodeJS can then be done with:
 * `asdf install`
+
+For Yarn, bring your own version in your global .tool_versions:
+* `asdf plugin-add yarn` (https://github.com/twuni/asdf-yarn)
+* `asdf install yarn 1.22.19` (or any other version)
+* `asdf global yarn 1.22.19`
 
 ### Postgresql
 
@@ -47,6 +54,8 @@ Download depencies using `mix deps.get`.
 Reply "Yes" to the question "Shall I install Hex? (if running non-interactively, use "mix local.hex --force")".
 
 #### Creating a database
+
+Make sure you have a postgres user with postgres password, and that the identification methode is set to md5 in your `pg_hba.conf` file.
 
 Create the database with the command `mix ecto.create`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can install this 2 different ways:
 
 ### 1. Install Elixir, Node and Yarn
 
-Make sure you have **Elixir**, **Node** and **Yarn** installed and up-to-date. **Docker** is optionnally needed if you want to run on your machine the [extra transport tools](https://github.com/etalab/transport-tools).
+Make sure you have **Elixir**, **Node.js** and **Yarn** installed and up-to-date. **Docker** is optionnally needed if you want to run on your machine the [extra transport tools](https://github.com/etalab/transport-tools).
 
 **Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects.
 
@@ -32,17 +32,17 @@ If you wish to use `asdf` (recommended), make sure to install the correct plugin
 * `asdf plugin-add elixir` (https://github.com/asdf-vm/asdf-elixir)
 * `asdf plugin-add nodejs` (https://github.com/asdf-vm/asdf-nodejs)
 
-Installation for Erlang, Elixir and NodeJS can then be done with:
+Installation for Erlang, Elixir and Node.js can then be done with:
 * `asdf install`
 
-For Yarn, bring your own version or also use asdf :
+For Yarn, bring your version or also use asdf:
 * `asdf plugin-add yarn` (https://github.com/twuni/asdf-yarn)
 * `asdf install yarn 1.22.19` (or any other version)
 * `asdf global yarn 1.22.19`
 
 ### 2. Install PostgreSQL
 
-You also need an up to date postgresql with postgis installed. Version 14+ is recommended.
+You also need an up-to-date PostgreSQL with Postgis installed. Version 14+ is recommended.
 
 For Mac users, you can use https://postgresapp.com/.
 
@@ -55,7 +55,7 @@ For Mac users, you can use https://postgresapp.com/.
 
 Alternatively, you can use Docker, see the [Docker section](#docker-installation-).
 
-## Prepare the Postgresql database
+## Prepare the PostgreSQL database
 
 ### Creating a database
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ You can install this 2 different ways:
 
 ## Manual installation <a name="manual_install"></a>
 
-  * Make sure you have **Elixir**, **Node**, **Yarn** and **Docker** installed and up-to-date
-    * **Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects. The project needs at least **Elixir** 1.8 and **Erlang** 21.0 See below if you wish to install the right tooling versions through ASDF
-  * Install Elixir dependencies with `mix deps.get`
-  * Install Node.js dependencies with `mix yarn install`
+### 1. Install Elixir, Node and Yarn
 
-  ### Erlang, Elixir, NodeJS and Yarn installation through ASDF
+Make sure you have **Elixir**, **Node** and **Yarn** installed and up-to-date. **Docker** is optionnally needed if you want to run on your machine the [extra transport tools](https://github.com/etalab/transport-tools).
+
+**Elixir** is often installed with [asdf](https://asdf-vm.com/) since it makes it easy to handle different **Elixir** versions accross projects.
 
 If you wish to use `asdf` (recommended), make sure to install the correct plugins:
 
@@ -36,24 +35,29 @@ If you wish to use `asdf` (recommended), make sure to install the correct plugin
 Installation for Erlang, Elixir and NodeJS can then be done with:
 * `asdf install`
 
-For Yarn, bring your own version in your global .tool_versions:
+For Yarn, bring your own version or also use asdf :
 * `asdf plugin-add yarn` (https://github.com/twuni/asdf-yarn)
 * `asdf install yarn 1.22.19` (or any other version)
 * `asdf global yarn 1.22.19`
 
-### Postgresql
+### 2. Install PostgreSQL
 
 You also need an up to date postgresql with postgis installed. Version 14+ is recommended.
 
 For Mac users, you can use https://postgresapp.com/.
 
-#### Dependencies
+### 3. Build project
 
-Download depencies using `mix deps.get`.
+  * Install Elixir dependencies with `mix deps.get`
+  * Install Node.js dependencies with `mix yarn install`
 
-Reply "Yes" to the question "Shall I install Hex? (if running non-interactively, use "mix local.hex --force")".
+## Docker installation
 
-#### Creating a database
+Alternatively, you can use Docker, see the [Docker section](#docker-installation-).
+
+## Prepare the Postgresql database
+
+### Creating a database
 
 Make sure you have a postgres user with postgres password, and that the identification methode is set to md5 in your `pg_hba.conf` file.
 
@@ -62,18 +66,18 @@ Create the database with the command `mix ecto.create`.
 Alternatively, you can create it manually. With the permission to create a database (on Debian based system, you need to be logged as `postgres`), type
 `createdb transport_repo`.
 
-#### Applying the migrations
+### Applying the migrations
 
 To have an up to date database schema run `mix ecto.migrate`.
 
-#### Restoring the production database
+### Restoring the production database
 
 The production database does not contains any sensitive data, you can retreive it for dev purpose.
 * You can retrieve the [latest clever-cloud backup](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/addons/addon_beebaa5e-c3a4-4c57-b124-cf9d1473450a) (you need some permissions to access it, if you don't have them, you can ask someone on the team to give you the database)
 * On the clever-cloud website, under transport-site-postgresql, there is a Backups section with download links.
 * restore the downloaded backup on you database: `./restore_db.sh <path_to_the_backup>`
 
-#### Binary CLI dependencies
+## Binary CLI dependencies (optional)
 
 The app uses a number of tools via [transport-tools](https://github.com/etalab/transport-tools).
 
@@ -95,7 +99,7 @@ For Rust binaries, you will have to compile them locally and copy them to the sa
 
 Once this is done, make sure to configure your configuration via `:transport_tools_folder`.
 
-## Usage
+# Usage
 
 Run the server with `mix phx.server` and you can visit [`127.0.0.1:5000`](http://127.0.0.1:5000) on your browser.
 
@@ -143,11 +147,11 @@ config :oauth2, Datagouvfr.Authentication,
   redirect_uri: "http://localhost:5000/login/callback"
 ```
 
-## Development
+# Development
 
-### Testing
+## Testing
 
-#### Running the tests
+### Running the tests
 
 Run the tests with `mix test`
 
@@ -168,7 +172,7 @@ mix cmd --app transport mix test --color test/transport_web/integrations/backoff
 
 The filenames must be relative to the app folder. This [will be improved](https://dockyard.com/blog/2019/06/17/testing-in-umbrella-apps-improves-in-elixir-1-9) when we upgrade to a more modern Elixir version.
 
-#### Measuring test coverage
+### Measuring test coverage
 
 We use [excoveralls](https://github.com/parroty/excoveralls) to measure which parts of the code are covered by testing (or not). This is useful to determine where we can improve the testing quality.
 
@@ -188,22 +192,22 @@ The coverage is written on screen by default, or in the `cover` subfolders for H
 
 Running in `--umbrella` mode will generate coverage report at the top-level `cover` folder, while running without it will generate reports under each umbrella sub-app (e.g. `apps/transport/cover`).
 
-### Linting
+## Linting
 
   * Run the elixir linter with `mix credo --strict`
   * Run the javascript linter with `mix npm "run linter:ecma"`
   * Run the sass linter with `mix npm "run linter:sass"`
 
-### Misc Elixir command
+## Misc Elixir command
 
-#### Translations
+### Translations
 
 To extract all translations from the source, you can run `mix gettext.extract --merge` (and then edit the modified .po files).
 
-#### Check all
+### Check all
 To perform all the checks done on the CI with a single command, you can run `mix check_all`. It will run the different linters, credo, check the translations are up-to-date, and launch the tests.
 
-#### DB migrations
+### DB migrations
 
 To generate a new migration file:
 `cd apps/transport && mix ecto.gen.migration <name of the migration> && cd ../..`
@@ -213,7 +217,7 @@ The generated [ecto](https://hexdocs.pm/ecto/Ecto.html) migration file will be `
 To apply all migrations on you database:
 `mix ecto.migrate`
 
-#### One shot tasks
+### One shot tasks
 
 Some custom one shot tasks are available.
 
@@ -223,13 +227,17 @@ To run a custom task: `mix <custom task>`
 * `Transport.ImportEPCI`: import the french EPCI from data.gouv
 * `Transport.OpenApiSpec`: generate an OpenAPI specification file
 
-### Testing emails
+## Testing emails
 
 To locally test emails in a dev environment, a Swoosh preview inbox available in your browser at `/dev/mailbox`. Your server needs to be run through iex : `iex -S mix phx.server`.
 
-## Docker installation <a name="docker_install"></a>
+## Learn more and debug
 
-### Development
+See the [learning track document](learning_track.md).
+
+# Docker installation <a name="docker_install"></a>
+
+## Development
 
 If you don't plan to work a lot on this project, the docker installation is way easier.
 
@@ -251,14 +259,14 @@ For the tests you also need to add an environment variable:
 
 `docker-compose run -e web mix test`
 
-### Production
+## Production
 
   The Dockerfile needed to run the continuous integration is in the project:
   https://github.com/etalab/transport-ops
 
   Update it if needed (e.g. updating Elixir’s version) and then update `.circleci/config.yml`.
 
-### Domain names
+# Domain names
 
 The following domain names are currently in use by the deployed Elixir app:
 


### PR DESCRIPTION
Quelques améliorations :
- Clarification de l’installation de Yarn
- Instructions d’installation remises dans l’ordre chronologique
- Niveau d’indentation corrigé pour une bonne partie du document.

Pour Docker, je ne l’ai jamais installé, j’ai l’impression qu’avec le docker-compose.yml on s’évite l’installation sur son propre système de postgresql (qui est du coup contenerisé) mais pas la création de la base de données et les migrations, j’ai écrit la doc dans ce sens là.

Voir [le rendu](https://github.com/etalab/transport-site/blob/improve-readme-yarn/README.md) Astuce : bouton en haut à droite pour afficher le menu et vérifier que l’arborescence est logique.