### PR TITLE
ConsolidateBNLCJob : retours à la ligne dans rapport de consolidation

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -207,7 +207,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
     """
     <h2>Erreurs liées aux jeux de données</h2>
-    #{Enum.map_join(dataset_errors, "\n", fn el -> format.(el) end)}
+    #{Enum.map_join(dataset_errors, "<br/>", fn el -> format.(el) end)}
     """
   end
 
@@ -216,7 +216,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   def format_validation_errors(%{validation_errors: validation_errors}) do
     """
     <h2>Ressources non valides par rapport au schéma #{@schema_name}</h2>
-    #{Enum.map_join(validation_errors, "\n", &link_to_resource/1)}
+    #{Enum.map_join(validation_errors, "<br/>", &link_to_resource/1)}
     """
   end
 
@@ -231,7 +231,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
     """
     <h2>Impossible de télécharger les ressources suivantes</h2>
-    #{Enum.map_join(errors, "\n", &link_to_resource/1)}
+    #{Enum.map_join(errors, "<br/>", &link_to_resource/1)}
     """
   end
 
@@ -246,7 +246,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
     """
     <h2>Impossible de décoder les fichiers CSV suivants</h2>
-    #{Enum.map_join(errors, "\n", &link_to_resource/1)}
+    #{Enum.map_join(errors, "<br/>", &link_to_resource/1)}
     """
   end
 

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -95,8 +95,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       assert """
              <h2>Erreurs liées aux jeux de données</h2>
-             Le slug du jeu de données `404-slug` est introuvable via l'API
-             Pas de ressources avec le schéma etalab/schema-lieux-covoiturage pour <a href=\"https://example.com/jdd\">JDD sans ressources</a>
+             Le slug du jeu de données `404-slug` est introuvable via l'API<br/>Pas de ressources avec le schéma etalab/schema-lieux-covoiturage pour <a href=\"https://example.com/jdd\">JDD sans ressources</a>
 
 
              <h2>Ressources non valides par rapport au schéma etalab/schema-lieux-covoiturage</h2>


### PR DESCRIPTION
En lien avec #3419. Discuté [dans Front](https://app.frontapp.com/open/cnv_16n2m1na?key=ZTkFyOix4G-PGnrW2Q2NyytcW9iksF7A).

Met de véritables retours à la ligne dans le rapport de consolidation envoyé par e-mail. Le rapport est envoyé en HTML, il faut donc du `<br/>` et non du `\n`.