### PR TITLE
EmailView : lien absolu vers espace réutilisateur

### DIFF
--- a/apps/transport/lib/transport_web/views/email_view.ex
+++ b/apps/transport/lib/transport_web/views/email_view.ex
@@ -1,6 +1,14 @@
 defmodule TransportWeb.EmailView do
   use TransportWeb, :view
-  import TransportWeb.Router.Helpers
+
+  import TransportWeb.Router.Helpers,
+    # Use only *_url helpers, not *_path as we need absolute URLs
+    only: [
+      dataset_url: 3,
+      resource_url: 3,
+      page_url: 3,
+      reuser_space_url: 3
+    ]
 
   def link_for_dataset_section(%DB.Dataset{} = dataset, :discussion) do
     link_for_dataset(dataset, "#dataset-discussions")
@@ -34,7 +42,7 @@ defmodule TransportWeb.EmailView do
 
   def link_for_reuser_space(view_name) do
     url =
-      reuser_space_path(TransportWeb.Endpoint, :espace_reutilisateur,
+      reuser_space_url(TransportWeb.Endpoint, :espace_reutilisateur,
         utm_source: "transactional_email",
         utm_medium: "email",
         utm_campaign: to_string(view_name)

--- a/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
+++ b/apps/transport/test/transport/jobs/promote_reuser_space_job_test.exs
@@ -27,7 +27,7 @@ defmodule Transport.Test.Transport.Jobs.PromoteReuserSpaceJobTest do
                "Vous venez d’ajouter votre 1er favori pour suivre un jeu de données référencé sur le PAN et nous vous en félicitons !"
 
       assert html_body =~
-               ~s(Rendez-vous sur votre <a href="/espace_reutilisateur?utm_source=transactional_email&amp;utm_medium=email&amp;utm_campaign=promote_reuser_space">Espace réutilisateur</a> pour personnaliser vos préférences)
+               ~s(Rendez-vous sur votre <a href="http://127.0.0.1:5100/espace_reutilisateur?utm_source=transactional_email&amp;utm_medium=email&amp;utm_campaign=promote_reuser_space">Espace réutilisateur</a> pour personnaliser vos préférences)
     end)
   end
 end


### PR DESCRIPTION
Petit problème en travaillant sur #3864 : le lien vers l'espace réutilisateur était relatif et non complet. Ce n'est pas bon pour un lien présent dans un e-mail.