### PR TITLE
Fixer un msgid mal renommé

### DIFF
--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -418,5 +418,5 @@ msgid "number of stop points:"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The GTFS file %{gtfs_original_file_name_2} has differences with the GTFS file {gtfs_original_file_name_1}, as summarized below:"
+msgid "The GTFS file %{gtfs_original_file_name_2} has differences with the GTFS file %{gtfs_original_file_name_1}, as summarized below:"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -418,5 +418,5 @@ msgid "number of stop points:"
 msgstr "nombre d'arrêts :"
 
 #, elixir-autogen, elixir-format
-msgid "The GTFS file %{gtfs_original_file_name_2} has differences with the GTFS file {gtfs_original_file_name_1}, as summarized below:"
+msgid "The GTFS file %{gtfs_original_file_name_2} has differences with the GTFS file %{gtfs_original_file_name_1}, as summarized below:"
 msgstr "Le fichier GTFS %{gtfs_original_file_name_2} comporte les différences ci-dessous par rapport au fichier GTFS %{gtfs_original_file_name_1} :"


### PR DESCRIPTION
Etrangement, ça fonctionne aussi bien avant qu'après.