### PR TITLE
Notifications pour les réutilisateurs : nouvelles discussions

### DIFF
--- a/apps/transport/lib/jobs/new_comments_notification_job.ex
+++ b/apps/transport/lib/jobs/new_comments_notification_job.ex
@@ -1,0 +1,105 @@
+defmodule Transport.Jobs.NewCommentsNotificationJob do
+  @moduledoc """
+  Job sending email notifications to each reuser when comments have been posted
+  on datasets they follow.
+
+  `dataset.latest_data_gouv_comment_timestamp` is updated daily by
+  `Transport.CommentsChecker` and is currently in charge of sending
+  notifications to producers.
+
+  This job should be scheduled for every weekday.
+  """
+  use Oban.Worker, max_attempts: 3, tags: ["notifications"]
+  import Ecto.Query
+  @notification_reason DB.NotificationSubscription.reason(:daily_new_comments)
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"contact_id" => contact_id, "dataset_ids" => dataset_ids}}) do
+    contact = DB.Repo.get!(DB.Contact, contact_id)
+
+    datasets =
+      DB.Contact.base_query()
+      |> join(:inner, [contact: c], d in assoc(c, :followed_datasets), as: :dataset)
+      |> where([contact: c, dataset: d], c.id == ^contact_id and d.id in ^dataset_ids)
+      |> select([dataset: d], d)
+      |> DB.Repo.all()
+
+    contact
+    |> Transport.NewCommentsNotifier.new_comments(datasets)
+    |> Transport.Mailer.deliver()
+
+    Enum.each(datasets, fn %DB.Dataset{} = dataset -> save_notification(dataset, contact) end)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{scheduled_at: %DateTime{} = scheduled_at}) do
+    dataset_ids = scheduled_at |> relevant_datasets_query() |> select([dataset: d], d.id) |> DB.Repo.all()
+
+    scheduled_at
+    |> relevant_contacts()
+    |> Enum.map(fn %DB.Contact{id: contact_id} -> new(%{contact_id: contact_id, dataset_ids: dataset_ids}) end)
+    |> Oban.insert_all()
+
+    :ok
+  end
+
+  @doc """
+  Identifies contacts for which we should send an email today.
+  - they follow datasets with recent comments
+  - they are subscribed to the relevant notification's reason
+  """
+  def relevant_contacts(%DateTime{} = datetime) do
+    datetime
+    |> relevant_datasets_query()
+    |> join(:inner, [dataset: d], f in assoc(d, :followers), as: :contact)
+    |> join(:inner, [contact: c], ns in assoc(c, :notification_subscriptions), as: :notification_subscription)
+    |> where([notification_subscription: ns], ns.role == :reuser and ns.reason == @notification_reason)
+    |> select([contact: c], c)
+    |> distinct(true)
+    |> DB.Repo.all()
+  end
+
+  @doc """
+  Identifies datasets for which new comments have been posted recently.
+  [Tuesday; Thursday] -> last day
+  Monday -> Friday, Saturday or Sunday
+  """
+  def relevant_datasets_query(%DateTime{} = datetime) do
+    days_delay = datetime |> DateTime.to_date() |> nb_days_delay()
+    dt_limit = DateTime.add(datetime, -days_delay, :day)
+
+    DB.Dataset.base_query()
+    |> where([dataset: d], not is_nil(d.latest_data_gouv_comment_timestamp))
+    |> where([dataset: d], d.latest_data_gouv_comment_timestamp >= ^dt_limit)
+  end
+
+  @doc """
+  iex> nb_days_delay(~D[2024-03-28])
+  1
+  iex> nb_days_delay(~D[2024-03-25])
+  3
+  """
+  def nb_days_delay(%Date{} = date) do
+    if Date.day_of_week(date) == 1, do: 3, else: 1
+  end
+
+  def save_notification(%DB.Dataset{} = dataset, %DB.Contact{email: email}) do
+    DB.Notification.insert!(@notification_reason, dataset, email)
+  end
+end
+
+defmodule Transport.NewCommentsNotifier do
+  @moduledoc """
+  Module in charge of building the email.
+  """
+  use Phoenix.Swoosh, view: TransportWeb.EmailView
+
+  def new_comments(%DB.Contact{email: email}, datasets) do
+    new()
+    |> from({"transport.data.gouv.fr", Application.fetch_env!(:transport, :contact_email)})
+    |> to(email)
+    |> reply_to(Application.fetch_env!(:transport, :contact_email))
+    |> subject("Nouveaux commentaires")
+    |> render_body("new_comments_reuser.html", %{datasets: datasets})
+  end
+end

