### PR TITLE
Table dataset : ajout de contraintes not null

### DIFF
--- a/apps/transport/priv/repo/migrations/20240102144643_dataset_add_not_null.exs
+++ b/apps/transport/priv/repo/migrations/20240102144643_dataset_add_not_null.exs
@@ -1,0 +1,31 @@
+defmodule DB.Repo.Migrations.DatasetAddNotNull do
+  use Ecto.Migration
+
+  @attributes [
+    :datagouv_id,
+    :custom_title,
+    :licence,
+    :logo,
+    :full_logo,
+    :slug,
+    :tags,
+    :datagouv_title,
+    :type,
+    :frequency,
+    :has_realtime,
+    :is_active,
+    :nb_reuses
+  ]
+
+  def up do
+    Enum.each(@attributes, fn attribute ->
+      execute("ALTER TABLE dataset ALTER COLUMN #{attribute} SET NOT NULL")
+    end)
+  end
+
+  def down do
+    Enum.each(@attributes, fn attribute ->
+      execute("ALTER TABLE dataset ALTER COLUMN #{attribute} DROP NOT NULL")
+    end)
+  end
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -61,7 +61,7 @@ defmodule DB.Factory do
       tags: [],
       type: "public-transit",
       logo: "https://example.com/#{Ecto.UUID.generate()}_small.png",
-      full_logo: "https://example.com/#{Ecto.UUID.generate()}_small.png",
+      full_logo: "https://example.com/#{Ecto.UUID.generate()}.png",
       frequency: "daily",
       has_realtime: false,
       is_active: true,

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -59,7 +59,13 @@ defmodule DB.Factory do
       # NOTE: need to figure out how to pass aom/region together with changeset checks here
       aom: build(:aom),
       tags: [],
-      type: "public-transit"
+      type: "public-transit",
+      logo: "https://example.com/#{Ecto.UUID.generate()}_small.png",
+      full_logo: "https://example.com/#{Ecto.UUID.generate()}_small.png",
+      frequency: "daily",
+      has_realtime: false,
+      is_active: true,
+      nb_reuses: Enum.random(0..10)
     }
   end
 
@@ -211,15 +217,17 @@ defmodule DB.Factory do
       region_id: Keyword.get(opts, :region_id),
       has_realtime: Keyword.get(opts, :has_realtime),
       type: Keyword.get(opts, :type),
-      aom: Keyword.get(opts, :aom),
+      aom: aom = Keyword.get(opts, :aom),
       custom_title: Keyword.get(opts, :custom_title)
     ]
 
     dataset_opts =
-      case Keyword.get(opts, :aom) do
+      aom
+      |> case do
         nil -> dataset_opts
         aom -> dataset_opts |> Keyword.merge(aom: aom)
       end
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
 
     dataset = Keyword.get(opts, :dataset, insert(:dataset, dataset_opts))
 
@@ -318,5 +326,29 @@ defmodule DB.Factory do
     }
     |> Map.merge(args)
     |> DB.Contact.insert!()
+  end
+
+  def datagouv_dataset_response(%{} = attributes \\ %{}) do
+    Map.merge(
+      %{
+        "id" => Ecto.UUID.generate(),
+        "title" => "dataset",
+        "created_at" => DateTime.utc_now() |> to_string(),
+        "last_update" => DateTime.utc_now() |> to_string(),
+        "slug" => "dataset-slug",
+        "license" => "lov2",
+        "frequency" => "daily",
+        "tags" => [],
+        "organization" => %{
+          "id" => Ecto.UUID.generate(),
+          "name" => "Org " <> Ecto.UUID.generate(),
+          "badges" => [],
+          "logo" => "https://example.com/img.jpg",
+          "logo_thumbnail" => "https://example.com/img.small.jpg",
+          "slug" => Ecto.UUID.generate()
+        }
+      },
+      attributes
+    )
   end
 end

