### PR TITLE
Améliorations pour l'ajout d'un JDD en favori

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -64,6 +64,28 @@
   }
   .follow-dataset-icon {
     text-align: right;
+
+    p.notification {
+      text-align: left;
+      transition: all 1s;
+      opacity: 0;
+      display: none;
+      &.active {
+        display: block;
+        animation: fade-in 1s;
+        opacity: 1;
+      }
+    }
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
   }
 }
 

--- a/apps/transport/lib/jobs/promote_reuser_space_job.ex
+++ b/apps/transport/lib/jobs/promote_reuser_space_job.ex
@@ -29,7 +29,7 @@ defmodule Transport.PromoteReuserSpaceNotifier do
     |> from({"transport.data.gouv.fr", Application.fetch_env!(:transport, :contact_email)})
     |> to(email)
     |> reply_to(Application.fetch_env!(:transport, :contact_email))
-    |> subject("Découvrez l'Espace réutilisateur")
+    |> subject("Gestion de vos favoris dans votre espace réutilisateur")
     |> render_body("promote_reuser_space.html")
   end
 end

--- a/apps/transport/lib/jobs/promote_reuser_space_job.ex
+++ b/apps/transport/lib/jobs/promote_reuser_space_job.ex
@@ -1,0 +1,35 @@
+defmodule Transport.Jobs.PromoteReuserSpaceJob do
+  @moduledoc """
+  Send an email to a contact just after following a dataset for
+  the first time.
+  """
+  use Oban.Worker, unique: [period: :infinity], max_attempts: 3
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"contact_id" => contact_id}}) do
+    contact = DB.Repo.get!(DB.Contact, contact_id)
+
+    {:ok, _} =
+      contact.email
+      |> Transport.PromoteReuserSpaceNotifier.promote_reuser_space()
+      |> Transport.Mailer.deliver()
+
+    :ok
+  end
+end
+
+defmodule Transport.PromoteReuserSpaceNotifier do
+  @moduledoc """
+  Module in charge of building the email.
+  """
+  use Phoenix.Swoosh, view: TransportWeb.EmailView
+
+  def promote_reuser_space(email) do
+    new()
+    |> from({"transport.data.gouv.fr", Application.fetch_env!(:transport, :contact_email)})
+    |> to(email)
+    |> reply_to(Application.fetch_env!(:transport, :contact_email))
+    |> subject("Découvrez l'Espace réutilisateur")
+    |> render_body("promote_reuser_space.html")
+  end
+end

--- a/apps/transport/lib/jobs/promote_reuser_space_job.ex
+++ b/apps/transport/lib/jobs/promote_reuser_space_job.ex
@@ -1,7 +1,7 @@
 defmodule Transport.Jobs.PromoteReuserSpaceJob do
   @moduledoc """
-  Send an email to a contact just after following a dataset for
-  the first time.
+  Sends an email to a contact when they follow a dataset for
+  the first time using the button.
   """
   use Oban.Worker, unique: [period: :infinity], max_attempts: 3
 

--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -1,0 +1,7 @@
+defmodule TransportWeb.ReuserSpaceController do
+  use TransportWeb, :controller
+
+  def espace_reutilisateur(%Plug.Conn{} = conn, _) do
+    text(conn, "Coming soon")
+  end
+end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -94,6 +94,10 @@ defmodule TransportWeb.Router do
       end
     end
 
+    scope "/espace_reutilisateur" do
+      get("/", ReuserSpaceController, :espace_reutilisateur)
+    end
+
     get("/stats", StatsController, :index)
     get("/atom.xml", AtomController, :index)
     post("/send_mail", ContactController, :send_mail)

--- a/apps/transport/lib/transport_web/templates/email/promote_reuser_space.html.md
+++ b/apps/transport/lib/transport_web/templates/email/promote_reuser_space.html.md
@@ -1,8 +1,8 @@
 Bonjour,
 
-Vous venez d'ajouter votre 1er favori pour suivre un jeu de données référencé sur le PAN et nous vous en félicitons !
+Vous venez d’ajouter votre 1er favori pour suivre un jeu de données référencé sur le PAN et nous vous en félicitons !
 
