### PR TITLE
Mise à jour du fichier Protobuf

### DIFF
--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
@@ -1,6 +1,7 @@
 defmodule TransitRealtime.FeedHeader.Incrementality do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:FULL_DATASET, 0)
   field(:DIFFERENTIAL, 1)
@@ -8,7 +9,8 @@ end
 
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:SKIPPED, 1)
@@ -18,7 +20,8 @@ end
 
 defmodule TransitRealtime.VehiclePosition.VehicleStopStatus do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:INCOMING_AT, 0)
   field(:STOPPED_AT, 1)
@@ -27,7 +30,8 @@ end
 
 defmodule TransitRealtime.VehiclePosition.CongestionLevel do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:UNKNOWN_CONGESTION_LEVEL, 0)
   field(:RUNNING_SMOOTHLY, 1)
@@ -38,7 +42,8 @@ end
 
 defmodule TransitRealtime.VehiclePosition.OccupancyStatus do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:EMPTY, 0)
   field(:MANY_SEATS_AVAILABLE, 1)
@@ -53,7 +58,8 @@ end
 
 defmodule TransitRealtime.Alert.Cause do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:UNKNOWN_CAUSE, 1)
   field(:OTHER_CAUSE, 2)
@@ -71,7 +77,8 @@ end
 
 defmodule TransitRealtime.Alert.Effect do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:NO_SERVICE, 1)
   field(:REDUCED_SERVICE, 2)
@@ -88,7 +95,8 @@ end
 
 defmodule TransitRealtime.Alert.SeverityLevel do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:UNKNOWN_SEVERITY, 1)
   field(:INFO, 2)
@@ -98,7 +106,8 @@ end
 
 defmodule TransitRealtime.TripDescriptor.ScheduleRelationship do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:ADDED, 1)
@@ -111,7 +120,8 @@ end
 
 defmodule TransitRealtime.VehicleDescriptor.WheelchairAccessible do
   @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:NO_VALUE, 0)
   field(:UNKNOWN, 1)
@@ -119,9 +129,20 @@ defmodule TransitRealtime.VehicleDescriptor.WheelchairAccessible do
   field(:WHEELCHAIR_INACCESSIBLE, 3)
 end
 
+defmodule TransitRealtime.Stop.WheelchairBoarding do
+  @moduledoc false
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:UNKNOWN, 0)
+  field(:AVAILABLE, 1)
+  field(:NOT_AVAILABLE, 2)
+end
+
 defmodule TransitRealtime.FeedMessage do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:header, 1, required: true, type: TransitRealtime.FeedHeader)
   field(:entity, 2, repeated: true, type: TransitRealtime.FeedEntity)
@@ -131,7 +152,8 @@ end
 
 defmodule TransitRealtime.FeedHeader do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:gtfs_realtime_version, 1, required: true, type: :string)
 
@@ -149,7 +171,8 @@ end
 
 defmodule TransitRealtime.FeedEntity do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:id, 1, required: true, type: :string)
   field(:is_deleted, 2, optional: true, type: :bool, default: false)
@@ -157,13 +180,16 @@ defmodule TransitRealtime.FeedEntity do
   field(:vehicle, 4, optional: true, type: TransitRealtime.VehiclePosition)
   field(:alert, 5, optional: true, type: TransitRealtime.Alert)
   field(:shape, 6, optional: true, type: TransitRealtime.Shape)
+  field(:stop, 7, optional: true, type: TransitRealtime.Stop)
+  field(:trip_modifications, 8, optional: true, type: TransitRealtime.TripModifications)
 
   extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.TripUpdate.StopTimeEvent do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:delay, 1, optional: true, type: :int32)
   field(:time, 2, optional: true, type: :int64)
@@ -174,7 +200,8 @@ end
 
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:assigned_stop_id, 1, optional: true, type: :string)
 
@@ -183,7 +210,8 @@ end
 
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32)
   field(:stop_id, 4, optional: true, type: :string)
@@ -213,7 +241,8 @@ end
 
 defmodule TransitRealtime.TripUpdate.TripProperties do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string)
   field(:start_date, 2, optional: true, type: :string)
