### PR TITLE
Résultats de recherche : affichage des coeurs de suivi

### DIFF
--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -127,13 +127,24 @@
   .dataset__type {
     display: flex;
     flex: 0 0 5em;
-    align-items: center;
-    padding: 1em;
-  }
+    align-items: end;
+    padding: .5em 1em;
+    flex-direction: column;
 
-  .dataset__type img {
-    width: 100%;
-    max-height: 100%;
+    i.fa {
+      margin-bottom: .5em;
+      &.producer {
+        color: var(--blue);
+      }
+      &.following {
+        color: red;
+      }
+    }
+
+    img {
+      width: 100%;
+      max-height: 100%;
+    }
   }
 
   .panel__extra {

--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -22,14 +22,17 @@ defmodule TransportWeb.DatasetController do
         false -> conn
       end
 
+    datasets = get_datasets(params)
+
     conn
-    |> assign(:datasets, get_datasets(params))
+    |> assign(:datasets, datasets)
     |> assign(:types, get_types(params))
     |> assign(:licences, get_licences(params))
     |> assign(:number_realtime_datasets, get_realtime_count(params))
     |> assign(:number_climate_resilience_bill_datasets, climate_resilience_bill_count(params))
     |> assign(:order_by, params["order_by"])
     |> assign(:q, Map.get(params, "q"))
+    |> put_dataset_heart_values(datasets)
     |> put_empty_message(params)
     |> put_category_custom_message(params)
     |> put_climate_resilience_bill_message(params)
@@ -467,4 +470,47 @@ defmodule TransportWeb.DatasetController do
       )
 
   defp put_page_title(conn, _), do: conn
+
+  defp put_dataset_heart_values(%Plug.Conn{assigns: %{current_user: current_user}} = conn, datasets) do
+    if is_nil(current_user) do
+      conn
+    else
+      assign(conn, :dataset_heart_values, dataset_heart_values(current_user, datasets))
+    end
+  end
+
+  @doc """
+  Compute, for each dataset displayed on the current page, what the heart icon$
+  should look like.
+
+  The current user can be a producer/follow the dataset or nothing (not a producer and not following it).
+  """
+  def dataset_heart_values(%{"id" => datagouv_user_id} = _current_user, datasets) do
+    dataset_ids = Enum.map(datasets, & &1.id)
+
+    contact_org_ids =
+      DB.Contact.base_query()
+      |> join(:left, [contact: c], c in assoc(c, :organizations), as: :organization)
+      |> where([contact: c], c.datagouv_user_id == ^datagouv_user_id)
+      |> select([organization: o], o.id)
+      |> DB.Repo.all()
+
+    followed_dataset_ids =
+      DB.Contact.base_query()
+      |> join(:left, [contact: c], c in assoc(c, :followed_datasets), as: :dataset)
+      |> where([contact: c, dataset: d], c.datagouv_user_id == ^datagouv_user_id and d.id in ^dataset_ids)
+      |> select([dataset: d], d.id)
+      |> DB.Repo.all()
+
+    Map.new(datasets, fn %DB.Dataset{id: dataset_id, organization_id: organization_id} ->
+      value =
+        cond do
+          organization_id in contact_org_ids -> :producer
+          dataset_id in followed_dataset_ids -> :following
+          true -> nil
+        end
+
+      {dataset_id, value}
+    end)
+  end
 end

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -195,11 +195,14 @@
                       </div>
                     </div>
                   </div>
-                  <%= unless is_nil(icon_type_path(dataset)) do %>
-                    <div class="dataset__type">
+                  <div class="dataset__type">
+                    <%= unless is_nil(@current_user) do %>
+                      <i class={heart_class(@dataset_heart_values, dataset)}></i>
+                    <% end %>
+                    <%= unless is_nil(icon_type_path(dataset)) do %>
                       <%= img_tag(icon_type_path(dataset), alt: dataset.type) %>
-                    </div>
-                  <% end %>
+                    <% end %>
+                  </div>
                 </div>
                 <div class="panel__extra">
                   <div class="dataset__info">

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -196,7 +196,7 @@
                     </div>
                   </div>
                   <div class="dataset__type">
-                    <%= unless is_nil(@current_user) do %>
+                    <%= if TransportWeb.Session.admin?(@conn) do %>
                       <i class={heart_class(@dataset_heart_values, dataset)}></i>
                     <% end %>
                     <%= unless is_nil(icon_type_path(dataset)) do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -543,4 +543,15 @@ defmodule TransportWeb.DatasetView do
   false
   """
   def seasonal_warning?(%Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
+
+  @doc """
+  iex> heart_class(%{42 => :producer}, %DB.Dataset{id: 42})
+  "fa fa-heart producer"
+  iex> heart_class(%{42 => nil}, %DB.Dataset{id: 42})
+  "fa fa-heart"
+  """
+  def heart_class(dataset_heart_values, %DB.Dataset{id: dataset_id}) do
+    value = dataset_heart_values |> Map.fetch!(dataset_id) |> to_string()
+    "fa fa-heart #{value}" |> String.trim()
+  end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -200,6 +200,7 @@ defmodule TransportWeb.DatasetControllerTest do
         |> Floki.parse_document!()
 
       assert ["A", "B", "C"] == dataset_titles(document)
+
       assert [
                {"i", [{"class", "fa fa-heart producer"}], []},
                {"i", [{"class", "fa fa-heart following"}], []},

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -160,7 +160,7 @@ defmodule TransportWeb.DatasetControllerTest do
                |> Floki.find(".dataset__type")
     end
 
-    test "non admin: hidden for now now", %{conn: conn} do
+    test "non admin: hidden for now", %{conn: conn} do
       contact = insert_contact(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()})
 
       insert(:dataset, custom_title: "A")


### PR DESCRIPTION
En lien avec #3908

Sur la page des résultats de recherche, affiche l'icône de coeur de suivi pour chaque JDD :
- si utilisateur non connecté, l'icône n'est pas affichée
- si l'utilisateur est connecté : coeur bleu si producteur, rouge si suivi et gris sinon

## Captures d'écran

![image](https://github.com/etalab/transport-site/assets/295709/73e47ba1-af33-40ff-a866-7c369c30820b)
![image](https://github.com/etalab/transport-site/assets/295709/2303ae10-b4d8-437f-a33b-d7420b79b9e7)