-Vous pourrez désormais être alerté lorsque le jeu de données est indisponible ou contient des erreurs par exemple. Vous serez également tenu au courant des différentes discussions publiques initiées par les producteurs de données ou d'autres réutilisateurs.
+Vous pourrez désormais être alerté lorsque le jeu de données est indisponible ou contient des erreurs par exemple. Vous serez également tenu au courant des différentes discussions publiques initiées par les producteurs de données ou d’autres réutilisateurs.
 
 Rendez-vous sur votre <%= link_for_reuser_space(:promote_reuser_space) %> pour personnaliser vos préférences et participer à la constante amélioration de la qualité des données de mobilité !
 

--- a/apps/transport/lib/transport_web/templates/email/promote_reuser_space.html.md
+++ b/apps/transport/lib/transport_web/templates/email/promote_reuser_space.html.md
@@ -1,0 +1,11 @@
+Bonjour,
+
+Vous venez d'ajouter votre 1er favori pour suivre un jeu de données référencé sur le PAN et nous vous en félicitons !
+
+Vous pourrez désormais être alerté lorsque le jeu de données est indisponible ou contient des erreurs par exemple. Vous serez également tenu au courant des différentes discussions publiques initiées par les producteurs de données ou d'autres réutilisateurs.
+
+Rendez-vous sur votre <%= link_for_reuser_space(:promote_reuser_space) %> pour personnaliser vos préférences et participer à la constante amélioration de la qualité des données de mobilité !
+
+À bientôt,
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/lib/transport_web/views/email_view.ex
+++ b/apps/transport/lib/transport_web/views/email_view.ex
@@ -1,29 +1,41 @@
 defmodule TransportWeb.EmailView do
   use TransportWeb, :view
+  import TransportWeb.Router.Helpers
 
   def link_for_dataset(%DB.Dataset{slug: slug, custom_title: custom_title}) do
-    url = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
+    url = dataset_url(TransportWeb.Endpoint, :details, slug)
     link(custom_title, to: url)
   end
 
   def link_for_dataset_discussions(%DB.Dataset{slug: slug}) do
-    url = TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, slug)
+    url = dataset_url(TransportWeb.Endpoint, :details, slug)
     link("l’espace de discussion du jeu de données", to: url <> "#dataset-discussions")
   end
 
   def link_for_resource(%DB.Resource{id: id, title: title}) do
-    url = TransportWeb.Router.Helpers.resource_url(TransportWeb.Endpoint, :details, id)
+    url = resource_url(TransportWeb.Endpoint, :details, id)
     link(title, to: url)
   end
 
   def link_for_espace_producteur(view_name) do
     url =
-      TransportWeb.Router.Helpers.page_url(TransportWeb.Endpoint, :espace_producteur,
+      page_url(TransportWeb.Endpoint, :espace_producteur,
         utm_source: "transactional_email",
         utm_medium: "email",
         utm_campaign: to_string(view_name)
       )
 
     link("Espace Producteur", to: url)
+  end
+
+  def link_for_reuser_space(view_name) do
+    url =
+      reuser_space_path(TransportWeb.Endpoint, :espace_reutilisateur,
+        utm_source: "transactional_email",
+        utm_medium: "email",
+        utm_campaign: to_string(view_name)
+      )
+
+    link("Espace réutilisateur", to: url)
   end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -685,3 +685,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Your comment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Dataset added to your favorites! Personalise your settings from your <a href=\"%{url}\" target=\"_blank\">reuser space</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -685,3 +685,11 @@ msgstr "Ce jeu de données est masqué"
 #, elixir-autogen, elixir-format
 msgid "Your comment"
 msgstr "Votre commentaire"
+
+#, elixir-autogen, elixir-format
+msgid "Dataset added to your favorites! Personalise your settings from your <a href=\"%{url}\" target=\"_blank\">reuser space</a>."
+msgstr "Jeu de données ajouté à vos favoris ! Personnalisez vos préférences depuis votre <a href=\"%{url}\" target=\"_blank\">espace réutilisateur</a>."
+
+#, elixir-autogen, elixir-format
+msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
+msgstr "<a href=\"%{url}\">Inscrivez-vous ou connectez-vous</a> pour bénéficier des services liés aux jeux de données."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -685,3 +685,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Your comment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Dataset added to your favorites! Personalise your settings from your <a href=\"%{url}\" target=\"_blank\">reuser space</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
+msgstr ""

--- a/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
+++ b/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
@@ -18,7 +18,7 @@ defmodule Transport.Test.Transport.Jobs.PromoteReuserSpaceJobTest do
                from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
                to: [{"", ^email}],
                reply_to: {"", "contact@transport.data.gouv.fr"},
-               subject: "Découvrez l'Espace réutilisateur",
+               subject: "Gestion de vos favoris dans votre espace réutilisateur",
                text_body: nil,
                html_body: html_body
              } = sent

