### PR TITLE
Ajout page infos_reutilisateurs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -96,6 +96,8 @@ defmodule TransportWeb.PageController do
     |> render("infos_producteurs.html")
   end
 
+  def infos_reutilisateurs(%Plug.Conn{} = conn, _params), do: render(conn, "infos_reutilisateurs.html")
+
   def robots_txt(%Plug.Conn{} = conn, _params) do
     # See http://www.robotstxt.org/robotstxt.html
     # for documentation on how to use the robots.txt file

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -74,6 +74,7 @@ defmodule TransportWeb.Router do
     get("/loi-climat-resilience", PageController, :loi_climat_resilience)
     get("/accessibilite", PageController, :accessibility)
     get("/infos_producteurs", PageController, :infos_producteurs)
+    get("/infos_reutilisateurs", PageController, :infos_reutilisateurs)
     get("/robots.txt", PageController, :robots_txt)
     get("/.well-known/security.txt", PageController, :security_txt)
     get("/humans.txt", PageController, :humans_txt)

--- a/apps/transport/lib/transport_web/templates/page/infos_reutilisateurs.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/infos_reutilisateurs.html.heex
@@ -1,0 +1,62 @@
+<%!--
+This page uses `producteurs-*` CSS classes because it has the
+same layout than `infos_producteurs`.
+
+These CSS classes may be removed (soon?) when switching to the DSFR.
+--%>
+<div class="with-gradient">
+  <div class="container producteurs-section">
+    <section class="section producteurs-top">
+      <div class="producteurs-title">
+        <h1>
+          <%= dgettext("reuser-space", "transport.data.gouv.fr helps you follow the data you reuse") %>
+        </h1>
+      </div>
+      <%= if assigns[:current_user] do %>
+        <div class="panel-producteurs signed-in">
+          <h2><%= dgettext("reuser-space", "Welcome!") %></h2>
+          <a class="button" href={reuser_space_path(@conn, :espace_reutilisateur, utm_source: "reuser_infos_page")}>
+            <%= dgettext("reuser-space", "Access your reuser space") %>
+          </a>
+          <div class="pt-24">
+            <%= dgettext(
+              "reuser-space",
+              "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data"
+            ) %>
+          </div>
+        </div>
+      <% else %>
+        <div class="panel-producteurs">
+          <h2><%= dgettext("reuser-space", "Access your reuser space") %></h2>
+          <div>
+            <%= dgettext(
+              "reuser-space",
+              "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
+            ) %>
+          </div>
+          <a class="button" href={page_path(@conn, :login, redirect_path: current_path(@conn))}>
+            <%= dgettext("page-dataset-details", "Log in") %>
+          </a>
+        </div>
+      <% end %>
+    </section>
+    <section class="section producteurs-content">
+      <div class="producteurs-presentation">
+        <div class="panel">
+          <div class="presentation-description">
+            <div class="presentation-icon">
+              <i class="fa fa-bell"></i>
+            </div>
+            <h2><%= dgettext("reuser-space", "Set up notifications") %></h2>
+            <div>
+              <%= dgettext("reuser-space", "Receive helpful notifications about the data you follow.") %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+<div class="tgv">
+  <img src={static_path(@conn, "/images/producteurs/tgv.svg")} alt="TGV" />
+</div>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -78,3 +78,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "notifications are good for you"
 msgstr "Email notifications alert you to quality or availability issues that could affect your reuse of transport data. To activate notifications for a dataset, first add it to your favorites (❤️ icon on the dataset page).<br/><br/>You can also follow the general activity of transport.data.gouv.fr through comments and new datasets."
