### PR TITLE
Espace réutilisateur : inscription aux notifications générales

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -101,6 +101,21 @@ defmodule DB.NotificationSubscription do
   @spec platform_wide_reasons :: [reason()]
   def platform_wide_reasons, do: @platform_wide_reasons
 
+  @doc """
+  iex> platform_wide_reasons(:reuser) != platform_wide_reasons(:producer)
+  true
+  iex> platform_wide_reasons(:producer)
+  []
+  iex> platform_wide_reasons(:reuser)
+  [:new_dataset, :daily_new_comments]
+  """
+  @spec platform_wide_reasons(role()) :: [reason()]
+  def platform_wide_reasons(:reuser) do
+    Enum.reject(platform_wide_reasons(), &(&1 == reason(:datasets_switching_climate_resilience_bill)))
+  end
+
+  def platform_wide_reasons(:producer), do: []
+
   @spec possible_reasons :: [reason()]
   def possible_reasons, do: @all_reasons
 

--- a/apps/transport/lib/transport_web/live/notifications_live.html.heex
+++ b/apps/transport/lib/transport_web/live/notifications_live.html.heex
@@ -14,8 +14,9 @@ display_error = is_producer and not is_nil(@error) %>
     <h2><%= dgettext("espace-producteurs", "Manage my notifications") %></h2>
     <div :if={display_error} class="notification error"><%= @error %></div>
 
-    <div :if={is_producer} class="panel mb-24">
-      <p><%= dgettext("espace-producteurs", "notifications are good for you") %></p>
+    <div class="panel mb-24">
+      <p :if={is_producer}><%= dgettext("espace-producteurs", "notifications are good for you") %></p>
+      <p :if={is_reuser}><%= raw(dgettext("reuser-space", "notifications are good for you")) %></p>
     </div>
 
     <div class="row">

--- a/apps/transport/lib/transport_web/live/notifications_live.html.heex
+++ b/apps/transport/lib/transport_web/live/notifications_live.html.heex
@@ -1,4 +1,5 @@
 <% is_producer = @role == :producer
+is_reuser = not is_producer
 colspan = if is_producer, do: 3, else: 2
 breadcrumb = if is_producer, do: :espace_producteur_notifications, else: :reuser_space_notifications
 display_error = is_producer and not is_nil(@error) %>
@@ -29,7 +30,45 @@ display_error = is_producer and not is_nil(@error) %>
     </div>
 
     <div :if={!display_error} class="panel mt-24">
-      <table class="table">
+      <div :if={is_reuser} data-content="platform-wide-notifications">
+        <h3><%= dgettext("reuser-space", "Global notifications") %></h3>
+        <table class="table">
+          <.form :let={f} for={%{}}>
+            <%= for reason <- @platform_wide_reasons do %>
+              <% subscribed = reason in @subscribed_platform_wide_reasons %>
+              <tr>
+                <td><%= DB.NotificationSubscription.reason_to_str(reason) %></td>
+                <td>
+                  <div class="form__group">
+                    <fieldset>
+                      <span {if subscribed, do: [class: "is-grey"], else: []}>
+                        <%= dgettext("espace-producteurs", "Off") %>&nbsp;
+                      </span>
+                      <label class="switch">
+                        <%= checkbox(
+                          f,
+                          reason,
+                          checked: subscribed,
+                          phx_value_reason: reason,
+                          phx_value_action: if(subscribed, do: "turn_off", else: "turn_on"),
+                          phx_click: "toggle"
+                        ) %>
+                        <span class="slider"></span>
+                        <span {if not subscribed, do: [class: "is-grey"], else: []}>
+                          &nbsp;<%= dgettext("espace-producteurs", "On") %>
+                        </span>
+                      </label>
+                    </fieldset>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </.form>
+        </table>
+      </div>
+
+      <h3 :if={is_reuser}><%= dgettext("reuser-space", "Notifications by dataset") %></h3>
+      <table class="table" data-content="dataset-notifications">
         <.form :let={f} for={%{}}>
           <tr>
             <td><strong><%= dgettext("espace-producteurs", "All notifications") %></strong></td>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -56,6 +56,10 @@ msgid "data expiration notification explanation"
 msgstr "You are warned ahead of the last date covered by the data."
 
 #, elixir-autogen, elixir-format
+msgid "resources changed notification explanation"
+msgstr "You are warned if a resource is added, removed or if its URL changed."
+
+#, elixir-autogen, elixir-format
 msgid "unavailable resources notification explanation"
 msgstr "You are warned if a resource couldn't be downloaded during 6 consecutive hours."
 
@@ -63,7 +67,10 @@ msgstr "You are warned if a resource couldn't be downloaded during 6 consecutive
 msgid "validation errors notification explanation"
 msgstr "You are warned if a resource doesn't respect the standard, rendering it unusable."
 