--- a/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
+++ b/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
@@ -1,0 +1,33 @@
+defmodule Transport.Test.Transport.Jobs.PromoteReuserSpaceJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Swoosh.TestAssertions
+  alias Transport.Jobs.PromoteReuserSpaceJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    %DB.Contact{email: email, id: contact_id} = insert_contact()
+    assert :ok == perform_job(PromoteReuserSpaceJob, %{"contact_id" => contact_id})
+
+    assert_email_sent(fn %Swoosh.Email{} = sent ->
+      assert %Swoosh.Email{
+               from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
+               to: [{"", ^email}],
+               reply_to: {"", "contact@transport.data.gouv.fr"},
+               subject: "Découvrez l'Espace réutilisateur",
+               text_body: nil,
+               html_body: html_body
+             } = sent
+
+      assert html_body =~
+               "Vous venez d’ajouter votre 1er favori pour suivre un jeu de données référencé sur le PAN et nous vous en félicitons !"
+
+      assert html_body =~
+               ~s(Rendez-vous sur votre <a href="/espace_reutilisateur?utm_source=transactional_email&amp;utm_medium=email&amp;utm_campaign=promote_reuser_space">Espace réutilisateur</a> pour personnaliser vos préférences)
+    end)
+  end
+end

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -1,0 +1,7 @@
+defmodule TransportWeb.ReuserSpaceControllerTest do
+  use TransportWeb.ConnCase, async: true
+
+  test "espace_reutilisateur", %{conn: conn} do
+    assert conn |> get(reuser_space_path(conn, :espace_reutilisateur)) |> text_response(200)
+  end
+end

--- a/apps/transport/test/transport_web/live_views/follow_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/follow_dataset_live_test.exs
@@ -10,16 +10,23 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "when current_user is nil", %{conn: conn} do
+  test "when user is logged out", %{conn: conn} do
+    dataset = insert(:dataset)
+
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.Live.FollowDatasetLive,
         session: %{
-          "dataset_id" => insert(:dataset).id,
+          "dataset_id" => dataset.id,
           "current_user" => nil
         }
       )
 
-    assert_renders_empty_div(view)
+    assert_renders_logged_out_div(view, with_banner: false)
+
+    # Clicking the heart icon
+    view |> element("div i") |> render_click()
+
+    assert_renders_logged_out_div(view, with_banner: true, dataset_slug: dataset.slug)
   end
 
   test "when current_user is a producer of the dataset", %{conn: conn} do
@@ -43,6 +50,15 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
     %DB.Contact{id: contact_id} = contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
     insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset.id, source: :datagouv)
 
+    notification_subscription =
+      insert(:notification_subscription,
+        contact_id: contact.id,
+        dataset_id: dataset.id,
+        source: :user,
+        role: :reuser,
+        reason: :expiration
+      )
+
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.Live.FollowDatasetLive,
         session: %{
@@ -51,7 +67,8 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
         }
       )
 
-    assert_renders_red_heart(view)
+    assert [notification_subscription] == DB.NotificationSubscription |> DB.Repo.all()
+    assert_renders_red_heart(view, with_banner: false)
     assert [%DB.DatasetFollower{dataset_id: ^dataset_id, contact_id: ^contact_id}] = DB.DatasetFollower |> DB.Repo.all()
 
     # Clicking the heart icon
