### PR TITLE
Import des stats mensuelles data.gouv.fr pour les ressources

### DIFF
--- a/apps/transport/lib/db/resource_monthly_metric.ex
+++ b/apps/transport/lib/db/resource_monthly_metric.ex
@@ -1,0 +1,26 @@
+defmodule DB.ResourceMonthlyMetric do
+  @moduledoc """
+  Monthly metrics related to resources as given by the data.gouv.fr
+  API.
+  Example: https://metric-api.data.gouv.fr/api/resources/data/?metric_month__sort=desc&resource_id__exact=e0dbd217-15cd-4e28-9459-211a27511a34&page_size=50
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+  import Ecto.Changeset
+
+  typed_schema "resource_monthly_metrics" do
+    belongs_to(:resource, DB.Resource, foreign_key: :resource_datagouv_id, references: :datagouv_id, type: :string)
+    field(:year_month, :string)
+    field(:metric_name, Ecto.Enum, values: [:downloads])
+    field(:count, :integer)
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, [:resource_datagouv_id, :year_month, :metric_name, :count])
+    |> validate_required([:resource_datagouv_id, :year_month, :metric_name, :count])
+    |> validate_format(:year_month, ~r/\A2\d{3}-(0[1-9]|1[012])\z/)
+    |> validate_number(:count, greater_than_or_equal_to: 0)
+  end
+end

--- a/apps/transport/lib/jobs/import_dataset_monthly_metrics_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_monthly_metrics_job.ex
@@ -87,7 +87,9 @@ defmodule Transport.Jobs.ImportMonthlyMetrics do
 
   defp insert_or_update(model_name, datagouv_id, %{"metric_month" => metric_month} = data)
        when model_name in [:dataset, :resource] do
-    Enum.each(metrics(model_name, data), fn {metric_name, count} ->
+    model_name
+    |> metrics_for_model(data)
+    |> Enum.each(fn {metric_name, count} ->
       count = count || 0
 
       model_name
@@ -104,14 +106,14 @@ defmodule Transport.Jobs.ImportMonthlyMetrics do
     end)
   end
 
-  defp metrics(:dataset, %{
+  defp metrics_for_model(:dataset, %{
          "monthly_visit" => monthly_visit,
          "monthly_download_resource" => monthly_download_resource
        }) do
     [{:views, monthly_visit}, {:downloads, monthly_download_resource}]
   end
 
-  defp metrics(:resource, %{"monthly_download_resource" => monthly_download_resource}) do
+  defp metrics_for_model(:resource, %{"monthly_download_resource" => monthly_download_resource}) do
     [{:downloads, monthly_download_resource}]
   end
 

--- a/apps/transport/lib/jobs/import_resource_monthly_metrics_job.ex
+++ b/apps/transport/lib/jobs/import_resource_monthly_metrics_job.ex
@@ -2,7 +2,10 @@ defmodule Transport.Jobs.ImportResourceMonthlyMetricsJob do
   @moduledoc """
   Import monthly metrics related to resources coming from the data.gouv.fr's API.
 
-  This job is executed daily and imports metrics for all resources for the last 2 years.
+  This job is executed daily and imports metrics for all resources.
+  If resource metrics have not been imported previously, we well fetch metrics for the last 2 years.
+  Otherwise we will fetch metrics only for the last 3 months.
+
   Records are not supposed to change in the past, except for the current month.
   """
   use Oban.Worker, max_attempts: 3

--- a/apps/transport/lib/jobs/import_resource_monthly_metrics_job.ex
+++ b/apps/transport/lib/jobs/import_resource_monthly_metrics_job.ex
@@ -1,0 +1,29 @@
+defmodule Transport.Jobs.ImportResourceMonthlyMetricsJob do
+  @moduledoc """
+  Import monthly metrics related to resources coming from the data.gouv.fr's API.
+
+  This job is executed daily and imports metrics for all resources for the last 2 years.
+  Records are not supposed to change in the past, except for the current month.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+
+  # The number of workers to run in parallel when importing metrics
+  @task_concurrency 5
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    resource_datagouv_ids()
+    |> Task.async_stream(
+      fn datagouv_id -> Transport.Jobs.ImportMonthlyMetrics.import_metrics(:resource, datagouv_id) end,
+      max_concurrency: @task_concurrency,
+      on_timeout: :kill_task,
+      timeout: 10_000
+    )
+    |> Stream.run()
+  end
+
+  def resource_datagouv_ids do
+    DB.Resource.base_query() |> select([resource: r], r.datagouv_id) |> DB.Repo.all()
+  end
+end