@@ -225,7 +254,8 @@ end
 
 defmodule TransitRealtime.TripUpdate do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:trip, 1, required: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 3, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -239,7 +269,8 @@ end
 
 defmodule TransitRealtime.VehiclePosition.CarriageDetails do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -259,7 +290,8 @@ end
 
 defmodule TransitRealtime.VehiclePosition do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:trip, 1, optional: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 8, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -300,7 +332,8 @@ end
 
 defmodule TransitRealtime.Alert do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:active_period, 1, repeated: true, type: TransitRealtime.TimeRange)
   field(:informed_entity, 5, repeated: true, type: TransitRealtime.EntitySelector)
@@ -342,7 +375,8 @@ end
 
 defmodule TransitRealtime.TimeRange do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:start, 1, optional: true, type: :uint64)
   field(:end, 2, optional: true, type: :uint64)
@@ -352,7 +386,8 @@ end
 
 defmodule TransitRealtime.Position do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:latitude, 1, required: true, type: :float)
   field(:longitude, 2, required: true, type: :float)
@@ -363,9 +398,19 @@ defmodule TransitRealtime.Position do
   extensions([{1000, 2000}, {9000, 10000}])
 end
 
+defmodule TransitRealtime.TripDescriptor.ModifiedTripSelector do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:modifications_id, 1, optional: true, type: :string)
+  field(:affected_trip_id, 2, optional: true, type: :string)
+end
+
 defmodule TransitRealtime.TripDescriptor do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string)
   field(:route_id, 5, optional: true, type: :string)
@@ -379,12 +424,18 @@ defmodule TransitRealtime.TripDescriptor do
     enum: true
   )
 
+  field(:modified_trip, 7,
+    optional: true,
+    type: TransitRealtime.TripDescriptor.ModifiedTripSelector
+  )
+
   extensions([{1000, 2000}, {9000, 10000}])
 end
 
 defmodule TransitRealtime.VehicleDescriptor do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -402,7 +453,8 @@ end
 
 defmodule TransitRealtime.EntitySelector do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:agency_id, 1, optional: true, type: :string)
   field(:route_id, 2, optional: true, type: :string)
@@ -416,7 +468,8 @@ end
 
 defmodule TransitRealtime.TranslatedString.Translation do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:text, 1, required: true, type: :string)
   field(:language, 2, optional: true, type: :string)
@@ -426,7 +479,8 @@ end
 
 defmodule TransitRealtime.TranslatedString do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:translation, 1, repeated: true, type: TransitRealtime.TranslatedString.Translation)
 
@@ -435,7 +489,8 @@ end
 
 defmodule TransitRealtime.TranslatedImage.LocalizedImage do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:url, 1, required: true, type: :string)
   field(:media_type, 2, required: true, type: :string)
@@ -446,7 +501,8 @@ end
 
 defmodule TransitRealtime.TranslatedImage do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:localized_image, 1, repeated: true, type: TransitRealtime.TranslatedImage.LocalizedImage)
 
@@ -455,10 +511,102 @@ end
 
 defmodule TransitRealtime.Shape do
   @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
 
   field(:shape_id, 1, optional: true, type: :string)
   field(:encoded_polyline, 2, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.Stop do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:stop_id, 1, optional: true, type: :string)
+  field(:stop_code, 2, optional: true, type: TransitRealtime.TranslatedString)
+  field(:stop_name, 3, optional: true, type: TransitRealtime.TranslatedString)
+  field(:tts_stop_name, 4, optional: true, type: TransitRealtime.TranslatedString)
+  field(:stop_desc, 5, optional: true, type: TransitRealtime.TranslatedString)
+  field(:stop_lat, 6, optional: true, type: :float)
+  field(:stop_lon, 7, optional: true, type: :float)
+  field(:zone_id, 8, optional: true, type: :string)
+  field(:stop_url, 9, optional: true, type: TransitRealtime.TranslatedString)
+  field(:parent_station, 11, optional: true, type: :string)
+  field(:stop_timezone, 12, optional: true, type: :string)
+
+  field(:wheelchair_boarding, 13,
+    optional: true,
+    type: TransitRealtime.Stop.WheelchairBoarding,
+    default: :UNKNOWN,
+    enum: true
+  )
+
+  field(:level_id, 14, optional: true, type: :string)
+  field(:platform_code, 15, optional: true, type: TransitRealtime.TranslatedString)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TripModifications.Modification do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:start_stop_selector, 1, optional: true, type: TransitRealtime.StopSelector)
+  field(:end_stop_selector, 2, optional: true, type: TransitRealtime.StopSelector)
+  field(:propagated_modification_delay, 3, optional: true, type: :int32, default: 0)
+  field(:replacement_stops, 4, repeated: true, type: TransitRealtime.ReplacementStop)
+  field(:service_alert_id, 5, optional: true, type: :string)
+  field(:last_modified_time, 6, optional: true, type: :uint64)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TripModifications.SelectedTrips do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:trip_ids, 1, repeated: true, type: :string)
+  field(:shape_id, 2, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.TripModifications do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:selected_trips, 1, repeated: true, type: TransitRealtime.TripModifications.SelectedTrips)
+  field(:start_times, 2, repeated: true, type: :string)
+  field(:service_dates, 3, repeated: true, type: :string)
+  field(:modifications, 4, repeated: true, type: TransitRealtime.TripModifications.Modification)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.StopSelector do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:stop_sequence, 1, optional: true, type: :uint32)
+  field(:stop_id, 2, optional: true, type: :string)
+
+  extensions([{1000, 2000}, {9000, 10000}])
+end
+
+defmodule TransitRealtime.ReplacementStop do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  field(:travel_time_to_stop, 1, optional: true, type: :int32)
+  field(:stop_id, 2, optional: true, type: :string)
 
   extensions([{1000, 2000}, {9000, 10000}])
 end

