### PR TITLE
Ajout tuile JOP Paris 2024

### DIFF
--- a/apps/transport/client/images/icons/olympics.svg
+++ b/apps/transport/client/images/icons/olympics.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1020" height="1020">
+  <g stroke-width="30" stroke="#fff" fill="none">
+    <g stroke-width="45">
+      <circle cx="345" cy="577.5" r="135"/>
+      <circle cx="675" cy="577.5" r="135"/>
+    </g>
+    <circle cx="345" cy="577.5" r="135" stroke="#010101"/>
+    <circle cx="675" cy="577.5" r="135" stroke="#010101"/>
+    <g stroke-width="45">
+      <circle cx="180" cy="442.5" r="135"/>
+      <circle cx="510" cy="442.5" r="135"/>
+      <circle cx="840" cy="442.5" r="135"/>
+    </g>
+    <circle cx="180" cy="442.5" r="135" stroke="#010101"/>
+    <circle cx="510" cy="442.5" r="135" stroke="#010101"/>
+    <circle cx="840" cy="442.5" r="135" stroke="#010101"/>
+    <g stroke-width="45">
+      <path d="M345 442.5a135 135 0 0 1 81 27M237 658.5a135 135 0 0 1 0-162M675 442.5a135 135 0 0 1 81 27M567 658.5a135 135 0 0 1 0-162"/>
+    </g>
+    <g stroke="#010101">
+      <path d="M345 442.5a135 135 0 0 1 108 54M264 685.5a135 135 0 0 1 0-216"/>
+    </g>
+    <g stroke="#010101">
+      <path d="M675 442.5a135 135 0 0 1 108 54M594 685.5a135 135 0 0 1 0-216"/>
+    </g>
+  </g>
+</svg>

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -235,10 +235,17 @@ defmodule DB.Dataset do
 
   @spec filter_by_climate_resilience_bill(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_climate_resilience_bill(%Ecto.Query{} = query, %{"loi-climat-resilience" => "true"}) do
-    where(query, [dataset: d], fragment("'loi-climat-resilience' = any(?)", d.custom_tags))
+    filter_by_custom_tag(query, %{"custom_tag" => "loi-climat-resilience"})
   end
 
   defp filter_by_climate_resilience_bill(%Ecto.Query{} = query, _), do: query
+
+  @spec filter_by_custom_tag(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  defp filter_by_custom_tag(%Ecto.Query{} = query, %{"custom_tag" => custom_tag}) do
+    where(query, [dataset: d], fragment("? = any(?)", ^custom_tag, d.custom_tags))
+  end
+
+  defp filter_by_custom_tag(%Ecto.Query{} = query, _), do: query
 
   @spec filter_by_feature(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_feature(query, %{"features" => [feature]})
@@ -377,6 +384,7 @@ defmodule DB.Dataset do
       |> filter_by_commune(params)
       |> filter_by_licence(params)
       |> filter_by_climate_resilience_bill(params)
+      |> filter_by_custom_tag(params)
       |> filter_by_fulltext(params)
       |> select([dataset: d], d.id)
 
@@ -631,6 +639,13 @@ defmodule DB.Dataset do
   def count_public_transport_has_realtime do
     __MODULE__
     |> where([d], d.has_realtime and d.is_active and d.type == "public-transit")
+    |> Repo.aggregate(:count, :id)
+  end
+
+  @spec count_by_custom_tag(binary()) :: non_neg_integer()
+  def count_by_custom_tag(custom_tag) do
+    base_query()
+    |> where([dataset: d], fragment("? = any(?)", ^custom_tag, d.custom_tags))
     |> Repo.aggregate(:count, :id)
   end
 

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -240,10 +240,13 @@ defmodule DB.Dataset do
 
   defp filter_by_climate_resilience_bill(%Ecto.Query{} = query, _), do: query
 
-  @spec filter_by_custom_tag(Ecto.Query.t(), map()) :: Ecto.Query.t()
-  defp filter_by_custom_tag(%Ecto.Query{} = query, %{"custom_tag" => custom_tag}) do
+  @spec filter_by_custom_tag(Ecto.Query.t(), binary() | map()) :: Ecto.Query.t()
+  defp filter_by_custom_tag(%Ecto.Query{} = query, custom_tag) when is_binary(custom_tag) do
     where(query, [dataset: d], fragment("? = any(?)", ^custom_tag, d.custom_tags))
   end
+
+  defp filter_by_custom_tag(%Ecto.Query{} = query, %{"custom_tag" => custom_tag}),
+    do: filter_by_custom_tag(query, custom_tag)
 
   defp filter_by_custom_tag(%Ecto.Query{} = query, _), do: query
 
@@ -644,9 +647,7 @@ defmodule DB.Dataset do
 
   @spec count_by_custom_tag(binary()) :: non_neg_integer()
   def count_by_custom_tag(custom_tag) do
-    base_query()
-    |> where([dataset: d], fragment("? = any(?)", ^custom_tag, d.custom_tags))
-    |> Repo.aggregate(:count, :id)
+    base_query() |> filter_by_custom_tag(custom_tag) |> Repo.aggregate(:count, :id)
   end
 
   @spec get_by_slug(binary) :: {:ok, __MODULE__.t()} | {:error, binary()}

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -48,6 +48,7 @@ defmodule TransportWeb.PageController do
       count_aoms_with_dataset: count_aoms_with_dataset(),
       count_regions_completed: count_regions_completed(),
       count_public_transport_has_realtime: Dataset.count_public_transport_has_realtime(),
+      count_paris2024: Dataset.count_by_custom_tag("paris2024"),
       percent_population: percent_population(),
       reusers: CSVDocuments.reusers(),
       facilitators: CSVDocuments.facilitators()
@@ -276,7 +277,13 @@ defmodule TransportWeb.PageController do
       type_tile(conn, "charging-stations"),
       type_tile(conn, "private-parking"),
       type_tile(conn, "locations"),
-      type_tile(conn, "informations")
+      type_tile(conn, "informations"),
+      %Tile{
+        link: dataset_path(conn, :index, %{"custom_tag" => "paris2024"}),
+        icon: icon_type_path("paris2024"),
+        title: "JOP Paris 2024",
+        count: Keyword.fetch!(counts, :count_paris2024)
+      }
     ]
   end
 

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -203,7 +203,9 @@ defmodule TransportWeb.DatasetView do
       "real-time-public-transit" => "bus-stop.svg",
       "long-distance-coach" => "bus.svg",
       "train" => "train.svg",
-      "boat" => "boat.svg"
+      "boat" => "boat.svg",
+      # Custom tags
+      "paris2024" => "olympics.svg"
     }
 
     if Map.has_key?(icons, type), do: "/images/icons/#{Map.get(icons, type)}"

--- a/apps/transport/priv/search_custom_messages.yml
+++ b/apps/transport/priv/search_custom_messages.yml
@@ -299,3 +299,17 @@
         They contain traffic data for pedestrians, bicycles, and micro-mobility.
 
         The standard used is described [in this documentation](https://doc.transport.data.gouv.fr/producteurs/comptage-des-mobilites).
+
+- category: paris2024
+  search_params:
+    - key: custom_tag
+      value: paris2024
+  msg:
+    fr: |
+        Les jeux de données référencés dans cette catégorie contiennent des données publiés sur data.gouv.fr contenant des informations liées à la mobilité à l'occasion des jeux Olympiques et Paralympiques 2024.
+
+        Les données ne sont pas forcément aux standards attendus, mais nous avons fait le choix de les répertorier étant donné l'importance de l'évènement.
+    en: |
+        The datasets listed in this category contain data published on data.gouv.fr related to mobility during the 2024 Olympic and Paralympic Games.
+
+        While the datasets listed here may not fully meet all quality standards, we have chosen to include them due to their potential importance

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -584,6 +584,12 @@ defmodule DB.DatasetDBTest do
     assert DB.Dataset.count_coach() == 1
   end
 
+  test "count_by_custom_tag" do
+    assert 0 == DB.Dataset.count_by_custom_tag("foo")
+    insert(:dataset, type: "public-transit", is_active: true, custom_tags: ["bar", "foo"])
+    assert 1 == DB.Dataset.count_by_custom_tag("foo")
+  end
+
   test "correct organization type" do
     insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
 

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -184,6 +184,18 @@ defmodule TransportWeb.DatasetSearchControllerTest do
              %{"type" => "public-transit", "loi-climat-resilience" => "true"} |> Dataset.list_datasets() |> Repo.all()
   end
 
+  test "searching with a custom tag" do
+    %DB.Dataset{id: dataset_id} =
+      insert(:dataset, type: "public-transit", is_active: true, custom_tags: ["bar", "foo"])
+
+    assert 3 == %{"type" => "public-transit"} |> Dataset.list_datasets() |> Repo.all() |> Enum.count()
+
+    assert [%DB.Dataset{id: ^dataset_id}] =
+             %{"type" => "public-transit", "custom_tag" => "foo"} |> Dataset.list_datasets() |> Repo.all()
+
+    assert 1 == DB.Dataset.count_by_custom_tag("foo")
+  end
+
   test "searching for datasets in an AOM" do
     aom = insert(:aom)
     aom2 = insert(:aom)


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/3790

Ajoute une tuile pour les JOP Paris 2024 sur la page d'accueil. Il faudra indiquer le tag `paris2024` dans le backoffice. Il n'y a pas de suppression automatique du code, on devra revert ça durant l'été/rentrée.

![image](https://github.com/etalab/transport-site/assets/295709/6180400a-7d85-4f68-afd9-3ae8ed484d92)

![image](https://github.com/etalab/transport-site/assets/295709/61b89bad-5383-440c-bff8-d0c97fc9ffb8)

