### PR TITLE
Augmentation de la durée autorisée de GTFS-Diff (de 5 à 15 minutes)

### DIFF
--- a/apps/transport/lib/jobs/gtfs_diff_job.ex
+++ b/apps/transport/lib/jobs/gtfs_diff_job.ex
@@ -51,6 +51,6 @@ defmodule Transport.Jobs.GTFSDiff do
   @impl Oban.Worker
   def timeout(_job), do: :timer.seconds(job_timeout_sec())
 
-  # 5 minutes timeout
-  def job_timeout_sec, do: 300
+  # 15 minutes, in seconds
+  def job_timeout_sec, do: 15 * 60
 end


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-site/issues/3738#issuecomment-1913077010