### PR TITLE
Dataset#details : corrige nombre de ressources

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -15,13 +15,14 @@ defmodule TransportWeb.DatasetView do
   @gtfs_rt_validator_name Transport.Validators.GTFSRT.validator_name()
 
   @doc """
-  Count the number of resources (official + community), excluding resources with a `documentation` type.
+  Count the number of resources, excluding:
+  - community resources
+  - resources with a `documentation` type.
   """
   @spec count_resources(Dataset.t()) :: non_neg_integer
   def count_resources(dataset) do
-    nb_resources = Enum.count(official_available_resources(dataset))
-    nb_community_resources = Enum.count(community_resources(dataset))
-    nb_resources + nb_community_resources - count_documentation_resources(dataset)
+    nb_official_resources = dataset |> official_available_resources() |> Enum.count()
+    nb_official_resources - count_documentation_resources(dataset)
   end
 
   @spec count_documentation_resources(Dataset.t()) :: non_neg_integer

--- a/apps/transport/test/transport_web/controllers/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_view_test.exs
@@ -120,13 +120,14 @@ defmodule TransportWeb.DatasetViewTest do
   test "count_resources and count_documentation_resources" do
     dataset = insert(:dataset)
     insert(:resource, type: "documentation", url: "https://example.com/doc", dataset: dataset)
+    insert(:resource, type: "documentation", url: "https://example.com/more_doc", dataset: dataset)
     insert(:resource, type: "main", url: "https://example.com/file", dataset: dataset)
     insert(:resource, type: "main", url: "https://example.com/community", dataset: dataset, is_community_resource: true)
 
     dataset = dataset |> DB.Repo.preload(:resources)
 
-    assert count_resources(dataset) == 2
-    assert count_documentation_resources(dataset) == 1
+    assert count_resources(dataset) == 1
+    assert count_documentation_resources(dataset) == 2
   end
 
   describe "licence_link" do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3705

Corrige ce compteur, retire le nombre de ressources communautaires étant donné qu'on a un menu distinct juste en dessous.