@@ -59,6 +76,7 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
 
     assert_renders_grey_heart(view)
     assert [] == DB.DatasetFollower |> DB.Repo.all()
+    assert [] == DB.NotificationSubscription |> DB.Repo.all()
   end
 
   test "does not follow the dataset, clicking the heart icon", %{conn: conn} do
@@ -75,13 +93,132 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
 
     assert_renders_grey_heart(view)
 
+    assert [] == DB.NotificationSubscription |> DB.Repo.all()
+
     # Clicking the heart icon
     view |> element("div i") |> render_click()
 
-    assert_renders_red_heart(view)
+    assert_renders_red_heart(view, with_banner: true)
 
+    # Dataset is now being followed
     assert [%DB.DatasetFollower{dataset_id: ^dataset_id, contact_id: ^contact_id, source: :follow_button}] =
              DB.DatasetFollower |> DB.Repo.all()
+
+    # The user is subscribed to all reasons
+    assert [
+             %DB.NotificationSubscription{
+               reason: :daily_new_comments,
+               source: :user,
+               role: :reuser,
+               contact_id: ^contact_id,
+               dataset_id: nil
+             },
+             %DB.NotificationSubscription{
+               reason: :dataset_with_error,
+               source: :user,
+               role: :reuser,
+               contact_id: ^contact_id,
+               dataset_id: ^dataset_id
+             },
+             %DB.NotificationSubscription{
+               reason: :expiration,
+               source: :user,
+               role: :reuser,
+               contact_id: ^contact_id,
+               dataset_id: ^dataset_id
+             },
+             %DB.NotificationSubscription{
+               reason: :resource_unavailable,
+               source: :user,
+               role: :reuser,
+               contact_id: ^contact_id,
+               dataset_id: ^dataset_id
+             }
+           ] =
+             DB.NotificationSubscription
+             |> DB.Repo.all()
+             |> Enum.sort_by(fn %DB.NotificationSubscription{reason: reason} -> reason end)
+  end
+
+  describe "maybe_subscribe_to_daily_new_comments" do
+    test "user not subscribed to daily comments, 0 subscriptions" do
+      %DB.Contact{id: contact_id} = contact = insert_contact()
+      TransportWeb.Live.FollowDatasetLive.maybe_subscribe_to_daily_new_comments(contact)
+
+      assert [
+               %DB.NotificationSubscription{
+                 reason: :daily_new_comments,
+                 source: :user,
+                 role: :reuser,
+                 contact_id: ^contact_id,
+                 dataset_id: nil
+               }
+             ] = DB.NotificationSubscription |> DB.Repo.all()
+    end
+
+    test "user is already subscribed to daily comments" do
+      %DB.Contact{id: contact_id} = contact = insert_contact()
+
+      notification_subscription =
+        insert(:notification_subscription,
+          reason: :daily_new_comments,
+          role: :reuser,
+          source: :user,
+          contact_id: contact_id
+        )
+
+      TransportWeb.Live.FollowDatasetLive.maybe_subscribe_to_daily_new_comments(contact)
+      assert [notification_subscription] == DB.NotificationSubscription |> DB.Repo.all()
+    end
+
+    test "user not subscribed to daily comments, an existing subscription" do
+      %DB.Contact{id: contact_id} = contact = insert_contact()
+      %DB.Dataset{id: dataset_id} = insert(:dataset)
+
+      notification_subscription =
+        insert(:notification_subscription,
+          reason: :expiration,
+          role: :reuser,
+          source: :user,
+          contact_id: contact_id,
+          dataset_id: dataset_id
+        )
+
+      TransportWeb.Live.FollowDatasetLive.maybe_subscribe_to_daily_new_comments(contact)
+
+      assert [notification_subscription] == DB.NotificationSubscription |> DB.Repo.all()
+    end
+  end
+
+  defp assert_renders_logged_out_div(%Phoenix.LiveViewTest.View{} = view, with_banner: true, dataset_slug: dataset_slug) do
+    login_url = "/login/explanation?redirect_path=%2Fdatasets%2F#{dataset_slug}"
+
+    assert [
+             {"div", _,
+              [
+                {"div", [{"class", "follow-dataset-icon"}],
+                 [
+                   {"i", [{"class", "fa fa-heart fa-2x icon---animated-heart"}, {"phx-click", "nudge_signup"}], []},
+                   {
+                     "p",
+                     [{"class", "notification active"}],
+                     [{"a", [{"href", ^login_url}], _}, _]
+                   }
+                 ]}
+              ]}
+           ] = view |> render() |> Floki.parse_document!()
+  end
+
+  defp assert_renders_logged_out_div(%Phoenix.LiveViewTest.View{} = view, with_banner: false) do
+    assert [
+             {"div", _,
+              [
+                {"div", [{"class", "follow-dataset-icon"}],
+                 [
+                   {"i", [{"class", "fa fa-heart fa-2x icon---animated-heart"}, {"phx-click", "nudge_signup"}], []}
+                 ]}
+              ]}
+           ] = view |> render() |> Floki.parse_document!()
   end
 
   defp assert_renders_empty_div(%Phoenix.LiveViewTest.View{} = view) do
