### PR TITLE
Discussions: Autoresize des textarea

### DIFF
--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -29,8 +29,9 @@ Hooks.SyntaxColoring = {
 }
 Hooks.TextareaAutoexpand = {
     mounted () {
-        this.el.addEventListener("input", event =>
-            event.target.parentNode.dataset.replicatedValue = event.target.value)
+        this.el.addEventListener('input', event => {
+            event.target.parentNode.dataset.replicatedValue = event.target.value
+        })
     }
 }
 

--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -27,6 +27,12 @@ Hooks.SyntaxColoring = {
         Prism.highlightElement(target)
     }
 }
+Hooks.TextareaAutoexpand = {
+    mounted () {
+        this.el.addEventListener("input", event =>
+            event.target.parentNode.dataset.replicatedValue = event.target.value)
+    }
+}
 
 window.addEventListener('phx:backoffice-form-reset', () => {
     document.getElementById('custom_tag').value = ''

--- a/apps/transport/client/stylesheets/components/_discussions.scss
+++ b/apps/transport/client/stylesheets/components/_discussions.scss
@@ -40,7 +40,43 @@
   }
 
   textarea {
-    height: 10em;
+    min-height: 10em;
+  }
+
+  // Auto expanding textarea, deeply inspired by https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
+  .autoexpand {
+    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+    display: grid;
+
+    &::after {
+      /* Note the weird space! Needed to preventy jumpy behavior */
+      content: attr(data-replicated-value) " ";
+
+      /* This is how textarea text behaves */
+      white-space: pre-wrap;
+
+      /* Hidden from view, clicks, and screen readers */
+      visibility: hidden;
+    }
+
+    > textarea {
+      /* You could leave this, but after a user resizes, then it ruins the auto sizing */
+      resize: none;
+
+      /* Firefox shows scrollbar on growth, you can hide like this. */
+      overflow: hidden;
+    }
+
+    &::after, > textarea {
+      /* Identical styling required!! */
+      font: inherit;
+      padding: 0.5em 0.875em;
+      border: 1px solid var(--theme-border);
+      border-radius: var(--theme-border-radius);
+
+      /* Place on top of each other */
+      grid-area: 1 / 1 / 2 / 2;
+    }
   }
 
   .discussion__post {

--- a/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
@@ -47,7 +47,7 @@
       </a>
       <div id={"reply-#{@discussion["id"]}"} class="discussion-modal">
         <%= form_for %{}, discussion_path(@socket, :post_answer, @dataset.datagouv_id, @discussion["id"]), fn f -> %>
-          <%= textarea(f, :comment) %>
+          <%= textarea_autoexpand(f, :comment) %>
           <%= hidden_input(f, :dataset_slug, value: @dataset.slug) %>
           <div class="form__group">
             <button class="button" name="anwser" type="submit">

--- a/apps/transport/lib/transport_web/views/input_helpers.ex
+++ b/apps/transport/lib/transport_web/views/input_helpers.ex
@@ -122,7 +122,7 @@ defmodule TransportWeb.InputHelpers do
   end
 
   def textarea_autoexpand(form, field, opts \\ []) do
-    opts = opts |> Keyword.put_new(:phx, [hook: "TextareaAutoexpand"])
+    opts = opts |> Keyword.put_new(:phx, hook: "TextareaAutoexpand")
     form_group(autoexpand_wrapper(Form.textarea(form, field, opts)))
   end
 

--- a/apps/transport/lib/transport_web/views/input_helpers.ex
+++ b/apps/transport/lib/transport_web/views/input_helpers.ex
@@ -122,7 +122,7 @@ defmodule TransportWeb.InputHelpers do
   end
 
   def textarea_autoexpand(form, field, opts \\ []) do
-    opts = opts |> Keyword.put_new(:onInput, "this.parentNode.dataset.replicatedValue = this.value")
+    opts = opts |> Keyword.put_new(:phx, [hook: "TextareaAutoexpand"])
     form_group(autoexpand_wrapper(Form.textarea(form, field, opts)))
   end
 

--- a/apps/transport/lib/transport_web/views/input_helpers.ex
+++ b/apps/transport/lib/transport_web/views/input_helpers.ex
@@ -121,6 +121,13 @@ defmodule TransportWeb.InputHelpers do
     form_group(Form.textarea(form, field, opts))
   end
 
+  def textarea_autoexpand(form, field, opts \\ []) do
+    opts = opts |> Keyword.put_new(:onInput, "this.parentNode.dataset.replicatedValue = this.value")
+    form_group(autoexpand_wrapper(Form.textarea(form, field, opts)))
+  end
+
+  def autoexpand_wrapper(content), do: content_tag(:div, content, class: "autoexpand")
+
   def file_input(form, field, opts \\ []) do
     label = Keyword.get(opts, :label)
     opts = Keyword.drop(opts, [:label])


### PR DESCRIPTION
Fait en CSS avec pour seul javascript un handler défini directement sur l'élément.

Le helper textarea_autoexpand est utilisé pour les discussions pour l'instant.

Le truc est d'empiler dans une grille CSS le textarea est un div dont le contenu sera répliqué du textarea via l'attribut `onInput`. Le changement de contenu du div va déclencher un recalcul de la hauteur, et le placement dans une grille forcera la hauteur du textarea à le suivre.

La hauteur initiale du textarea est conservé à 10rem mais n'est désormais plus qu'un `min-height` pour ne plus la fixer.

J'imagine qu'on pourrait choisir un `max-height` pour ne pas rendre le champs exhubérant.

Fixes #3793.


https://github.com/etalab/transport-site/assets/346377/2e88667e-4c7e-45e3-a5bc-77ed6235fcfe

