### PR TITLE
ImportDatasetMonthlyMetricsJob : mise à jour updated_at

### DIFF
--- a/apps/transport/lib/jobs/import_dataset_monthly_metrics_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_monthly_metrics_job.ex
@@ -69,16 +69,18 @@ defmodule Transport.Jobs.ImportDatasetMonthlyMetricsJob do
          dataset_datagouv_id
        ) do
     Enum.each([{:views, monthly_visit}, {:downloads, monthly_download_resource}], fn {metric_name, count} ->
+      count = count || 0
+
       %DB.DatasetMonthlyMetric{}
       |> DB.DatasetMonthlyMetric.changeset(%{
         dataset_datagouv_id: dataset_datagouv_id,
         year_month: metric_month,
         metric_name: metric_name,
-        count: count || 0
+        count: count
       })
       |> DB.Repo.insert!(
         conflict_target: [:dataset_datagouv_id, :year_month, :metric_name],
-        on_conflict: {:replace, [:count]}
+        on_conflict: [set: [count: count, updated_at: DateTime.utc_now()]]
       )
     end)
   end

--- a/apps/transport/test/transport/jobs/import_dataset_monthly_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_monthly_metrics_job_test.exs
@@ -103,7 +103,9 @@ defmodule Transport.Test.Transport.Jobs.ImportDatasetMonthlyMetricsTestJob do
                  dataset_datagouv_id: ^datagouv_id,
                  year_month: "2023-12",
                  metric_name: :views,
-                 count: 1337
+                 count: 1337,
+                 inserted_at: inserted_at,
+                 updated_at: updated_at
                },
                # Has been inserted
                %DB.DatasetMonthlyMetric{
@@ -113,6 +115,9 @@ defmodule Transport.Test.Transport.Jobs.ImportDatasetMonthlyMetricsTestJob do
                  count: 43
                }
              ] = DB.Repo.all(DB.DatasetMonthlyMetric)
+
+      # `updated_at` has been updated to reflect that this row has changed
+      assert DateTime.after?(updated_at, inserted_at)
     end
   end
 


### PR DESCRIPTION
Adapte `ImportDatasetMonthlyMetricsJob` pour mettre à jour la colonne `updated_at` quand la ligne a été modifiée : ie qu'on a mis à jour le nombre de téléchargements ou de vues pour un JDD pour un mois donné.

Ceci permet de vérifier que les lignes anciennes (pas le mois courant) ne sont pas modifiées. Je voulais vérifier cette propriété mais avec l'ancien fonctionne ma requête donnait 0 rows 😅 

```sql
select distinct d.year_month
from dataset_monthly_metrics d
where d.inserted_at != d.updated_at
```

Job mis en place dans cette PR https://github.com/etalab/transport-site/pull/3663