### PR TITLE
Fix s3 en local

### DIFF
--- a/apps/transport/lib/S3/s3.ex
+++ b/apps/transport/lib/S3/s3.ex
@@ -17,14 +17,6 @@ defmodule Transport.S3 do
     host |> to_string() |> URI.merge(path) |> URI.to_string()
   end
 
-  @spec all_permanent_urls_domains() :: [binary()]
-  def all_permanent_urls_domains do
-    :transport
-    |> Application.fetch_env!(:s3_buckets)
-    |> Map.keys()
-    |> Enum.map(&Transport.S3.permanent_url(&1, "/"))
-  end
-
   @spec bucket_names() :: [binary()]
   def bucket_names do
     buckets_response = ExAws.S3.list_buckets() |> Transport.Wrapper.ExAWS.impl().request!()

--- a/apps/transport/lib/S3/s3.ex
+++ b/apps/transport/lib/S3/s3.ex
@@ -13,8 +13,13 @@ defmodule Transport.S3 do
 
   @spec permanent_url(bucket_feature(), binary()) :: binary()
   def permanent_url(feature, path \\ "") do
-    host = :io_lib.format(Application.fetch_env!(:ex_aws, :cellar_url), [bucket_name(feature)])
-    host |> to_string() |> URI.merge(path) |> URI.to_string()
+    base_url = :io_lib.format(Application.fetch_env!(:ex_aws, :cellar_url), [bucket_name(feature)]) |> to_string()
+
+    if String.length(path) > 0 do
+      base_url |> URI.parse() |> URI.append_path("/" <> path) |> URI.to_string()
+    else
+      base_url
+    end
   end
 
   @spec bucket_names() :: [binary()]


### PR DESCRIPTION
Avec une config minio classique en local, le nom du bucket est dans le path et non dans le hostname. Cette PR fix ceci.