--- a/apps/transport/priv/repo/migrations/20240117075117_resource_monthly_metrics.exs
+++ b/apps/transport/priv/repo/migrations/20240117075117_resource_monthly_metrics.exs
@@ -1,0 +1,16 @@
+defmodule DB.Repo.Migrations.ResourceMonthlyMetrics do
+  use Ecto.Migration
+
+  def change do
+    create table(:resource_monthly_metrics) do
+      add(:resource_datagouv_id, :string, null: false, size: 50)
+      # Example: 2023-12
+      add(:year_month, :string, null: false, size: 7)
+      add(:metric_name, :string, null: false, size: 50)
+      add(:count, :integer, null: false)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:resource_monthly_metrics, [:resource_datagouv_id, :year_month, :metric_name]))
+  end
+end

--- a/apps/transport/test/db/resource_monthly_metric_test.exs
+++ b/apps/transport/test/db/resource_monthly_metric_test.exs
@@ -1,0 +1,42 @@
+defmodule DB.ResourceMonthlyMetricTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "changeset" do
+    test "can insert a record" do
+      resource = insert(:resource)
+
+      assert %Ecto.Changeset{valid?: true} =
+               changeset =
+               DB.ResourceMonthlyMetric.changeset(%DB.ResourceMonthlyMetric{}, %{
+                 resource_datagouv_id: resource.datagouv_id,
+                 metric_name: :downloads,
+                 count: 42,
+                 year_month: "2023-12"
+               })
+
+      DB.Repo.insert!(changeset)
+    end
+
+    test "identifies errors" do
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [
+                 {:count, _},
+                 {:year_month, _},
+                 {:metric_name, _}
+               ]
+             } =
+               DB.ResourceMonthlyMetric.changeset(%DB.ResourceMonthlyMetric{}, %{
+                 resource_datagouv_id: Ecto.UUID.generate(),
+                 metric_name: :foo,
+                 count: -1,
+                 year_month: "bar"
+               })
+    end
+  end
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -73,6 +73,10 @@ defmodule DB.Factory do
     %DB.DatasetMonthlyMetric{}
   end
 
