### PR TITLE
Plug RateLimiter uniquement pour l'app transport

### DIFF
--- a/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/index_controller_test.exs
@@ -35,4 +35,13 @@ defmodule GBFS.IndexControllerTest do
     # We did not receive telemetry events (ie metrics have not been saved to the database)
     refute_receive {:telemetry_event, [:gbfs, :request, _], %{}, %{}}
   end
+
+  test "rate limiter is not enabled for the GBFS app", %{conn: conn} do
+    [blocked_ip] = Application.fetch_env!(:phoenix_ddos, :blocklist_ips)
+
+    conn
+    |> Plug.Conn.put_req_header("x-forwarded-for", to_string(blocked_ip))
+    |> get("/gbfs")
+    |> json_response(200)
+  end
 end

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -40,7 +40,6 @@ defmodule TransportWeb.Endpoint do
 
   plug(Plug.RequestId)
   plug(RemoteIp, headers: ["x-forwarded-for"])
-  plug(TransportWeb.Plugs.RateLimiter, :use_env_variables)
   plug(Plug.Logger)
 
   plug(Plug.Parsers,

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -10,6 +10,7 @@ defmodule TransportWeb.Router do
 
   pipeline :browser_no_csp do
     plug(:canonical_host)
+    plug(TransportWeb.Plugs.RateLimiter, :use_env_variables)
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_flash)

--- a/apps/transport/test/transport_web/routing/proxy_routing_test.exs
+++ b/apps/transport/test/transport_web/routing/proxy_routing_test.exs
@@ -1,16 +1,24 @@
 defmodule TransportWeb.ProxyRoutingTest do
   use TransportWeb.ConnCase, async: true
-  import Phoenix.ConnTest
 
-  test "accepts proxy. subdomain calls and delegates them to unlock", %{conn: conn} do
-    conn =
-      conn
-      |> Map.put(:host, "proxy.example.com")
-      |> get(~p"/")
+  test "accepts proxy. subdomain, calls and delegates them to Unlock", %{conn: conn} do
+    conn = %{conn | host: "proxy.example.com"} |> get(~p"/")
 
     [h] = Plug.Conn.get_resp_header(conn, "x-request-id")
     assert h
 
-    assert text_response(conn, 200) =~ ~r/Unlock/
+    assert text_response(conn, 200) =~ "Unlock"
+  end
+
+  test "rate limiter is not enabled for proxy", %{conn: conn} do
+    [blocked_ip] = Application.fetch_env!(:phoenix_ddos, :blocklist_ips)
+
+    response =
+      %{conn | host: "proxy.example.com"}
+      |> Plug.Conn.put_req_header("x-forwarded-for", to_string(blocked_ip))
+      |> get(~p"/")
+      |> text_response(200)
+
+    assert response =~ "Unlock"
   end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3677

Active le plug de rate limiter uniquement pour l'application transport et désactive en particulier pour proxy et GBFS.