### PR TITLE
Espace producteur : édition d'un JDD/logo personnalisé

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -59,25 +59,26 @@
   }
 }
 
-.resource-update-section {
+.espace-producteur-section {
   background-color: var(--theme-background-grey);
   min-height: 80vh;
-  .resources-update-list {
+}
+
+.resources-update-list {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -24px;
+  .panel {
+    margin: 0 24px 12px;
     display: flex;
-    flex-wrap: wrap;
-    margin: 0 -24px;
-    .panel {
-      margin: 0 24px 12px;
-      display: flex;
-      align-items: center;
-      img {
-        padding-right: 12px;
-      }
+    align-items: center;
+    img {
+      padding-right: 12px;
     }
-    a {
-      text-decoration: none;
-      color: initial;
-    }
+  }
+  a {
+    text-decoration: none;
+    color: initial;
   }
 }
 

--- a/apps/transport/lib/S3/s3.ex
+++ b/apps/transport/lib/S3/s3.ex
@@ -3,7 +3,7 @@ defmodule Transport.S3 do
   This module contains common code related to S3 object storage.
   """
   require Logger
-  @type bucket_feature :: :history | :on_demand_validation | :gtfs_diff
+  @type bucket_feature :: :history | :on_demand_validation | :gtfs_diff | :logos
 
   @spec bucket_name(bucket_feature()) :: binary()
   def bucket_name(feature) do

--- a/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
@@ -1,7 +1,7 @@
 defmodule TransportWeb.EspaceProducteurController do
   use TransportWeb, :controller
 
-  plug(:find_dataset when action in [:edit_dataset, :upload_logo])
+  plug(:find_dataset_or_redirect when action in [:edit_dataset, :upload_logo])
 
   def edit_dataset(%Plug.Conn{} = conn, %{"dataset_id" => _}) do
     conn |> render("edit_dataset.html")
@@ -51,7 +51,7 @@ defmodule TransportWeb.EspaceProducteurController do
     conn
   end
 
-  defp find_dataset(%Plug.Conn{path_params: %{"dataset_id" => dataset_id}} = conn, _options) do
+  defp find_dataset_or_redirect(%Plug.Conn{path_params: %{"dataset_id" => dataset_id}} = conn, _options) do
     case find_dataset_for_user(conn, dataset_id) do
       %DB.Dataset{} = dataset ->
         conn |> assign(:dataset, dataset)

--- a/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
@@ -1,0 +1,79 @@
+defmodule TransportWeb.EspaceProducteurController do
+  use TransportWeb, :controller
+
+  plug(:find_dataset when action in [:edit_dataset, :upload_logo])
+
+  def edit_dataset(%Plug.Conn{} = conn, %{"dataset_id" => _}) do
+    conn |> render("edit_dataset.html")
+  end
+
+  def upload_logo(%Plug.Conn{} = conn, %{"dataset_id" => _, "upload" => %{"file" => %Plug.Upload{} = file}}) do
+    conn
+    |> upload_logo_and_send_email(file)
+    |> put_flash(:info, dgettext("espace-producteurs", "Your logo has been received. We will get back to you soon."))
+    |> redirect(to: page_path(conn, :espace_producteur))
+  end
+
+  defp upload_logo_and_send_email(
+         %Plug.Conn{
+           assigns: %{
+             current_user: current_user,
+             dataset: %DB.Dataset{custom_title: custom_title, datagouv_id: datagouv_id}
+           }
+         } = conn,
+         %Plug.Upload{path: filepath, filename: filename}
+       ) do
+    extension = filename |> Path.extname() |> String.downcase()
+    destination_path = "tmp_#{datagouv_id}#{extension}"
+    Transport.S3.stream_to_s3!(:logos, filepath, destination_path)
+
+    Transport.EmailSender.impl().send_mail(
+      "transport.data.gouv.fr",
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :contact_email),
+      Application.get_env(:transport, :contact_email),
+      "Logo personnalisé : #{custom_title}",
+      """
+      Bonjour,
+
+      Un logo personnalisé vient d'être envoyé.
+
+      Scripts à exécuter :
+      s3cmd mv s3://#{Transport.S3.bucket_name(:logos)}/#{destination_path} /tmp/#{destination_path}
+      elixir scripts/custom_logo.exs /tmp/#{destination_path} #{datagouv_id}
+
+      Personne à contacter :
+      #{current_user["email"]}
+      """,
+      ""
+    )
+
+    conn
+  end
+
+  defp find_dataset(%Plug.Conn{path_params: %{"dataset_id" => dataset_id}} = conn, _options) do
+    case find_dataset_for_user(conn, dataset_id) do
+      %DB.Dataset{} = dataset ->
+        conn |> assign(:dataset, dataset)
+
+      nil ->
+        conn
+        |> put_flash(:error, dgettext("alert", "Unable to get this dataset for the moment"))
+        |> redirect(to: page_path(conn, :espace_producteur))
+        |> halt()
+    end
+  end
+
+  @spec find_dataset_for_user(Plug.Conn.t(), binary()) :: DB.Dataset.t() | nil
+  defp find_dataset_for_user(%Plug.Conn{} = conn, dataset_id_str) do
+    {dataset_id, ""} = Integer.parse(dataset_id_str)
+
+    conn
+    |> DB.Dataset.datasets_for_user()
+    |> case do
+      datasets when is_list(datasets) -> datasets
+      {:error, _} -> []
+    end
+    |> Enum.find(fn %DB.Dataset{id: id} -> id == dataset_id end)
+  end
+end

--- a/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
@@ -77,11 +77,11 @@ end
 defmodule Transport.CustomLogoNotifier do
   import Swoosh.Email
 
-  def custom_logo(html_body, subject) do
+  def custom_logo(text_body, subject) do
     new()
     |> from({"transport.data.gouv.fr", Application.fetch_env!(:transport, :contact_email)})
     |> to(Application.fetch_env!(:transport, :contact_email))
     |> subject(subject)
-    |> html_body(html_body)
+    |> text_body(text_body)
   end
 end

--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -34,6 +34,8 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
     vega_hash_values =
       "'sha256-9uoGUaZm3j6W7+Fh2wfvjI8P7zXcclRw5tVUu3qKZa0=' 'sha256-MmUum7+PiN7Rz79EUMm0OmUFWjCx6NZ97rdjoIbTnAg='"
 
+    logos_bucket_url = Transport.S3.permanent_url(:logos)
+
     csp_content =
       case app_env do
         :production ->
@@ -41,7 +43,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           default-src 'none';
           connect-src *;
           font-src *;
-          img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{Application.fetch_env!(:transport, :logos_bucket_url)};
+          img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
           frame-src https://www.dailymotion.com/;
           style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
@@ -54,7 +56,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
             default-src 'none';
             connect-src *;
             font-src *;
-            img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{Application.fetch_env!(:transport, :logos_bucket_url)};
+            img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
             frame-src https://www.dailymotion.com/;
             style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -82,6 +82,11 @@ defmodule TransportWeb.Router do
       pipe_through([:authenticated])
       get("/", PageController, :espace_producteur)
 
+      scope "/datasets" do
+        get("/:dataset_id/edit", EspaceProducteurController, :edit_dataset)
+        post("/:dataset_id/upload_logo", EspaceProducteurController, :upload_logo)
+      end
+
       scope "/notifications" do
         get("/", NotificationController, :index)
         post("/", NotificationController, :create)

--- a/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
@@ -1,0 +1,48 @@
+<% datagouv_admin_url = "https://www.data.gouv.fr/admin/dataset/#{@dataset.datagouv_id}/" %>
+<section class="pt-48">
+  <div class="container pb-24">
+    <%= breadcrumbs([@conn, :edit_dataset, @dataset.custom_title]) %>
+  </div>
+</section>
+<section class="espace-producteur-section">
+  <div class="container pt-24">
+    <div class="panel">
+      <h2><%= @dataset.custom_title %></h2>
+      <p>
+        <%= raw(
+          dgettext(
+            "espace-producteurs",
+            ~s(You can edit this dataset on <a href="%{datagouv_admin_url}" target="_blank">data.gouv.fr</a>.),
+            datagouv_admin_url: datagouv_admin_url
+          )
+        ) %>
+      </p>
+      <h3><%= dgettext("espace-producteurs", "Update your logo") %></h3>
+      <div :if={is_nil(@dataset.custom_logo)}>
+        <%= form_for @conn, espace_producteur_path(@conn, :upload_logo, @dataset.id), [as: "upload", multipart: :true], fn f -> %>
+          <div class="dataset__logo">
+            <p><%= dgettext("espace-producteurs", "Your current logo") %></p>
+            <%= img_tag(DB.Dataset.full_logo(@dataset), alt: @dataset.custom_title) %>
+          </div>
+          <p>
+            <%= dgettext("espace-producteurs", "Your custom logo") %>
+          </p>
+          <%= file_input(f, :file, accept: "image/png, image/jpeg") %>
+          <%= submit(dgettext("espace-producteurs", "Upload")) %>
+        <% end %>
+      </div>
+      <div :if={@dataset.custom_logo != nil}>
+        <div class="dataset__logo">
+          <p><%= dgettext("espace-producteurs", "Your current logo") %></p>
+          <%= img_tag(DB.Dataset.full_logo(@dataset), alt: @dataset.custom_title) %>
+        </div>
+        <p>
+          <%= dgettext(
+            "espace-producteurs",
+            "You currently have a custom logo. If you want to remove or update it, please contact our team."
+          ) %>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
@@ -37,7 +37,13 @@
                   <a href={dataset_path} target="_blank"><i class="icon fa fa-external-link" aria-hidden="true"></i></a>
                   <%= dataset.datagouv_title %>
                 </h5>
-                <hr class="mb-0" />
+                <%= link(dgettext("espace-producteurs", "Edit"),
+                  to: espace_producteur_path(@conn, :edit_dataset, dataset.id),
+                  class: "button-outline secondary small",
+                  "data-tracking-category": "espace_producteur",
+                  "data-tracking-action": "edit_dataset"
+                ) %>
+                <hr class="mb-0 mt-24" />
                 <div class="pt-6">
                   <%= dngettext("espace-producteurs", "1 resource", "%{count} resources", nb_resources) %>
                 </div>

--- a/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
@@ -5,7 +5,7 @@ resource_id = Map.fetch!(@conn.params, "resource_id") %>
     <%= breadcrumbs([@conn, :delete_resource, dataset_id]) %>
   </div>
 </section>
-<section class="resource-update-section">
+<section class="espace-producteur-section">
   <div class="container pt-24">
     <strong><%= @dataset["title"] %> > <%= @resource["title"] %></strong>
     <%= form_for @conn, resource_path(@conn, :delete, dataset_id, resource_id), [method: "delete", class: "pt-48"], fn _ -> %>

--- a/apps/transport/lib/transport_web/templates/resource/resources_list.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/resources_list.html.heex
@@ -4,7 +4,7 @@
     <%= breadcrumbs([@conn, :select_resource, @dataset["id"]]) %>
   </div>
 </section>
-<section class="resource-update-section">
+<section class="espace-producteur-section">
   <div class="container">
     <div class="pt-24">
       <strong><%= @dataset["title"] %></strong>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -66,6 +66,10 @@ defmodule TransportWeb.BreadCrumbs do
       ]
   end
 
+  def crumbs(conn, :edit_dataset, dataset_custom_title) do
+    crumbs(conn, :espace_producteur) ++ [{dataset_custom_title, nil}]
+  end
+
   def render_crumbs(crumbs_element) do
     content_tag :div, class: "breadcrumbs" do
       render_crumbs_elements(crumbs_element)

--- a/apps/transport/lib/transport_web/views/espace_producteur_view.ex
+++ b/apps/transport/lib/transport_web/views/espace_producteur_view.ex
@@ -1,0 +1,4 @@
+defmodule TransportWeb.EspaceProducteurView do
+  use TransportWeb, :view
+  import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
+end

--- a/apps/transport/priv/gettext/alert.pot
+++ b/apps/transport/priv/gettext/alert.pot
@@ -25,3 +25,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unable to get all your resources for the moment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Unable to get this dataset for the moment"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
@@ -25,3 +25,7 @@ msgstr "Vous devez être membre de l’équipe transport.data.gouv.fr."
 #, elixir-autogen, elixir-format
 msgid "Unable to get all your resources for the moment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Unable to get this dataset for the moment"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -208,3 +208,35 @@ msgstr[1] ""
 #, elixir-autogen, elixir-format
 msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Update your logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Upload"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You can edit this dataset on <a href=\"%{datagouv_admin_url}\" target=\"_blank\">data.gouv.fr</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You currently have a custom logo. If you want to remove or update it, please contact our team."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your current logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your custom logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your logo has been received. We will get back to you soon."
+msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -207,3 +207,35 @@ msgstr[1] ""
 #, elixir-autogen, elixir-format
 msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Update your logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Upload"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You can edit this dataset on <a href=\"%{datagouv_admin_url}\" target=\"_blank\">data.gouv.fr</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You currently have a custom logo. If you want to remove or update it, please contact our team."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your current logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your custom logo"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your logo has been received. We will get back to you soon."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -20,8 +20,12 @@ msgstr "Une erreur est survenue, veuillez réessayer"
 
 #, elixir-autogen
 msgid "You need to be a member of the transport.data.gouv.fr team."
-msgstr ""
+msgstr "Vous devez être un membre de l'équipe transport.data.gouv.fr."
 
 #, elixir-autogen, elixir-format
 msgid "Unable to get all your resources for the moment"
 msgstr "Une erreur a eu lieu lors de la récupération de vos ressources"
+
+#, elixir-autogen, elixir-format
+msgid "Unable to get this dataset for the moment"
+msgstr "Impossible de récupérer ce jeu de données pour le moment"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -208,3 +208,35 @@ msgstr[1] "%{count} ressources"
 #, elixir-autogen, elixir-format
 msgid "%{nb_downloads} <div class=\"tooltip\">downloads in %{year}<span class=\"tooltiptext\">Number of downloads for all the files hosted on data.gouv.fr</span></div>"
 msgstr "%{nb_downloads} <div class=\"tooltip\">téléchargements en %{year}<span class=\"tooltiptext\">Nombre de téléchargements pour tous les fichiers hébergés sur data.gouv.fr</span></div>"
+
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr "Éditer"
+
+#, elixir-autogen, elixir-format
+msgid "Update your logo"
+msgstr "Mettre à jour votre logo"
+
+#, elixir-autogen, elixir-format
+msgid "Upload"
+msgstr "Envoyer"
+
+#, elixir-autogen, elixir-format
+msgid "You can edit this dataset on <a href=\"%{datagouv_admin_url}\" target=\"_blank\">data.gouv.fr</a>."
+msgstr "Vous pouvez modifier ce jeu de données sur <a href=\"%{datagouv_admin_url}\" target=\"_blank\">data.gouv.fr</a>."
+
+#, elixir-autogen, elixir-format
+msgid "You currently have a custom logo. If you want to remove or update it, please contact our team."
+msgstr "Vous avez actuellement un logo personnalisé. Si vous souhaitez le retirer ou le mettre à jour, veuillez contacter notre équipe."
+
+#, elixir-autogen, elixir-format
+msgid "Your current logo"
+msgstr "Votre logo actuel"
+
+#, elixir-autogen, elixir-format
+msgid "Your custom logo"
+msgstr "Votre logo personnalisé"
+
+#, elixir-autogen, elixir-format
+msgid "Your logo has been received. We will get back to you soon."
+msgstr "Votre logo a bien été reçu. Nous reviendrons vers vous rapidement."

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -59,7 +59,7 @@ defmodule TransportWeb.BackofficeControllerTest do
     assert redirected_to(conn, 302) =~ "/login/explanation"
 
     assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-             "You need to be a member of the transport.data.gouv.fr team."
+             "Vous devez être un membre de l'équipe transport.data.gouv.fr."
   end
 
   test "Show 'add new dataset' form", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -128,10 +128,10 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
                              from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
                              to: [{"", "contact@transport.data.gouv.fr"}],
                              subject: ^email_subject,
-                             text_body: nil,
-                             html_body: html_body
+                             text_body: text_body,
+                             html_body: nil
                            } ->
-        assert html_body == """
+        assert text_body == """
                Bonjour,
 
                Un logo personnalisé vient d'être envoyé.

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -1,0 +1,151 @@
+defmodule TransportWeb.EspaceProducteurControllerTest do
+  use TransportWeb.ConnCase, async: true
+  import DB.Factory
+  import Plug.Test, only: [init_test_session: 2]
+  import Mox
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "edit_dataset" do
+    test "requires authentication", %{conn: conn} do
+      conn = conn |> get(espace_producteur_path(conn, :edit_dataset, 42))
+      assert redirected_to(conn, 302) =~ "/login"
+    end
+
+    test "redirects if you're not a member of the dataset organization", %{conn: conn} do
+      dataset = insert(:dataset)
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => []}} end)
+
+      conn =
+        conn
+        |> init_test_session(current_user: %{})
+        |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
+
+      assert redirected_to(conn, 302) == page_path(conn, :espace_producteur)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Impossible de récupérer ce jeu de données pour le moment"
+    end
+
+    test "renders successfully and finds the dataset using organization IDs", %{conn: conn} do
+      %DB.Dataset{organization_id: organization_id} = dataset = insert(:dataset, custom_title: custom_title = "Foobar")
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => organization_id}]}} end)
+
+      content =
+        conn
+        |> init_test_session(current_user: %{})
+        |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
+        |> html_response(200)
+
+      assert custom_title == content |> Floki.parse_document!() |> Floki.find("h2") |> Floki.text()
+    end
+
+    test "when a custom logo is set", %{conn: conn} do
+      dataset = insert(:dataset, custom_logo: "https://example.com/pic.png")
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => dataset.organization_id}]}} end)
+
+      content =
+        conn
+        |> init_test_session(current_user: %{})
+        |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
+        |> html_response(200)
+
+      assert content =~
+               "Vous avez actuellement un logo personnalisé. Si vous souhaitez le retirer ou le mettre à jour, veuillez contacter notre équipe."
+    end
+  end
+
+  describe "upload_logo" do
+    test "requires authentication", %{conn: conn} do
+      conn = conn |> post(espace_producteur_path(conn, :upload_logo, 42), %{"upload" => %{"file" => %Plug.Upload{}}})
+      assert redirected_to(conn, 302) =~ "/login"
+    end
+
+    test "redirects if you're not a member of the dataset organization", %{conn: conn} do
+      dataset = insert(:dataset)
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => []}} end)
+
+      conn =
+        conn
+        |> init_test_session(current_user: %{})
+        |> post(espace_producteur_path(conn, :upload_logo, dataset.id), %{"upload" => %{"file" => %Plug.Upload{}}})
+
+      assert redirected_to(conn, 302) == page_path(conn, :espace_producteur)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Impossible de récupérer ce jeu de données pour le moment"
+    end
+
+    test "uploads the logo to S3, send an email and redirect", %{conn: conn} do
+      %DB.Dataset{organization_id: organization_id, datagouv_id: datagouv_id, custom_title: custom_title} =
+        dataset = insert(:dataset)
+
+      filename = "sample.jpg"
+      local_path = System.tmp_dir!() |> Path.join("#{filename}")
+      upload_path = "tmp_#{datagouv_id}.jpg"
+      user_email = "john@example.com"
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => organization_id}]}} end)
+
+      Transport.ExAWS.Mock
+      |> expect(:request!, fn %ExAws.S3.Upload{
+                                src: %File.Stream{path: ^local_path},
+                                bucket: "transport-data-gouv-fr-logos-test",
+                                path: ^upload_path,
+                                opts: [acl: :private],
+                                service: :s3
+                              } ->
+        :ok
+      end)
+
+      email_subject = "Logo personnalisé : #{custom_title}"
+
+      Transport.EmailSender.Mock
+      |> expect(:send_mail, fn "transport.data.gouv.fr" = _display_name,
+                               "contact@transport.data.gouv.fr" = _from,
+                               "contact@transport.data.gouv.fr" = _to,
+                               "contact@transport.data.gouv.fr" = _reply_to,
+                               ^email_subject,
+                               body,
+                               "" ->
+        assert body == """
+               Bonjour,
+
+               Un logo personnalisé vient d'être envoyé.
+
+               Scripts à exécuter :
+               s3cmd mv s3://transport-data-gouv-fr-logos-test/#{upload_path} /tmp/#{upload_path}
+               elixir scripts/custom_logo.exs /tmp/#{upload_path} #{datagouv_id}
+
+               Personne à contacter :
+               #{user_email}
+               """
+
+        :ok
+      end)
+
+      conn =
+        conn
+        |> init_test_session(current_user: %{"email" => user_email})
+        |> post(espace_producteur_path(conn, :upload_logo, dataset.id), %{
+          "upload" => %{"file" => %Plug.Upload{path: local_path, filename: filename}}
+        })
+
+      assert redirected_to(conn, 302) == page_path(conn, :espace_producteur)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Votre logo a bien été reçu. Nous reviendrons vers vous rapidement."
+    end
+  end
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -71,11 +71,11 @@ config :transport,
   s3_buckets: %{
     history: "resource-history-dev",
     on_demand_validation: "on-demand-validation-dev",
-    gtfs_diff: "gtfs-diff-dev"
+    gtfs_diff: "gtfs-diff-dev",
+    logos: "logos-dev"
   },
   # by default, use the production validator. This can be overriden with dev.secret.exs
-  gtfs_validator_url: "https://validation.transport.data.gouv.fr",
-  logos_bucket_url: "https://transport-data-gouv-fr-logos-dev.cellar-c2.services.clever-cloud.com"
+  gtfs_validator_url: "https://validation.transport.data.gouv.fr"
 
 config :oauth2, Datagouvfr.Authentication,
   site: datagouvfr_site,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -8,7 +8,8 @@ config :transport,
   s3_buckets: %{
     history: "resource-history-prod",
     on_demand_validation: "on-demand-validation-prod",
-    gtfs_diff: "gtfs-diff-prod"
+    gtfs_diff: "gtfs-diff-prod",
+    logos: "logos-prod"
   }
 
 # Configure Sentry for production and staging.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,9 +85,9 @@ if app_env == :staging do
     s3_buckets: %{
       history: "resource-history-staging",
       on_demand_validation: "on-demand-validation-staging",
-      gtfs_diff: "gtfs-diff-staging"
-    },
-    logos_bucket_url: "https://transport-data-gouv-fr-logos-staging.cellar-c2.services.clever-cloud.com"
+      gtfs_diff: "gtfs-diff-staging",
+      logos: "logos-staging"
+    }
 end
 
 base_oban_conf = [repo: DB.Repo, insert_trigger: false]
@@ -249,8 +249,7 @@ if config_env() == :prod do
               "aires" => "673a16bf-49ec-4645-9da2-cf975d0aa0ea"
             }
           }
-        }),
-      logos_bucket_url: "https://transport-data-gouv-fr-logos-prod.cellar-c2.services.clever-cloud.com"
+        })
 
     config :transport, Transport.Mailer,
       adapter: Swoosh.Adapters.Mailjet,

--- a/config/test.exs
+++ b/config/test.exs
@@ -48,7 +48,8 @@ config :transport,
   s3_buckets: %{
     history: "resource-history-test",
     on_demand_validation: "on-demand-validation-test",
-    gtfs_diff: "gtfs-diff-test"
+    gtfs_diff: "gtfs-diff-test",
+    logos: "logos-test"
   },
   workflow_notifier: Transport.Jobs.Workflow.ProcessNotifier,
   export_secret_key: "fake_export_secret_key",


### PR DESCRIPTION
Fixes #3701

Suite de #3741. Cette PR ajoute la possibilité d'envoyer un logo personnalisé depuis l'Espace Producteur. Ce logo est alors déposé sur un bucket "logos", un e-mail est envoyé à notre équipe pour traiter cette demande à l'aide du script ajouté dans la PR précédente (le script prépare et upload les images sur le bucket).

## Captures d'écran

![image](https://github.com/etalab/transport-site/assets/295709/127f8a08-6f2d-463d-8241-47aafc51862e)
![Screenshot 2024-01-25 at 14 24 00](https://github.com/etalab/transport-site/assets/295709/59b21181-ca8c-4baf-9fd7-5c958eb21a46)
