### PR TITLE
Recherche : tri par défaut déterministe

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -451,7 +451,11 @@ defmodule DB.Dataset do
         fragment(
           "case when organization = ? and custom_title ilike 'base nationale%' then 1 else 0 end",
           ^pan_publisher
-        )
+        ),
+      # Gotcha, population can be null for datasets covering France/Europe
+      # https://github.com/etalab/transport-site/issues/3848
+      desc: fragment("coalesce(population, 100000000)"),
+      asc: :custom_title
     )
   end
 

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -285,6 +285,23 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     assert list_datasets.(%{}) != list_datasets.(%{"region" => region.id |> to_string()})
   end
 
+  test "uses population and custom_title to sort by default" do
+    small_aom = insert(:aom, population: 100)
+    big_aom = insert(:aom, population: 200)
+    type = "private-parking"
+
+    # small population: last result expected
+    small_dataset = insert(:dataset, is_active: true, type: type, aom: small_aom, custom_title: "AAA")
+    # equal population, alphabetical order expected
+    big_dataset_1 = insert(:dataset, is_active: true, type: type, aom: big_aom, custom_title: "ABC")
+    big_dataset_2 = insert(:dataset, is_active: true, type: type, aom: big_aom, custom_title: "BBB")
+    # national dataset, population is null
+    national_dataset = insert(:dataset, is_active: true, type: type, population: nil)
+
+    assert [national_dataset.id, big_dataset_1.id, big_dataset_2.id, small_dataset.id] ==
+             %{"type" => type} |> Dataset.list_datasets() |> DB.Repo.all() |> Enum.map(& &1.id)
+  end
+
   test "hidden datasets are not included" do
     hidden_dataset = insert(:dataset, is_active: true, is_hidden: true)
 


### PR DESCRIPTION
Fixes #3847

Ajoute un tri par défaut pour les jeux de données sur la recherche, quand on ne spécifie pas l'ordre alphabétique ou ajouté récemment.

Tri par ordre décroissant de la population couverte et par ordre alphabétique en cas d'égalité.

https://github.com/etalab/transport-site/issues/3848 découvert à l'occasion en travaillant sur cette PR