### PR TITLE
Espace Producteur : ajout attribut required

### DIFF
--- a/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
@@ -27,7 +27,7 @@
           <p>
             <%= dgettext("espace-producteurs", "Your custom logo") %>
           </p>
-          <%= file_input(f, :file, accept: "image/png, image/jpeg") %>
+          <%= file_input(f, :file, accept: "image/png, image/jpeg", required: true) %>
           <%= submit(dgettext("espace-producteurs", "Upload")) %>
         <% end %>
       </div>


### PR DESCRIPTION
Adapte le HTML pour ajouter un attribut `required` sur l'input permettant d'envoyer un logo personnalisé.