### PR TITLE
S3 : migration vers de l'upload en streaming

### DIFF
--- a/apps/transport/lib/S3/s3.ex
+++ b/apps/transport/lib/S3/s3.ex
@@ -48,15 +48,4 @@ defmodule Transport.S3 do
     |> ExAws.S3.upload(Transport.S3.bucket_name(feature), upload_path, options)
     |> Transport.Wrapper.ExAWS.impl().request!()
   end
-
-  @spec upload_to_s3!(bucket_feature(), binary(), binary(), acl: atom()) :: any()
-  def upload_to_s3!(feature, body, path, options \\ []) do
-    Logger.debug("Uploading file to #{path}")
-    options = Keyword.validate!(options, acl: :private)
-
-    feature
-    |> Transport.S3.bucket_name()
-    |> ExAws.S3.put_object(path, body, options)
-    |> Transport.Wrapper.ExAWS.impl().request!()
-  end
 end

--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -132,10 +132,9 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   end
 
   defp upload_temporary_file do
-    content = File.read!(@bnlc_path)
     now = DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_string() |> String.replace(" ", "_")
     filename = "bnlc-#{now}.csv"
-    Transport.S3.upload_to_s3!(@s3_bucket, content, filename, acl: :public_read)
+    Transport.S3.stream_to_s3!(@s3_bucket, @bnlc_path, filename, acl: :public_read)
     filename
   end
 

--- a/apps/transport/lib/jobs/conversions/gtfs_generic_converter.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_generic_converter.ex
@@ -140,13 +140,12 @@ defmodule Transport.Jobs.GTFSGenericConverter do
               conversion_output_path
             end
 
-          file = File.read!(path)
           %File.Stat{size: filesize} = File.stat!(path)
 
           conversion_file_name =
             resource_filename |> conversion_file_name(format_lower) |> add_zip_extension(zip_conversion?)
 
-          Transport.S3.upload_to_s3!(:history, file, conversion_file_name, acl: :public_read)
+          Transport.S3.stream_to_s3!(:history, path, conversion_file_name, acl: :public_read)
 
           %DataConversion{
             convert_from: :GTFS,

--- a/apps/transport/lib/transport/gtfs_diff.ex
+++ b/apps/transport/lib/transport/gtfs_diff.ex
@@ -307,7 +307,7 @@ defmodule Transport.GTFSDiff do
     diff |> Enum.zip_with(id_range, &Map.merge(&1, %{id: &2}))
   end
 
-  def dump_diff(diff) do
+  def dump_diff(diff, filepath) do
     headers = ["id", "file", "action", "target", "identifier", "initial_value", "new_value", "note"]
 
     body =
@@ -331,11 +331,9 @@ defmodule Transport.GTFSDiff do
         ]
       end)
 
-    res = [headers | body]
-
-    res
-    |> CSV.dump_to_iodata()
-    |> IO.iodata_to_binary()
+    [headers | body]
+    |> CSV.dump_to_stream()
+    |> Stream.into(File.stream!(filepath))
   end
 
   def apply_delete(file, diff, primary_key) do

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -56,7 +56,7 @@ defmodule TransportWeb.ValidationController do
       }) do
     if is_valid_type?(type) do
       oban_args = build_oban_args(type)