@@ -93,17 +230,34 @@ defmodule Transport.TransportWeb.FollowDatasetLiveTest do
              {"div", _,
               [
                 {"div", [{"class", "follow-dataset-icon"}],
-                 [{"i", [{"class", "fa fa-heart fa-2x icon---animated-heart"}, {"phx-click", "toggle"}], []}]}
+                 [
+                   {"i", [{"class", "fa fa-heart fa-2x icon---animated-heart"}, {"phx-click", "toggle"}], []}
+                 ]}
               ]}
            ] = view |> render() |> Floki.parse_document!()
   end
 
-  defp assert_renders_red_heart(%Phoenix.LiveViewTest.View{} = view) do
+  defp assert_renders_red_heart(%Phoenix.LiveViewTest.View{} = view, with_banner: true) do
     assert [
              {"div", _,
               [
                 {"div", [{"class", "follow-dataset-icon"}],
-                 [{"i", [{"class", "fa fa-heart fa-2x icon---animated-heart active"}, {"phx-click", "toggle"}], []}]}
+                 [
+                   {"i", [{"class", "fa fa-heart fa-2x icon---animated-heart active"}, {"phx-click", "toggle"}], []},
+                   {"p", [{"class", "notification active"}], _}
+                 ]}
+              ]}
+           ] = view |> render() |> Floki.parse_document!()
+  end
+
+  defp assert_renders_red_heart(%Phoenix.LiveViewTest.View{} = view, with_banner: false) do
+    assert [
+             {"div", _,
+              [
+                {"div", [{"class", "follow-dataset-icon"}],
+                 [
+                   {"i", [{"class", "fa fa-heart fa-2x icon---animated-heart active"}, {"phx-click", "toggle"}], []}
+                 ]}
               ]}
            ] = view |> render() |> Floki.parse_document!()
   end


### PR DESCRIPTION
Fixes #3859

Apporte les modifications suivantes :
- lors du suivi d'un JDD, s'abonne automatiquement aux notifications liées à ce jeu de données
- s'abonne au suivi quotidien des discussions lors du premier suivi
- affiche le coeur permettant de suivre un JDD pour les personnes non connectées, faisant la promotion de la fonctionnalité
- lorsqu'un utilisateur suit un JDD pour la première fois par le biais du bouton, envoie un e-mail faisant la promotion de l'espace réutilisateur
- ajoute un controller pour l'espace réutilisateur, qui ne fait rien pour le moment (affiche "coming soon")

La fonctionnalité reste visible uniquement par les membres du PAN pour le moment, la partie déconnectée sera donc cachée pour le moment (couvert par des tests précédemment dans https://github.com/etalab/transport-site/issues/3835).

https://github.com/etalab/transport-site/assets/295709/ddcd4422-c99d-4e6b-ae0a-dcf1998dcf37
