### PR TITLE
Mise à jour de l'UI pour les cartes ressource

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -187,10 +187,6 @@
   .button-outline:hover {
     background-color: transparent;
   }
-  .button-outline.secondary {
-    border: none;
-    background-color: transparent;
-  }
   h4 {
     display: inline-block;
     margin-bottom: 0;
@@ -207,8 +203,9 @@
       flex-wrap: wrap;
       align-items: flex-end;
       justify-content: space-between;
-      .button-outline.secondary {
+      .button-outline.secondary.no-border {
         padding: 0 12px 0 0;
+        border: none;
       }
     }
   }

--- a/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_conversions.html.heex
@@ -5,7 +5,7 @@
   <div>
     <%= for {_, %{format: human_format, stable_url: stable_url}} <- Enum.sort_by(conversions, fn {_, %{format: format}} -> format end, :asc) do %>
       <a class="download-button" rel="nofollow" href={stable_url}>
-        <button class="button-outline secondary small">
+        <button class="button-outline secondary no-border small">
           <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("page-dataset-details", "Download") %> <%= human_format %>
         </button>
       </a>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -1,22 +1,16 @@
 <% locale = get_session(@conn, :locale) %>
 <% has_conversions = ResourceView.has_associated_files(@resources_related_files, @resource.id) %>
-<% has_associated_geojson = ResourceView.has_associated_geojson(@resources_related_files, @resource.id) %>
-<% geojson_with_viz? =
-  ResourceView.geojson_with_viz?(@resource, Map.get(@latest_resources_history_infos || %{}, @resource.id)) %>
 <% unavailabilities = @resources_infos.unavailabilities %>
 <% resources_updated_at = @resources_infos.resources_updated_at %>
 <% [validation] = @resources_infos.validations |> Map.get(@resource.id) %>
 <% is_gtfs_outdated = Transport.Validators.GTFSTransport.is_gtfs_outdated(validation) %>
-<% resource_modes = get_metadata_modes(validation, []) %>
 <% related_gtfs_resource = related_gtfs_resource(@resource) %>
 
 <div
   class={"panel resource #{valid_panel_class(@resource, is_gtfs_outdated)}"}
   title={resource_tooltip_content(@resource)}
 >
-  <h4>
-    <%= @resource.title %>
-  </h4>
+  <h4><%= @resource.title %></h4>
 
   <%= unless is_nil(@resource.schema_name) do %>
     <div title={dgettext("page-dataset-details", "Resource declared schema")}>
@@ -43,6 +37,7 @@
       <i class="icon icon--sync-alt" aria-hidden="true"></i>
       <%= show_resource_last_update(resources_updated_at, @resource, locale) %>
     </span>
+    <span class="small"><%= dgettext("page-dataset-details", "Latest modification") %></span>
 
     <% resource_ttl = validation |> get_metadata_info("ttl") %>
     <%= unless is_nil(resource_ttl) do %>
@@ -78,6 +73,7 @@
               to: resource_path(@conn, :details, @resource.id) <> "#download-availability"
             ) %>
           </span>
+          <span class="small"><%= dgettext("page-dataset-details", "Availability rate") %></span>
         </span>
       </div>
     <% end %>
@@ -133,23 +129,8 @@
     <% end %>
   <% end %>
 
-  <%= if has_associated_geojson or geojson_with_viz? do %>
-    <div>
-      <a class="light-grey-link" href={resource_path(@conn, :details, @resource.id) <> "#visualization"}>
-        <%= dgettext("page-dataset-details", "Data visualization available!") %>
-      </a>
-    </div>
-  <% end %>
-
   <div class="resource-panel-bottom">
     <div class="resource-features">
-      <%= if length(resource_modes) > 0 do %>
-        <div title={dgettext("page-dataset-details", "Dataset modes")}>
-          <%= for mode <- resource_modes do %>
-            <span class="label mode"><%= mode %></span>
-          <% end %>
-        </div>
-      <% end %>
       <%= if Resource.is_gtfs_rt?(@resource) and not Enum.empty?(Map.get(@resources_infos.gtfs_rt_entities, @resource.id, [])) do %>
         <%= dgettext("page-dataset-details", "Features available in the resource:") %>
         <div>
@@ -176,7 +157,7 @@
       </div>
       <div>
         <a href={resource_path(@conn, :details, @resource.id)}>
-          <button class="button-outline secondary small">
+          <button class="button-outline primary small">
             <i class="icon icon--plus" aria-hidden="true"></i><%= dgettext("page-dataset-details", "details") %>
           </button>
         </a>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -8,7 +8,7 @@ defmodule TransportWeb.DatasetView do
   # ~H expects a variable named `assigns`, so wrapping the calls to `~H` inside
   # a helper function would be cleaner and more future-proof to avoid conflicts at some point.
   import Phoenix.Component, only: [sigil_H: 2, live_render: 3]
