### PR TITLE
NewCommentsNotificationJobTest : répare tests

### DIFF
--- a/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
@@ -18,15 +18,15 @@ defmodule Transport.Test.Transport.Jobs.NewCommentsNotificationJobTest do
     test "a weekday excluding Monday" do
       # Ignored: inactive
       insert(:dataset,
-        is_active: true,
-        is_hidden: true,
+        is_active: false,
+        is_hidden: false,
         latest_data_gouv_comment_timestamp: ~U[2024-03-27 10:00:00.00Z]
       )
 
       # Ignored: hidden
       insert(:dataset,
-        is_active: false,
-        is_hidden: false,
+        is_active: true,
+        is_hidden: true,
         latest_data_gouv_comment_timestamp: ~U[2024-03-27 12:00:00.00Z]
       )
 
@@ -51,15 +51,15 @@ defmodule Transport.Test.Transport.Jobs.NewCommentsNotificationJobTest do
     test "on a Monday" do
       # Ignored: inactive
       insert(:dataset,
-        is_active: true,
-        is_hidden: true,
+        is_active: false,
+        is_hidden: false,
         latest_data_gouv_comment_timestamp: ~U[2024-03-30 10:00:00.00Z]
       )
 
       # Ignored: hidden
       insert(:dataset,
-        is_active: false,
-        is_hidden: false,
+        is_active: true,
+        is_hidden: true,
         latest_data_gouv_comment_timestamp: ~U[2024-03-30 12:00:00.00Z]
       )
 


### PR DESCRIPTION
Suite de https://github.com/etalab/transport-site/pull/3846

Commentaires relevés lors de la review, le setup de certains jeux de données avait été mal effectué et ne correspondait pas aux commentaires. Met les bonnes valeurs d'attributs aux bons endroits.