### PR TITLE
Première page d'accueil de l'espace réutilisateur

### DIFF
--- a/apps/transport/client/stylesheets/app.scss
+++ b/apps/transport/client/stylesheets/app.scss
@@ -46,6 +46,7 @@
 @import 'producteurs';
 @import 'espace_producteur';
 @import 'climate_resilience_bill';
+@import 'reuser_space';
 
 // Prism for syntax coloring ; TODO: cherry-pick from the npm package instead
 // (and remove the manual download)

--- a/apps/transport/client/stylesheets/reuser_space.scss
+++ b/apps/transport/client/stylesheets/reuser_space.scss
@@ -1,0 +1,45 @@
+.reuser-space {
+  .row {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+
+    &> * {
+      max-width: 25em;
+      margin-right: var(--space-m);
+      margin-left: 0;
+    }
+
+    .dataset__panel {
+      margin-top: 1em;
+    }
+  }
+}
+
+.action-panel {
+  display: flex;
+  flex-grow: 1;
+
+  img.picto {
+    height: 40px;
+    padding-right: 12px;
+    margin-top: -5px;
+  }
+
+  a.button {
+    background-color: var(--primary-color-producer);
+  }
+}
+
+form.search-followed-datasets {
+  max-width: 100%;
+
+  input#search {
+    padding-left: 30px;
+    width: 350px;
+  }
+
+  .form__group {
+    margin-top: 0;
+    display: inline-block;
+  }
+}

--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -1,7 +1,14 @@
 defmodule TransportWeb.ReuserSpaceController do
   use TransportWeb, :controller
+  import Ecto.Query
 
-  def espace_reutilisateur(%Plug.Conn{} = conn, _) do
-    text(conn, "Coming soon")
+  def espace_reutilisateur(%Plug.Conn{assigns: %{current_user: %{"id" => datagouv_user_id}}} = conn, _) do
+    contact = DB.Repo.get_by!(DB.Contact, datagouv_user_id: datagouv_user_id)
+    followed_datasets_ids = contact |> Ecto.assoc(:followed_datasets) |> select([d], d.id) |> DB.Repo.all()
+
+    conn
+    |> assign(:contact, contact)
+    |> assign(:followed_datasets_ids, followed_datasets_ids)
+    |> render("index.html")
   end
 end

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -7,7 +7,7 @@ defmodule TransportWeb.DiscussionsLive do
 
   def render(assigns) do
     ~H"""
-    <script>
+    <script nonce={@nonce}>
       window.addEventListener('phx:discussions-loaded', (event) => {
         event.detail.ids.forEach(id =>
           addSeeMore(
@@ -48,7 +48,8 @@ defmodule TransportWeb.DiscussionsLive do
         %{
           "current_user" => current_user,
           "dataset" => dataset,
-          "locale" => locale
+          "locale" => locale,
+          "csp_nonce_value" => nonce
         },
         socket
       ) do
@@ -57,6 +58,7 @@ defmodule TransportWeb.DiscussionsLive do
       |> assign(:current_user, current_user)
       |> assign(:dataset, dataset)
       |> assign(:locale, locale)
+      |> assign(:nonce, nonce)
 
     Gettext.put_locale(locale)
 

--- a/apps/transport/lib/transport_web/live/feedback_live.ex
+++ b/apps/transport/lib/transport_web/live/feedback_live.ex
@@ -12,15 +12,16 @@ defmodule TransportWeb.Live.FeedbackLive do
   """
 
   @feedback_rating_values ["like", "neutral", "dislike"]
-  @feedback_features ["gtfs-stops", "on-demand-validation", "gbfs-validation"]
+  @feedback_features ["gtfs-stops", "on-demand-validation", "gbfs-validation", "reuser-space"]
 
