### PR TITLE
Graphique des indicateurs : améliore responsive

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_dataset_scores_chart.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_dataset_scores_chart.html.heex
@@ -30,5 +30,15 @@
 <script src={static_path(@conn, "/js/vega.js")} nonce={@conn.assigns[:csp_nonce_value]} />
 <script nonce={@conn.assigns[:csp_nonce_value]}>
   const spec = <%= raw Jason.encode!(@scores_chart) %>;
+
+  // Make sure the chart has got the appropriate width.
+  // It may be too large at the beginning, listen to resize
+  // events and rerender the chart.
+  // https://talk.observablehq.com/t/embedding-vega-lite-charts-that-have-width-value-set-to-container-leads-to-null-width-until-window-is-resized/6120/6
+  // https://github.com/vega/react-vega/issues/85#issuecomment-1826421132
+  new ResizeObserver(() => {
+    window.dispatchEvent(new Event("resize"));
+  }).observe(document.getElementById("vega-vis"));
+
   window.vegaEmbed("#vega-vis", spec, {renderer: "svg"});
 </script>


### PR DESCRIPTION
Fixes #3851

Le graphique des indicateurs peut avoir une taille trop grande malgré des règles CSS ou une spec Vega Lite qui parait prendre ceci en compte.

https://github.com/etalab/transport-site/blob/4698271861462b72ea2eed4c310c301562ad3eee/apps/transport/client/stylesheets/components/_dataset-details.scss#L601-L606
https://github.com/etalab/transport-site/blob/4698271861462b72ea2eed4c310c301562ad3eee/apps/transport/lib/transport_web/controllers/dataset_controller.ex#L82

Toutefois ceci ne semble pas suffisant car le `div` parent n'a pas une largeur fixe. La largeur est connue après le render complet et il arrive que le graphique soit trop grand et déborde.

Cette PR répare ce problème. Le fix que j'ai adopté est peut-être un peu complexe mais je n'ai pas réussi autrement après avoir tenté de faire du CSS, de dispatch l'event de resize juste après le render ou dans la promise qui est retournée. J'obtenais le même résultat en envoyant l'event de `resize` après 500ms par exemple (via un `setTimeout`) mais l'utilisation d'un `ResizeObserver` parait plus appropriée.