### PR TITLE
Déplace la config Sentry v10 vers prod.exs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,6 @@ RUN cd apps/transport/client && yarn install && npm run build
 # assets digest must happen after the npm build step
 RUN mix phx.digest
 # Package source code for Sentry https://hexdocs.pm/sentry/upgrade-10-x.html
-# If we switch to releases, make sure to call this before `mix release`.
-# Because we configure Sentry in `runtime.exs` we need to run `mix app.config` before.
-# See https://github.com/getsentry/sentry-elixir/pull/661
-RUN mix app.config
 RUN mix sentry.package_source_code
 
 EXPOSE 8080

--- a/config/config.exs
+++ b/config/config.exs
@@ -186,7 +186,7 @@ config :transport,
   transport_tools_folder: Path.absname("transport-tools/")
 
 # Disable sending events to Sentry by default.
-# Events are sent in production and staging, configured in `runtime.exs`
+# Events are sent in production and staging, configured in `prod.exs`
 config :sentry, dsn: nil
 
 # For now, never send session data (containing sensitive data in our case) nor params,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,10 @@ config :transport, TransportWeb.Endpoint,
   ]
 
 config :transport,
+  # The key used by Cloak. See `Transport.Vault`.
+  # This value should be base64 encrypted
+  # See https://github.com/danielberkompas/cloak#configuration
+  cloak_key: System.get_env("CLOAK_KEY"),
   s3_buckets: %{
     history: "resource-history-prod",
     on_demand_validation: "on-demand-validation-prod",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,6 +17,22 @@ config :transport,
     gtfs_diff: "gtfs-diff-prod"
   }
 
+# Configure Sentry for production and staging.
+# Check out https://sentry.io/settings/transport-data-gouv-fr/projects/transport-site/install/elixir/
+config :sentry,
+  # Sentry events are only sent when `dsn` is not nil
+  # https://hexdocs.pm/sentry/upgrade-10-x.html#stop-using-included_environments
+  dsn: System.get_env("SENTRY_DSN"),
+  csp_url: System.get_env("SENTRY_CSP_URL"),
+  environment_name: "SENTRY_ENV" |> System.get_env(to_string(config_env())) |> String.to_atom(),
+  enable_source_code_context: true,
+  # https://hexdocs.pm/sentry/Sentry.html#module-configuration
+  # > a list of paths to the root of your application's source code.
+  # > For umbrella apps, you should set this to all the application paths in your umbrella
+  # Caveat: https://github.com/getsentry/sentry-elixir/issues/638
+  root_source_code_paths: [File.cwd!() |> Path.join("apps")],
+  filter: Transport.Shared.SentryExceptionFilter
+
 config :gbfs, GBFSWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 # Do not print debug messages in production

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -228,10 +228,6 @@ if config_env() == :prod do
     # published by us on data.gouv.fr.
     # Overrides values set in `config.exs`
     config :transport,
-      # The key used by Cloak. See `Transport.Vault`.
-      # This value should be base64 encrypted
-      # See https://github.com/danielberkompas/cloak#configuration
-      cloak_key: System.fetch_env!("CLOAK_KEY"),
       consolidation:
         Map.merge(Application.fetch_env!(:transport, :consolidation), %{
           zfe: %{

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -223,21 +223,6 @@ if config_env() == :prod do
     # under "Queue config". For most users, configuring :timeout is enough, as it now includes both queue and query time
     timeout: 15_000
 
-  # Configure Sentry for production and staging.
-  # Check out https://sentry.io/settings/transport-data-gouv-fr/projects/transport-site/install/elixir/
-  config :sentry,
-    # Sentry events are only sent when `dsn` is not nil
-    # https://hexdocs.pm/sentry/upgrade-10-x.html#stop-using-included_environments
-    dsn: System.get_env("SENTRY_DSN"),
-    csp_url: System.get_env("SENTRY_CSP_URL"),
-    environment_name: "SENTRY_ENV" |> System.get_env() |> String.to_atom(),
-    enable_source_code_context: true,
-    # https://hexdocs.pm/sentry/Sentry.html#module-configuration
-    # > a list of paths to the root of your application's source code.
-    # > For umbrella apps, you should set this to all the application paths in your umbrella
-    root_source_code_path: File.cwd!() |> Path.join("apps/*") |> Path.wildcard(),
-    filter: Transport.Shared.SentryExceptionFilter
-
   if app_env == :production do
     # data.gouv.fr IDs for national databases created automatically and
     # published by us on data.gouv.fr.


### PR DESCRIPTION
Correction suite à la mise à jour de Sentry en v10, https://github.com/etalab/transport-site/pull/3685 et https://github.com/etalab/transport-site/pull/3681

`RUN mix app.config` produit une erreur dans le Dockerfile étant donné qu'on n'a pas toutes les variables d'environnement attendues lors du build du Dockerfile.

Je retravaille la configuration de Sentry pour [éviter le runtime configuration](https://github.com/getsentry/sentry-elixir/blob/f62d10150a3532ce16e7d45815623b71acc9e2ee/lib/mix/tasks/sentry.package_source_code.ex#L36-L44) en déplaçant la configuration de prod vers `prod.exs` au lieu de `runtime.exs`.

## Packaging du code

J'en profite pour corriger le packaging du code source, la clé de config n'était pas la bonne (`root_source_code_path` VS `root_source_code_paths` (`s` à la fin), [c'était un problème dans le CHANGELOG](https://github.com/getsentry/sentry-elixir/issues/614#issuecomment-1731947439)).

## Configuration pour apps Umbrella

Reste à savoir comment bien configurer le packaging du code pour avoir les bonnes stracktaces avec les applications Umbrella, ça ne semble pas être un problème résolu https://github.com/getsentry/sentry-elixir/issues/638

La [doc de configuration](https://hexdocs.pm/sentry/Sentry.html#module-configuration) indiquait :

> root_source_code_paths
> For umbrella apps, you should set this to all the application paths in your umbrella (such as `[Path.join(File.cwd!(), "apps/app1"), ...]`)

mais j'obtiens ensuite

```
** (Mix) Found two source files in different source root paths with the same relative path:

  1. apps/unlock/lib/application.ex
  2. apps/shared/lib/application.ex

The part of those paths that causes the conflict is:

  lib/application.ex

Sentry cannot report the right source code context if this happens, because
it won't be able to retrieve the correct file from exception stacktraces.

To fix this, you'll have to rename one of the conflicting paths.
```

La configuration actuelle semble produire un source map (`Wrote 437 files in 883.16 kb to: _build/prod/lib/sentry/priv/sentry.map` après avoir exécuté `mix sentry.package_source_cod` dans `Dockerfile`). Si il y a encore des problèmes je verrai avec @thbar / sur le dépôt [sentry-elixir](https://github.com/getsentry/sentry-elixir).

> [!NOTE]
> J'ai déployé cette branche en staging (`git push origin sentry_10_prod_config:prochainement -f`) pour vérifier que le build sur Clever fonctionnait bien, pour éviter les surprises au deploy.