### PR TITLE
Récupération des logos d’organisation dans les discussions via l’ID et non le nom de l’organisation

### DIFF
--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -117,10 +117,10 @@ defmodule TransportWeb.DiscussionsLive do
     end
   end
 
-  defp organization_info(%DB.Dataset{organization: nil}), do: :no_organization
+  defp organization_info(%DB.Dataset{organization_id: nil}), do: :no_organization
 
-  defp organization_info(%DB.Dataset{organization: organization}) when is_binary(organization) do
-    Datagouvfr.Client.Organization.Wrapper.get(organization, restrict_fields: true)
+  defp organization_info(%DB.Dataset{organization_id: organization_id}) when is_binary(organization_id) do
+    Datagouvfr.Client.Organization.Wrapper.get(organization_id, restrict_fields: true)
   end
 end
 

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -11,12 +11,16 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
   end
 
   test "render some discussions", %{conn: conn} do
-    dataset = insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), organization: "producer_org")
+    dataset =
+      insert(:dataset,
+        datagouv_id: datagouv_id = Ecto.UUID.generate(),
+        organization_id: organization_id = Ecto.UUID.generate()
+      )
 
     Datagouvfr.Client.Discussions.Mock |> expect(:get, 1, fn ^datagouv_id -> discussions() end)
 
     Datagouvfr.Client.Organization.Mock
-    |> expect(:get, 1, fn "producer_org", [restrict_fields: true] -> organization() end)
+    |> expect(:get, 1, fn ^organization_id, [restrict_fields: true] -> organization() end)
 
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.DiscussionsLive,
@@ -73,7 +77,7 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
   end
 
   test "renders even if there is no organization", %{conn: conn} do
-    dataset = insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), organization: nil)
+    dataset = insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), organization_id: nil)
 
     Datagouvfr.Client.Discussions.Mock |> expect(:get, 1, fn ^datagouv_id -> discussions() end)
 


### PR DESCRIPTION
Fixes #3726