### PR TITLE
Score de disponibilité : gère cas avec 0 ressources

### DIFF
--- a/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
@@ -263,6 +263,14 @@ defmodule Transport.Test.Transport.Jobs.DatasetQualityScoreTest do
                score: 0.75
              } == current_dataset_availability(dataset.id)
     end
+
+    test "a dataset with 0 resources" do
+      dataset = insert(:dataset, is_active: true)
+
+      assert [] == dataset |> DB.Repo.preload(:resources) |> Map.fetch!(:resources)
+
+      assert %{score: 0.0, details: %{resources: []}} == current_dataset_availability(dataset.id)
+    end
   end
 
   describe "current dataset freshness" do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3786

Adapte le calcul du score de disponibilité dans le cas où le JDD a 0 ressources (ou uniquement de la documentation) pour attribuer un score de 0, dénotant qu'un JDD sans ressources est "indisponible".