-  import DB.MultiValidation, only: [get_metadata_info: 2, get_metadata_info: 3, get_metadata_modes: 2]
+  import DB.MultiValidation, only: [get_metadata_info: 2, get_metadata_info: 3]
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport
 

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -97,26 +97,6 @@ defmodule TransportWeb.ResourceView do
 
   def has_associated_files(_, _), do: false
 
-  def has_associated_file(%{} = resources_related_files, resource_id, get_associated_file) do
-    resources_related_files
-    |> Map.get(resource_id)
-    |> get_associated_file.()
-    |> case do
-      nil -> false
-      _ -> true
-    end
-  end
-
-  def has_associated_file(_, _, _), do: false
-
-  def has_associated_geojson(resources_related_files, resource_id) do
-    has_associated_file(resources_related_files, resource_id, &get_associated_geojson/1)
-  end
-
-  def has_associated_netex(resources_related_files, resource_id) do
-    has_associated_file(resources_related_files, resource_id, &get_associated_netex/1)
-  end
-
   def get_associated_geojson(%{GeoJSON: geojson_details}), do: geojson_details
   def get_associated_geojson(_), do: nil
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -271,10 +271,6 @@ msgid "during validation"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Data visualization available!"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
@@ -296,10 +292,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Visualization of the resource"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Dataset modes"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -624,4 +616,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "transport.data.gouv.fr computes quality indicators daily to assess the quality of the published data. <i class=\"fa fa-external-link-alt\"></i> <a href=\"%{doc_url}\" target=\"_blank\">Learn more</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Availability rate"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Latest modification"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -271,10 +271,6 @@ msgid "during validation"
 msgstr "lors de la validation"
 
 #, elixir-autogen, elixir-format
-msgid "Data visualization available!"
-msgstr "Visualisation des données disponible !"
-
-#, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Télécharger"
 
@@ -297,10 +293,6 @@ msgstr "Visualisation temps-réel de "
 #, elixir-autogen, elixir-format
 msgid "Visualization of the resource"
 msgstr "Visualisation de la ressource"
-
-#, elixir-autogen, elixir-format
-msgid "Dataset modes"
-msgstr "Modes présents dans le jeu de données"
 
 #, elixir-autogen, elixir-format
 msgid "Features available in the resource:"
@@ -625,3 +617,11 @@ msgstr "Derniers indicateurs qualité"
 #, elixir-autogen, elixir-format
 msgid "transport.data.gouv.fr computes quality indicators daily to assess the quality of the published data. <i class=\"fa fa-external-link-alt\"></i> <a href=\"%{doc_url}\" target=\"_blank\">Learn more</a>."
 msgstr "transport.data.gouv.fr calcule des indicateurs qualité de manière quotidienne afin de mieux appréhender les données publiées. <i class=\"fa fa-external-link-alt\"></i> <a href=\"%{doc_url}\" target=\"_blank\">En savoir plus</a>."
+
+#, elixir-autogen, elixir-format
+msgid "Availability rate"
+msgstr "Taux de disponibilité"
+
+#, elixir-autogen, elixir-format
+msgid "Latest modification"
+msgstr "Dernière modification"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -271,10 +271,6 @@ msgid "during validation"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Data visualization available!"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
@@ -296,10 +292,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Visualization of the resource"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Dataset modes"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -624,4 +616,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "transport.data.gouv.fr computes quality indicators daily to assess the quality of the published data. <i class=\"fa fa-external-link-alt\"></i> <a href=\"%{doc_url}\" target=\"_blank\">Learn more</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Availability rate"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Latest modification"
 msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -182,7 +182,8 @@ defmodule TransportWeb.DatasetControllerTest do
 
     conn = conn |> get(dataset_path(conn, :details, slug))
     assert conn |> html_response(200) =~ "1 information"
-    assert conn |> html_response(200) =~ "ferry"
+    # Dataset modes are not displayed
+    refute conn |> html_response(200) =~ "ferry"
   end
 
   test "show number of errors for a GBFS", %{conn: conn} do


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/3739

Implémente les modifications d'UI discutées avec @cyrimorin :
- Légendes pour dernière modification et taux de disponibilité
- Travail sur les boutons : mise en avant de plus de "+ détails"
- Suppression de l'affichage des modes pour les GTFS
- ne plus afficher "visualisation disponible" pour un GTFS avec une conversion GeoJSON ou pour une ressource GeoJSON

## Avant

![image](https://github.com/etalab/transport-site/assets/295709/33e46da2-63c7-497a-8283-872b2f5796e5)


## Après

![image](https://github.com/etalab/transport-site/assets/295709/25a7bae2-2845-4638-a5fe-270644fa62e2)
