### PR TITLE
TransportWeb.Session : corrige erreur pattern matching

### DIFF
--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -20,12 +20,9 @@ defmodule TransportWeb.Session do
     set_session_attribute_attribute(conn, @is_producer_key_name, is_producer?(params))
   end
 
-  def set_is_producer(%Plug.Conn{} = conn, [%DB.Dataset{}] = _datasets_for_user) do
-    set_session_attribute_attribute(conn, @is_producer_key_name, true)
-  end
-
-  def set_is_producer(%Plug.Conn{} = conn, [] = _datasets_for_user) do
-    set_session_attribute_attribute(conn, @is_producer_key_name, false)
+  def set_is_producer(%Plug.Conn{} = conn, datasets_for_user) when is_list(datasets_for_user) do
+    is_producer = not Enum.empty?(datasets_for_user)
+    set_session_attribute_attribute(conn, @is_producer_key_name, is_producer)
   end
 
   @doc """

--- a/apps/transport/test/transport_web/session_test.exs
+++ b/apps/transport/test/transport_web/session_test.exs
@@ -27,12 +27,30 @@ defmodule TransportWeb.SessionTest do
     test "is_admin?" do
       refute is_admin?(Plug.Test.init_test_session(%Plug.Conn{}, %{}))
       assert is_admin?(Plug.Test.init_test_session(%Plug.Conn{}, %{current_user: %{"is_admin" => true}}))
-      assert is_admin?(%{"is_admin" => true})
+      assert is_admin?(%Phoenix.LiveView.Socket{assigns: %{current_user: %{"is_admin" => true}}})
     end
 
     test "is_producer?" do
       assert is_producer?(Plug.Test.init_test_session(%Plug.Conn{}, %{current_user: %{"is_producer" => true}}))
       refute is_producer?(Plug.Test.init_test_session(%Plug.Conn{}, %{}))
+    end
+  end
+
+  describe "set_is_producer" do
+    test "no datasets" do
+      assert %{"is_producer" => false} ==
+               %Plug.Conn{}
+               |> Plug.Test.init_test_session(%{current_user: %{}})
+               |> set_is_producer([])
+               |> Plug.Conn.get_session(:current_user)
+    end
+
+    test "2 datasets" do
+      assert %{"is_producer" => true} ==
+               %Plug.Conn{}
+               |> Plug.Test.init_test_session(%{current_user: %{}})
+               |> set_is_producer([build(:dataset), build(:dataset)])
+               |> Plug.Conn.get_session(:current_user)
     end
   end
 


### PR DESCRIPTION
Corrige un bug introduit à l'occasion de #3684

```elixir
def set_is_producer(%Plug.Conn{} = conn, [%DB.Dataset{}] = _datasets_for_user)
```

est trop restrictif et match uniquement quand il y a un `DB.Dataset` dans la liste. En conséquence on avait [une erreur 500](https://transport-data-gouv-fr.sentry.io/issues/4836987776/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0) quand il y avait plus de datasets dans la liste.