### PR TITLE
Nouvelle discussion: champs obligatoires

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/api.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/api.ex
@@ -70,7 +70,7 @@ defmodule Datagouvfr.Client.API do
   end
 
   @spec request(
-          :delete | :get | :head | :options | :patch | :post | :put,
+          method(),
           path(),
           any(),
           [{binary(), binary()}],

--- a/apps/transport/client/stylesheets/components/_discussions.scss
+++ b/apps/transport/client/stylesheets/components/_discussions.scss
@@ -39,46 +39,6 @@
     margin-bottom: 0;
   }
 
-  textarea {
-    min-height: 10em;
-  }
-
-  // Auto expanding textarea, deeply inspired by https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
-  .autoexpand {
-    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
-    display: grid;
-
-    &::after {
-      /* Note the weird space! Needed to preventy jumpy behavior */
-      content: attr(data-replicated-value) " ";
-
-      /* This is how textarea text behaves */
-      white-space: pre-wrap;
-
-      /* Hidden from view, clicks, and screen readers */
-      visibility: hidden;
-    }
-
-    > textarea {
-      /* You could leave this, but after a user resizes, then it ruins the auto sizing */
-      resize: none;
-
-      /* Firefox shows scrollbar on growth, you can hide like this. */
-      overflow: hidden;
-    }
-
-    &::after, > textarea {
-      /* Identical styling required!! */
-      font: inherit;
-      padding: 0.5em 0.875em;
-      border: 1px solid var(--theme-border);
-      border-radius: var(--theme-border-radius);
-
-      /* Place on top of each other */
-      grid-area: 1 / 1 / 2 / 2;
-    }
-  }
-
   .discussion__post {
     padding-top: 2em;
   }
@@ -92,9 +52,51 @@
   }
 }
 
+.discussion-modal, .discussion {
+  textarea {
+    min-height: 10em;
+  }
+}
+
 .discussion-modal {
   display: none;
   &:target {
     display: block;
+  }
+}
+
+// Auto expanding textarea, deeply inspired by https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
+.autoexpand {
+  /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+  display: grid;
+
+  &::after {
+    /* Note the weird space! Needed to preventy jumpy behavior */
+    content: attr(data-replicated-value) " ";
+
+    /* This is how textarea text behaves */
+    white-space: pre-wrap;
+
+    /* Hidden from view, clicks, and screen readers */
+    visibility: hidden;
+  }
+
+  > textarea {
+    /* You could leave this, but after a user resizes, then it ruins the auto sizing */
+    resize: none;
+
+    /* Firefox shows scrollbar on growth, you can hide like this. */
+    overflow: hidden;
+  }
+
+  &::after, > textarea {
+    /* Identical styling required!! */
+    font: inherit;
+    padding: 0.5em 0.875em;
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-border-radius);
+
+    /* Place on top of each other */
+    grid-area: 1 / 1 / 2 / 2;
   }
 }

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -199,7 +199,7 @@
               <%= form_for @conn, discussion_path(@conn, :post_discussion, @dataset.datagouv_id), fn f -> %>
                 <%= hidden_input(f, :dataset_slug, value: @dataset.slug) %>
                 <%= text_input(f, :title, placeholder: dgettext("page-dataset-details", "Title")) %>
-                <%= textarea(f, :comment) %>
+                <%= textarea_autoexpand(f, :comment) %>
                 <%= submit(dgettext("page-dataset-details", "Start a new discussion")) %>
               <% end %>
             </div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -198,8 +198,8 @@
             <div id="new_discussion" class="discussion-modal">
               <%= form_for @conn, discussion_path(@conn, :post_discussion, @dataset.datagouv_id), fn f -> %>
                 <%= hidden_input(f, :dataset_slug, value: @dataset.slug) %>
-                <%= text_input(f, :title, placeholder: dgettext("page-dataset-details", "Title")) %>
-                <%= textarea_autoexpand(f, :comment) %>
+                <%= text_input(f, :title, placeholder: dgettext("page-dataset-details", "Title"), required: true) %>
+                <%= textarea_autoexpand(f, :comment, required: true) %>
                 <%= submit(dgettext("page-dataset-details", "Start a new discussion")) %>
               <% end %>
             </div>


### PR DESCRIPTION
Le titre et le commentaire sont requis pour créer une discussion sur un dataset.

Ceci est fait [côté client en HTML](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation).

L'API data.gouv vérifie également cela. Je n'ai pas implémenté cette validation dans notre API par manque de maitrise de Phoenix essentiellement. Je me demande si cela en vaudrait réellement la peine pour ce cas précis.

MDN recommande d'expliciter quels champs d'un formulaire sont requis. Dans ce cas, pensez-vous qu'il faille:
- rajouter un indice visuel sur chaque champs (traditionnellement une astérisque)
- rajouter un message entre les champs et le bouton de soumission
- les deux mon capitaine
- rien parce que c'est suffisamment simple pour qu'on comprenne

Closes #3825.