### PR TITLE
Config : migration syntaxe :system

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :transport, TransportWeb.Endpoint,
-  http: [port: {:system, "PORT"}, compress: true],
+  http: [port: System.get_env("PORT"), compress: true],
   url: [scheme: "https", host: System.get_env("DOMAIN_NAME", "transport.data.gouv.fr"), port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json",
   secret_key_base: System.get_env("SECRET_KEY_BASE"),


### PR DESCRIPTION
On a un warning pour la syntaxe actuelle, je la migre donc.

```
:http configuration containing {:system, env_var} tuples for TransportWeb.Endpoint is deprecated.

Configuration with deprecated values:

    config :transport, TransportWeb.Endpoint,
      http: [
        port: {:system, "PORT"}
      ]

Move this configuration into config/runtime.exs and replace the {:system, env_var} tuples
with System.get_env/1 function calls:

    config :transport, TransportWeb.Endpoint,
      http: [
        port: System.get_env("PORT")
      ]
```

Il ne me semble pas nécessaire que ceci soit placé dans `runtime.exs`.