### PR TITLE
Configuration : cloak_key doit être pour :transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ RUN cd apps/transport/client && yarn install && npm run build
 # assets digest must happen after the npm build step
 RUN mix phx.digest
 # Package source code for Sentry https://hexdocs.pm/sentry/upgrade-10-x.html
-# If we switch to releases, make sure to call this before `mix release`
+# If we switch to releases, make sure to call this before `mix release`.
+# Because we configure Sentry in `runtime.exs` we need to run `mix app.config` before.
+# See https://github.com/getsentry/sentry-elixir/pull/661
+RUN mix app.config
 RUN mix sentry.package_source_code
 
 EXPOSE 8080

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -217,10 +217,6 @@ if config_env() == :prod do
       tcp_keepalives_interval: "5",
       tcp_keepalives_count: "3"
     ],
-    # The key used by Cloak. See `Transport.Vault`.
-    # This value should be base64 encrypted
-    # See https://github.com/danielberkompas/cloak#configuration
-    cloak_key: System.fetch_env!("CLOAK_KEY"),
     socket_options: [keepalive: true],
     # See https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
     # [Ecto.Repo] :pool_timeout is no longer supported in favor of a new queue system described in DBConnection.start_link/2
@@ -247,6 +243,10 @@ if config_env() == :prod do
     # published by us on data.gouv.fr.
     # Overrides values set in `config.exs`
     config :transport,
+      # The key used by Cloak. See `Transport.Vault`.
+      # This value should be base64 encrypted
+      # See https://github.com/danielberkompas/cloak#configuration
+      cloak_key: System.fetch_env!("CLOAK_KEY"),
       consolidation:
         Map.merge(Application.fetch_env!(:transport, :consolidation), %{
           zfe: %{


### PR DESCRIPTION
J'ai fait une erreur dans mon refactoring de config dans https://github.com/etalab/transport-site/pull/3681 :cry:

`cloak_key` avait été définie dans `config :transport, DB.Repo,` et non dans `config :transport`.

Clever [n'arrivait pas à démarrer l'app](https://console.clever-cloud.com/organisations/orga_f33ebcbc-4403-4e4c-82f5-12305e0ecb1b/applications/app_04f647ef-4a10-4021-a04b-fe510e6cd003/logs) en conséquence.

```
2023-12-26T14:59:40+01:00 14:59:39.182 [notice] Application transport exited: Transport.Application.start(:normal, []) returned an error: shutdown: failed to start child: Transport.Vault
2023-12-26T14:59:40+01:00 ** (EXIT) an exception was raised:
2023-12-26T14:59:40+01:00 ** (MatchError) no match of right hand side value: {:error, {%ArgumentError{message: "could not fetch application environment :cloak_key for application :transport because configuration at :cloak_key was not set"}, [{Application, :fetch_env!, 2, [file: ~c"lib/application.ex", line: 775]}, {Transport.Vault, :key, 0, [file: ~c"lib/transport/vault.ex", line: 22]}, {Transport.Vault, :init, 1, [file: ~c"lib/transport/vault.ex", line: 13]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 423]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 390]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 226]}]}}
2023-12-26T14:59:40+01:00 (stdlib 3.17.2.4) gen_server.erl:390: :gen_server.init_it/6
2023-12-26T14:59:40+01:00 (stdlib 3.17.2.4) supervisor.erl:350: :supervisor.init_children/2
2023-12-26T14:59:40+01:00 (stdlib 3.17.2.4) supervisor.erl:390: anonymous fn/3 in :supervisor.start_children/2
2023-12-26T14:59:40+01:00 (stdlib 3.17.2.4) supervisor.erl:406: :supervisor.do_start_child/2
2023-12-26T14:59:40+01:00 (transport 0.0.1) /phoenixapp/deps/cloak/lib/cloak/vault.ex:184: Transport.Vault.start_link/1
```