### PR TITLE
Évite les resources avec à la fois un format de donnnées de transport public et un schéma de données

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -116,6 +116,7 @@ defmodule DB.Resource do
       ]
     )
     |> validate_required([:url, :datagouv_id])
+    |> no_schema_name_for_public_transport()
   end
 
   @spec is_gtfs?(__MODULE__.t()) :: boolean()
@@ -371,4 +372,17 @@ defmodule DB.Resource do
   """
   def proxy_namespace(%__MODULE__{format: "gbfs"}), do: "gbfs"
   def proxy_namespace(%__MODULE__{}), do: "proxy"
+
+  def no_schema_name_for_public_transport(changeset) do
+    schema_name = get_field(changeset, :schema_name)
+    format = get_field(changeset, :format)
+    public_transport_formats = ["GTFS", "gtfs-rt", "NeTEx", "SIRI", "SIRI Lite"]
+
+    if format in public_transport_formats and is_binary(schema_name) do
+      changeset
+      |> add_error(:schema_name, "public transport formats can’t have schema name")
+    else
+      changeset
+    end
+  end
 end

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -373,14 +373,14 @@ defmodule DB.Resource do
   def proxy_namespace(%__MODULE__{format: "gbfs"}), do: "gbfs"
   def proxy_namespace(%__MODULE__{}), do: "proxy"
 
-  def no_schema_name_for_public_transport(changeset) do
+  def no_schema_name_for_public_transport(%Ecto.Changeset{} = changeset) do
     schema_name = get_field(changeset, :schema_name)
     format = get_field(changeset, :format)
     public_transport_formats = ["GTFS", "gtfs-rt", "NeTEx", "SIRI", "SIRI Lite"]
 
     if format in public_transport_formats and is_binary(schema_name) do
       changeset
-      |> add_error(:schema_name, "public transport formats can’t have schema name")
+      |> add_error(:schema_name, "Public transport formats can’t have a schema set", resource_id: get_field(changeset, :id), resource_datagouv_id: get_field(changeset, :datagouv_id))
     else
       changeset
     end

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -380,7 +380,10 @@ defmodule DB.Resource do
 
     if format in public_transport_formats and is_binary(schema_name) do
       changeset
-      |> add_error(:schema_name, "Public transport formats can’t have a schema set", resource_id: get_field(changeset, :id), resource_datagouv_id: get_field(changeset, :datagouv_id))
+      |> add_error(:schema_name, "Public transport formats can’t have a schema set",
+        resource_id: get_field(changeset, :id),
+        resource_datagouv_id: get_field(changeset, :datagouv_id)
+      )
     else
       changeset
     end

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -195,4 +195,10 @@ defmodule DB.ResourceTest do
                "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/898dc67fb19fae2464c24a85a0557e8ccce18791/bnlc-.csv"
            }) == resource_url(TransportWeb.Endpoint, :download, id)
   end
+
+  test "invalid resource" do
+    resource = %Resource{format: "GTFS", schema_name: "anything"}
+    changeset = Resource.changeset(resource, %{})
+    assert {"public transport formats can’t have schema name", []} == changeset.errors[:schema_name]
+  end
 end

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -199,6 +199,8 @@ defmodule DB.ResourceTest do
   test "invalid resource" do
     resource = %Resource{format: "GTFS", schema_name: "anything"}
     assert %Ecto.Changeset{valid?: false} = changeset = Resource.changeset(resource, %{})
-    assert {"public transport formats can’t have schema name", []} == changeset.errors[:schema_name]
+
+    assert {"Public transport formats can’t have a schema set", [{:resource_id, nil}, {:resource_datagouv_id, nil}]} ==
+             changeset.errors[:schema_name]
   end
 end

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -198,7 +198,7 @@ defmodule DB.ResourceTest do
 
   test "invalid resource" do
     resource = %Resource{format: "GTFS", schema_name: "anything"}
-    changeset = Resource.changeset(resource, %{})
+    assert %Ecto.Changeset{valid?: false} = changeset = Resource.changeset(resource, %{})
     assert {"public transport formats can’t have schema name", []} == changeset.errors[:schema_name]
   end
 end

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -197,10 +197,11 @@ defmodule DB.ResourceTest do
   end
 
   test "invalid resource" do
-    resource = %Resource{format: "GTFS", schema_name: "anything"}
+    resource = %Resource{format: "GTFS", schema_name: "anything", datagouv_id: datagouv_id = Ecto.UUID.generate()}
     assert %Ecto.Changeset{valid?: false} = changeset = Resource.changeset(resource, %{})
 
-    assert {"Public transport formats can’t have a schema set", [{:resource_id, nil}, {:resource_datagouv_id, nil}]} ==
+    assert {"Public transport formats can’t have a schema set",
+            [{:resource_id, nil}, {:resource_datagouv_id, datagouv_id}]} ==
              changeset.errors[:schema_name]
   end
 end


### PR DESCRIPTION
Fixes #3723 

Un fait divers, une loi : je rajoute une validation pour éviter le cas cité dans #3723.

Import_data fait appel au changeset de DB.Dataset, qui lui-même fait un cast sur DB.Resource donc fait appel à sa fonction changeset.

Ça marche bien, en tentant d’importer[ ce jeu de données ](https://demo.data.gouv.fr/fr/datasets/gtfs-avec-un-schema-bizarre/)sur Demo, ça donne ça :

![image](https://github.com/etalab/transport-site/assets/15861435/27a12471-fea2-491e-b508-8b19f1627c7b)

![image](https://github.com/etalab/transport-site/assets/15861435/4be1c81b-621c-4ac3-828d-79afec654fa1)
