### PR TITLE
Suivi d'un jeu de données et import des JDDs suivis depuis data.gouv.fr

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/datasets.ex
@@ -119,13 +119,13 @@ defmodule Datagouvfr.Client.Datasets do
   end
 
   @doc """
-  Get folowers of a dataset
+  Fetch **only user IDs** following a dataset.
   """
   @spec get_followers(String.t()) :: {atom, map}
   def get_followers(dataset_id) do
-    [@endpoint, dataset_id, "followers", "?page_size=100"]
+    [@endpoint, dataset_id, "followers", "?page_size=500"]
     |> Path.join()
-    |> API.get()
+    |> API.get([{"x-fields", "data{follower{id}}, next_page"}])
   end
 
   @doc """

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -31,6 +31,7 @@ defmodule DB.Contact do
 
     has_many(:notification_subscriptions, DB.NotificationSubscription, on_delete: :delete_all)
     many_to_many(:organizations, DB.Organization, join_through: "contacts_organizations", on_replace: :delete)
+    many_to_many(:followed_datasets, DB.Dataset, join_through: "dataset_followers", on_replace: :delete)
   end
 
   def base_query, do: from(c in __MODULE__, as: :contact)

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -92,7 +92,6 @@ defmodule DB.Dataset do
     field(:associated_territory_name, :string)
 
     field(:search_payload, :map)
-
     many_to_many(:followers, DB.Contact, join_through: "dataset_followers", on_replace: :delete)
   end
 

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -92,6 +92,8 @@ defmodule DB.Dataset do
     field(:associated_territory_name, :string)
 
     field(:search_payload, :map)
+
+    many_to_many(:followers, DB.Contact, join_through: "dataset_followers", on_replace: :delete)
   end
 
   def base_query, do: from(d in DB.Dataset, as: :dataset, where: d.is_active)

--- a/apps/transport/lib/db/dataset_follower.ex
+++ b/apps/transport/lib/db/dataset_follower.ex
@@ -9,13 +9,14 @@ defmodule DB.DatasetFollower do
   typed_schema "dataset_followers" do
     belongs_to(:dataset, DB.Dataset)
     belongs_to(:contact, DB.Contact)
-
+    field(:source, Ecto.Enum, values: [:datagouv])
     timestamps(type: :utc_datetime_usec)
   end
 
   def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
     struct
-    |> cast(attrs, [:dataset_id, :contact_id])
+    |> cast(attrs, [:dataset_id, :contact_id, :source])
+    |> validate_required([:dataset_id, :contact_id, :source])
     |> assoc_constraint(:dataset)
     |> assoc_constraint(:contact)
     |> unique_constraint([:dataset_id, :contact_id])

--- a/apps/transport/lib/db/dataset_follower.ex
+++ b/apps/transport/lib/db/dataset_follower.ex
@@ -1,0 +1,23 @@
+defmodule DB.DatasetFollower do
+  @moduledoc """
+  Represents contacts following datasets.
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+  import Ecto.Changeset
+
+  typed_schema "dataset_followers" do
+    belongs_to(:dataset, DB.Dataset)
+    belongs_to(:contact, DB.Contact)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, [:dataset_id, :contact_id])
+    |> assoc_constraint(:dataset)
+    |> assoc_constraint(:contact)
+    |> unique_constraint([:dataset_id, :contact_id])
+  end
+end

--- a/apps/transport/lib/db/dataset_follower.ex
+++ b/apps/transport/lib/db/dataset_follower.ex
@@ -1,6 +1,7 @@
 defmodule DB.DatasetFollower do
   @moduledoc """
   Represents contacts following datasets.
+  We insert data **only for existing contacts and datasets.**
   """
   use Ecto.Schema
   use TypedEctoSchema

