### PR TITLE
Premier script pour "résumer" un gros fichier NeTEx

### DIFF
--- a/apps/shared/lib/wrapper/wrapper_req.ex
+++ b/apps/shared/lib/wrapper/wrapper_req.ex
@@ -40,6 +40,7 @@ defmodule Transport.HTTPClient do
         :custom_cache_dir,
         :decode_body,
         :compressed,
+        :into,
         enable_cache: false
       ])
 

--- a/scripts/netex-accessibilite.exs
+++ b/scripts/netex-accessibilite.exs
@@ -1,0 +1,59 @@
+#! /usr/bin/env mix run
+
+#
+# A script to have a summaried look at largish NeTEx, leveraging SAX parsing.
+#
+# ```
+# mix run scripts/netex-accessibilite.exs | uniq -c | sed -e 's/ *//' -e 's/ /\t/'
+# ```
+#
+
+# https://www.data.gouv.fr/fr/datasets/cheminements-pietons-dans-paris-dapres-openstreetmap/
+url = "https://www.data.gouv.fr/fr/datasets/r/7cef040d-c211-4bef-a239-75afa5cd357b"
+
+file = Path.join("cache-dir", "netex-accessibilite.xml")
+
+if File.exists?(file) do
+  IO.puts("File available at #{file}")
+else
+  IO.puts("Downloading #{url} to #{file}")
+  %{status: 200} = Transport.HTTPClient.get!(url, into: File.stream!(file))
+end
+
+defmodule IndentedElementPrinterParser do
+  @moduledoc """
+  A simple SAX parser able to print only the XML elements, in indented fashion,
+  with a notion of depth limit.
+
+  TODO: given we show a large number of items, a summary similar to how `uniq` works in Linux would help,
+  for now it is recommended to pipe into `uniq` (see top of the script).
+  """
+
+  @behaviour Saxy.Handler
+
+  def handle_event(:start_element, {name, _attributes}, state) do
+    {indent_level, state} = Keyword.get_and_update(state, :indent_level, fn i -> {i || 0, (i || 0) + 1} end)
+
+    unless indent_level >= state[:max_level] do
+      IO.puts(String.duplicate(" ", indent_level) <> "<" <> name <> ">")
+    end
+
+    {:ok, state}
+  end
+
+  def handle_event(:end_element, _, state) do
+    {_indent_level, state} = Keyword.get_and_update(state, :indent_level, fn i -> {i, i - 1} end)
+    {:ok, state}
+  end
+
+  def handle_event(_, _, state), do: {:ok, state}
+end
+
+file
+|> File.stream!()
+# NOTE: temporary work-around for https://github.com/qcam/saxy/issues/127
+|> Stream.with_index()
+|> Stream.map(fn {x, index} ->
+  if index == 0, do: String.replace(x, " encoding='ASCII'", ""), else: x
+end)
+|> Saxy.parse_stream(IndentedElementPrinterParser, max_level: System.get_env("LEVEL", "5") |> String.to_integer())


### PR DESCRIPTION
En lien avec:
- #3806

Poke @nlehuby que ça intéressera peut-être.

J'ai souhaité pouvoir avoir une vue d'ensemble de ce qui est dans le fichier (qui fait près de 500MB), et je pense que ça peut être un outil qui aurait du sens à terme en affichage direct sur le PAN pour les visiteurs, dans une déclinaison ou une autre.

