### PR TITLE
Espace producteur : affichage stats téléchargements

### DIFF
--- a/apps/transport/client/stylesheets/components/_tooltip.scss
+++ b/apps/transport/client/stylesheets/components/_tooltip.scss
@@ -8,7 +8,7 @@
 /* Tooltip text */
 .tooltip .tooltiptext {
   visibility: hidden;
-  width: 100px;
+  width: 150px;
   background-color: var(--theme-background-white);
   color: var(--theme-dark-text);
   text-align: center;

--- a/apps/transport/lib/db/dataset_monthly_metric.ex
+++ b/apps/transport/lib/db/dataset_monthly_metric.ex
@@ -7,6 +7,7 @@ defmodule DB.DatasetMonthlyMetric do
   use Ecto.Schema
   use TypedEctoSchema
   import Ecto.Changeset
+  import Ecto.Query
 
   typed_schema "dataset_monthly_metrics" do
     # Foreign key constraint is not enforced on the dataset table
@@ -24,5 +25,32 @@ defmodule DB.DatasetMonthlyMetric do
     |> validate_required([:dataset_datagouv_id, :year_month, :metric_name, :count])
     |> validate_format(:year_month, ~r/\A2\d{3}-(0[1-9]|1[012])\z/)
     |> validate_number(:count, greater_than_or_equal_to: 0)
+  end
+
+  @spec downloads_for_year([DB.Dataset.t()], integer()) :: %{integer() => integer()}
+  def downloads_for_year(datasets, year) do
+    datagouv_ids = Enum.map(datasets, fn %DB.Dataset{datagouv_id: datagouv_id} -> datagouv_id end)
+    year_months = year_months(year)
+
+    DB.DatasetMonthlyMetric
+    |> where(
+      [dm],
+      dm.metric_name == :downloads and dm.dataset_datagouv_id in ^datagouv_ids and dm.year_month in ^year_months
+    )
+    |> group_by([dm], dm.dataset_datagouv_id)
+    |> select([dm], {dm.dataset_datagouv_id, sum(dm.count)})
+    |> DB.Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  `YYYY-MM` possibilities for a specific year
+
+  iex> year_months(2023)
+  ["2023-01", "2023-02", "2023-03", "2023-04", "2023-05", "2023-06", "2023-07", "2023-08", "2023-09", "2023-10", "2023-11", "2023-12"]
+  """
+  @spec year_months(integer()) :: [binary()]
+  def year_months(year) do
+    Enum.map(1..12, &("#{year}-" <> String.pad_leading(to_string(&1), 2, "0")))
   end
 end

--- a/apps/transport/lib/db/dataset_monthly_metric.ex
+++ b/apps/transport/lib/db/dataset_monthly_metric.ex
@@ -2,6 +2,12 @@ defmodule DB.DatasetMonthlyMetric do
   @moduledoc """
   Monthly metrics related to datasets as given by the data.gouv.fr
   API.
+
+  - `:downloads`: counts the number of `GET` requests for all the dataset resources,
+  as seen by the data.gouv.fr's infrastructure. It only makes sense for resources
+  hosted on data.gouv.fr, not for resources hosted on third party servers.
+  - `:views`: counts the number of `GET` requests on the dataset web page.
+
   Example: https://metric-api.data.gouv.fr/api/datasets/data/?metric_month__sort=asc&dataset_id__exact=5b3cc551c751df4822526c1c
   """
   use Ecto.Schema

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -186,8 +186,12 @@ defmodule TransportWeb.PageController do
           {conn, []}
       end
 
+    last_year = Date.utc_today().year - 1
+
     conn
     |> assign(:datasets, datasets)
+    |> assign(:downloads_reference_year, last_year)
+    |> assign(:downloads_last_year, DB.DatasetMonthlyMetric.downloads_for_year(datasets, last_year))
     |> TransportWeb.Session.set_is_producer(datasets)
     |> render("espace_producteur.html")
   end

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
@@ -30,7 +30,8 @@
             <% end %>
             <%= for dataset <- Enum.sort_by(@datasets, & &1.datagouv_title) do %>
               <% dataset_path = dataset_path(@conn, :details, dataset.id)
-              nb_resources = dataset |> DB.Dataset.official_resources() |> Enum.count() %>
+              nb_resources = dataset |> DB.Dataset.official_resources() |> Enum.count()
+              has_downloads_stats = Map.has_key?(@downloads_last_year, dataset.datagouv_id) %>
               <div class="pt-24 panel dataset-item">
                 <h5>
                   <a href={dataset_path} target="_blank"><i class="icon fa fa-external-link" aria-hidden="true"></i></a>
@@ -59,6 +60,21 @@
                     "data-tracking-category": "espace_producteur",
                     "data-tracking-action": "delete_resource_button"
                   ) %>
+                </div>
+                <div :if={has_downloads_stats and show_downloads_stats?(dataset)}>
+                  <% nb_downloads =
+                    nb_downloads_for_humans(
+                      Map.fetch!(@downloads_last_year, dataset.datagouv_id),
+                      get_session(@conn, :locale)
+                    ) %>
+                  <div class="pt-6">
+                    <i class="icon fa fa-download" aria-hidden="true"></i> <%= dgettext(
+                      "espace-producteurs",
+                      "%{nb_downloads} downloads in %{year}",
+                      nb_downloads: nb_downloads,
+                      year: @downloads_reference_year
+                    ) %>
+                  </div>
                 </div>
               </div>
             <% end %>

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
@@ -68,11 +68,13 @@
                       get_session(@conn, :locale)
                     ) %>
                   <div class="pt-6">
-                    <i class="icon fa fa-download" aria-hidden="true"></i> <%= dgettext(
-                      "espace-producteurs",
-                      "%{nb_downloads} downloads in %{year}",
-                      nb_downloads: nb_downloads,
-                      year: @downloads_reference_year
+                    <i class="icon fa fa-download" aria-hidden="true"></i> <%= raw(
+                      dgettext(
+                        "espace-producteurs",
+                        ~s(%{nb_downloads} <div class="tooltip">downloads in %{year}<span class="tooltiptext">Number of downloads for all the files hosted on data.gouv.fr</span></div>),
+                        nb_downloads: nb_downloads,
+                        year: @downloads_reference_year
+                      )
                     ) %>
                   </div>
                 </div>

--- a/apps/transport/lib/transport_web/views/page_view.ex
+++ b/apps/transport/lib/transport_web/views/page_view.ex
@@ -24,4 +24,23 @@ defmodule TransportWeb.PageView do
   def show_proxy_stats_block?(datasets) do
     datasets |> Enum.flat_map(& &1.resources) |> Enum.any?(&DB.Resource.served_by_proxy?/1)
   end
+
+  @spec show_downloads_stats?(DB.Dataset.t()) :: boolean()
+  def show_downloads_stats?(%DB.Dataset{resources: resources}) do
+    Enum.any?(resources, &DB.Resource.hosted_on_datagouv?/1)
+  end
+
+  @doc """
+  iex> nb_downloads_for_humans(2_400_420, "fr")
+  "2 M"
+  iex> nb_downloads_for_humans(215_500, "fr")
+  "216 k"
+  iex> nb_downloads_for_humans(1_200, "fr")
+  "1 k"
+  iex> nb_downloads_for_humans(623, "fr")
+  "623"
+  """
+  def nb_downloads_for_humans(value, locale) do
+    Transport.Cldr.Number.to_string!(value, format: :short, locale: locale)
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -206,5 +206,5 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-autogen, elixir-format
-msgid "%{nb_downloads} downloads in %{year}"
+msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -204,3 +204,7 @@ msgid "1 resource"
 msgid_plural "%{count} resources"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "%{nb_downloads} downloads in %{year}"
+msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -205,5 +205,5 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-autogen, elixir-format
-msgid "%{nb_downloads} downloads in %{year}"
+msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
 msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -203,3 +203,7 @@ msgid "1 resource"
 msgid_plural "%{count} resources"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "%{nb_downloads} downloads in %{year}"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -206,5 +206,5 @@ msgstr[0] "1 ressource"
 msgstr[1] "%{count} ressources"
 
 #, elixir-autogen, elixir-format
-msgid "%{nb_downloads} downloads in %{year}"
-msgstr "%{nb_downloads} téléchargements en %{year}"
+msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
+msgstr "%{nb_downloads} <div class=\"tooltip\">téléchargements en %{year}<span class=\"tooltiptext\">Nombre de téléchargements pour tous les fichiers hébergés sur data.gouv.fr</span></div>"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -204,3 +204,7 @@ msgid "1 resource"
 msgid_plural "%{count} resources"
 msgstr[0] "1 ressource"
 msgstr[1] "%{count} ressources"
+
+#, elixir-autogen, elixir-format
+msgid "%{nb_downloads} downloads in %{year}"
+msgstr "%{nb_downloads} téléchargements en %{year}"

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -103,9 +103,64 @@ defmodule TransportWeb.PageControllerTest do
       assert doc |> Floki.find(".dataset-item h5") |> Enum.map(&(&1 |> Floki.text() |> String.trim())) == [
                datagouv_title
              ]
+    end
 
-      # Download stats for last year are displayed
-      assert doc |> Floki.find(".dataset-item") |> Floki.text() =~ "120 k téléchargements en #{last_year}"
+    test "download stats are displayed", %{conn: conn} do
+      # A dataset with a resource hosted on data.gouv.fr
+      %DB.Dataset{organization_id: organization_id} = dataset = insert(:dataset, datagouv_title: "A")
+      resource = insert(:resource, url: "https://static.data.gouv.fr/file", dataset: dataset)
+
+      # Another dataset but the resource is not hosted on data.gouv.fr
+      %DB.Dataset{} = other_dataset = insert(:dataset, datagouv_title: "B", organization_id: organization_id)
+      other_resource = insert(:resource, url: "https://example.com/file", dataset: other_dataset)
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => organization_id}]}} end)
+
+      last_year = Date.utc_today().year - 1
+
+      insert(:dataset_monthly_metric,
+        dataset_datagouv_id: dataset.datagouv_id,
+        year_month: "#{last_year}-12",
+        metric_name: :downloads,
+        count: 50_250
+      )
+
+      insert(:dataset_monthly_metric,
+        dataset_datagouv_id: dataset.datagouv_id,
+        year_month: "#{last_year}-11",
+        metric_name: :downloads,
+        count: 70_000
+      )
+
+      insert(:dataset_monthly_metric,
+        dataset_datagouv_id: other_dataset.datagouv_id,
+        year_month: "#{last_year}-11",
+        metric_name: :downloads,
+        count: 100_000
+      )
+
+      parsed_document =
+        conn
+        |> init_test_session(current_user: %{})
+        |> get(page_path(conn, :espace_producteur))
+        |> html_response(200)
+        |> Floki.parse_document!()
+
+      # Download stats for last year are displayed only for the dataset
+      # with at least a resource hosted on data.gouv.fr
+      assert DB.Resource.hosted_on_datagouv?(resource)
+      refute DB.Resource.hosted_on_datagouv?(other_resource)
+
+      assert dataset |> DB.Repo.preload(:resources) |> TransportWeb.PageView.show_downloads_stats?()
+      refute other_dataset |> DB.Repo.preload(:resources) |> TransportWeb.PageView.show_downloads_stats?()
+
+      assert %{dataset.datagouv_id => 50_250 + 70_000} ==
+               DB.DatasetMonthlyMetric.downloads_for_year([dataset], last_year)
+
+      [first_dataset, second_dataset] = parsed_document |> Floki.find(".dataset-item")
+      assert first_dataset |> Floki.text() =~ "120 k téléchargements en #{last_year}"
+      refute second_dataset |> Floki.text() =~ "téléchargements"
     end
 
     test "with an OAuth2 error", %{conn: conn} do

--- a/apps/transport/test/transport_web/views/page_view_test.exs
+++ b/apps/transport/test/transport_web/views/page_view_test.exs
@@ -1,0 +1,22 @@
+defmodule TransportWeb.PageViewTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  doctest TransportWeb.PageView, import: true
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "show_downloads_stats?" do
+    dataset = insert(:dataset)
+    refute dataset |> DB.Repo.preload(:resources) |> TransportWeb.PageView.show_downloads_stats?()
+
+    resource = insert(:resource, dataset: dataset)
+    refute DB.Resource.hosted_on_datagouv?(resource)
+    refute dataset |> DB.Repo.preload(:resources) |> TransportWeb.PageView.show_downloads_stats?()
+
+    resource = insert(:resource, dataset: dataset, url: "https://static.data.gouv.fr/file.csv")
+    assert DB.Resource.hosted_on_datagouv?(resource)
+    assert dataset |> DB.Repo.preload(:resources) |> TransportWeb.PageView.show_downloads_stats?()
+  end
+end


### PR DESCRIPTION
Ajoute les statistiques de téléchargement provenant de l'API data.gouv.fr dans l'Espace Producteur.

Affiche :
- le nombre de téléchargements pour l'année civile entière précédente (2023 pour 2024)
- uniquement pour les jeux de données qui contiennent au moins une ressource hébergée sur data.gouv.fr (les statistiques de téléchargements ne sont pas représentatives en cas d'hébergement ailleurs)

On pourra afficher dans un second temps :
- les statistiques de téléchargements des ressources directement sur la page d'un jeu de données. On ne dispose pas encore de ces données chez nous.
- des détails sur la méthode dont sont obtenus ces chiffres, des graphiques mois par mois, offrir le téléchargement de ces données. On attend un peu le retour de producteurs à cette fonctionnalité.

![image](https://github.com/etalab/transport-site/assets/295709/2c27bb35-2d63-4565-ac5c-eebfd9b2551b)

Voir [discussion sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/qcxiezibp3fzfjfgdr5wg8zimy)