### PR TITLE
Ajuste CSS logo dataset#index

### DIFF
--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -89,9 +89,7 @@
   }
 
   .dataset__image img {
-    object-fit: contain;
-    height: 100%;
-    max-height: 4.5em;
+    max-width: 100%;
   }
 
   .side-pane__submenu a {


### PR DESCRIPTION
Ajuste cette règle CSS utilisée uniquement pour les logos dans la recherche des JDDs. Utile pour les quelques logos personnalisés qui sont donnés en CSS (exemple avec le réseau [SEMO](https://transport.data.gouv.fr/datasets?q=semo)).