### PR TITLE
ImportDatasetFollowersJob : ignore les producteurs

### DIFF
--- a/apps/transport/lib/db/dataset_follower.ex
+++ b/apps/transport/lib/db/dataset_follower.ex
@@ -15,6 +15,8 @@ defmodule DB.DatasetFollower do
     timestamps(type: :utc_datetime_usec)
   end
 
+  def base_query, do: from(df in __MODULE__, as: :dataset_follower)
+
   def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
     struct
     |> cast(attrs, [:dataset_id, :contact_id, :source])

--- a/apps/transport/lib/jobs/import_dataset_followers_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_followers_job.ex
@@ -1,6 +1,14 @@
 defmodule Transport.Jobs.ImportDatasetFollowersJob do
   @moduledoc """
   Import dataset followers coming from the data.gouv.fr's API.
+
+  We *do not* create rows when a contact is a producer of a dataset
+  (ie member of its organization) and the contact follows the dataset.
+
+  We clean up contacts following datasets for which they are a producer
+  at the beginning of the job to handle:
+  - contacts leaving organizations
+  - previous bad states.
   """
   use Oban.Worker, max_attempts: 3
   import Ecto.Query
@@ -11,6 +19,8 @@ defmodule Transport.Jobs.ImportDatasetFollowersJob do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
+    delete_producers_following_their_datasets()
+
     DB.Dataset.base_query()
     |> DB.Repo.all()
     |> Task.async_stream(
@@ -22,20 +32,32 @@ defmodule Transport.Jobs.ImportDatasetFollowersJob do
     |> Stream.run()
   end
 
-  def import_dataset_followers(%DB.Dataset{id: dataset_id, datagouv_id: datagouv_id}) do
+  def delete_producers_following_their_datasets do
+    DB.DatasetFollower.base_query()
+    |> join(:inner, [dataset_follower: df], c in assoc(df, :contact), as: :contact)
+    |> join(:inner, [contact: c], c in assoc(c, :organizations), as: :organization)
+    |> join(:inner, [dataset_follower: df, contact: c, organization: o], d in assoc(df, :dataset),
+      on: d.organization_id == o.id,
+      as: :dataset
+    )
+    |> DB.Repo.delete_all()
+  end
+
+  def import_dataset_followers(%DB.Dataset{id: dataset_id, datagouv_id: datagouv_id} = dataset) do
     case Datagouvfr.Client.Datasets.get_followers(datagouv_id) do
       {:ok, %{"data" => data, "next_page" => next_page}} ->
+        # Pagination is not implemented yet (and shouldn't be needed soon as page_size is 500).
+        # We want to know when we need to implement it.
         unless is_nil(next_page) do
           Sentry.capture_message("#{__MODULE__}: should iterate to get all followers for Dataset##{datagouv_id}")
         end
 
-        datagouv_user_ids = data |> Enum.map(& &1["follower"]["id"]) |> MapSet.new()
+        datagouv_user_ids = Enum.map(data, & &1["follower"]["id"])
 
-        contacts_with_datagouv_id()
-        |> Enum.filter(fn %{datagouv_user_id: datagouv_user_id} ->
-          MapSet.member?(datagouv_user_ids, datagouv_user_id)
-        end)
-        |> Enum.each(fn %{contact_id: contact_id} ->
+        contact_details()
+        |> Map.take(datagouv_user_ids)
+        |> Enum.reject(&contact_is_producer?(&1, dataset))
+        |> Enum.each(fn {_, %{contact_id: contact_id}} ->
           %DB.DatasetFollower{}
           |> DB.DatasetFollower.changeset(%{contact_id: contact_id, dataset_id: dataset_id, source: :datagouv})
           |> DB.Repo.insert!(
@@ -49,21 +71,36 @@ defmodule Transport.Jobs.ImportDatasetFollowersJob do
     end
   end
 
-  @spec contacts_with_datagouv_id() :: %{contact_id: integer(), datagouv_user_id: binary()}
+  def contact_is_producer?({_, %{organization_ids: _}}, %DB.Dataset{organization_id: nil}), do: false
+
+  def contact_is_producer?({_, %{organization_ids: contact_org_ids}}, %DB.Dataset{organization_id: dataset_org_id}) do
+    dataset_org_id in contact_org_ids
+  end
+
   @doc """
-  Fetches all contact IDs and datagouv user IDs for `DB.Contact`.
+  Fetches all contact IDs, datagouv user IDs and their organization IDs for `DB.Contact`.
+
   Caches the result since it's pretty stable and it needs to be used by
   every worker, for every datasets.
   """
-  def contacts_with_datagouv_id do
+  @spec contact_details() :: %{
+          binary() => %{contact_id: integer(), datagouv_user_id: binary(), organization_ids: [binary() | nil]}
+        }
+  def contact_details do
     Transport.Cache.API.fetch(
-      "#{__MODULE__}:contacts_with_datagouv_id",
+      "#{__MODULE__}:contact_details",
       fn ->
         DB.Contact.base_query()
+        |> join(:left, [contact: c], o in assoc(c, :organizations), as: :organization)
         |> where([contact: c], not is_nil(c.datagouv_user_id))
-        |> select([contact: c], %{contact_id: c.id, datagouv_user_id: c.datagouv_user_id})
+        |> select([contact: c, organization: o], %{
+          contact_id: c.id,
+          datagouv_user_id: c.datagouv_user_id,
+          organization_ids: fragment("array_agg(?)", o.id)
+        })
+        |> group_by([contact: c], [c.id, c.datagouv_user_id])
         |> DB.Repo.all()
-        |> MapSet.new()
+        |> Map.new(&{&1.datagouv_user_id, &1})
       end,
       :timer.seconds(60)
     )

--- a/apps/transport/test/transport/jobs/import_dataset_followers_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_followers_job_test.exs
@@ -1,8 +1,8 @@
 defmodule Transport.Test.Transport.Jobs.ImportDatasetFollowersJobTest do
   use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
   import DB.Factory
   import Mox
-  use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.ImportDatasetFollowersJob
 
   setup :verify_on_exit!
@@ -13,23 +13,35 @@ defmodule Transport.Test.Transport.Jobs.ImportDatasetFollowersJobTest do
 
   test "perform" do
     insert(:dataset, is_active: false)
-    dataset = insert(:dataset)
+    producer_org = :organization |> build() |> Map.from_struct()
+    other_org = :organization |> build() |> Map.from_struct()
+    dataset = insert(:dataset, organization_id: producer_org.id)
     other_dataset = insert(:dataset)
     not_found_dataset = insert(:dataset)
     %DB.Contact{id: contact_id} = contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
-    %DB.Contact{id: other_contact_id} = other_contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+    %DB.Contact{id: other_contact_id} =
+      other_contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate(), organizations: [other_org]})
+
+    contact_producer = insert_contact(%{datagouv_user_id: Ecto.UUID.generate(), organizations: [producer_org]})
 
     insert(:dataset_follower, dataset: dataset, contact: contact, source: :datagouv)
 
     setup_http_responses([
-      {dataset,
-       %{
-         data: [
-           %{"follower" => %{"id" => contact.datagouv_user_id}},
-           %{"follower" => %{"id" => Ecto.UUID.generate()}}
-         ],
-         status_code: 200
-       }},
+      {
+        dataset,
+        # Should only create a row for `contact`:
+        # - 2nd follower is not a known contact
+        # - `contact_producer` is a member of the dataset organization and we don't create rows for producers
+        %{
+          data: [
+            %{"follower" => %{"id" => contact.datagouv_user_id}},
+            %{"follower" => %{"id" => Ecto.UUID.generate()}},
+            %{"follower" => %{"id" => contact_producer.datagouv_user_id}}
+          ],
+          status_code: 200
+        }
+      },
       {
         other_dataset,
         %{
@@ -49,11 +61,85 @@ defmodule Transport.Test.Transport.Jobs.ImportDatasetFollowersJobTest do
     assert :ok == perform_job(ImportDatasetFollowersJob, %{})
 
     assert [%DB.Contact{id: ^contact_id}] = dataset_followers(dataset)
-    [%DB.Contact{id: id1}, %DB.Contact{id: id2}] = dataset_followers(other_dataset)
-    assert MapSet.new([id1, id2]) == MapSet.new([contact_id, other_contact_id])
+    assert [%DB.Contact{id: ^contact_id}, %DB.Contact{id: ^other_contact_id}] = dataset_followers(other_dataset)
   end
 
-  defp dataset_followers(%DB.Dataset{} = dataset), do: dataset |> DB.Repo.preload(:followers) |> Map.fetch!(:followers)
+  test "deletes producers following their datasets" do
+    producer_org = :organization |> build() |> Map.from_struct()
+    dataset = insert(:dataset, organization_id: producer_org.id)
+    other_dataset = insert(:dataset)
+    %DB.Contact{id: producer_id} = producer = insert_contact(%{organizations: [producer_org]})
+
+    insert(:dataset_follower, dataset: dataset, contact: producer, source: :datagouv)
+    insert(:dataset_follower, dataset: other_dataset, contact: producer, source: :datagouv)
+
+    setup_http_responses([
+      {
+        dataset,
+        %{
+          data: [%{"follower" => %{"id" => Ecto.UUID.generate()}}],
+          status_code: 200
+        }
+      },
+      {
+        other_dataset,
+        %{
+          data: [%{"follower" => %{"id" => Ecto.UUID.generate()}}],
+          status_code: 200
+        }
+      }
+    ])
+
+    assert :ok == perform_job(ImportDatasetFollowersJob, %{})
+
+    assert [] == dataset_followers(dataset)
+    assert [%DB.Contact{id: ^producer_id}] = dataset_followers(other_dataset)
+  end
+
+  test "delete_producers_following_their_datasets" do
+    producer_org = :organization |> build() |> Map.from_struct()
+    other_org = :organization |> build() |> Map.from_struct()
+    dataset = insert(:dataset, organization_id: producer_org.id)
+    other_dataset = insert(:dataset)
+    %DB.Contact{id: contact_id} = contact = insert_contact()
+    %DB.Contact{id: other_contact_id} = other_contact = insert_contact(%{organizations: [other_org]})
+    %DB.Contact{id: producer_id} = contact_producer = insert_contact(%{organizations: [producer_org]})
+
+    Enum.each([dataset, other_dataset], fn current_dataset ->
+      insert(:dataset_follower, dataset: current_dataset, contact: contact, source: :datagouv)
+      insert(:dataset_follower, dataset: current_dataset, contact: other_contact, source: :datagouv)
+      insert(:dataset_follower, dataset: current_dataset, contact: contact_producer, source: :datagouv)
+    end)
+
+    ImportDatasetFollowersJob.delete_producers_following_their_datasets()
+
+    assert [%DB.Contact{id: ^contact_id}, %DB.Contact{id: ^other_contact_id}] = dataset_followers(dataset)
+
+    assert [%DB.Contact{id: ^contact_id}, %DB.Contact{id: ^other_contact_id}, %DB.Contact{id: ^producer_id}] =
+             dataset_followers(other_dataset)
+  end
+
+  test "contact_is_producer?" do
+    refute ImportDatasetFollowersJob.contact_is_producer?({"foo", %{organization_ids: []}}, %DB.Dataset{
+             organization_id: nil
+           })
+
+    refute ImportDatasetFollowersJob.contact_is_producer?({"foo", %{organization_ids: []}}, %DB.Dataset{
+             organization_id: "bar"
+           })
+
+    refute ImportDatasetFollowersJob.contact_is_producer?({"foo", %{organization_ids: ["baz"]}}, %DB.Dataset{
+             organization_id: "bar"
+           })
+
+    assert ImportDatasetFollowersJob.contact_is_producer?({"foo", %{organization_ids: ["bar"]}}, %DB.Dataset{
+             organization_id: "bar"
+           })
+  end
+
+  defp dataset_followers(%DB.Dataset{} = dataset) do
+    dataset |> DB.Repo.preload(:followers, force: true) |> Map.fetch!(:followers) |> Enum.sort_by(& &1.id)
+  end
 
   defp setup_http_responses(data) do
     responses =


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-site/issues/3896

- Ne pas importer (depuis l'API de data.gouv.fr) la relation `dataset_followers` pour un user qui suit un dataset pour lequel il est producteur
- Supprimer les JDDs suivis par un contact dans le cas où il est producteur du JDD (nettoyage des lignes non souhaitées existantes + gère le cas où l'utilisateur quitte l'organisation)