--- a/apps/transport/test/transport/community_resource_cleaner_test.exs
+++ b/apps/transport/test/transport/community_resource_cleaner_test.exs
@@ -13,7 +13,11 @@ defmodule Transport.CommunityResourcesCleanerTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  defp insert_dataset_associated_with_ressources(resources, datagouv_id \\ nil) do
+  defp insert_dataset_associated_with_ressources(resources) do
+    insert_dataset_associated_with_ressources(resources, Ecto.UUID.generate())
+  end
+
+  defp insert_dataset_associated_with_ressources(resources, datagouv_id) do
     :dataset
     |> insert(%{datagouv_id: datagouv_id})
     |> Repo.preload(:resources)

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -39,6 +39,7 @@ defmodule Transport.ImportDataTest do
         "id" => id || "resource1_id",
         "type" => "main",
         "filetype" => filetype || "remote",
+        "format" => "zip",
         "last_modified" => DateTime.utc_now() |> DateTime.add(-1, :hour) |> DateTime.to_iso8601(),
         "schema" => %{"name" => schema_name, "version" => schema_version}
       }
@@ -46,37 +47,11 @@ defmodule Transport.ImportDataTest do
   end
 
   def generate_dataset_payload(datagouv_id, resources \\ nil) do
-    resources = resources || generate_resources_payload()
-
-    %{
-      "title" => "dataset1",
-      "id" => datagouv_id,
-      "created_at" => DateTime.utc_now() |> to_string(),
-      "last_update" => DateTime.utc_now() |> to_string(),
-      "slug" => "dataset-slug",
-      "resources" => resources,
-      "organization" => %{
-        "id" => Ecto.UUID.generate(),
-        "name" => "Org " <> Ecto.UUID.generate(),
-        "badges" => [],
-        "logo" => "https://example.com/img.jpg",
-        "logo_thumbnail" => "https://example.com/img.small.jpg",
-        "slug" => Ecto.UUID.generate()
-      }
-    }
+    datagouv_dataset_response(%{"id" => datagouv_id, "resources" => resources || generate_resources_payload()})
   end
 
   def insert_national_dataset(datagouv_id) do
-    {:ok, changes} =
-      DB.Dataset.changeset(%{
-        "created_at" => DateTime.utc_now(),
-        "last_update" => DateTime.utc_now(),
-        "datagouv_id" => datagouv_id,
-        "slug" => "ma_limace",
-        "national_dataset" => "true"
-      })
-
-    DB.Repo.insert!(changes)
+    insert(:dataset, datagouv_id: datagouv_id, aom: nil, region_id: DB.Repo.get_by!(DB.Region, nom: "National").id)
   end
 
   def http_get_mock_200(datagouv_id, payload \\ nil) do

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -253,7 +253,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
 
   test "GET /api/datasets/:id *without* history, multi_validation and resource_metadata", %{conn: conn} do
     dataset =