-  def mount(_params, %{"feature" => feature, "locale" => locale} = session, socket)
+  def mount(_params, %{"feature" => feature, "locale" => locale, "csp_nonce_value" => nonce} = session, socket)
       when feature in @feedback_features do
     current_email = session |> get_in(["current_user", "email"])
 
     socket =
       socket
       |> assign(
+        nonce: nonce,
         feature: feature,
         current_email: current_email,
         feedback_sent: false,

--- a/apps/transport/lib/transport_web/live/feedback_live.html.heex
+++ b/apps/transport/lib/transport_web/live/feedback_live.html.heex
@@ -47,7 +47,7 @@
   <p :if={@feedback_sent} class="notification"><%= dgettext("feedback", "Thanks for your feedback!") %></p>
   <p :if={@feedback_error}><%= gettext("There has been an error, try again later") %></p>
 
-  <script>
+  <script nonce={@nonce}>
     document.querySelectorAll(".feedback-selector label").forEach(
       function(el) {
       el.addEventListener('click', function() {

--- a/apps/transport/lib/transport_web/live/followed_datasets_live.ex
+++ b/apps/transport/lib/transport_web/live/followed_datasets_live.ex
@@ -1,0 +1,153 @@
+defmodule TransportWeb.Live.FollowedDatasetsLive do
+  @moduledoc """
+  Display followed datasets on the reuser space.
+  """
+  use Phoenix.LiveView
+  use TransportWeb.InputHelpers
+  import Ecto.Query
+  import TransportWeb.DatasetView, only: [icon_type_path: 1]
+  import TransportWeb.Gettext
+  import TransportWeb.InputHelpers
+  import TransportWeb.Router.Helpers
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="pb-24">
+      <.form :let={f} for={%{}} phx-change="change" class="search-followed-datasets">
+        <%= search_input(f, :search, value: @search) %>
+        <%= if Enum.count(@select_options) > 1 do %>
+          <%= select(f, :type, [{dgettext("reuser-space", "All"), ""}] ++ @select_options,
+            selected: @type,
+            label: dgettext("reuser-space", "Data type")
+          ) %>
+        <% end %>
+      </.form>
+    </div>
+    <div :if={Enum.empty?(@filtered_datasets)} class="notification">
+      <%= dgettext("reuser-space", "No results") %>
+    </div>
+    <div :if={not Enum.empty?(@filtered_datasets)} class="row">
+      <%= for dataset <- Enum.sort_by(@filtered_datasets, & &1.custom_title) do %>
+        <div class="panel dataset__panel">
+          <div class="panel__content">
+            <div class="dataset__description">
+              <div class="dataset__image">
+                <%= img_tag(DB.Dataset.logo(dataset), alt: dataset.custom_title) %>
+              </div>
+              <div class="dataset__infos">
+                <h3 class="dataset__title">
+                  <a href={dataset_path(@socket, :details, dataset.slug)} target="_blank">
+                    <%= dataset.custom_title %>
+                  </a>
+                </h3>
+                <div class="dataset-localization">
+                  <i class="icon fa fa-map-marker-alt" /><%= DB.Dataset.get_territory_or_nil(dataset) %>
+                </div>
+              </div>
+            </div>
+            <div :if={not is_nil(icon_type_path(dataset))} class="dataset__type">
+              <%= img_tag(icon_type_path(dataset), alt: dataset.type) %>
+            </div>
+          </div>
+          <div class="panel__extra">
+            <div class="dataset__info">
+              <div class="shortlist__notices">
+                <dl class="dataset-format shortlist__notice">
+                  <%= unless dataset |> DB.Dataset.formats() |> Enum.empty?() do %>
+                    <dt class="shortlist__label"><%= dgettext("page-shortlist", "Format") %></dt>
+                    <%= for format <- DB.Dataset.formats(dataset) do %>
+                      <dd class="label"><%= format %></dd>
+                    <% end %>
+                  <% end %>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <script type="text/javascript" src={static_path(@socket, "/js/app.js")} />
+    <script nonce={@nonce}>
+      [form] = document.getElementsByClassName("search-followed-datasets");
+      form.onkeydown = function(event) {
+        if (event.key === "Enter") return false;
+      }
+    </script>
+    """
+  end
+
+  @impl true
+  def mount(
+        _params,
+        %{"dataset_ids" => dataset_ids, "locale" => locale, "csp_nonce_value" => nonce},
+        %Phoenix.LiveView.Socket{} = socket
+      ) do
+    Gettext.put_locale(locale)
+
+    datasets =
+      DB.Dataset.base_query()
+      |> preload([:region, :aom, :communes, :resources])
+      |> where([dataset: d], d.id in ^dataset_ids)
+      |> DB.Repo.all()
+
+    socket =
+      assign(socket, %{
+        nonce: nonce,
+        datasets: datasets,
+        filtered_datasets: datasets,
+        select_options: select_options(datasets),
+        search: "",
+        type: ""
+      })
+
+    {:ok, socket}
+  end
+
+  defp select_options(datasets) do
+    datasets
+    |> Enum.map(fn %DB.Dataset{type: type} -> type end)
+    |> Enum.uniq()
+    |> Enum.map(fn type -> {DB.Dataset.type_to_str(type), type} end)
+    |> Enum.sort_by(fn {friendly_type, _} -> friendly_type end)
+  end
+
+  @impl true
+  def handle_event("change", params, %Phoenix.LiveView.Socket{} = socket) do
+    {:noreply, filter_datasets(socket, params)}
+  end
+
+  def filter_datasets(%Phoenix.LiveView.Socket{assigns: %{datasets: datasets}} = socket, %{
+        "search" => search,
+        "type" => type
+      }) do
+    filtered_datasets = datasets |> filter_by_type(type) |> filter_by_search(search)
+
+    socket |> assign(%{filtered_datasets: filtered_datasets, search: search, type: type})
+  end
+
+  defp filter_by_type(datasets, ""), do: datasets
+
+  defp filter_by_type(datasets, value),
+    do: Enum.filter(datasets, fn %DB.Dataset{type: type} -> type == value end)
+
+  defp filter_by_search(datasets, ""), do: datasets
+
+  defp filter_by_search(datasets, value) do
+    Enum.filter(datasets, fn %DB.Dataset{custom_title: custom_title} ->
+      String.contains?(normalize(custom_title), normalize(value))
+    end)
+  end
+
+  @doc """
+  iex> normalize("Paris")
+  "paris"
+  iex> normalize("vélo")
+  "velo"
+  iex> normalize("Châteauroux")
+  "chateauroux"
+  """
+  def normalize(value) do
+    value |> String.normalize(:nfd) |> String.replace(~r/[^A-z]/u, "") |> String.downcase()
+  end
+end

--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -14,6 +14,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
     conn
     # used by the phoenix LivedDashboard to allow secure inlined CSS
     |> Plug.Conn.assign(:csp_nonce_value, nonce)
+    |> Plug.Conn.put_session(:csp_nonce_value, nonce)
     |> Phoenix.Controller.put_secure_browser_headers(csp_headers)
   end
 

--- a/apps/transport/lib/transport_web/templates/reuser_space/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/index.html.heex
@@ -1,0 +1,45 @@
+<div class="container pt-48 pb-24">
+  <%= breadcrumbs([@conn, :reuser_space]) %>
+</div>
+<section class="section section-grey reuser-space">
+  <div class="container">
+    <h1><%= dgettext("reuser-space", "Reuser space") %></h1>
+    <h2><%= dgettext("reuser-space", "Actions") %></h2>
+    <div class="row">
+      <div class="panel action-panel">
+        <img
+          class="picto"
+          src={static_path(@conn, "/images/producteurs/picto-bell.svg")}
+          alt={dgettext("reuser-space", "Notification bell")}
+        />
+        <div>
+          <div class="publish-header">
+            <h4><%= dgettext("reuser-space", "Receive notifications") %></h4>
+          </div>
+          <div class="pt-12">
+            <%= dgettext(
+              "reuser-space",
+              "Receive helpful notifications about the data you follow."
+            ) %>
+          </div>
+          <div class="pt-12">
+            <a href="#" class="button">
+              <%= dgettext("reuser-space", "Manage notifications") %>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <h2 class="pt-48"><%= dgettext("reuser-space", "Followed datasets") %></h2>
+    <%= live_render(@conn, TransportWeb.Live.FollowedDatasetsLive, session: %{"dataset_ids" => @followed_datasets_ids}) %>
+  </div>
+</section>
+<div class="tramway">
+  <img src={static_path(@conn, "/images/producteurs/tramway.svg")} alt="" />
+</div>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "reuser-space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -14,6 +14,10 @@ defmodule TransportWeb.BreadCrumbs do
     [{dgettext("espace-producteurs", "Your producer space"), page_path(conn, :espace_producteur)}]
   end
 
+  def crumbs(conn, :reuser_space) do
+    [{dgettext("reuser-space", "Reuser space"), reuser_space_path(conn, :espace_reutilisateur)}]
+  end
+
   def crumbs(conn, :new_resource) do
     crumbs(conn, :espace_producteur) ++
       [

--- a/apps/transport/lib/transport_web/views/input_helpers.ex
+++ b/apps/transport/lib/transport_web/views/input_helpers.ex
@@ -65,6 +65,7 @@ defmodule TransportWeb.InputHelpers do
   @spec search_input(Phoenix.HTML.Form.t(), atom() | binary(), Keyword.t()) :: any
   def search_input(form, field, opts \\ []) do
     icon = content_tag(:i, "", class: "fas icon--magnifier", id: "magnifier")
+    opts = Keyword.put(opts, :type, "search")
 
     form_group(
       content_tag(

--- a/apps/transport/lib/transport_web/views/reuser_space_view.ex
+++ b/apps/transport/lib/transport_web/views/reuser_space_view.ex
@@ -1,0 +1,4 @@
+defmodule TransportWeb.ReuserSpaceView do
+  use TransportWeb, :view
+  import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
+end

--- a/apps/transport/lib/transport_web/views/seo_metadata.ex
+++ b/apps/transport/lib/transport_web/views/seo_metadata.ex
@@ -72,6 +72,11 @@ defmodule TransportWeb.SeoMetadata do
       title: dgettext("seo", "Climate and Resilience bill: compulsory data reuse")
     }
 
+  def metadata(TransportWeb.ReuserSpaceView, _),
+    do: %{
+      title: dgettext("seo", "Reuser space")
+    }
+
   def metadata(_, %{live_module: TransportWeb.Live.OnDemandValidationSelectLive}),
     do: %{
       title: dgettext("seo", "Data quality evaluation")

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -1,0 +1,52 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data type"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification bell"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Receive helpful notifications about the data you follow."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Receive notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Followed datasets"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/seo.po
@@ -58,3 +58,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Climate and Resilience bill: compulsory data reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -29,7 +29,7 @@ msgstr "Pas de résultats"
 
 #, elixir-autogen, elixir-format
 msgid "Notification bell"
-msgstr "Icone de notifications"
+msgstr "Icône de notifications"
 
 #, elixir-autogen, elixir-format
 msgid "Receive helpful notifications about the data you follow."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -1,0 +1,52 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n>1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr "Tout"
+
+#, elixir-autogen, elixir-format
+msgid "Data type"
+msgstr "Type de données"
+
+#, elixir-autogen, elixir-format
+msgid "Manage notifications"
+msgstr "Gérer vos notifications"
+
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr "Pas de résultats"
+
+#, elixir-autogen, elixir-format
+msgid "Notification bell"
+msgstr "Icone de notifications"
+
+#, elixir-autogen, elixir-format
+msgid "Receive helpful notifications about the data you follow."
+msgstr "Recevez des notifications pertinentes à propos des données que vous suivez."
+
+#, elixir-autogen, elixir-format
+msgid "Receive notifications"
+msgstr "Recevoir des notifications"
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr "Espace réutilisateur"
+
+#, elixir-autogen, elixir-format
+msgid "Followed datasets"
+msgstr "Jeux de données suivis"
+
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr "Actions"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/seo.po
@@ -58,3 +58,8 @@ msgstr "État de l’ouverture des données de transport en France"
 #, elixir-autogen, elixir-format
 msgid "Climate and Resilience bill: compulsory data reuse"
 msgstr "Loi climat et résilience : obligation d'intégration de données"
+
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr "Espace réutilisateur"

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -1,0 +1,52 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data type"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Notification bell"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Receive helpful notifications about the data you follow."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Receive notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Followed datasets"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""

--- a/apps/transport/priv/gettext/seo.pot
+++ b/apps/transport/priv/gettext/seo.pot
@@ -57,3 +57,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Climate and Resilience bill: compulsory data reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -1,7 +1,21 @@
 defmodule TransportWeb.ReuserSpaceControllerTest do
   use TransportWeb.ConnCase, async: true
+  import DB.Factory
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
 
   test "espace_reutilisateur", %{conn: conn} do
-    assert conn |> get(reuser_space_path(conn, :espace_reutilisateur)) |> text_response(200)
+    contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+    content =
+      conn
+      |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+      |> get(reuser_space_path(conn, :espace_reutilisateur))
+      |> html_response(200)
+
+    # Feedback form is displayed
+    refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
   end
 end

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -28,7 +28,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
           "dataset_datagouv_id" => datagouv_id,
           "current_user" => %{"email" => "fc@tdg.fr"},
           "dataset" => dataset,
-          "locale" => "fr"
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -69,7 +70,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
                  "dataset_datagouv_id" => datagouv_id,
                  "current_user" => %{"email" => "fc@tdg.fr"},
                  "dataset" => dataset,
-                 "locale" => "fr"
+                 "locale" => "fr",
+                 "csp_nonce_value" => Ecto.UUID.generate()
                }
              )
 
@@ -90,7 +92,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
           "dataset_datagouv_id" => datagouv_id,
           "current_user" => %{"email" => "fc@tdg.fr"},
           "dataset" => dataset,
-          "locale" => "fr"
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -116,7 +119,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
           "dataset_datagouv_id" => datagouv_id,
           "current_user" => %{"email" => "fc@tdg.fr"},
           "dataset" => dataset,
-          "locale" => "fr"
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -132,7 +136,8 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
           "dataset_datagouv_id" => datagouv_id,
           "current_user" => %{"email" => "fc@tdg.fr", "id" => user_id},
           "dataset" => dataset,
-          "locale" => "fr"
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 

--- a/apps/transport/test/transport_web/live_views/feedback_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/feedback_live_test.exs
@@ -12,7 +12,7 @@ defmodule TransportWeb.FeedbackLiveTest do
   test "Render the feedback component", %{conn: conn} do
     {:ok, _view, html} =
       live_isolated(conn, TransportWeb.Live.FeedbackLive,
-        session: %{"feature" => "on-demand-validation", "locale" => "fr"}
+        session: %{"feature" => "on-demand-validation", "locale" => "fr", "csp_nonce_value" => Ecto.UUID.generate()}
       )
 
     assert html =~ "Qu’avez-vous pensé de cette page ?"
@@ -21,7 +21,7 @@ defmodule TransportWeb.FeedbackLiveTest do
   test "Post feedback form with honey pot filled", %{conn: conn} do
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.Live.FeedbackLive,
-        session: %{"feature" => "on-demand-validation", "locale" => "fr"}
+        session: %{"feature" => "on-demand-validation", "locale" => "fr", "csp_nonce_value" => Ecto.UUID.generate()}
       )
 
     view
@@ -36,7 +36,7 @@ defmodule TransportWeb.FeedbackLiveTest do
   test "Post feedback form without honey pot", %{conn: conn} do
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.Live.FeedbackLive,
-        session: %{"feature" => "on-demand-validation", "locale" => "fr"}
+        session: %{"feature" => "on-demand-validation", "locale" => "fr", "csp_nonce_value" => Ecto.UUID.generate()}
       )
 
     view
@@ -66,7 +66,7 @@ defmodule TransportWeb.FeedbackLiveTest do
   test "Post invalid parameters in feedback form and check it doesn’t crash", %{conn: conn} do
     {:ok, view, _html} =
       live_isolated(conn, TransportWeb.Live.FeedbackLive,
-        session: %{"feature" => "on-demand-validation", "locale" => "fr"}
+        session: %{"feature" => "on-demand-validation", "locale" => "fr", "csp_nonce_value" => Ecto.UUID.generate()}
       )
 
     {view, logs} =

--- a/apps/transport/test/transport_web/live_views/follow_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/follow_dataset_live_test.exs
@@ -1,4 +1,4 @@
-defmodule Transport.TransportWeb.FollowDatasetLiveTest do
+defmodule TransportWeb.Live.FollowDatasetLiveTest do
   use TransportWeb.ConnCase, async: true
   use Oban.Testing, repo: DB.Repo
   import Phoenix.LiveViewTest

--- a/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
@@ -1,0 +1,84 @@
+defmodule TransportWeb.Live.FollowedDatasetsLiveTest do
+  use TransportWeb.ConnCase, async: true
+  use Oban.Testing, repo: DB.Repo
+  import Phoenix.LiveViewTest
+  import DB.Factory
+
+  doctest TransportWeb.Live.FollowedDatasetsLive, import: true
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "can filter datasets", %{conn: conn} do
+    dijon_pt = insert(:dataset, type: "public-transit", custom_title: "Divia")
+    dijon_vls = insert(:dataset, type: "bike-scooter-sharing", custom_title: "DiviaVélo")
+
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.Live.FollowedDatasetsLive,
+        session: %{
+          "dataset_ids" => [dijon_pt.id, dijon_vls.id],
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
+        }
+      )
+
+    assert [
+             {"select", [{"id", "type"}, {"name", "type"}],
+              [
+                {"option", [{"selected", "selected"}, {"value", ""}], ["Tout"]},
+                {"option", [{"value", "public-transit"}], ["Transport public collectif - horaires théoriques"]},
+                {"option", [{"value", "bike-scooter-sharing"}], ["Vélos et trottinettes en libre-service"]}
+              ]}
+           ] == view |> element("form select") |> render() |> Floki.parse_document!()
+
+    refute has_element?(view, ".notification")
+
+    assert ["Divia", "DiviaVélo"] == dataset_titles(view)
+
+    form = view |> element("form")
+
+    assert ["DiviaVélo"] == form |> search_by_value("velo") |> dataset_titles()
+    assert ["DiviaVélo"] == form |> search_by_type("bike-scooter-sharing") |> dataset_titles()
+    # Search "velo" + "public-transit" = no results
+    assert [] == form |> search_by_type("public-transit") |> dataset_titles()
+    assert has_element?(view, ".notification", "Pas de résultats")
+
+    # Resetting the search value, only public-transit filter
+    assert ["Divia"] == form |> search_by_value("") |> dataset_titles()
+    # Resetting the type filter
+    assert ["Divia", "DiviaVélo"] == form |> search_by_type("") |> dataset_titles()
+  end
+
+  test "does not display select by data type when there is a single type", %{conn: conn} do
+    dijon_pt = insert(:dataset, type: "public-transit", custom_title: "Divia")
+
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.Live.FollowedDatasetsLive,
+        session: %{
+          "dataset_ids" => [dijon_pt.id],
+          "locale" => "fr",
+          "csp_nonce_value" => Ecto.UUID.generate()
+        }
+      )
+
+    refute has_element?(view, "form select")
+  end
+
+  defp search_by_value(%Phoenix.LiveViewTest.Element{} = el, value) do
+    render_change(el, %{_target: ["search"], search: value})
+  end
+
+  defp search_by_type(%Phoenix.LiveViewTest.Element{} = el, value) do
+    render_change(el, %{_target: ["type"], type: value})
+  end
+
+  defp dataset_titles(%Phoenix.LiveViewTest.View{} = view), do: view |> render() |> dataset_titles()
+
+  defp dataset_titles(content) when is_binary(content) do
+    content
+    |> Floki.parse_document!()
+    |> Floki.find(".dataset__title")
+    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+  end
+end


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/3803

Réalise une première page d'accueil de l'espace réutilisateur affichant les actions disponibles ("Gérer ses notifications" uniquement pour le moment) et une liste des jeux de données favoris.

Cette PR ajoute un squelette de page et un module permettant d'afficher les JDDs suivis et de les filtrer pour y accéder rapidement.

L'espace réutilisateur reste "caché" et inaccessible par le grand public, la possibilité d'ajouter un JDD en favori étant réservée aux admins pour le moment.

## À venir

L'accueil de l'espace réutilisateur ne sera pas terminé et rendu disponible après cette PR. Les éléments à venir seront :

- un travail sur le texte
- ajout de contenu explicatif et gestion des _empty states_ en lien avec @cyrilmorin 
- adaptation du module de gestion des notifications pour gérer le rôle de producteur et réutilisateur 🆕 

## Démo

https://github.com/etalab/transport-site/assets/295709/75a18653-9ab8-4d1d-bfb3-03fe50fd2933