-      upload_to_s3(file_path, Map.fetch!(oban_args, "filename"))
+      stream_to_s3(file_path, Map.fetch!(oban_args, "filename"))
 
       validation =
         %MultiValidation{
@@ -193,8 +193,8 @@ defmodule TransportWeb.ValidationController do
 
   def is_valid_type?(type), do: type in (select_options() |> Enum.map(&elem(&1, 1)))
 
-  defp upload_to_s3(file_path, path) do
-    Transport.S3.upload_to_s3!(:on_demand_validation, File.read!(file_path), path, acl: :public_read)
+  defp stream_to_s3(local_filepath, path) do
+    Transport.S3.stream_to_s3!(:on_demand_validation, local_filepath, path, acl: :public_read)
   end
 
   defp build_oban_args(%{"url" => url, "feed_url" => feed_url, "type" => "gtfs-rt"}) do

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -49,7 +49,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     [gtfs_file_name_2, gtfs_file_name_1] =
       consume_uploaded_entries(socket, :gtfs, fn %{path: path}, _entry ->
         file_name = Path.basename(path)
-        upload_to_s3(path, file_name)
+        stream_to_s3(path, file_name)
         {:ok, file_name}
       end)
 
@@ -138,8 +138,8 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     {:noreply, socket}
   end
 
-  defp upload_to_s3(file_path, path) do
-    Transport.S3.upload_to_s3!(:gtfs_diff, File.read!(file_path), path, acl: :public_read)
+  defp stream_to_s3(file_path, path) do
+    Transport.S3.stream_to_s3!(:gtfs_diff, file_path, path, acl: :public_read)
   end
 
   def uploads_are_valid(%{gtfs: %{entries: gtfs}}) do

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -313,9 +313,10 @@ defmodule Transport.Validators.GTFSRT do
   end
 
   defp download_latest_gtfs(%ResourceHistory{payload: %{"permanent_url" => url, "format" => "GTFS"}}, tmp_path) do
+    req_options = [compressed: false, decode_body: false, into: File.stream!(tmp_path)]
+
     unless File.exists?(tmp_path) do
-      %HTTPoison.Response{status_code: 200, body: body} = http_client().get!(url, [], follow_redirect: true)
-      File.write!(tmp_path, body)
+      {:ok, %Req.Response{status: 200}} = Transport.Req.impl().get(url, req_options)
     end
   end
 
@@ -358,6 +359,5 @@ defmodule Transport.Validators.GTFSRT do
     "#{download_path(resource)}.results.json"
   end
 
-  defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
   defp remove_file(path), do: File.rm(path)
 end

--- a/apps/transport/test/support/s3_test_utils.ex
+++ b/apps/transport/test/support/s3_test_utils.ex
@@ -19,17 +19,16 @@ defmodule Transport.Test.S3TestUtils do
     end)
   end
 
-  def s3_mocks_upload_file(assert_path) do
+  def s3_mock_stream_file(start_path: expected_start_path, bucket: expected_bucket) do
     Transport.ExAWS.Mock
-    |> expect(:request!, fn %{
-                              service: :s3,
-                              http_method: :put,
+    |> expect(:request!, fn %ExAws.S3.Upload{
+                              src: %File.Stream{},
+                              bucket: ^expected_bucket,
                               path: path,
-                              bucket: _bucket_name,
-                              body: _content,
-                              headers: %{"x-amz-acl" => "public-read"}
+                              opts: [acl: :public_read],
+                              service: :s3
                             } ->
-      assert(path |> String.starts_with?(assert_path))
+      assert String.starts_with?(path, expected_start_path)
     end)
   end
 

--- a/apps/transport/test/transport/jobs/conversions/single_gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/single_gtfs_to_geojson_converter_job_test.exs
@@ -63,7 +63,10 @@ defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJobTest do
       {:ok, "this my geojson content"}
     end)
 
-    Transport.Test.S3TestUtils.s3_mocks_upload_file("conversions/gtfs-to-geojson/")
+    Transport.Test.S3TestUtils.s3_mock_stream_file(
+      start_path: "conversions/gtfs-to-geojson/",
+      bucket: "transport-data-gouv-fr-resource-history-test"
+    )
 
     # job succeed
     assert :ok ==

--- a/apps/transport/test/transport/jobs/conversions/single_gtfs_to_netex_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/single_gtfs_to_netex_converter_job_test.exs
@@ -69,7 +69,10 @@ defmodule Transport.Jobs.SingleGTFSToNeTExHoveConverterJobTest do
       {:ok, ""}
     end)
 
-    Transport.Test.S3TestUtils.s3_mocks_upload_file("conversions/gtfs-to-netex/")
+    Transport.Test.S3TestUtils.s3_mock_stream_file(
+      start_path: "conversions/gtfs-to-netex/",
+      bucket: "transport-data-gouv-fr-resource-history-test"
+    )
 
     # job succeed
     assert :ok ==

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -119,11 +119,6 @@ defmodule Transport.Validators.GTFSRTTest do
           url: gtfs_rt_no_errors_url
         )
 