-      %DB.Dataset{
+      insert(:dataset,
         custom_title: "title",
         is_active: true,
         type: "public-transit",
@@ -287,9 +287,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
         created_at: ~U[2021-12-23 13:30:40.000000Z],
         last_update: DateTime.utc_now(),
         aom: %DB.AOM{id: 4242, nom: "Angers Métropole", siren: "siren"}
-      }
-      |> DB.Repo.insert!()
-      |> DB.Repo.preload(:resources)
+      )
 
     Transport.History.Fetcher.Mock
     |> expect(:history_resources, fn _, options ->

--- a/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
@@ -212,7 +212,11 @@ defmodule TransportWeb.API.StatsControllerTest do
     insert(:dataset, type: "public-transit", is_active: true, legal_owners_aom: [aom])
     insert(:dataset, type: "public-transit", is_active: true, legal_owners_aom: [aom])
 
-    insert_resource_and_friends(Date.utc_today() |> Date.add(10), aom: aom, max_error: "Error")
+    insert_resource_and_friends(Date.utc_today() |> Date.add(10),
+      aom: aom,
+      max_error: "Error",
+      type: "low-emission-zones"
+    )
 
     assert [
              %{

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -137,11 +137,9 @@ defmodule TransportWeb.BackofficeControllerTest do
     |> expect(:get!, fn "https://demo.data.gouv.fr/api/1/datasets/12/", [], _ ->
       body =
         %{
-          "created_at" => DateTime.utc_now(),
-          "last_update" => DateTime.utc_now(),
+          "id" => dataset_datagouv_id,
           "slug" => "dataset-slug",
           "type" => "public-transit",
-          "id" => dataset_datagouv_id,
           "resources" => [
             %{
               "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601(),
@@ -151,6 +149,7 @@ defmodule TransportWeb.BackofficeControllerTest do
             }
           ]
         }
+        |> DB.Factory.datagouv_dataset_response()
         |> Jason.encode!()
 
       %HTTPoison.Response{body: body, status_code: 200}

--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -55,8 +55,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
       assert "https://demo.data.gouv.fr/api/1/datasets/#{datagouv_id_2}/" == url
 
       %HTTPoison.Response{
-        body:
-          ~s({"id": "#{datagouv_id_2}", "resources": [], "slug": "#{slug_2}", "created_at": "2023-03-22 15:53:50+00:00", "last_update": "2023-03-22 15:53:50+00:00"}),
+        body: Jason.encode!(datagouv_dataset_response(%{"id" => datagouv_id_2, "slug" => slug_2, "resources" => []})),
         status_code: 200
       }
     end)
@@ -151,8 +150,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
     Transport.HTTPoison.Mock
     |> expect(:get!, fn "https://demo.data.gouv.fr/api/1/datasets/datagouv_id/", _, _ ->
       %HTTPoison.Response{
-        body:
-          ~s({"id": "datagouv_id", "resources": [], "created_at": "2023-03-22 15:53:50+00:00", "last_update": "2023-03-22 15:53:50+00:00"}),
+        body: Jason.encode!(datagouv_dataset_response(%{"resources" => []})),
         status_code: 200
       }
     end)

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -2,59 +2,53 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   use TransportWeb.ConnCase, async: true
   use TransportWeb.DatabaseCase, cleanup: [:datasets]
   import DB.Factory
-  alias DB.{AOM, Dataset, Repo, Resource}
-  import DB.Factory
 
   doctest TransportWeb.DatasetController
 
   setup do
-    {:ok, _} =
-      %Dataset{
-        created_at: DateTime.utc_now(),
-        last_update: DateTime.utc_now(),
-        description: "Un jeu de données",
-        licence: "odc-odbl",
-        datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
-        custom_title: "Horaires Angers",
-        type: "public-transit",
-        slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
-        datagouv_id: "5b4cd3a0b59508054dd496cd",
-        frequency: "yearly",
-        tags: [],
-        resources: [
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "https://link.to/angers.zip",
-            title: "angers.zip"
-          }
-        ],
-        aom: %AOM{id: 4242, nom: "Angers Métropôle"}
-      }
-      |> Repo.insert()
+    insert(:dataset,
+      created_at: DateTime.utc_now(),
+      last_update: DateTime.utc_now(),
+      description: "Un jeu de données",
+      licence: "odc-odbl",
+      datagouv_title: "Horaires et arrêts du réseau IRIGO - format GTFS",
+      custom_title: "Horaires Angers",
+      type: "public-transit",
+      slug: "horaires-et-arrets-du-reseau-irigo-format-gtfs",
+      datagouv_id: "5b4cd3a0b59508054dd496cd",
+      frequency: "yearly",
+      tags: [],
+      resources: [
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "https://link.to/angers.zip",
+          title: "angers.zip"
+        }
+      ],
+      aom: %DB.AOM{id: 4242, nom: "Angers Métropôle"}
+    )
 
-    {:ok, _} =
-      %Dataset{
-        created_at: DateTime.utc_now(),
-        last_update: DateTime.utc_now(),
-        description: "Un autre jeu de données",
-        licence: "lov2",
-        datagouv_title: "offre de transport du réseau de LAVAL Agglomération (GTFS)",
-        custom_title: "Horaires Laval",
-        slug: "offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
-        type: "public-transit",
-        datagouv_id: "5bc493d08b4c416c84a69500",
-        frequency: "yearly",
-        tags: [],
-        resources: [
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "https://link.to/angers.zip"
-          }
-        ]
-      }
-      |> Repo.insert()
+    insert(:dataset,
+      created_at: DateTime.utc_now(),
+      last_update: DateTime.utc_now(),
+      description: "Un autre jeu de données",
+      licence: "lov2",
+      datagouv_title: "offre de transport du réseau de LAVAL Agglomération (GTFS)",
+      custom_title: "Horaires Laval",
+      slug: "offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
+      type: "public-transit",
+      datagouv_id: "5bc493d08b4c416c84a69500",
+      frequency: "yearly",
+      tags: [],
+      resources: [
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "https://link.to/angers.zip"
+        }
+      ]
+    )
 
     :ok
   end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule TransportWeb.ResourceControllerTest do
   use TransportWeb.ConnCase, async: false
   use TransportWeb.DatabaseCase, cleanup: [:datasets], async: false
