### PR TITLE
Augmentation du timeout gtfs-diff à 30 minutes

### DIFF
--- a/apps/transport/lib/jobs/gtfs_diff_job.ex
+++ b/apps/transport/lib/jobs/gtfs_diff_job.ex
@@ -51,6 +51,6 @@ defmodule Transport.Jobs.GTFSDiff do
   @impl Oban.Worker
   def timeout(_job), do: :timer.seconds(job_timeout_sec())
 
-  # 15 minutes, in seconds
-  def job_timeout_sec, do: 15 * 60
+  # 30 minutes, in seconds
+  def job_timeout_sec, do: 30 * 60
 end


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-site/issues/3738

Le dernier test réalisé par l'utilisateur donnait:
- un time-out visuel
- mais pas de crash du worker derrière (j'ai vérifié dans les logs d'activité)

Donc avec un peu de bol, ça traitera le souci pour cette taille de fichier en tout cas.