+  def resource_monthly_metric_factory do
+    %DB.ResourceMonthlyMetric{}
+  end
+
   def resource_factory do
     %DB.Resource{
       last_import: DateTime.utc_now(),

--- a/apps/transport/test/transport/jobs/import_resource_monthly_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_resource_monthly_metrics_job_test.exs
@@ -1,0 +1,171 @@
+defmodule Transport.Test.Transport.Jobs.ImportResourceMonthlyMetricsTestJob do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Ecto.Query
+  import Mox
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.ImportResourceMonthlyMetricsJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "import_metrics" do
+    test "base case" do
+      %DB.Resource{datagouv_id: datagouv_id} = insert(:resource)
+
+      setup_http_response(datagouv_id, [
+        %{
+          "resource_id" => datagouv_id,
+          "metric_month" => "2022-08",
+          "monthly_download_resource" => 557_626
+        },
+        %{
+          "resource_id" => datagouv_id,
+          "metric_month" => "2022-07",
+          "monthly_download_resource" => 343_617
+        }
+      ])
+
+      assert DB.ResourceMonthlyMetric |> DB.Repo.all() |> Enum.empty?()
+
+      Transport.Jobs.ImportMonthlyMetrics.import_metrics(:resource, datagouv_id)
+
+      assert [
+               %DB.ResourceMonthlyMetric{
+                 resource_datagouv_id: ^datagouv_id,
+                 year_month: "2022-08",
+                 metric_name: :downloads,
+                 count: 557_626
+               },
+               %DB.ResourceMonthlyMetric{
+                 resource_datagouv_id: ^datagouv_id,
+                 year_month: "2022-07",
+                 metric_name: :downloads,
+                 count: 343_617
+               }
+             ] = DB.Repo.all(DB.ResourceMonthlyMetric)
+    end
+
+    test "replaces existing records" do
+      %DB.Resource{datagouv_id: datagouv_id} = insert(:resource)
+
+      insert(:resource_monthly_metric,
+        resource_datagouv_id: datagouv_id,
+        year_month: "2023-12",
+        metric_name: :downloads,
+        count: 42
+      )
+
+      setup_http_response(datagouv_id, [
+        %{
+          "resource_id" => datagouv_id,
+          "metric_month" => "2023-12",
+          "monthly_download_resource" => 43
+        },
+        %{
+          "resource_id" => datagouv_id,
+          "metric_month" => "2023-11",
+          "monthly_download_resource" => 1337
+        }
+      ])
+
+      assert [
+               %DB.ResourceMonthlyMetric{
+                 id: metric_id,
+                 resource_datagouv_id: ^datagouv_id,
+                 year_month: "2023-12",
+                 metric_name: :downloads,
+                 count: 42
+               }
+             ] = DB.Repo.all(DB.ResourceMonthlyMetric)
+
+      Transport.Jobs.ImportMonthlyMetrics.import_metrics(:resource, datagouv_id)
+
+      assert [
+               # Count has been updated, primary key is still the same
+               %DB.ResourceMonthlyMetric{
+                 id: ^metric_id,
+                 resource_datagouv_id: ^datagouv_id,
+                 year_month: "2023-12",
+                 metric_name: :downloads,
+                 count: 43,
+                 inserted_at: inserted_at,
+                 updated_at: updated_at
+               },
+               # Has been inserted
+               %DB.ResourceMonthlyMetric{
+                 resource_datagouv_id: ^datagouv_id,
+                 year_month: "2023-11",
+                 metric_name: :downloads,
+                 count: 1337
+               }
+             ] = DB.Repo.all(DB.ResourceMonthlyMetric)
+
+      # `updated_at` has been updated to reflect that this row has changed
+      assert DateTime.after?(updated_at, inserted_at)
+    end
+  end
+
+  test "perform" do
+    %DB.Resource{datagouv_id: r1_datagouv_id} = insert(:resource)
+    %DB.Resource{datagouv_id: r2_datagouv_id} = insert(:resource)
+
+    assert MapSet.new([r1_datagouv_id, r2_datagouv_id]) ==
+             ImportResourceMonthlyMetricsJob.resource_datagouv_ids() |> MapSet.new()
+
+    setup_http_response(r1_datagouv_id, [
+      %{
+        "resource_id" => r1_datagouv_id,
+        "metric_month" => "2023-12",
+        "monthly_download_resource" => 43
+      }
+    ])
+
+    setup_http_response(r2_datagouv_id, [
+      %{
+        "resource_id" => r2_datagouv_id,
+        "metric_month" => "2023-12",
+        "monthly_download_resource" => 5
+      }
+    ])
+
+    assert :ok == perform_job(ImportResourceMonthlyMetricsJob, %{})
+
+    assert 2 == DB.Repo.aggregate(DB.ResourceMonthlyMetric, :count, :id)
+
+    assert [
+             %DB.ResourceMonthlyMetric{
+               resource_datagouv_id: ^r1_datagouv_id,
+               year_month: "2023-12",
+               metric_name: :downloads,
+               count: 43
+             }
+           ] =
+             DB.ResourceMonthlyMetric
+             |> where([rmm], rmm.resource_datagouv_id == ^r1_datagouv_id)
+             |> DB.Repo.all()
+
+    assert [
+             %DB.ResourceMonthlyMetric{
+               resource_datagouv_id: ^r2_datagouv_id,
+               year_month: "2023-12",
+               metric_name: :downloads,
+               count: 5
+             }
+           ] =
+             DB.ResourceMonthlyMetric
+             |> where([rmm], rmm.resource_datagouv_id == ^r2_datagouv_id)
+             |> DB.Repo.all()
+  end
+
+  defp setup_http_response(datagouv_id, data) do
+    metrics_api_url = Transport.Jobs.ImportMonthlyMetrics.api_url(:resource, datagouv_id)
+
+    expect(Transport.Req.Mock, :get, fn ^metrics_api_url, [] ->
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}}
+    end)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -138,7 +138,8 @@ oban_prod_crontab = [
   # "At 08:15 on Monday in March, June, and November.""
   # The job will make sure that it's executed only on the first Monday of these months
   {"15 8 * 3,6,11 1", Transport.Jobs.PeriodicReminderProducersNotificationJob},
-  {"30 5 * * *", Transport.Jobs.ImportDatasetMonthlyMetricsJob}
+  {"30 5 * * *", Transport.Jobs.ImportDatasetMonthlyMetricsJob},
+  {"45 5 * * *", Transport.Jobs.ImportResourceMonthlyMetricsJob}
 ]
 
 # Make sure that all modules exist


### PR DESCRIPTION
Fixes #3724 

Importe les statistiques de téléchargement des ressources depuis l'API de data.gouv.fr.

Ceci est similaire à ce qui a été fait dans #3663. J'ai suivi la même approche que dans la PR précédente pour les JDDs, j'en ai profité pour effectuer un refactor et extraire des méthodes communes.

L'import est planifié de manière quotidienne et importe les statistiques :
- si le modèle n'a jamais été importé, pour les 24 derniers mois
- si on a déjà importé des statistiques, pour les 3 derniers mois (🆕, ceci n'était le cas dans la précédente PR)

Ce job en local importe ~16 800 lignes pour ~1 300 ressources. On mettra à jour uniquement 3  * 1 300 lignes par jour ensuite.