### PR TITLE
Augmentation du seuil de RAM de GTFS-DIFF de 10 à 20MB (expérimental)

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -8,7 +8,8 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
   import TransportWeb.Gettext
   alias TransportWeb.GTFSDiffExplain
 
-  @max_file_size_mb 10
+  @max_file_size_mb 20
+
   def mount(_params, %{"locale" => locale} = _session, socket) do
     Gettext.put_locale(locale)
 

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
@@ -15,9 +15,8 @@
     <div id="gtfs-diff-input" phx-drop-target={@uploads.gtfs.ref}>
       <form id="upload-form" phx-submit="gtfs_diff" phx-change="validate">
         <div class="drop-zone panel">
-          <%= dgettext("validations", "Drop your GTFS files here or browse your local drive") %> <%= live_file_input(
-            @uploads.gtfs
-          ) %>
+          <%= dgettext("validations", "Drop your GTFS files here or browse your local drive") %>
+          <.live_file_input upload={@uploads.gtfs} />
         </div>
         <%= if assigns[:job_running] do %>
           <button class="button" disabled><%= dgettext("validations", "Compare") %></button>


### PR DESCRIPTION
Correctif pour:
- https://github.com/etalab/transport-site/issues/3738

C'est un test, il faudra vérifier en production que ça ne fait pas trop crasher le worker.

Je partagerai les résultats sur l'issue linkée plus haut.