--- a/apps/transport/lib/jobs/import_dataset_followers_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_followers_job.ex
@@ -1,0 +1,71 @@
+defmodule Transport.Jobs.ImportDatasetFollowersJob do
+  @moduledoc """
+  Import dataset followers coming from the data.gouv.fr's API.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+  require Logger
+
+  # The number of workers to run in parallel when importing followers
+  @task_concurrency 5
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    DB.Dataset.base_query()
+    |> DB.Repo.all()
+    |> Task.async_stream(
+      &import_dataset_followers/1,
+      max_concurrency: @task_concurrency,
+      on_timeout: :kill_task,
+      timeout: 10_000
+    )
+    |> Stream.run()
+  end
+
+  def import_dataset_followers(%DB.Dataset{id: dataset_id, datagouv_id: datagouv_id}) do
+    case Datagouvfr.Client.Datasets.get_followers(datagouv_id) do
+      {:ok, %{"data" => data, "next_page" => next_page}} ->
+        unless is_nil(next_page) do
+          Sentry.capture_message("#{__MODULE__}: should iterate to get all followers for Dataset##{datagouv_id}")
+        end
+
+        datagouv_user_ids = data |> Enum.map(& &1["follower"]["id"]) |> MapSet.new()
+
+        contacts_with_datagouv_id()
+        |> Enum.filter(fn %{datagouv_user_id: datagouv_user_id} ->
+          MapSet.member?(datagouv_user_ids, datagouv_user_id)
+        end)
+        |> Enum.each(fn %{contact_id: contact_id} ->
+          %DB.DatasetFollower{}
+          |> DB.DatasetFollower.changeset(%{contact_id: contact_id, dataset_id: dataset_id, source: :datagouv})
+          |> DB.Repo.insert!(
+            conflict_target: [:dataset_id, :contact_id],
+            on_conflict: :nothing
+          )
+        end)
+
+      response ->
+        Logger.info("Followers not found for Dataset##{datagouv_id}: #{inspect(response)}")
+    end
+  end
+
+  @spec contacts_with_datagouv_id() :: %{contact_id: integer(), datagouv_user_id: binary()}
+  @doc """
+  Fetches all contact IDs and datagouv user IDs for `DB.Contact`.
+  Caches the result since it's pretty stable and it needs to be used by
+  every worker, for every datasets.
+  """
+  def contacts_with_datagouv_id do
+    Transport.Cache.API.fetch(
+      "#{__MODULE__}:contacts_with_datagouv_id",
+      fn ->
+        DB.Contact.base_query()
+        |> where([contact: c], not is_nil(c.datagouv_user_id))
+        |> select([contact: c], %{contact_id: c.id, datagouv_user_id: c.datagouv_user_id})
+        |> DB.Repo.all()
+        |> MapSet.new()
+      end,
+      :timer.seconds(60)
+    )
+  end
+end

--- a/apps/transport/priv/repo/migrations/20240311141215_create_dataset_followers.exs
+++ b/apps/transport/priv/repo/migrations/20240311141215_create_dataset_followers.exs
@@ -5,7 +5,7 @@ defmodule DB.Repo.Migrations.CreateDatasetsFollowers do
     create table(:dataset_followers) do
       add(:dataset_id, references(:dataset, on_delete: :delete_all), null: false)
       add(:contact_id, references(:contact, on_delete: :delete_all), null: false)
-
+      add(:source, :string, size: 25)
       timestamps(type: :utc_datetime_usec)
     end
 

--- a/apps/transport/priv/repo/migrations/20240311141215_create_dataset_followers.exs
+++ b/apps/transport/priv/repo/migrations/20240311141215_create_dataset_followers.exs
@@ -1,0 +1,14 @@
+defmodule DB.Repo.Migrations.CreateDatasetsFollowers do
+  use Ecto.Migration
+
+  def change do
+    create table(:dataset_followers) do
+      add(:dataset_id, references(:dataset, on_delete: :delete_all), null: false)
+      add(:contact_id, references(:contact, on_delete: :delete_all), null: false)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:dataset_followers, [:dataset_id, :contact_id]))
+  end
+end

--- a/apps/transport/test/db/dataset_follower_test.exs
+++ b/apps/transport/test/db/dataset_follower_test.exs
@@ -1,0 +1,47 @@
+defmodule DB.DatasetFollowerTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  alias DB.DatasetFollower
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "changeset" do
+    contact = insert_contact()
+    dataset = insert(:dataset)
+
+    # Valid case
+    assert %Ecto.Changeset{valid?: true} = changeset(%{dataset_id: dataset.id, contact_id: contact.id})
+
+    # Errors
+    assert {:error, %Ecto.Changeset{errors: [contact: {"does not exist", _}]}} =
+             %{dataset_id: dataset.id, contact_id: -1} |> changeset() |> DB.Repo.insert()
+
+    assert {:error, %Ecto.Changeset{errors: [dataset: {"does not exist", _}]}} =
+             %{dataset_id: -1, contact_id: contact.id} |> changeset() |> DB.Repo.insert()
+
+    # Unique constraint is enforced
+    %{dataset_id: dataset.id, contact_id: contact.id} |> changeset() |> DB.Repo.insert!()
+
+    assert {:error, %Ecto.Changeset{errors: [dataset_id: {"has already been taken", _}]}} =
+             %{dataset_id: dataset.id, contact_id: contact.id} |> changeset() |> DB.Repo.insert()
+  end
+
+  test "foreign relations" do
+    %DB.Contact{id: contact_id} = contact = insert_contact()
+    %DB.Dataset{id: dataset_id} = dataset = insert(:dataset)
+
+    assert [] = dataset |> DB.Repo.preload(:followers) |> Map.fetch!(:followers)
+    assert [] = contact |> DB.Repo.preload(:followed_datasets) |> Map.fetch!(:followed_datasets)
+
+    %{dataset_id: dataset_id, contact_id: contact_id} |> changeset() |> DB.Repo.insert!()
+
+    assert [%DB.Contact{id: ^contact_id}] = dataset |> DB.Repo.preload(:followers) |> Map.fetch!(:followers)
+
+    assert [%DB.Dataset{id: ^dataset_id}] =
+             contact |> DB.Repo.preload(:followed_datasets) |> Map.fetch!(:followed_datasets)
+  end
+
+  defp changeset(args), do: DatasetFollower.changeset(%DatasetFollower{}, args)
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -73,6 +73,10 @@ defmodule DB.Factory do
     %DB.DatasetMonthlyMetric{}
   end
 
+  def dataset_follower_factory do
+    %DB.DatasetFollower{}
+  end
+
   def resource_monthly_metric_factory do
     %DB.ResourceMonthlyMetric{}
   end

--- a/apps/transport/test/transport/jobs/import_dataset_followers_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_followers_job_test.exs
@@ -1,0 +1,75 @@
+defmodule Transport.Test.Transport.Jobs.ImportDatasetFollowersJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Mox
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.ImportDatasetFollowersJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    insert(:dataset, is_active: false)
+    dataset = insert(:dataset)
+    other_dataset = insert(:dataset)
+    not_found_dataset = insert(:dataset)
+    %DB.Contact{id: contact_id} = contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+    %DB.Contact{id: other_contact_id} = other_contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+    insert(:dataset_follower, dataset: dataset, contact: contact, source: :datagouv)
+
+    setup_http_responses([
+      {dataset,
+       %{
+         data: [
+           %{"follower" => %{"id" => contact.datagouv_user_id}},
+           %{"follower" => %{"id" => Ecto.UUID.generate()}}
+         ],
+         status_code: 200
+       }},
+      {
+        other_dataset,
+        %{
+          data: [
+            %{"follower" => %{"id" => other_contact.datagouv_user_id}},
+            %{"follower" => %{"id" => contact.datagouv_user_id}}
+          ],
+          status_code: 200
+        }
+      },
+      {not_found_dataset, %{data: "", status_code: 404}}
+    ])
+
+    assert [%DB.Contact{id: ^contact_id}] = dataset_followers(dataset)
+    assert [] = dataset_followers(other_dataset)
+
+    assert :ok == perform_job(ImportDatasetFollowersJob, %{})
+
+    assert [%DB.Contact{id: ^contact_id}] = dataset_followers(dataset)
+    [%DB.Contact{id: id1}, %DB.Contact{id: id2}] = dataset_followers(other_dataset)
+    assert MapSet.new([id1, id2]) == MapSet.new([contact_id, other_contact_id])
+  end
+
+  defp dataset_followers(%DB.Dataset{} = dataset), do: dataset |> DB.Repo.preload(:followers) |> Map.fetch!(:followers)
+
+  defp setup_http_responses(data) do
+    responses =
+      Map.new(data, fn {%DB.Dataset{datagouv_id: datagouv_id}, %{data: _, status_code: _} = params} ->
+        url = "https://demo.data.gouv.fr/api/1/datasets/#{datagouv_id}/followers/?page_size=500"
+        {url, params}
+      end)
+
+    Transport.HTTPoison.Mock
+    |> expect(:request, Enum.count(responses), fn :get,
+                                                  request_url,
+                                                  "",
+                                                  [{"x-fields", "data{follower{id}}, next_page"}],
+                                                  [follow_redirect: true] ->
+      %{status_code: status_code, data: data} = Map.fetch!(responses, request_url)
+      {:ok, %HTTPoison.Response{status_code: status_code, body: Jason.encode!(%{"data" => data, "next_page" => nil})}}
+    end)
+  end
+end

--- a/apps/transport/test/transport/jobs/import_dataset_monthly_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_monthly_metrics_job_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.Test.Transport.Jobs.ImportDatasetMonthlyMetricsTestJob do
+defmodule Transport.Test.Transport.Jobs.ImportDatasetMonthlyMetricsJobTest do
   use ExUnit.Case, async: true
   import DB.Factory
   import Ecto.Query

--- a/apps/transport/test/transport/jobs/import_resource_monthly_metrics_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_resource_monthly_metrics_job_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.Test.Transport.Jobs.ImportResourceMonthlyMetricsTestJob do
+defmodule Transport.Test.Transport.Jobs.ImportResourceMonthlyMetricsJobTest do
   use ExUnit.Case, async: true
   import DB.Factory
   import Ecto.Query

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -139,6 +139,7 @@ oban_prod_crontab = [
   # "At 08:15 on Monday in March, June, and November.""
   # The job will make sure that it's executed only on the first Monday of these months
   {"15 8 * 3,6,11 1", Transport.Jobs.PeriodicReminderProducersNotificationJob},
+  {"15 5 * * *", Transport.Jobs.ImportDatasetFollowersJob},
   {"30 5 * * *", Transport.Jobs.ImportDatasetMonthlyMetricsJob},
   {"45 5 * * *", Transport.Jobs.ImportResourceMonthlyMetricsJob}
 ]


### PR DESCRIPTION
## Sur le concept de suivre un JDD

Il n'y en a pas vraiment pour le moment et c'est largement à définir car la PR est uniquement du backend. Cette notion est floue sur data.gouv.fr aussi. Mais c'est globalement une notion de suivi/favori/liste de sauvegarde.

Ce que j'envisage ensuite : un utilisateur suite JDD/le met dans ses favoris, il voit cette liste dans l'espace réutilisateurs et ensuite prend des actions sur cet ensemble (notifications, lire les discussions etc).

Une précédente étude sur la volumétrie actuelle des suivis de JDDs https://github.com/etalab/transport-site/pull/3497

## Fonctionnalités ajoutées

- Ajoute une migration et le modèle associé permettant de modéliser le suivi d'un jeu de données (`DatasetFollower`)
- Import des données existantes tous les jours depuis data.gouv.fr

J'ai fait la demande d'un endpoint qui pourra être utile plus tard https://github.com/etalab/data.gouv.fr/issues/1318