Dans le principe général c'est pas très éloigné de la gem netex Ruby d'EnRoute (https://bitbucket.org/enroute-mobi/netex), mais avec des usages potentiellement différents, et directement intégrable dans notre stack.

### Principe général

Le script télécharge le fichier NeTEx accessibilité pointé dans #3806, et l'analyse avec un "streaming parser SAX", pour n'afficher que les éléments de façon indentée et pas plus, et jusqu'à un certain niveau de profondeur, configurable.

Derrière je fais un peu de stats pour l'instant pas dans le script mais avec du post-processing pour "compter" les noeuds similaires qui se suivent.

### Output actuel

```
mix run scripts/netex-accessibilite.exs | uniq -c | sed -e 's/ *//' -e 's/ /\t/'
```

Je trie un peu le début qui sont des logs applicatifs, et ça donne:

```
1	<PublicationDelivery>
1	 <PublicationTimestamp>
1	 <ParticipantRef>
1	 <Description>
1	 <dataObjects>
1	  <GeneralFrame>
1	   <FrameDefaults>
1	    <DefaultLocationSystem>
1	   <members>
3	    <StopPlace>
71	    <PointOfInterest>
14232	    <PointOfInterestEntrance>
1051	    <Entrance>
112654	    <SitePathLink>
15283	    <EntranceEquipment>
1	    <TicketingEquipment>
2	    <RubbishDisposalEquipment>
9	    <SeatingEquipment>
8	    <CommunicationService>
25	    <GeneralSign>
1	    <AssistanceService>
5	    <ShelterEquipment>
2	    <SanitaryEquipment>
17	    <TicketValidatorEquipment>
1	    <SeatingEquipment>
1	    <TicketValidatorEquipment>
1	    <AssistanceService>
18	    <TicketValidatorEquipment>
1	    <AssistanceService>
14	    <TicketValidatorEquipment>
1	    <GeneralSign>
7	    <CommunicationService>
3	    <GeneralSign>
6	    <CommunicationService>
5	    <GeneralSign>
4	    <SanitaryEquipment>
1	    <CommunicationService>
24	    <TicketValidatorEquipment>
1	    <CommunicationService>
2	    <TicketValidatorEquipment>
1	    <SanitaryEquipment>
2	    <TicketValidatorEquipment>
1	    <SanitaryEquipment>
1	    <TicketValidatorEquipment>
1	    <SanitaryEquipment>
1	    <TicketValidatorEquipment>
1	    <SeatingEquipment>
4	    <TicketValidatorEquipment>
19	    <SeatingEquipment>
1	    <CommunicationService>
2	    <GeneralSign>
4	    <SeatingEquipment>
1	    <GeneralSign>
3	    <SeatingEquipment>
1	    <CommunicationService>
2	    <GeneralSign>
3	    <CommunicationService>
5	    <GeneralSign>
1	    <CommunicationService>
6	    <GeneralSign>
1	    <AssistanceService>
3	    <GeneralSign>
1	    <RubbishDisposalEquipment>
1	    <CommunicationService>
1	    <SeatingEquipment>
2	    <TicketValidatorEquipment>
1	    <AssistanceService>
145	    <TicketValidatorEquipment>
9	    <GeneralSign>
1	    <CommunicationService>
1	    <GeneralSign>
2	    <CommunicationService>
1	    <GeneralSign>
4	    <CommunicationService>
1	    <RubbishDisposalEquipment>
3	    <CommunicationService>
3	    <GeneralSign>
1	    <CommunicationService>
3	    <GeneralSign>
1	    <SeatingEquipment>
1	    <CommunicationService>
2	    <GeneralSign>
1	    <CommunicationService>
5	    <GeneralSign>
1	    <SanitaryEquipment>
1	    <CommunicationService>
1	    <GeneralSign>
1	    <CommunicationService>
1	    <GeneralSign>
176	    <LiftEquipment>
1	    <CrossingEquipment>
1	    <StaircaseEquipment>
1	    <RampEquipment>
1	    <CrossingEquipment>
1	    <EscalatorEquipment>
10	    <CrossingEquipment>
1	    <EscalatorEquipment>
1	    <CrossingEquipment>
1	    <StaircaseEquipment>
1	    <CrossingEquipment>
1	    <StaircaseEquipment>
2	    <CrossingEquipment>
1	    <StaircaseEquipment>
20	    <CrossingEquipment>
1	    <EscalatorEquipment>
39	    <CrossingEquipment>
1	    <StaircaseEquipment>
1	    <RampEquipment>
2	    <CrossingEquipment>
1	    <StaircaseEquipment>
1	    <TravelatorEquipment>
4	    <CrossingEquipment>
1	    <EscalatorEquipment>
27	    <CrossingEquipment>
6	    <StaircaseEquipment>
152	    <RampEquipment>
5137	    <StaircaseEquipment>
18	    <TravelatorEquipment>
735	    <EscalatorEquipment>
19900	    <CrossingEquipment>
1	    <StaircaseEquipment>
2242	    <CrossingEquipment>
4222	    <ParkingBay>
142898	    <PathJunction>
1	    <DataSource>
```