### PR TITLE
NotificationSubscription : migre platform-wide vers reuser

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -119,22 +119,6 @@ defmodule DB.NotificationSubscription do
   @spec possible_reasons :: [reason()]
   def possible_reasons, do: @all_reasons
 
-  @spec subscriptions_for_reason(atom()) :: [__MODULE__.t()]
-  def subscriptions_for_reason(reason) do
-    base_query()
-    |> preload([:contact])
-    |> where([notification_subscription: ns], ns.reason == ^reason and is_nil(ns.dataset_id))
-    |> DB.Repo.all()
-  end
-
-  @spec subscriptions_for_reason(atom(), DB.Dataset.t()) :: [__MODULE__.t()]
-  def subscriptions_for_reason(reason, %DB.Dataset{id: dataset_id}) do
-    base_query()
-    |> preload([:contact])
-    |> where([notification_subscription: ns], ns.reason == ^reason and ns.dataset_id == ^dataset_id)
-    |> DB.Repo.all()
-  end
-
   @spec subscriptions_for_reason_dataset_and_role(atom(), DB.Dataset.t(), role()) :: [__MODULE__.t()]
   def subscriptions_for_reason_dataset_and_role(reason, %DB.Dataset{id: dataset_id}, role)
       when role in @possible_roles do

--- a/apps/transport/lib/jobs/datasets_switching_climate_resilience_bill_job.ex
+++ b/apps/transport/lib/jobs/datasets_switching_climate_resilience_bill_job.ex
@@ -23,7 +23,7 @@ defmodule Transport.Jobs.DatasetsSwitchingClimateResilienceBillJob do
   def send_email(datasets_previously_climate_resilience, datasets_now_climate_resilience) do
     emails =
       @notification_reason
-      |> DB.NotificationSubscription.subscriptions_for_reason()
+      |> DB.NotificationSubscription.subscriptions_for_reason_and_role(:reuser)
       |> DB.NotificationSubscription.subscriptions_to_emails()
 
     Enum.each(emails, fn email ->

--- a/apps/transport/lib/jobs/resources_changed_notification_job.ex
+++ b/apps/transport/lib/jobs/resources_changed_notification_job.ex
@@ -25,7 +25,7 @@ defmodule Transport.Jobs.ResourcesChangedNotificationJob do
     subject = "#{dataset.custom_title} : ressources modifiées"
 
     @notification_reason
-    |> DB.NotificationSubscription.subscriptions_for_reason()
+    |> DB.NotificationSubscription.subscriptions_for_reason_and_role(:reuser)
     |> DB.NotificationSubscription.subscriptions_to_emails()
     |> Enum.each(fn email ->
       resources_changed_email = Transport.ResourcesChangedNotifier.resources_changed(email, subject, dataset)

--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -140,7 +140,7 @@ defmodule Transport.DataChecker do
     end
 
     @new_dataset_reason
-    |> DB.NotificationSubscription.subscriptions_for_reason()
+    |> DB.NotificationSubscription.subscriptions_for_reason_and_role(:reuser)
     |> DB.NotificationSubscription.subscriptions_to_emails()
     |> Enum.each(fn email ->
       Transport.EmailSender.impl().send_mail(

--- a/apps/transport/priv/repo/migrations/20240502134737_notification_subscriptions_migrate_platform_producer.exs
+++ b/apps/transport/priv/repo/migrations/20240502134737_notification_subscriptions_migrate_platform_producer.exs
@@ -1,0 +1,14 @@
+defmodule DB.Repo.Migrations.NotificationSubscriptionsMigratePlatformProducer do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE notification_subscription
+    SET role = 'reuser'
+    WHERE reason in ('datasets_switching_climate_resilience_bill', 'new_dataset')
+      AND role = 'producer'
+    """)
+  end
+
+  def down, do: IO.puts("No going back")
+end

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -268,7 +268,7 @@ defmodule Transport.DataCheckerTest do
 
       insert(:notification_subscription, %{
         reason: :expiration,
-        source: :admin,
+        source: :user,
         role: :reuser,
         contact_id: reuser_id,
         dataset_id: dataset.id
@@ -371,8 +371,8 @@ defmodule Transport.DataCheckerTest do
 
       insert(:notification_subscription, %{
         reason: :new_dataset,
-        source: :admin,
-        role: :producer,
+        source: :user,
+        role: :reuser,
         contact_id: contact_id
       })
 
@@ -413,7 +413,7 @@ defmodule Transport.DataCheckerTest do
     test "with no subscriptions from producers" do
       insert(:notification_subscription, %{
         reason: :expiration,
-        source: :admin,
+        source: :user,
         role: :reuser,
         contact: insert_contact(),
         dataset: dataset = insert(:dataset)

--- a/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_switching_climate_resilience_bill_job_test.exs
@@ -122,7 +122,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetsSwitchingClimateResilienceBillJo
     insert(:notification_subscription, %{
       reason: :datasets_switching_climate_resilience_bill,
       source: :admin,
-      role: :producer,
+      role: :reuser,
       contact_id: contact_id
     })
 

--- a/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
@@ -28,7 +28,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatasetNotificationsJobTest do
   test "perform" do
     %DB.Dataset{id: dataset_id} = insert(:dataset, inserted_at: hours_ago(23), is_active: true)
     %DB.Contact{id: contact_id, email: email} = insert_contact()
-    insert(:notification_subscription, %{reason: :new_dataset, source: :admin, role: :producer, contact_id: contact_id})
+    insert(:notification_subscription, %{reason: :new_dataset, source: :admin, role: :reuser, contact_id: contact_id})
 
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -35,7 +35,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
 
       # Contact should be ignored: it's a reuser
       insert(:notification_subscription,
-        source: :admin,
+        source: :user,
         role: :reuser,
         reason: :expiration,
         dataset: dataset,


### PR DESCRIPTION
En lien avec #3896

Modifie le role à `reuser` pour les abonnements existants aux motifs platform-wide qui avaient précédemment un role à `producer`, l'abonnement ayant été créé depuis le backoffice. https://github.com/etalab/transport-site/pull/3899 ajoute une validation de la cohérence (reason / role) à terme.

Seul le combo `reason=daily_new_comments` et `role=producer` n'est pas migré. Il doit rester ainsi, il y a 2 abonnements existants (le PAN et l'ART). Le code gère bien le cas `producer` et `reuser`

https://github.com/etalab/transport-site/blob/48d10ae88b4df656ef4cfefa4edbbc8c800d2987/apps/transport/lib/transport/comments_checker.ex#L62-L71