### PR TITLE
DatasetNowOnNAPNotificationJob : uniquement producer

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -155,14 +155,6 @@ defmodule DB.NotificationSubscription do
     |> DB.Repo.all()
   end
 
-  @spec subscriptions_for_dataset(DB.Dataset.t()) :: [__MODULE__.t()]
-  def subscriptions_for_dataset(%DB.Dataset{id: dataset_id}) do
-    base_query()
-    |> preload([:contact])
-    |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id)
-    |> DB.Repo.all()
-  end
-
   def producer_subscriptions_for_datasets(dataset_ids, contact_id) do
     DB.NotificationSubscription.base_query()
     |> preload(:contact)

--- a/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
+++ b/apps/transport/lib/jobs/dataset_now_on_nap_notification_job.ex
@@ -12,7 +12,7 @@ defmodule Transport.Jobs.DatasetNowOnNAPNotificationJob do
     dataset = DB.Repo.get!(DB.Dataset, dataset_id)
 
     dataset
-    |> DB.NotificationSubscription.subscriptions_for_dataset()
+    |> DB.NotificationSubscription.subscriptions_for_dataset_and_role(:producer)
     |> DB.NotificationSubscription.subscriptions_to_emails()
     |> MapSet.new()
     |> MapSet.difference(email_addresses_already_sent(dataset))

--- a/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_now_on_nap_notification_job_test.exs
@@ -35,6 +35,15 @@ defmodule Transport.Test.Transport.Jobs.DatasetNowOnNAPNotificationJobTest do
       })
     end)
 
+    # Should be ignored, it's a reuser
+    insert(:notification_subscription, %{
+      reason: :expiration,
+      source: :user,
+      role: :reuser,
+      contact: insert_contact(),
+      dataset: dataset
+    })
+
     Transport.EmailSender.Mock
     |> expect(:send_mail, fn "transport.data.gouv.fr",
                              "contact@transport.data.gouv.fr",


### PR DESCRIPTION
En lien avec #3896.

Merci @vdegove pour la remarque, ce job prenait toutes les `NotificationSubscriptions`, sans vérifier le role. Cette PR répare ceci en vérifiant qu'on exclut bien les réutilisateurs.