-      Transport.HTTPoison.Mock
-      |> expect(:get!, fn ^gtfs_permanent_url, [], [follow_redirect: true] ->
-        %HTTPoison.Response{status_code: 200, body: "gtfs"}
-      end)
-
       Transport.Req.Mock
       |> expect(:get, fn ^gtfs_rt_url, [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
         File.write!(stream_path, body = "gtfs-rt")
@@ -135,6 +130,13 @@ defmodule Transport.Validators.GTFSRTTest do
                          [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
         File.write!(stream_path, body = "gtfs-rt")
         {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_permanent_url,
+                         [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "gtfs_content")
+        {:ok, %Req.Response{status: 200}}
       end)
 
       mock_s3_stream_upload(gtfs_rt)
@@ -289,15 +291,17 @@ defmodule Transport.Validators.GTFSRTTest do
           url: gtfs_rt_no_errors_url
         )
 
-      Transport.HTTPoison.Mock
-      |> expect(:get!, fn ^gtfs_permanent_url, [], [follow_redirect: true] ->
-        %HTTPoison.Response{status_code: 200, body: "gtfs"}
-      end)
-
       Transport.Req.Mock
       |> expect(:get, fn ^gtfs_rt_url, [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
         File.write!(stream_path, body = "gtfs-rt")
         {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_permanent_url,
+                         [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "gtfs_content")
+        {:ok, %Req.Response{status: 200}}
       end)
 
       mock_s3_stream_upload(gtfs_rt)
@@ -393,15 +397,17 @@ defmodule Transport.Validators.GTFSRTTest do
           url: gtfs_rt_url
         )
 
-      Transport.HTTPoison.Mock
-      |> expect(:get!, fn ^gtfs_permanent_url, [], [follow_redirect: true] ->
-        %HTTPoison.Response{status_code: 200, body: "gtfs"}
-      end)
-
       Transport.Req.Mock
       |> expect(:get, fn ^gtfs_rt_url, [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
         File.write!(stream_path, body = "gtfs-rt")
         {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_permanent_url,
+                         [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "gtfs_content")
+        {:ok, %Req.Response{status: 200}}
       end)
 
       mock_s3_stream_upload(gtfs_rt)
@@ -462,15 +468,17 @@ defmodule Transport.Validators.GTFSRTTest do
           url: gtfs_rt_url
         )
 
-      Transport.HTTPoison.Mock
-      |> expect(:get!, fn ^gtfs_permanent_url, [], [follow_redirect: true] ->
-        %HTTPoison.Response{status_code: 200, body: "gtfs"}
-      end)
-
       Transport.Req.Mock
       |> expect(:get, fn ^gtfs_rt_url, [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
         File.write!(stream_path, body = "gtfs-rt")
         {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_permanent_url,
+                         [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "gtfs_content")
+        {:ok, %Req.Response{status: 200}}
       end)
 
       mock_s3_stream_upload(gtfs_rt)

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -88,7 +88,7 @@ defmodule TransportWeb.ValidationControllerTest do
 
     test "with a GTFS", %{conn: conn} do
       Transport.Shared.Schemas.Mock |> expect(:transport_schemas, fn -> %{} end)
-      S3TestUtils.s3_mocks_upload_file("")
+      S3TestUtils.s3_mock_stream_file(start_path: "", bucket: "transport-data-gouv-fr-on-demand-validation-test")
       assert 0 == count_validations()
 
       conn =
@@ -154,7 +154,7 @@ defmodule TransportWeb.ValidationControllerTest do
       Transport.Shared.Schemas.Mock
       |> expect(:transport_schemas, 2, fn -> %{schema_name => %{"schema_type" => "tableschema", "title" => "foo"}} end)
 
-      S3TestUtils.s3_mocks_upload_file("")
+      S3TestUtils.s3_mock_stream_file(start_path: "", bucket: "transport-data-gouv-fr-on-demand-validation-test")
       assert 0 == count_validations()
 
       conn =


### PR DESCRIPTION
Fixes #2067

Adapte le code de toute la codebase pour passer à de l'upload en streaming pour Cellar. J'en ai profité pour changer le client HTTP de `Transport.Validators.GTFSRT` et passer à du streaming avec `Req`.