### PR TITLE
CommentsChecker : gère uniquement les producteurs

### DIFF
--- a/apps/transport/lib/transport/comments_checker.ex
+++ b/apps/transport/lib/transport/comments_checker.ex
@@ -64,9 +64,10 @@ defmodule Transport.CommentsChecker do
 
     email_content = Phoenix.View.render_to_string(TransportWeb.EmailView, "index.html", comments_with_context: comments)
 
+    # Notifications for reusers are handled by `NewCommentsNotificationJob`
     emails =
       @notification_reason
-      |> DB.NotificationSubscription.subscriptions_for_reason()
+      |> DB.NotificationSubscription.subscriptions_for_reason_and_role(:producer)
       |> DB.NotificationSubscription.subscriptions_to_emails()
 
     Enum.each(emails, fn email ->

--- a/apps/transport/test/transport/comments_checker_test.exs
+++ b/apps/transport/test/transport/comments_checker_test.exs
@@ -39,6 +39,14 @@ defmodule Transport.CommentsCheckerTest do
       role: :producer
     })
 
+    # Should be ignored: reuser
+    insert(:notification_subscription, %{
+      reason: :daily_new_comments,
+      source: :user,
+      contact_id: insert_contact().id,
+      role: :reuser
+    })
+
     # when the dataset is created, no comment timestamp is stored
     assert_dataset_ts(dataset_id, nil)
 


### PR DESCRIPTION
#3844 a ajouté l'envoi d'une notification aux réutilisateurs concernant les nouvelles discussions.

Il est nécessaire d'adapter `CommentsChecker` pour s'assurer que ceci gère uniquement les producteurs : le scope est tous les datasets sur la plateforme et non seulement les datasets suivis. C'est adapté au PAN, ART etc.

Sans ceci `CommentsChecker` envoie à tout le monde, sans distinguer producteurs et réutilisateurs.