### PR TITLE
BNLCJobToGeoData : utilise nouvelle BNLC

### DIFF
--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -844,7 +844,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
     tmp_path = @tmp_path
 
     expected_url =
-      "https://demo.data.gouv.fr/api/1/datasets/5d6eaffc8b4c417cdc452ac3/resources/4fd78dee-e122-4c0d-8bf6-ff55d79f3af1/upload/"
+      "https://demo.data.gouv.fr/api/1/datasets/bnlc_fake_dataset_id/resources/bnlc_fake_resource_id/upload/"
 
     Transport.HTTPoison.Mock
     |> expect(:request, fn :post,

--- a/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
@@ -245,7 +245,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJobTest do
       assert String.ends_with?(path, "aires.geojson")
 
       assert url ==
-               "https://demo.data.gouv.fr/api/1/datasets/624ff4b1bbb449a550264040/resources/3ddd29ee-00dd-40af-bc98-3367adbd0289/upload/"
+               "https://demo.data.gouv.fr/api/1/datasets/zfe_fake_dataset_id/resources/zfe_aires_fake_resource_id/upload/"
 
       assert headers == [{"content-type", "multipart/form-data"}, {"X-API-KEY", "fake-datagouv-api-key"}]
       {:ok, %HTTPoison.Response{body: "", status_code: 200}}
@@ -257,7 +257,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJobTest do
       assert String.ends_with?(path, "voies.geojson")
 
       assert url ==
-               "https://demo.data.gouv.fr/api/1/datasets/624ff4b1bbb449a550264040/resources/98c6bcdb-1205-4481-8859-f885290763f2/upload/"
+               "https://demo.data.gouv.fr/api/1/datasets/zfe_fake_dataset_id/resources/zfe_voies_fake_resource_id/upload/"
 
       assert headers == [{"content-type", "multipart/form-data"}, {"X-API-KEY", "fake-datagouv-api-key"}]
       {:ok, %HTTPoison.Response{body: "", status_code: 200}}

--- a/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/bnlc_to_geodata_test.exs
@@ -11,6 +11,7 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
 
   setup :verify_on_exit!
 
+  @bnlc_datagouv_id "bnlc_fake_resource_id"
   @bnlc_content ~s("id_lieu","Xlong","Ylat","nbre_pl"\n"2A004-C-001","8.783403","41.9523692","0"\n"01024-C-001","5.158352778","46.28957222","5")
 
   test "import a BNLC to the DB" do
@@ -54,7 +55,7 @@ defmodule Transport.Jobs.BNLCToGeoDataTest do
 
     # insert bnlc resources
     insert(:resource, %{dataset_id: dataset_id, is_community_resource: true})
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id})
+    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, datagouv_id: @bnlc_datagouv_id})
     # insert bnlc resource history
     %{id: id_0} =
       insert(:resource_history, %{

--- a/config/test.exs
+++ b/config/test.exs
@@ -102,7 +102,20 @@ config :transport,
   datagouvfr_apikey: "fake-datagouv-api-key",
   # NOTE: some tests still rely on ExVCR cassettes at the moment. We configure the
   # expected host here, until we move to a behaviour-based testing instead.
-  gtfs_validator_url: "https://validation.transport.data.gouv.fr"
+  gtfs_validator_url: "https://validation.transport.data.gouv.fr",
+  consolidation: %{
+    zfe: %{
+      dataset_id: "zfe_fake_dataset_id",
+      resource_ids: %{
+        "voies" => "zfe_voies_fake_resource_id",
+        "aires" => "zfe_aires_fake_resource_id"
+      }
+    },
+    bnlc: %{
+      dataset_id: "bnlc_fake_dataset_id",
+      resource_id: "bnlc_fake_resource_id"
+    }
+  }
 
 secret_key_base = "SOME-LONG-SECRET-KEY-BASE-FOR-TESTING-SOME-LONG-SECRET-KEY-BASE-FOR-TESTING"
 


### PR DESCRIPTION
Traite ce qui a été mis en évidence dans https://github.com/etalab/transport-site/issues/3419#issuecomment-1864138833

Le job d'import de la BNLC chez nous doit être adapté pour utiliser la nouvelle ressource data.gouv.fr qui contient la BNLC consolidée. On réutilise les paramètres de la consolidation pour sélectionner la ressource pertinente.

J'en profite pour override les paramètres de consolidation de la ZFE dans l'environnement de test.