### PR TITLE
Espace producteur : redirection vers page info quand non connecté

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -48,6 +48,11 @@ defmodule TransportWeb.Router do
     plug(:check_export_secret_key)
   end
 
+  pipeline :producer_space do
+    plug(:browser)
+    plug(:authentication_required, destination_path: "/infos_producteurs")
+  end
+
   scope "/", OpenApiSpex.Plug do
     pipe_through(:browser_no_csp)
 
@@ -79,7 +84,7 @@ defmodule TransportWeb.Router do
     get("/humans.txt", PageController, :humans_txt)
 
     scope "/espace_producteur" do
-      pipe_through([:authenticated])
+      pipe_through([:producer_space])
       get("/", PageController, :espace_producteur)
       get("/proxy_statistics", EspaceProducteurController, :proxy_statistics)
 
@@ -353,12 +358,27 @@ defmodule TransportWeb.Router do
     end
   end
 
-  defp authentication_required(conn, _) do
+  @doc """
+  Checks if the user is logged-in or not and redirects accordingly.
+
+  If the user is logged-in, do nothing.
+  If the user is not logged-in, redirects to the login page which then redirects
+  to the previous page.
+
+  Available options:
+  - `destination_path`: instead of redirecting to the login page, redirect to this path
+  """
+  def authentication_required(%Plug.Conn{} = conn, nil), do: authentication_required(conn, [])
+
+  def authentication_required(%Plug.Conn{} = conn, options) do
+    login_path = Helpers.page_path(conn, :login, redirect_path: current_path(conn))
+    destination_path = Keyword.get(options, :destination_path, login_path)
+
     case conn.assigns[:current_user] do
       nil ->
         conn
         |> put_flash(:info, dgettext("alert", "You need to be connected before doing this."))
-        |> redirect(to: Helpers.page_path(conn, :login, redirect_path: current_path(conn)))
+        |> redirect(to: destination_path)
         |> halt()
 
       _ ->

--- a/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
@@ -28,7 +28,7 @@
               "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
             ) %>
           </div>
-          <a class="button" href={page_path(@conn, :login, redirect_path: current_path(@conn))}>
+          <a class="button" href={page_path(@conn, :login, redirect_path: page_path(@conn, :espace_producteur))}>
             <%= dgettext("page-dataset-details", "Log in") %>
           </a>
         </div>

--- a/apps/transport/lib/transport_web/views/page_view.ex
+++ b/apps/transport/lib/transport_web/views/page_view.ex
@@ -1,6 +1,5 @@
 defmodule TransportWeb.PageView do
   use TransportWeb, :view
-  import Phoenix.Controller, only: [current_path: 1]
   import TransportWeb.ResourceView, only: [dataset_creation: 0]
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   import TransportWeb.DatasetView, only: [upcoming_icon_type_path: 1]

--- a/apps/transport/lib/transport_web/views/page_view.ex
+++ b/apps/transport/lib/transport_web/views/page_view.ex
@@ -1,5 +1,6 @@
 defmodule TransportWeb.PageView do
   use TransportWeb, :view
+  import Phoenix.Controller, only: [current_path: 1]
   import TransportWeb.ResourceView, only: [dataset_creation: 0]
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   import TransportWeb.DatasetView, only: [upcoming_icon_type_path: 1]

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -13,8 +13,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   describe "edit_dataset" do
     test "requires authentication", %{conn: conn} do
-      conn = conn |> get(espace_producteur_path(conn, :edit_dataset, 42))
-      assert redirected_to(conn, 302) =~ "/login"
+      conn |> get(espace_producteur_path(conn, :edit_dataset, 42)) |> assert_redirects_to_info_page()
     end
 
     test "redirects if you're not a member of the dataset organization", %{conn: conn} do
@@ -69,8 +68,9 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   describe "upload_logo" do
     test "requires authentication", %{conn: conn} do
-      conn = conn |> post(espace_producteur_path(conn, :upload_logo, 42), %{"upload" => %{"file" => %Plug.Upload{}}})
-      assert redirected_to(conn, 302) =~ "/login"
+      conn
+      |> post(espace_producteur_path(conn, :upload_logo, 42), %{"upload" => %{"file" => %Plug.Upload{}}})
+      |> assert_redirects_to_info_page()
     end
 
     test "redirects if you're not a member of the dataset organization", %{conn: conn} do
@@ -134,8 +134,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   describe "remove_custom_logo" do
     test "requires authentication", %{conn: conn} do
-      conn = conn |> delete(espace_producteur_path(conn, :remove_custom_logo, 42))
-      assert redirected_to(conn, 302) =~ "/login"
+      conn |> delete(espace_producteur_path(conn, :remove_custom_logo, 42)) |> assert_redirects_to_info_page()
     end
 
     test "redirects if you're not a member of the dataset organization", %{conn: conn} do
@@ -190,9 +189,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   describe "proxy_statistics" do
     test "requires authentication", %{conn: conn} do
-      conn = conn |> get(espace_producteur_path(conn, :proxy_statistics))
-
-      assert redirected_to(conn, 302) =~ "/login"
+      conn |> get(espace_producteur_path(conn, :proxy_statistics)) |> assert_redirects_to_info_page()
     end
 
     test "redirects when there is an error when fetching datasets", %{conn: conn} do
