### PR TITLE
NotificationSubscriptionProducerJob : supprime puis recrée les abonnements

### DIFF
--- a/apps/transport/lib/jobs/notification_subscription_producer_job.ex
+++ b/apps/transport/lib/jobs/notification_subscription_producer_job.ex
@@ -42,7 +42,7 @@ defmodule Transport.Jobs.NotificationSubscriptionProducerJob do
   end
 
   defp create_subscriptions(%{contact_id: _, dataset_id: _} = attrs) do
-    DB.NotificationSubscription.reasons_related_to_datasets(:producer)
+    DB.NotificationSubscription.subscribable_reasons_related_to_datasets(:producer)
     |> Enum.each(fn reason ->
       DB.NotificationSubscription.insert!(Map.merge(%{role: :producer, source: :admin, reason: reason}, attrs))
     end)

--- a/apps/transport/lib/jobs/notification_subscription_producer_job.ex
+++ b/apps/transport/lib/jobs/notification_subscription_producer_job.ex
@@ -1,15 +1,18 @@
 defmodule Transport.Jobs.NotificationSubscriptionProducerJob do
   @moduledoc """
-  Job in charge of updating `NotificationSubscription` objects to set the role
-  to `producer` for relevant contacts (they are members of an organization for which
-  we have datasets and they are subscribed to).
+  Job in charge identifying `NotificationSubscription` objects for
+  which the contact subscribed as a reuser and is now a producer
+  of the associated dataset.
+
+  The job deletes these notification subscriptions and creates
+  notification subscriptions for all producer reasons.
   """
   use Oban.Worker, max_attempts: 3
   import Ecto.Query
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    ids =
+    records =
       DB.NotificationSubscription.base_query()
       |> join(:inner, [notification_subscription: ns], c in assoc(ns, :contact), as: :contact)
       |> join(:inner, [contact: c], c in assoc(c, :organizations), as: :organization)
@@ -18,12 +21,30 @@ defmodule Transport.Jobs.NotificationSubscriptionProducerJob do
         as: :dataset
       )
       |> where([notification_subscription: ns], ns.role == :reuser)
-      |> select([notification_subscription: ns], ns.id)
+      |> select([notification_subscription: ns], ns)
+      |> DB.Repo.all()
 
-    DB.NotificationSubscription.base_query()
-    |> where([notification_subscription: ns], ns.id in subquery(ids))
-    |> DB.Repo.update_all(set: [role: :producer])
+    # Delete reusers subscriptions
+    records |> Enum.each(&DB.Repo.delete!/1)
+
+    create_producer_subscriptions(records)
 
     :ok
+  end
+
+  defp create_producer_subscriptions(subscriptions) do
+    subscriptions
+    |> Enum.map(fn %DB.NotificationSubscription{} = ns ->
+      ns |> Map.from_struct() |> Map.take([:contact_id, :dataset_id])
+    end)
+    |> Enum.uniq()
+    |> Enum.each(&create_subscriptions/1)
+  end
+
+  defp create_subscriptions(%{contact_id: _, dataset_id: _} = attrs) do
+    DB.NotificationSubscription.reasons_related_to_datasets(:producer)
+    |> Enum.each(fn reason ->
+      DB.NotificationSubscription.insert!(Map.merge(%{role: :producer, source: :admin, reason: reason}, attrs))
+    end)
   end
 end

--- a/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
+++ b/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
@@ -9,9 +9,9 @@ defmodule Transport.Test.Transport.Jobs.NotificationSubscriptionProducerJobTest 
   end
 
   test "updates relevant notification subscriptions" do
-    reuser = insert_contact()
+    %DB.Contact{id: reuser_id} = insert_contact()
 
-    producer =
+    %DB.Contact{id: producer_id} =
       insert_contact(%{
         organizations: [
           %{
@@ -26,31 +26,76 @@ defmodule Transport.Test.Transport.Jobs.NotificationSubscriptionProducerJobTest 
         ]
       })
 
-    dataset = insert(:dataset, organization_id: org_id)
+    %DB.Dataset{id: dataset_id} = insert(:dataset, organization_id: org_id)
 
-    ns_reuser =
-      insert(:notification_subscription, %{
-        reason: :expiration,
-        source: :admin,
-        dataset_id: dataset.id,
-        contact_id: reuser.id,
-        role: :reuser
-      })
+    insert(:notification_subscription, %{
+      reason: :expiration,
+      source: :admin,
+      dataset_id: dataset_id,
+      contact_id: reuser_id,
+      role: :reuser
+    })
 
-    # Should be updated: the contact is a producer for this dataset and
-    # the subscription's role is set to `reuser`
-    ns_producer =
-      insert(:notification_subscription, %{
-        reason: :expiration,
-        source: :admin,
-        dataset_id: dataset.id,
-        contact_id: producer.id,
-        role: :reuser
-      })
+    # Should be deleted: the contact is a producer for this dataset and
+    # the subscription's role is set to `reuser`.
+    # We should create subscriptions for this (contact_id, dataset_id) for all
+    # producer reasons
+    insert(:notification_subscription, %{
+      reason: :expiration,
+      source: :admin,
+      dataset_id: dataset_id,
+      contact_id: producer_id,
+      role: :reuser
+    })
+
+    # Should be left untouched: this is a platform-wide reason
+    insert(:notification_subscription, %{
+      reason: :new_dataset,
+      source: :admin,
+      dataset_id: nil,
+      contact_id: producer_id,
+      role: :reuser
+    })
 
     assert :ok == perform_job(NotificationSubscriptionProducerJob, %{})
 
-    assert [%DB.NotificationSubscription{role: :reuser}, %DB.NotificationSubscription{role: :producer}] =
-             DB.Repo.reload!([ns_reuser, ns_producer])
+    assert [
+             %DB.NotificationSubscription{
+               reason: :expiration,
+               source: :admin,
+               role: :reuser,
+               contact_id: ^reuser_id,
+               dataset_id: ^dataset_id
+             },
+             %DB.NotificationSubscription{
+               role: :producer,
+               reason: :dataset_with_error,
+               source: :admin,
+               contact_id: ^producer_id,
+               dataset_id: ^dataset_id
+             },
+             %DB.NotificationSubscription{
+               reason: :expiration,
+               source: :admin,
+               role: :producer,
+               contact_id: ^producer_id,
+               dataset_id: ^dataset_id
+             },
+             %DB.NotificationSubscription{
+               reason: :new_dataset,
+               source: :admin,
+               role: :reuser,
+               contact_id: ^producer_id,
+               dataset_id: nil
+             },
+             %DB.NotificationSubscription{
+               reason: :resource_unavailable,
+               source: :admin,
+               role: :producer,
+               contact_id: ^producer_id,
+               dataset_id: ^dataset_id
+             }
+           ] =
+             DB.NotificationSubscription |> DB.Repo.all() |> Enum.sort_by(&{&1.contact_id, &1.reason})
   end
 end


### PR DESCRIPTION
En lien avec #3896

Implémente cette partie.

> Quand quelqu’un passe de réutilisateur à producteur, supprimer ses notifs au lieu de les modifier et recréer toutes les notifs de l’autre rôle

Ce refactor permet d'utiliser `DB.NotificationSubscription.changeset` et gère la différence des motifs entre réutilisateur et producteur (avant on changeait juste le rôle).

La suppression des favoris (ancien réutilisateur qui suit un JDD dont il est producteur désormais) est gérée dans un autre job https://github.com/etalab/transport-site/blob/679085fcc7b73b805f5f33adbdd4ad32c5153e51/apps/transport/lib/jobs/import_dataset_followers_job.ex#L22