--- a/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.md
+++ b/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.md
@@ -1,0 +1,9 @@
+Bonjour,
+
+Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.
+
+<%= for dataset <- @datasets do %>
+- <%= link_for_dataset_section(dataset, :discussion) %>
+<% end %>
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/lib/transport_web/views/email_view.ex
+++ b/apps/transport/lib/transport_web/views/email_view.ex
@@ -1,9 +1,13 @@
 defmodule TransportWeb.EmailView do
   use TransportWeb, :view
 
-  def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}) do
+  def link_for_dataset_section(%DB.Dataset{} = dataset, :discussion) do
+    link_for_dataset(dataset, "#dataset-discussions")
+  end
+
+  def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}, anchor \\ "") do
     url = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
-    link(custom_title, to: url)
+    link(custom_title, to: url <> anchor)
   end
 
   def link_for_dataset_discussions(%DB.Dataset{slug: slug}) do

--- a/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
@@ -1,0 +1,206 @@
+defmodule Transport.Test.Transport.Jobs.NewCommentsNotificationJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Mox
+  import Swoosh.TestAssertions
+  alias Transport.Jobs.NewCommentsNotificationJob
+
+  setup :verify_on_exit!
+
+  doctest NewCommentsNotificationJob, import: true
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "relevant_datasets" do
+    test "a weekday excluding Monday" do
+      # Ignored: inactive
+      insert(:dataset,
+        is_active: true,
+        is_hidden: true,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-27 10:00:00.00Z]
+      )
+
+      # Ignored: hidden
+      insert(:dataset,
+        is_active: false,
+        is_hidden: false,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-27 12:00:00.00Z]
+      )
+
+      # Ignored: more than a day old
+      insert(:dataset,
+        is_active: true,
+        is_hidden: false,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-27 08:00:00.00Z]
+      )
+
+      %DB.Dataset{id: dataset_id} =
+        insert(:dataset,
+          is_active: true,
+          is_hidden: false,
+          latest_data_gouv_comment_timestamp: ~U[2024-03-27 10:00:00.00Z]
+        )
+
+      assert [%DB.Dataset{id: ^dataset_id}] =
+               ~U[2024-03-28 09:00:00.00Z] |> NewCommentsNotificationJob.relevant_datasets_query() |> DB.Repo.all()
+    end
+
+    test "on a Monday" do
+      # Ignored: inactive
+      insert(:dataset,
+        is_active: true,
+        is_hidden: true,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-30 10:00:00.00Z]
+      )
+
+      # Ignored: hidden
+      insert(:dataset,
+        is_active: false,
+        is_hidden: false,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-30 12:00:00.00Z]
+      )
+
+      # Ignored: more than 3 days old
+      insert(:dataset,
+        is_active: true,
+        is_hidden: false,
+        latest_data_gouv_comment_timestamp: ~U[2024-03-29 08:00:00.00Z]
+      )
+
+      %DB.Dataset{id: dataset_id} =
+        insert(:dataset,
+          is_active: true,
+          is_hidden: false,
+          latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z]
+        )
+
+      %DB.Dataset{id: other_dataset_id} =
+        insert(:dataset,
+          is_active: true,
+          is_hidden: false,
+          latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z]
+        )
+
+      assert [%DB.Dataset{id: ^dataset_id}, %DB.Dataset{id: ^other_dataset_id}] =
+               ~U[2024-04-01 09:00:00.00Z]
+               |> NewCommentsNotificationJob.relevant_datasets_query()
+               |> DB.Repo.all()
+               |> Enum.sort_by(& &1.id)
+    end
+  end
+
+  test "relevant_contacts" do
+    %DB.Contact{id: contact_id} = contact = insert_contact()
+    producer_contact = insert_contact()
+    follower_only_contact = insert_contact()
+    dataset = insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-27 10:00:00.00Z])
+
+    insert(:dataset_follower, dataset_id: dataset.id, contact_id: contact_id, source: :datagouv)
+    insert(:notification_subscription, contact: contact, source: :user, reason: :daily_new_comments, role: :reuser)
+
+    # `producer_contact` is subscribed and does not follow the dataset
+    insert(:notification_subscription,
+      contact: producer_contact,
+      source: :user,
+      reason: :daily_new_comments,
+      role: :producer
+    )
+
+    # `follower_only_contact` follows the dataset but is not subscribed for the relevant reason
+    insert(:dataset_follower, dataset_id: dataset.id, contact_id: follower_only_contact.id, source: :datagouv)
+
+    insert(:notification_subscription,
+      contact: follower_only_contact,
+      dataset: dataset,
+      source: :user,
+      reason: :expiration,
+      role: :reuser
+    )
+
+    assert [%DB.Contact{id: ^contact_id}] = NewCommentsNotificationJob.relevant_contacts(~U[2024-03-28 09:00:00.00Z])
+  end
+
+  test "enqueues jobs" do
+    %DB.Contact{id: contact_id} = contact = insert_contact()
+
+    %DB.Dataset{id: dataset_id} =
+      insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-27 10:00:00.00Z])
+
+    insert(:dataset_follower, dataset_id: dataset_id, contact_id: contact_id, source: :datagouv)
+    insert(:notification_subscription, contact: contact, source: :user, reason: :daily_new_comments, role: :reuser)
+
+    assert :ok == perform_job(NewCommentsNotificationJob, %{}, scheduled_at: ~U[2024-03-28 09:00:00.00Z])
+
+    assert [
+             %Oban.Job{
+               worker: "Transport.Jobs.NewCommentsNotificationJob",
+               args: %{"contact_id" => ^contact_id, "dataset_ids" => [^dataset_id]}
+             }
+           ] = all_enqueued()
+  end
+
+  test "perform for a single contact" do
+    %DB.Contact{id: contact_id, email: email} = insert_contact()
+    other_followed_dataset = insert(:dataset)
+
+    %DB.Dataset{id: dataset_id} =
+      dataset =
+      insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z])
+
+    %DB.Dataset{id: other_dataset_id} =
+      insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z])
+
+    # Identifies two datasets as relevant
+    assert [%DB.Dataset{id: ^dataset_id}, %DB.Dataset{id: ^other_dataset_id}] =
+             ~U[2024-04-01 09:00:00.00Z]
+             |> NewCommentsNotificationJob.relevant_datasets_query()
+             |> DB.Repo.all()
+             |> Enum.sort_by(& &1.id)
+
+    insert(:dataset_follower, dataset_id: dataset_id, contact_id: contact_id, source: :datagouv)
+    insert(:dataset_follower, dataset_id: other_followed_dataset.id, contact_id: contact_id, source: :datagouv)
+
+    # Perform the job for a single contact
+    assert :ok ==
+             perform_job(NewCommentsNotificationJob, %{
+               "contact_id" => contact_id,
+               "dataset_ids" => [dataset_id, other_dataset_id]
+             })
+
+    # Email has been sent
+    assert_email_sent(fn %Swoosh.Email{} = sent ->
+      assert %Swoosh.Email{
+               from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
+               to: [{"", ^email}],
+               reply_to: {"", "contact@transport.data.gouv.fr"},
+               subject: "Nouveaux commentaires",
+               text_body: nil,
+               html_body: html_body
+             } = sent
+
+      assert remove_whitespace(html_body) == remove_whitespace(~s|
+      <p>
+      Bonjour,</p>
+      <p>
+      Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.</p>
+      <p>
+      </p>
+      <ul>
+        <li>
+        <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}#dataset-discussions">#{dataset.custom_title}</a>
+        </li>
+        </ul>
+      <p>
+      L’équipe transport.data.gouv.fr</p>|)
+    end)
+
+    # Notification has been saved
+    assert [%DB.Notification{reason: :daily_new_comments, dataset_id: ^dataset_id, email: ^email}] =
+             DB.Notification |> DB.Repo.all()
+  end
+
+  defp remove_whitespace(value), do: value |> String.replace(" ", "") |> String.trim()
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -123,6 +123,7 @@ oban_prod_crontab = [
   {"15 */3 * * *", Transport.Jobs.ResourceHistoryTableSchemaValidationJob},
   {"5 6 * * *", Transport.Jobs.NewDatagouvDatasetsJob},
   {"0 6 * * *", Transport.Jobs.NewDatasetNotificationsJob},
+  {"0 8 * * 1-5", Transport.Jobs.NewCommentsNotificationJob},
   {"0 21 * * *", Transport.Jobs.DatasetHistoryDispatcherJob},
   # Should be executed after all `DatasetHistoryJob` have been executed
   {"50 21 * * *", Transport.Jobs.ResourcesChangedNotificationJob},


### PR DESCRIPTION
Fixes #3844

Ajoute une nouvelle notification, en charge de tenir au courant les réutilisateurs de nouvelles discussions sur les jeux de données qu'il suive.

Ce job est planifié du lundi au vendredi et le job du lundi listera les commentaires postés au cours des 3 derniers jours (vendredi, samedi et dimanche).

Ces notifications ne seront pas envoyées tout de suite car il fut que les utilisateurs puissent mettre des jeux de données en favori et s'inscrire à des notifications, ce qui sera possible seulement quand l'espace réutilisateur sera fini. Les notifications pour les réutilisateurs sont ajoutées au fur et à mesure (#3353, #3347, #3568 etc)