@@ -252,5 +249,10 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
       assert html =~ "<strong>2</strong>\nrequêtes gérées par le proxy au cours des 15 derniers jours"
       assert html =~ "<strong>1</strong>\nrequêtes transmises au serveur source au cours des 15 derniers jours"
     end
+  end
+
+  defp assert_redirects_to_info_page(%Plug.Conn{} = conn) do
+    Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+    assert redirected_to(conn, 302) == page_path(conn, :infos_producteurs)
   end
 end

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -190,7 +190,7 @@ defmodule TransportWeb.PageControllerTest do
       {:ok, doc} = Floki.parse_document(body)
       [item] = doc |> Floki.find(".panel-producteurs a.button")
 
-      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Finfos_producteurs"]
+      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Fespace_producteur"]
       assert item |> Floki.text() =~ "Identifiez-vous"
     end
 

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -65,7 +65,8 @@ defmodule TransportWeb.PageControllerTest do
   describe "GET /espace_producteur" do
     test "requires authentication", %{conn: conn} do
       conn = conn |> get(page_path(conn, :espace_producteur))
-      assert redirected_to(conn, 302) =~ "/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+      assert redirected_to(conn, 302) == page_path(conn, :infos_producteurs)
     end
 
     test "renders successfully and finds datasets using organization IDs", %{conn: conn} do
@@ -180,17 +181,34 @@ defmodule TransportWeb.PageControllerTest do
     end
   end
 
-  test "GET /producteurs for non-authenticated users", %{conn: conn} do
-    conn = conn |> get(page_path(conn, :infos_producteurs))
-    body = html_response(conn, 200)
-    assert body =~ "transport.data.gouv.fr vous aide à publier vos données"
+  describe "infos_producteurs" do
+    test "for logged-out users", %{conn: conn} do
+      conn = conn |> get(page_path(conn, :infos_producteurs))
+      body = html_response(conn, 200)
+      assert body =~ "transport.data.gouv.fr vous aide à publier vos données"
 
-    {:ok, doc} = Floki.parse_document(body)
-    [item] = doc |> Floki.find(".panel-producteurs a.button")
+      {:ok, doc} = Floki.parse_document(body)
+      [item] = doc |> Floki.find(".panel-producteurs a.button")
 
-    # behavior expected for non-authenticated users
-    assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Finfos_producteurs"]
-    assert item |> Floki.text() =~ "Identifiez-vous"
+      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Finfos_producteurs"]
+      assert item |> Floki.text() =~ "Identifiez-vous"
+    end
+
+    test "for logged-in users", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(current_user: %{"is_producer" => true})
+        |> get(page_path(conn, :infos_producteurs))
+
+      body = html_response(conn, 200)
+      assert body =~ "transport.data.gouv.fr vous aide à publier vos données"
+
+      {:ok, doc} = Floki.parse_document(body)
+      [item] = doc |> Floki.find(".panel-producteurs a.button")
+
+      assert Floki.attribute(item, "href") == ["/espace_producteur?utm_source=producer_infos_page"]
+      assert item |> Floki.text() =~ "Accédez à votre espace producteur"
+    end
   end
 
   test "404 page", %{conn: conn} do

--- a/apps/transport/test/transport_web/live_views/notifications_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/notifications_live_test.exs
@@ -15,12 +15,18 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "requires login", %{conn: conn} do
-    Enum.each([@producer_url, @reuser_url], fn url ->
-      conn = conn |> get(url)
-      assert "/login/explanation?" <> URI.encode_query(redirect_path: url) == redirected_to(conn, 302)
+  describe "requires login" do
+    test "as a producer", %{conn: conn} do
+      conn = conn |> get(@producer_url)
+      assert redirected_to(conn, 302) == page_path(conn, :infos_producteurs)
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
-    end)
+    end
+
+    test "as a reuser", %{conn: conn} do
+      conn = conn |> get(@reuser_url)
+      assert redirected_to(conn, 302) == "/login/explanation?" <> URI.encode_query(redirect_path: @reuser_url)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+    end
   end
 
   test "displays existing subscriptions for a producer", %{conn: conn} do


### PR DESCRIPTION
Gère la première partie de #3907, concernant l'Espace producteur.

Lorsque l'utilisateur n'est pas connecté et cherche à accéder à l'Espace producteur (lien envoyé par une notification par exemple), renvoie vers la page [infos producteur](https://transport.data.gouv.fr/infos_producteurs) pour expliquer le concept.

Cette page a du contenu/un bouton qui change en fonction du fait que l'utilisateur soit connecté ou non. Ceci n'a pas été modifié par rapport à la situation précédente (bouton, couleurs ou texte), j'ai simplement ajouté des tests.

## Démo vidéo

https://github.com/etalab/transport-site/assets/295709/f1f26349-996e-4418-9545-fcca3bfee64c

cc @cyrilmorin on peut rediriger directement vers l'Espace producteur après le passage sur data.gouv.fr si tu souhaites. Là on retourne sur "infos producteurs" avec un bouton et texte différent.