### PR TITLE
FollowedDatasetsLive : recherche quand 1 JDD suivi

### DIFF
--- a/apps/transport/lib/transport_web/live/followed_datasets_live.ex
+++ b/apps/transport/lib/transport_web/live/followed_datasets_live.ex
@@ -117,10 +117,11 @@ defmodule TransportWeb.Live.FollowedDatasetsLive do
     {:noreply, filter_datasets(socket, params)}
   end
 
-  def filter_datasets(%Phoenix.LiveView.Socket{assigns: %{datasets: datasets}} = socket, %{
-        "search" => search,
-        "type" => type
-      }) do
+  def filter_datasets(
+        %Phoenix.LiveView.Socket{assigns: %{datasets: datasets}} = socket,
+        %{"search" => search} = params
+      ) do
+    type = Map.get(params, "type", "")
     filtered_datasets = datasets |> filter_by_type(type) |> filter_by_search(search)
 
     socket |> assign(%{filtered_datasets: filtered_datasets, search: search, type: type})

--- a/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
@@ -63,6 +63,16 @@ defmodule TransportWeb.Live.FollowedDatasetsLiveTest do
       )
 
     refute has_element?(view, "form select")
+
+    assert ["Divia"] == dataset_titles(view)
+
+    form = view |> element("form")
+
+    assert ["Divia"] == form |> search_by_value("via") |> dataset_titles()
+
+    # No results
+    assert [] == form |> search_by_value("nope") |> dataset_titles()
+    assert has_element?(view, ".notification", "Pas de résultats")
   end
 
   defp search_by_value(%Phoenix.LiveViewTest.Element{} = el, value) do


### PR DESCRIPTION
Suite de #3878

Vérifie qu'il est possible de chercher un JDD quand on a une seule catégorie de JDD dans les favoris et que le `select` par type de données est absent.

Le pattern match [était trop contraignant](https://transport-data-gouv-fr.sentry.io/share/issue/5f999be1f4164deb972a3a3449adcdf8/) 🐛.