### PR TITLE
GBFS VLille : station_id doit être une string

### DIFF
--- a/apps/gbfs/lib/gbfs/controllers/vlille_controller.ex
+++ b/apps/gbfs/lib/gbfs/controllers/vlille_controller.ex
@@ -89,7 +89,7 @@ defmodule GBFS.VLilleController do
           is_open = r["etatconnexion"] == "CONNECTÉ"
 
           %{
-            station_id: r["libelle"],
+            station_id: to_string(r["libelle"]),
             num_bikes_available: r["nbvelosdispo"],
             num_docks_available: r["nbplacesdispo"],
             is_installed: is_open,
@@ -113,7 +113,7 @@ defmodule GBFS.VLilleController do
         |> Enum.filter(fn r -> r["etat"] == "EN SERVICE" end)
         |> Enum.map(fn r ->
           %{
-            station_id: r["libelle"],
+            station_id: to_string(r["libelle"]),
             name: r["nom"],
             lat: r["localisation"]["lat"],
             lon: r["localisation"]["lon"],

--- a/apps/gbfs/test/gbfs/controllers/vlille_controller_test.exs
+++ b/apps/gbfs/test/gbfs/controllers/vlille_controller_test.exs
@@ -35,7 +35,7 @@ defmodule GBFS.VlilleControllerTest do
                      "lat" => 50.689762,
                      "lon" => 3.177179,
                      "name" => "MOTTE BOSSUT",
-                     "station_id" => 231
+                     "station_id" => "231"
                    }
                  ]
                },
@@ -61,7 +61,7 @@ defmodule GBFS.VlilleControllerTest do
                      "last_reported" => 1_669_715_236,
                      "num_bikes_available" => 0,
                      "num_docks_available" => 10,
-                     "station_id" => 231
+                     "station_id" => "231"
                    }
                  ]
                },


### PR DESCRIPTION
Suite de #3874

Le type de `station_id` a changé chez le producteur. La spec GBFS indique que l'identifiant doit être une string, ceci produit [des erreurs](https://gbfs-validator.netlify.app/validator?url=https%3A%2F%2Ftransport.data.gouv.fr%2Fgbfs%2Fvlille%2Fgbfs.json) dans notre flux converti où c'est indiqué en entier actuellement.