+
+#, elixir-autogen, elixir-format
+msgid "Access your reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Set up notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Welcome!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr helps you follow the data you reuse"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -78,3 +78,27 @@ msgstr "Notifications par jeu de données"
 #, elixir-autogen, elixir-format
 msgid "notifications are good for you"
 msgstr "Les notifications e-mail vous préviennent des problèmes de qualité ou d’indisponibilité qui pourraient affecter vos réutilisations des données de transport. Afin d’activer les notifications sur un jeu de données, mettez-le d’abord en favori (icône ❤️ sur la page du jeu de donnée).<br/><br/>Vous pouvez également suivre l’activité générale de transport.data.gouv.fr à travers les commentaires et nouveaux jeux de données"
+
+#, elixir-autogen, elixir-format
+msgid "Access your reuser space"
+msgstr "Accédez à votre espace réutilisateur"
+
+#, elixir-autogen, elixir-format
+msgid "Set up notifications"
+msgstr "Gérez vos notifications"
+
+#, elixir-autogen, elixir-format
+msgid "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
+msgstr "Pour vous identifier vous allez être redirigé vers data.gouv.fr, la plateforme ouverte des données publiques françaises."
+
+#, elixir-autogen, elixir-format
+msgid "Welcome!"
+msgstr "Bienvenue !"
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr helps you follow the data you reuse"
+msgstr "transport.data.gouv.fr vous aide à suivre les données que vous réutilisez"
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data"
+msgstr "transport.data.gouv.fr est affilié à data.gouv.fr : la plateforme ouverte des données publiques françaises"

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -78,3 +78,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "notifications are good for you"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Access your reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Set up notifications"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Welcome!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr helps you follow the data you reuse"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "transport.data.gouv.fr is affiliated with data.gouv.fr, the open platform for French public data"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -193,6 +193,36 @@ defmodule TransportWeb.PageControllerTest do
     assert item |> Floki.text() =~ "Identifiez-vous"
   end
 
+  describe "infos_reutilisateurs" do
+    test "for logged-out users", %{conn: conn} do
+      conn = conn |> get(page_path(conn, :infos_reutilisateurs))
+      body = html_response(conn, 200)
+      assert body =~ "transport.data.gouv.fr vous aide à suivre les données que vous réutilisez"
+
+      {:ok, doc} = Floki.parse_document(body)
+      [item] = doc |> Floki.find(".panel-producteurs a.button")
+
+      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Finfos_reutilisateurs"]
+      assert item |> Floki.text() =~ "Identifiez-vous"
+    end
+
+    test "for logged-in users", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(current_user: %{"is_producer" => false})
+        |> get(page_path(conn, :infos_reutilisateurs))
+
+      body = html_response(conn, 200)
+      assert body =~ "transport.data.gouv.fr vous aide à suivre les données que vous réutilisez"
+
+      {:ok, doc} = Floki.parse_document(body)
+      [item] = doc |> Floki.find(".panel-producteurs a.button")
+
+      assert Floki.attribute(item, "href") == ["/espace_reutilisateur?utm_source=reuser_infos_page"]
+      assert item |> Floki.text() =~ "Accédez à votre espace réutilisateur"
+    end
+  end
+
   test "404 page", %{conn: conn} do
     conn = conn |> get("/this-page-does-not-exist")
     html = html_response(conn, 404)


### PR DESCRIPTION
Seconde partie de #3907.

Crée une page "Infos réutilisateurs", similaire à [Infos producteurs](https://transport.data.gouv.fr/infos_producteurs) permettant de présenter l'intérêt de l'espace réutilisateur. Elle sera complétée au fur et à mesure des fonctionnalités disponibles et des éléments donnés par @cyrilmorin.

❓ @cyrilmorin Faut-il rediriger vers cette nouvelle page quand on essaie d'accéder à l'espace réutilisateur en n'étant pas connecté ? Comme ce qui avait été fait demandé dans #3907 pour les producteurs (et implémenté dans #3915)

## Captures d'écran

### Non-connecté

![image](https://github.com/etalab/transport-site/assets/295709/92ffc2c9-1af6-43c7-9935-b968f20bee17)

### Connecté

![image](https://github.com/etalab/transport-site/assets/295709/a187899a-e72f-4da4-a5f0-42989db0d93b)
