### PR TITLE
NewDatagouvDatasetsJob : mise à jour champ date de création

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -78,7 +78,8 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
     dataset_ids = DB.Dataset.base_query() |> select([dataset: d], d.datagouv_id) |> DB.Repo.all()
 
     Enum.filter(datasets, fn dataset ->
-      dataset["id"] not in dataset_ids and after_datetime?(dataset["created_at"], a_day_ago) and
+      dataset["id"] not in dataset_ids and
+        after_datetime?(get_in(dataset, ["internal", "created_at_internal"]), a_day_ago) and
         dataset_is_relevant?(dataset)
     end)
   end

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -65,7 +65,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
       "resources" => [],
       "tags" => [],
       "description" => "",
-      "created_at" => "2022-11-01 00:01:00+00:00",
+      "internal" => %{"created_at_internal" => "2022-11-01 00:01:00+00:00"},
       "id" => Ecto.UUID.generate()
     }
 
@@ -73,7 +73,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
     datasets = [
       base,
-      %{base | "created_at" => "2022-10-30 00:00:00+00:00", "title" => "GTFS de Dijon"},
+      %{base | "internal" => %{"created_at_internal" => "2022-10-30 00:00:00+00:00"}, "title" => "GTFS de Dijon"},
       dataset_to_keep = %{base | "title" => "GTFS de Dijon"},
       %{base | "tags" => ["gbfs"], "id" => datagouv_id}
     ]
@@ -81,7 +81,13 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
     assert [false, true, true, true] == Enum.map(datasets, &NewDatagouvDatasetsJob.dataset_is_relevant?/1)
 
     assert [true, false, true, true] ==
-             Enum.map(datasets, &NewDatagouvDatasetsJob.after_datetime?(&1["created_at"], ~U[2022-11-01 00:00:00Z]))
+             Enum.map(
+               datasets,
+               &NewDatagouvDatasetsJob.after_datetime?(
+                 get_in(&1, ["internal", "created_at_internal"]),
+                 ~U[2022-11-01 00:00:00Z]
+               )
+             )
 
     assert [dataset_to_keep] == NewDatagouvDatasetsJob.filtered_datasets(datasets, ~U[2022-11-02 00:00:00Z])
   end
@@ -104,7 +110,9 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
         "resources" => [],
         "tags" => [],
         "description" => "",
-        "created_at" => DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601(),
+        "internal" => %{
+          "created_at_internal" => DateTime.utc_now() |> DateTime.add(-23, :hour) |> DateTime.to_iso8601()
+        },
         "page" => "https://example.com/link",
         "id" => Ecto.UUID.generate()
       }


### PR DESCRIPTION
Fixes #3742

Le champ du datetime de création a été modifié dans l'API data.gouv.fr dans #2815 ([code exact](https://github.com/opendatateam/udata/commit/c2539a5f9fd15cec3833e21013c17f3642851e4d#diff-40eddfe27558a331de9feb00ad21869b53b16cdf3c0c89074aefb00047b55211)) et cause un bug dans le job en charge d'identifier les JDDs créés récemment susceptibles d'être référencés sur le PAN.

Cette différence entre `created_at` et `internal.created_at_internal` survient uniquement pour les JDDs moissonnés.

Adapte le code du job en conséquence. Je verrai avec @etalab/transport-bizdev si on a laissé des JDDs de côté à cause de ce bug. EDIT : [liste ici](https://github.com/etalab/transport-site/issues/3742#issuecomment-1907934168) 