### PR TITLE
Répare GTFSDiff.dump_diff

### DIFF
--- a/apps/transport/lib/transport/gtfs_diff.ex
+++ b/apps/transport/lib/transport/gtfs_diff.ex
@@ -334,6 +334,7 @@ defmodule Transport.GTFSDiff do
     [headers | body]
     |> CSV.dump_to_stream()
     |> Stream.into(File.stream!(filepath))
+    |> Stream.run()
   end
 
   def apply_delete(file, diff, primary_key) do
@@ -410,11 +411,3 @@ defmodule Transport.GTFSDiff do
     |> IO.iodata_to_binary()
   end
 end
-
-# usage
-
-# unzip_1 = Transport.GTFSDiff.unzip("path/to/gtfs_1.zip")
-# unzip_2 = Transport.GTFSDiff.unzip("path/to/gtfs_2.zip")
-
-# diff = Transport.GTFSDiff.diff(unzip_1, unzip_2)
-# File.write!("diff_output.txt", diff |> Transport.GTFSDiff.dump_diff())


### PR DESCRIPTION
Répare un bug introduit dans #3666, [ici](https://github.com/etalab/transport-site/pull/3666/files#diff-8447a6cd2b7fa16ca30e0b99f967cdd9c2783bb0f4543f4725f151111bdd49ca).

Le passage a la sauvegarde sur disque par le biais d'un stream a introduit un bug, ce n'était pas exécuté.

Comme le dit bien [la doc](https://hexdocs.pm/elixir/Stream.html#into/3)

> This function is often used with run/1 since any evaluation is delayed until the stream is executed. 

:angel:

Bref, un `Stream` ça s'exécute.

C'était passé sous silence car il n'y avait pas de tests. Il y en a désormais !