--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
@@ -106,6 +106,8 @@ message FeedEntity {
 
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional Shape shape = 6;
+  optional Stop stop = 7;
+  optional TripModifications trip_modifications = 8;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
@@ -840,6 +842,15 @@ message TripDescriptor {
   }
   optional ScheduleRelationship schedule_relationship = 4;
 
+  message ModifiedTripSelector {
+    // The 'id' from the FeedEntity in which the contained TripModifications object affects this trip.
+    optional string modifications_id = 1;
+
+    // The trip_id from the GTFS feed that is modified by the modifications_id
+    optional string affected_trip_id = 2;
+  }
+  optional ModifiedTripSelector modified_trip = 7;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
@@ -1024,6 +1035,151 @@ message Shape {
   // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional string encoded_polyline = 2;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// Describes a stop which is served by trips. All fields are as described in the GTFS-Static specification.
+// NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+message Stop {
+  enum WheelchairBoarding {
+    UNKNOWN = 0;
+    AVAILABLE = 1;
+    NOT_AVAILABLE = 2;
+   }
+
+  optional string stop_id = 1;
+  optional TranslatedString stop_code = 2;
+  optional TranslatedString stop_name = 3;
+  optional TranslatedString tts_stop_name = 4;
+  optional TranslatedString stop_desc = 5;
+  optional float stop_lat = 6;
+  optional float stop_lon = 7;
+  optional string zone_id = 8;
+  optional TranslatedString stop_url = 9;
+  optional string parent_station = 11;
+  optional string stop_timezone = 12;
+  optional WheelchairBoarding wheelchair_boarding = 13 [default = UNKNOWN];
+  optional string level_id = 14;
+  optional TranslatedString platform_code = 15;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+message TripModifications {
+  // A `Modification` message replaces a span of n stop times from each affected trip starting at `start_stop_selector`.
+  message Modification {
+    // The stop selector of the first stop_time of the original trip that is to be affected by this modification.
+    // Used in conjuction with `end_stop_selector`.
+    // `start_stop_selector` is required and is used to define the reference stop used with `travel_time_to_stop`.
+    optional StopSelector start_stop_selector = 1;
+
+    // The stop selector of the last stop of the original trip that is to be affected by this modification.
+    // The selection is inclusive, so if only one stop_time is replaced by that modification, `start_stop_selector` and `end_stop_selector` must be equivalent.
+    // If no stop_time is replaced, `end_stop_selector` must not be provided. It's otherwise required.
+    optional StopSelector end_stop_selector = 2;
+
+    // The number of seconds of delay to add to all departure and arrival times following the end of this modification.
+    // If multiple modifications apply to the same trip, the delays accumulate as the trip advances.
+    optional int32 propagated_modification_delay = 3 [default = 0];
+
+    // A list of replacement stops, replacing those of the original trip.
+    // The length of the new stop times may be less, the same, or greater than the number of replaced stop times.
+    repeated ReplacementStop replacement_stops = 4;
+
+    // An `id` value from the `FeedEntity` message that contains the `Alert` describing this Modification for user-facing communication.
+    optional string service_alert_id = 5;
+
+    // This timestamp identifies the moment when the modification has last been changed.
+    // In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
+    optional uint64 last_modified_time = 6;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+
+  message SelectedTrips {
+    // A list of trips affected with this replacement that all have the same new `shape_id`.
+    repeated string trip_ids = 1;
+    // The ID of the new shape for the modified trips in this SelectedTrips.
+    // May refer to a new shape added using a GTFS-RT Shape message, or to an existing shape defined in the GTFS-Static feed’s shapes.txt.
+    optional string shape_id = 2;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+}
+
+   // A list of selected trips affected by this TripModifications.
+  repeated SelectedTrips selected_trips = 1;
+
+  // A list of start times in the real-time trip descriptor for the trip_id defined in trip_ids.
+  // Useful to target multiple departures of a trip_id in a frequency-based trip.
+  repeated string start_times = 2;
+
+  // Dates on which the modifications occurs, in the YYYYMMDD format. Producers SHOULD only transmit detours occurring within the next week.
+  // The dates provided should not be used as user-facing information, if a user-facing start and end date needs to be provided, they can be provided in the linked service alert with `service_alert_id`
+  repeated string service_dates = 3;
+
+  // A list of modifications to apply to the affected trips.
+  repeated Modification modifications = 4;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+// Select a stop by stop sequence or by stop_id. At least one of the two values must be provided.
+message StopSelector {
+  // Must be the same as in stop_times.txt in the corresponding GTFS feed.
+  optional uint32 stop_sequence = 1;
+  // Must be the same as in stops.txt in the corresponding GTFS feed.
+  optional string stop_id = 2;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+message ReplacementStop {
+  // The difference in seconds between the arrival time at this stop and the arrival time at the reference stop. The reference stop is the stop prior to start_stop_selector. If the modification begins at the first stop of the trip, then the first stop of the trip is the reference stop.
+  // This value MUST be monotonically increasing and may only be a negative number if the first stop of the original trip is the reference stop.
+  optional int32 travel_time_to_stop = 1;
+
+  // The replacement stop ID which will now be visited by the trip. May refer to a new stop added using a GTFS-RT Stop message, or to an existing stop defined in the GTFS-Static feed’s stops.txt. The stop MUST have location_type=0 (routable stops).
+  optional string stop_id = 2;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/apps/transport/lib/transport/protobuf/readme.md
+++ b/apps/transport/lib/transport/protobuf/readme.md
@@ -1,14 +1,14 @@
-`gtfs-realtime.pb.ex` is the compiled result of `gtfs-realtime.proto` via the elixir protobuf compiler plugin.
+`gtfs-realtime.pb.ex` is the compiled result of `gtfs-realtime.proto` via the Elixir protobuf compiler plugin.
 
 Do not edit it by hand please!
 
-### How to regenerate the files
+## How to regenerate the files
 
-* [gtfs-realtime.proto source](https://developers.google.com/transit/gtfs-realtime/gtfs-realtime-proto)
+* [gtfs-realtime.proto source](https://raw.githubusercontent.com/google/transit/master/gtfs-realtime/proto/gtfs-realtime.proto)
 
 On Mac:
 
-```
+```sh
 brew install protobuf
 mix escript.install hex protobuf
 asdf reshim elixir
@@ -16,6 +16,6 @@ asdf reshim elixir
 
 Then:
 
-```
+```sh
 protoc --elixir_out=. gtfs-realtime.proto
 ```

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -50,19 +50,3 @@ msgstr "Jeux de données suivis"
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Actions"
-
-#, elixir-autogen, elixir-format
-msgid "data expiration notification explanation"
-msgstr "Vous êtes alerté à l'approche de la date de fin du calendrier de fonctionnement."
-
-#, elixir-autogen, elixir-format
-msgid "unavailable resources notification explanation"
-msgstr "Vous êtes alerté au bout de 6h consécutives pendant lesquelles une ressource ne peut pas être téléchargée."
-
-#, elixir-autogen, elixir-format
-msgid "validation errors notification explanation"
-msgstr "Vous êtes alerté lorsqu'une ressource ne respecte pas les spécifications des normes/standards/schémas correspondants."
-
-#, elixir-autogen, elixir-format
-msgid "resources changed notification explanation"
-msgstr "Vous êtes alerté lorsque des ressources sont ajoutées, supprimées ou que l'URL est modifiée."


### PR DESCRIPTION
Fixes #3888

Mise à jour du fichier .proto avec la dernière version sur [google/transit](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto) et regénération du fichier Elixir en suivant le README.