### PR TITLE
Espace réutilisateur : middleware auth

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -95,6 +95,7 @@ defmodule TransportWeb.Router do
     end
 
     scope "/espace_reutilisateur" do
+      pipe_through([:authenticated])
       get("/", ReuserSpaceController, :espace_reutilisateur)
 
       live_session :reuser_space, session: %{"role" => :reuser}, root_layout: {TransportWeb.LayoutView, :app} do

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -2,20 +2,30 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
   use TransportWeb.ConnCase, async: true
   import DB.Factory
 
+  @home_url reuser_space_path(TransportWeb.Endpoint, :espace_reutilisateur)
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "espace_reutilisateur", %{conn: conn} do
-    contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+  describe "espace_reutilisateur" do
+    test "logged out", %{conn: conn} do
+      conn = conn |> get(@home_url)
+      assert "/login/explanation?" <> URI.encode_query(redirect_path: @home_url) == redirected_to(conn, 302)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+    end
 
-    content =
-      conn
-      |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
-      |> get(reuser_space_path(conn, :espace_reutilisateur))
-      |> html_response(200)
+    test "logged in", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
 
-    # Feedback form is displayed
-    refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
+      content =
+        conn
+        |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+        |> get(@home_url)
+        |> html_response(200)
+
+      # Feedback form is displayed
+      refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
+    end
   end
 end

--- a/apps/transport/test/transport_web/live_views/notifications_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/notifications_live_test.exs
@@ -16,7 +16,11 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
   end
 
   test "requires login", %{conn: conn} do
-    conn |> get(@producer_url) |> html_response(302)
+    Enum.each([@producer_url, @reuser_url], fn url ->
+      conn = conn |> get(url)
+      assert "/login/explanation?" <> URI.encode_query(redirect_path: url) == redirected_to(conn, 302)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+    end)
   end
 
   test "displays existing subscriptions for a producer", %{conn: conn} do
@@ -78,6 +82,15 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
         role: :reuser,
         source: :user
       )
+
+    # Unrelated (no dataset ID), should not be an issue
+    insert(:notification_subscription,
+      contact_id: contact_id,
+      dataset_id: nil,
+      reason: :daily_new_comments,
+      role: :reuser,
+      source: :user
+    )
 
     content =
       conn


### PR DESCRIPTION
Vérifie que la personne est connectée pour accéder à l'espace réutilisateur. Actuellement c'est un prérequis (on récupère un contact et les JDDs suivis), je pense qu'il faudra faire une version logged out afin de découvrir la fonctionnalité mais j'attends que @cyrilmorin (en congés) me partage des éléments d'UI/de contenu.