-  alias DB.{AOM, Dataset, Resource}
   import Plug.Test
   import Mox
   import DB.Factory
@@ -15,54 +14,52 @@ defmodule TransportWeb.ResourceControllerTest do
     Mox.stub_with(Transport.DataVisualization.Mock, Transport.DataVisualization.Impl)
     Mox.stub_with(Transport.ValidatorsSelection.Mock, Transport.ValidatorsSelection.Impl)
 
-    {:ok, _} =
-      %Dataset{
-        created_at: DateTime.utc_now(),
-        last_update: DateTime.utc_now(),
-        slug: "slug-1",
-        resources: [
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "https://link.to/angers.zip",
-            datagouv_id: "1",
-            format: "GTFS",
-            title: "GTFS",
-            description: "Une _très_ belle ressource"
-          },
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "http://link.to/angers.zip?foo=bar",
-            datagouv_id: "2",
-            format: "GTFS"
-          },
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "http://link.to/gbfs",
-            datagouv_id: "3",
-            format: "gbfs"
-          },
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "http://link.to/file",
-            datagouv_id: "4",
-            schema_name: "etalab/foo",
-            format: "json"
-          },
-          %Resource{
-            last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
-            last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
-            url: "http://link.to/gtfs-rt",
-            datagouv_id: "5",
-            format: "gtfs-rt"
-          }
-        ],
-        aom: %AOM{id: 4242, nom: "Angers Métropôle"}
-      }
-      |> Repo.insert()
+    insert(:dataset,
+      created_at: DateTime.utc_now(),
+      last_update: DateTime.utc_now(),
+      slug: "slug-1",
+      resources: [
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "https://link.to/angers.zip",
+          datagouv_id: "1",
+          format: "GTFS",
+          title: "GTFS",
+          description: "Une _très_ belle ressource"
+        },
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "http://link.to/angers.zip?foo=bar",
+          datagouv_id: "2",
+          format: "GTFS"
+        },
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "http://link.to/gbfs",
+          datagouv_id: "3",
+          format: "gbfs"
+        },
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "http://link.to/file",
+          datagouv_id: "4",
+          schema_name: "etalab/foo",
+          format: "json"
+        },
+        %DB.Resource{
+          last_update: DateTime.utc_now() |> DateTime.add(-6, :hour),
+          last_import: DateTime.utc_now() |> DateTime.add(-1, :hour),
+          url: "http://link.to/gtfs-rt",
+          datagouv_id: "5",
+          format: "gtfs-rt"
+        }
+      ],
+      aom: %DB.AOM{id: 4242, nom: "Angers Métropôle"}
+    )
 
     :ok
   end
@@ -89,7 +86,7 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "GTFS resource with associated NeTEx", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
     insert(:resource_history, resource_id: resource.id, payload: %{"uuid" => uuid = Ecto.UUID.generate()})
 
     insert(:data_conversion,
@@ -107,8 +104,8 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "GBFS resource with multi-validation sends back 200", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "3")
-    assert Resource.is_gbfs?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "3")
+    assert DB.Resource.is_gbfs?(resource)
 
     insert(:multi_validation, %{
       resource_history: insert(:resource_history, %{resource_id: resource.id}),
@@ -124,7 +121,7 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "resource has its description displayed", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "1")
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "1")
 
     assert resource.description == "Une _très_ belle ressource"
     html = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
@@ -132,7 +129,7 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "resource has download availability displayed", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "4")
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "4")
 
     Transport.Shared.Schemas.Mock
     |> expect(:schemas_by_type, 1, fn _type -> %{resource.schema_name => %{}} end)
@@ -183,14 +180,14 @@ defmodule TransportWeb.ResourceControllerTest do
       result: validation_result
     )
 
