### PR TITLE
Ajuste clés étrangères pour resource_related

### DIFF
--- a/apps/transport/priv/repo/migrations/20230404074406_add_resource_related.exs
+++ b/apps/transport/priv/repo/migrations/20230404074406_add_resource_related.exs
@@ -3,8 +3,8 @@ defmodule DB.Repo.Migrations.AddResourceRelated do
 
   def change do
     create table(:resource_related, primary_key: false) do
-      add(:resource_src_id, references(:resource), on_delete: :delete_all, null: false)
-      add(:resource_dst_id, references(:resource), on_delete: :delete_all, null: false)
+      add(:resource_src_id, references(:resource, on_delete: :nothing), null: false)
+      add(:resource_dst_id, references(:resource, on_delete: :nothing), null: false)
       add(:reason, :string, null: false)
     end
 

--- a/apps/transport/priv/repo/migrations/20240110085755_resource_related_on_delete.exs
+++ b/apps/transport/priv/repo/migrations/20240110085755_resource_related_on_delete.exs
@@ -1,0 +1,17 @@
+defmodule DB.Repo.Migrations.ResourceRelatedOnDelete do
+  use Ecto.Migration
+
+  def change do
+    # Review foreign key settings previously set in
+    # 20230404074406_add_resource_related.exs
+    alter table(:resource_related) do
+      modify(:resource_src_id, references(:resource, on_delete: :delete_all),
+        from: references(:resource, on_delete: :nothing)
+      )
+
+      modify(:resource_dst_id, references(:resource, on_delete: :delete_all),
+        from: references(:resource, on_delete: :nothing)
+      )
+    end
+  end
+end

--- a/apps/transport/test/db/resource_related_test.exs
+++ b/apps/transport/test/db/resource_related_test.exs
@@ -8,7 +8,7 @@ defmodule DB.ResourceRelatedTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "can create and load resources_related" do
+  test "can create, load and delete resources_related" do
     %DB.Resource{id: r1_id} = r1 = insert(:resource)
     %DB.Resource{id: r2_id} = insert(:resource)
     insert(:resource_related, resource_src_id: r1_id, resource_dst_id: r2_id, reason: :gtfs_rt_gtfs)
@@ -21,5 +21,9 @@ defmodule DB.ResourceRelatedTest do
                resource_dst: %DB.Resource{id: ^r2_id}
              }
            ] = DB.Repo.preload(r1, resources_related: [:resource_dst]).resources_related
+
+    # When deleting a resource, the `resource_related` row linking to it is deleted as well
+    DB.Repo.delete!(r1)
+    assert [] == DB.Repo.all(DB.ResourceRelated)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3712

Permet de supprimer automatiquement une ligne dans la table `resource_related` quand une `resource` est supprimée. Ceci bloquait l'import d'au moins un JDD.

Voir l'issue pour le détail.