-#, elixir-autogen, elixir-format
-msgid "resources changed notification explanation"
-msgstr "You are warned if a resource is added, removed or if its URL changed."
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Global notifications"
+msgstr ""
 
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Notifications by dataset"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -67,10 +67,14 @@ msgstr "You are warned if a resource couldn't be downloaded during 6 consecutive
 msgid "validation errors notification explanation"
 msgstr "You are warned if a resource doesn't respect the standard, rendering it unusable."
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Global notifications"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Notifications by dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "notifications are good for you"
+msgstr "Email notifications alert you to quality or availability issues that could affect your reuse of transport data. To activate notifications for a dataset, first add it to your favorites (❤️ icon on the dataset page).<br/><br/>You can also follow the general activity of transport.data.gouv.fr through comments and new datasets."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -56,6 +56,10 @@ msgid "data expiration notification explanation"
 msgstr "Vous êtes alerté à l'approche de la date de fin du calendrier de fonctionnement."
 
 #, elixir-autogen, elixir-format
+msgid "resources changed notification explanation"
+msgstr "Vous êtes alerté lorsque des ressources sont ajoutées, supprimées ou que l'URL est modifiée."
+
+#, elixir-autogen, elixir-format
 msgid "unavailable resources notification explanation"
 msgstr "Vous êtes alerté au bout de 6h consécutives pendant lesquelles une ressource ne peut pas être téléchargée."
 
@@ -64,5 +68,9 @@ msgid "validation errors notification explanation"
 msgstr "Vous êtes alerté lorsqu'une ressource ne respecte pas les spécifications des normes/standards/schémas correspondants."
 
 #, elixir-autogen, elixir-format
-msgid "resources changed notification explanation"
-msgstr "Vous êtes alerté lorsque des ressources sont ajoutées, supprimées ou que l'URL est modifiée."
+msgid "Global notifications"
+msgstr "Notifications générales"
+
+#, elixir-autogen, elixir-format
+msgid "Notifications by dataset"
+msgstr "Notifications par jeu de données"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -53,11 +53,11 @@ msgstr "Actions"
 
 #, elixir-autogen, elixir-format
 msgid "data expiration notification explanation"
-msgstr "Vous êtes alerté à l'approche de la date de fin du calendrier de fonctionnement."
+msgstr "Vous êtes alerté à l’approche de la date de fin du calendrier de fonctionnement."
 
 #, elixir-autogen, elixir-format
 msgid "resources changed notification explanation"
-msgstr "Vous êtes alerté lorsque des ressources sont ajoutées, supprimées ou que l'URL est modifiée."
+msgstr "Vous êtes alerté lorsque des ressources sont ajoutées, supprimées ou que l’URL est modifiée."
 
 #, elixir-autogen, elixir-format
 msgid "unavailable resources notification explanation"
@@ -65,7 +65,7 @@ msgstr "Vous êtes alerté au bout de 6h consécutives pendant lesquelles une re
 
 #, elixir-autogen, elixir-format
 msgid "validation errors notification explanation"
-msgstr "Vous êtes alerté lorsqu'une ressource ne respecte pas les spécifications des normes/standards/schémas correspondants."
+msgstr "Vous êtes alerté lorsqu’une ressource ne respecte pas les spécifications des normes/standards/schémas correspondants."
 
 #, elixir-autogen, elixir-format
 msgid "Global notifications"
@@ -74,3 +74,7 @@ msgstr "Notifications générales"
 #, elixir-autogen, elixir-format
 msgid "Notifications by dataset"
 msgstr "Notifications par jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "notifications are good for you"
+msgstr "Les notifications e-mail vous préviennent des problèmes de qualité ou d’indisponibilité qui pourraient affecter vos réutilisations des données de transport. Afin d’activer les notifications sur un jeu de données, mettez-le d’abord en favori (icône ❤️ sur la page du jeu de donnée).<br/><br/>Vous pouvez également suivre l’activité générale de transport.data.gouv.fr à travers les commentaires et nouveaux jeux de données"

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -66,3 +66,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "validation errors notification explanation"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Global notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Notifications by dataset"
+msgstr ""

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -67,10 +67,14 @@ msgstr ""
 msgid "validation errors notification explanation"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Global notifications"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Notifications by dataset"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "notifications are good for you"
 msgstr ""


### PR DESCRIPTION
Adapte `NotificationsLive` afin de pouvoir s'inscrire aux notifications générales (non spécifiques à un JDD).

Le motif "article 122 / loi climat résilience" est retiré tant que le décret et l'ensemble des fonctionnalités n'est pas de retour.

Cette inscription se fait uniquement via l'espace réutilisateur.

![image](https://github.com/etalab/transport-site/assets/295709/5fe251ce-e8b4-4475-9eb8-24d638a0428a)