-    resource = Resource |> preload(:dataset) |> DB.Repo.get!(resource.id)
+    resource = DB.Resource |> preload(:dataset) |> DB.Repo.get!(resource.id)
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn ^resource_url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{status_code: 200, body: File.read!(@service_alerts_file)}}
     end)
 
-    assert Resource.is_gtfs_rt?(resource)
+    assert DB.Resource.is_gtfs_rt?(resource)
 
     content = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
 
@@ -213,22 +210,22 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "gtfs-rt resource with feed decode error", %{conn: conn} do
-    %{url: url} = resource = Resource |> Repo.get_by(datagouv_id: "5")
+    %{url: url} = resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "5")
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn ^url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{status_code: 502, body: ""}}
     end)
 
-    assert Resource.is_gtfs_rt?(resource)
+    assert DB.Resource.is_gtfs_rt?(resource)
     content = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
 
     assert content =~ "Impossible de décoder le flux GTFS-RT"
   end
 
   test "HEAD request for an HTTP resource", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
-    refute Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
+    refute DB.Resource.can_direct_download?(resource)
 
     Transport.HTTPoison.Mock
     |> expect(:head, fn url, [] ->
@@ -243,22 +240,22 @@ defmodule TransportWeb.ResourceControllerTest do
     assert conn |> response(200) == ""
 
     # With a resource that can be directly downloaded
-    resource = Resource |> Repo.get_by(datagouv_id: "1")
-    assert Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "1")
+    assert DB.Resource.can_direct_download?(resource)
     assert conn |> head(resource_path(conn, :download, resource.id)) |> response(404) == ""
   end
 
   test "downloading a resource that can be directly downloaded", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "1")
-    assert Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "1")
+    assert DB.Resource.can_direct_download?(resource)
 
     location = conn |> get(resource_path(conn, :download, resource.id)) |> redirected_to
     assert location == resource.url
   end
 
   test "downloading a resource that cannot be directly downloaded", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
-    refute Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
+    refute DB.Resource.can_direct_download?(resource)
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn url, [], hackney: [follow_redirect: true] ->
@@ -274,8 +271,8 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "downloading a resource that cannot be directly downloaded with a filename", %{conn: conn} do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
-    refute Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
+    refute DB.Resource.can_direct_download?(resource)
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn url, [], hackney: [follow_redirect: true] ->
@@ -727,8 +724,8 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   test "resources_related are displayed", %{conn: conn} do
-    %{url: gtfs_url} = gtfs_rt_resource = Repo.get_by(Resource, datagouv_id: "5", format: "gtfs-rt")
-    gtfs_resource = Repo.get_by(Resource, datagouv_id: "1", format: "GTFS")
+    %{url: gtfs_url} = gtfs_rt_resource = DB.Repo.get_by(DB.Resource, datagouv_id: "5", format: "gtfs-rt")
+    gtfs_resource = DB.Repo.get_by(DB.Resource, datagouv_id: "1", format: "GTFS")
 
     insert(:resource_related, resource_src: gtfs_rt_resource, resource_dst: gtfs_resource, reason: :gtfs_rt_gtfs)
 
@@ -744,8 +741,8 @@ defmodule TransportWeb.ResourceControllerTest do
   end
 
   defp test_remote_download_error(%Plug.Conn{} = conn, mock_status_code) do
-    resource = Resource |> Repo.get_by(datagouv_id: "2")
-    refute Resource.can_direct_download?(resource)
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
+    refute DB.Resource.can_direct_download?(resource)
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn url, [], hackney: [follow_redirect: true] ->


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/3399

Ajoute de contraintes not null pour la table `dataset` sur les colonnes possibles :

- `datagouv_id`
- `custom_title` (attribut propre au PAN)
- `licence`
- `logo`
- `full_logo`
- `slug`
- `tags`
- `datagouv_title`
- `type`
- `frequency`
- `nb_reuses`
- `has_realtime` (généré par le PAN)
- `is_active` (attribut propre au PAN)

J'ai appliqué la migration en local avec les données de production.


> [!NOTE]
> On peut attendre après le 08/01 pour merger, en particulier après https://github.com/etalab/transport-site/issues/3647