### PR TITLE
Détail d'un GTFS : ajouter le nombre de routes

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details.html.heex
@@ -18,7 +18,7 @@ stats = @metadata["stats"] %>
         <li>
           <div>
             <div class="networks-list">
-              <%= dgettext("validations", "calendar span by network") %> :
+              <%= dgettext("validations", "calendar span by network:") %>
               <.networks_start_end_dates
                 networks_start_end_dates={networks_start_end_dates}
                 locale={get_session(@conn, :locale)}
@@ -40,11 +40,17 @@ stats = @metadata["stats"] %>
         <%= dngettext("validations", "transport mode", "transport modes", length(@modes)) %> :
         <strong><%= Enum.join(@modes, ", ") %></strong>
       </li>
-      <li :if={@metadata["stop_points_count"] != nil}>
-        <%= dgettext("validations", "number of stop points") %> : <strong><%= @metadata["stop_points_count"] %></strong>
+      <li :if={stats["routes_count"] != nil}>
+        <%= dgettext("validations", "number of routes:") %>
+        <strong><%= format_nil_or_number(stats["routes_count"], locale) %></strong>
       </li>
-      <li :if={@metadata["stop_areas_count"] != nil}>
-        <%= dgettext("validations", "number of stop areas") %> : <strong><%= @metadata["stop_areas_count"] %></strong>
+      <li :if={stats["stop_points_count"] != nil}>
+        <%= dgettext("validations", "number of stop points:") %>
+        <strong><%= format_nil_or_number(stats["stop_points_count"], locale) %></strong>
+      </li>
+      <li :if={stats["stop_areas_count"] != nil}>
+        <%= dgettext("validations", "number of stop areas:") %>
+        <strong><%= format_nil_or_number(stats["stop_areas_count"], locale) %></strong>
       </li>
     </ul>
   </div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -71,14 +71,6 @@ msgid "Validation report"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "number of stop areas"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "number of stop points"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
 
@@ -290,10 +282,6 @@ msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS fi
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "calendar span by network"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
@@ -415,4 +403,20 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "calendar span by network:"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "number of routes:"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "number of stop areas:"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "number of stop points:"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -71,14 +71,6 @@ msgid "Validation report"
 msgstr "Rapport de validation"
 
 #, elixir-autogen, elixir-format
-msgid "number of stop areas"
-msgstr "nombre de zones d'arrêts (stop areas)"
-
-#, elixir-autogen, elixir-format
-msgid "number of stop points"
-msgstr "nombre de stops (stop points)"
-
-#, elixir-autogen, elixir-format
 msgid "to"
 msgstr "au"
 
@@ -290,10 +282,6 @@ msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS fi
 msgstr "Validation effectuée en utilisant <a href=\"%{gtfs_link}\">le fichier GTFS en vigueur</a> le %{date} avec <a href=\"%{validator_url}\" target=\"_blank\">le validateur GTFS du <abbr title=\"Point d'Accès National\">PAN</abbr></a>."
 
 #, elixir-autogen, elixir-format
-msgid "calendar span by network"
-msgstr "couverture calendaire par réseau"
-
-#, elixir-autogen, elixir-format
 msgid "from"
 msgstr "du"
 
@@ -416,3 +404,19 @@ msgstr "Veuillez noter que notre validateur GTFS n'est pas en mesure de valider 
 #, elixir-autogen, elixir-format
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
 msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment."
+
+#, elixir-autogen, elixir-format
+msgid "calendar span by network:"
+msgstr "couverture calendaire par réseau :"
+
+#, elixir-autogen, elixir-format
+msgid "number of routes:"
+msgstr "nombre de lignes :"
+
+#, elixir-autogen, elixir-format
+msgid "number of stop areas:"
+msgstr "nombre de zones d'arrêts :"
+
+#, elixir-autogen, elixir-format
+msgid "number of stop points:"
+msgstr "nombre d'arrêts :"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -71,14 +71,6 @@ msgid "Validation report"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "number of stop areas"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "number of stop points"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
 
@@ -289,10 +281,6 @@ msgid "Validation carried out using the <a href=\"%{gtfs_link}\">current GTFS fi
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "calendar span by network"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
@@ -414,4 +402,20 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "calendar span by network:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "number of routes:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "number of stop areas:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "number of stop points:"
 msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -384,6 +384,9 @@ defmodule TransportWeb.ResourceControllerTest do
               }
             },
             "stats" => %{
+              "stop_points_count" => 1_322,
+              "stop_areas_count" => 30,
+              "routes_count" => 123,
               "routes_with_short_name_count" => 5
             }
           },
@@ -395,6 +398,9 @@ defmodule TransportWeb.ResourceControllerTest do
     content = conn |> get(resource_path(conn, :details, resource_id)) |> html_response(200)
     assert content =~ "Rapport de validation"
     assert content =~ "ferry"
+    assert content =~ ~r"nombre de lignes :(\s*)<strong>123</strong>"
+    assert content =~ ~r"nombre d&#39;arrêts :(\s*)<strong>1 322</strong>"
+    assert content =~ ~r"nombre de zones d&#39;arrêts :(\s*)<strong>30</strong>"
     assert content =~ "couverture calendaire par réseau"
     assert content =~ "3CM"
     assert content =~ "30/09/2022"


### PR DESCRIPTION
Fixes #3788

Ajoute une statistique indiquant le nombre de "routes" présentes dans le fichier GTFS.

Un peu de refactor des traductions au passage et utilisation des statistiques dans `stats` car les anciens attributs vont être supprimés https://github.com/etalab/transport-validator/pull/194