### PR TITLE
Dataset#details : fonctionnement du coeur des favoris

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -62,21 +62,6 @@
     display: flex;
     flex-wrap: wrap;
   }
-  .follow-dataset-icon {
-    text-align: right;
-
-    p.notification {
-      text-align: left;
-      transition: all 1s;
-      opacity: 0;
-      display: none;
-      &.active {
-        display: block;
-        animation: fade-in 1s;
-        opacity: 1;
-      }
-    }
-  }
 }
 
 @keyframes fade-in {
@@ -625,4 +610,24 @@ hr {
   max-width: 900px;
   margin: 1em auto;
   display: block;
+}
+
+.follow-dataset-icon {
+  text-align: right;
+
+  a:hover {
+    background: transparent;
+  }
+
+  p.notification {
+    text-align: left;
+    transition: all 1s;
+    opacity: 0;
+    display: none;
+    &.active {
+      display: block;
+      animation: fade-in 1s;
+      opacity: 1;
+    }
+  }
 }

--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -126,3 +126,7 @@
     color: red;
   }
 }
+
+.fa-heart.producer {
+  color: var(--blue);
+}

--- a/apps/transport/client/stylesheets/components/_tooltip.scss
+++ b/apps/transport/client/stylesheets/components/_tooltip.scss
@@ -1,5 +1,8 @@
 /* from https://www.w3schools.com/howto/howto_css_tooltip.asp */
 /* Tooltip container */
+
+$tooltip-width: 150px !default;
+
 .tooltip {
   position: relative;
   display: inline-block;
@@ -8,7 +11,7 @@
 /* Tooltip text */
 .tooltip .tooltiptext {
   visibility: hidden;
-  width: 150px;
+  width: $tooltip-width;
   background-color: var(--theme-background-white);
   color: var(--theme-dark-text);
   text-align: center;
@@ -21,7 +24,7 @@
   z-index: 1;
   bottom: 125%;
   left: 50%;
-  margin-left: -75px;
+  margin-left: -($tooltip-width / 2);
 
   /* Fade in tooltip */
   opacity: 0;

--- a/apps/transport/client/stylesheets/components/_tooltip.scss
+++ b/apps/transport/client/stylesheets/components/_tooltip.scss
@@ -21,11 +21,20 @@
   z-index: 1;
   bottom: 125%;
   left: 50%;
-  margin-left: -50px;
+  margin-left: -75px;
 
   /* Fade in tooltip */
   opacity: 0;
   transition: opacity 0.3s;
+
+  &.left {
+    top: -30%;
+    right: 105%;
+    bottom: 0;
+    left: auto;
+    margin-left: 0;
+    height: fit-content;
+  }
 }
 
 /* Tooltip arrow */
@@ -38,6 +47,14 @@
   border-width: 5px;
   border-style: solid;
   border-color: var(--theme-border) transparent transparent transparent;
+}
+
+.tooltip .tooltiptext.left::after {
+  top: 50%;
+  left: 100%;
+  margin-top: -5px;
+  margin-left: 0;
+  border-color: transparent transparent transparent var(--theme-border);
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */

--- a/apps/transport/lib/transport_web/live/follow_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/follow_dataset_live.ex
@@ -11,12 +11,14 @@ defmodule TransportWeb.Live.FollowDatasetLive do
   """
   use Phoenix.LiveView
   import Ecto.Query
-  import TransportWeb.Gettext, only: [dgettext: 3]
+  import TransportWeb.Gettext, only: [dgettext: 2, dgettext: 3]
   import TransportWeb.Router.Helpers
 
   @impl true
   def render(assigns) do
     ~H"""
+    <% reuser_space_path = reuser_space_path(@socket, :espace_reutilisateur, utm_source: "follow_dataset_heart")
+    producer_space_path = page_path(@socket, :espace_producteur, utm_source: "follow_dataset_heart") %>
     <div :if={is_nil(@current_user)} class="follow-dataset-icon">
       <i class={@heart_class} phx-click="nudge_signup"></i>
       <p :if={@display_banner?} class="notification active">
@@ -30,22 +32,41 @@ defmodule TransportWeb.Live.FollowDatasetLive do
       </p>
     </div>
     <div :if={not is_nil(@current_user) and not @producer?} class="follow-dataset-icon">
-      <i class={@heart_class} phx-click="toggle"></i>
+      <div :if={not @follows_dataset?} class="tooltip">
+        <i class={@heart_class} phx-click="follow"></i>
+        <span class="tooltiptext left"><%= dgettext("page-dataset-details", "Follow this dataset") %></span>
+      </div>
+      <div :if={@follows_dataset?} class="tooltip">
+        <a href={reuser_space_path} target="_blank">
+          <i class={@heart_class}></i>
+        </a>
+        <span class="tooltiptext left"><%= dgettext("page-dataset-details", "Manage services for this dataset") %></span>
+      </div>
       <p :if={@display_banner?} class="notification active">
         <%= Phoenix.HTML.raw(
           dgettext(
             "page-dataset-details",
             ~s|Dataset added to your favorites! Personalise your settings from your <a href="%{url}" target="_blank">reuser space</a>.|,
-            url: reuser_space_path(@socket, :espace_reutilisateur)
+            url: reuser_space_path
           )
         ) %>
       </p>
+    </div>
+    <div :if={@producer?} class="follow-dataset-icon">
+      <div class="tooltip">
+        <a href={producer_space_path} target="_blank">
+          <i class={@heart_class}></i>
+        </a>
+        <span class="tooltiptext left"><%= dgettext("page-dataset-details", "Manage your dataset") %></span>
+      </div>
     </div>
     """
   end
 
   @impl true
-  def mount(_params, %{"current_user" => current_user, "dataset_id" => dataset_id}, socket) do
+  def mount(_params, %{"current_user" => current_user, "dataset_id" => dataset_id, "locale" => locale}, socket) do
+    Gettext.put_locale(locale)
+
     socket =
       socket
       |> assign(%{
@@ -61,11 +82,12 @@ defmodule TransportWeb.Live.FollowDatasetLive do
 
   defp set_computed_assigns(%Phoenix.LiveView.Socket{assigns: %{dataset: dataset, contact: contact}} = socket) do
     follows_dataset? = DB.DatasetFollower.follows_dataset?(contact, dataset)
+    producer? = producer?(contact, dataset)
 
     assign(socket, %{
       follows_dataset?: follows_dataset?,
-      producer?: producer?(contact, dataset),
-      heart_class: heart_class(follows_dataset?: follows_dataset?)
+      producer?: producer?,
+      heart_class: heart_class(producer?: producer?, follows_dataset?: follows_dataset?)
     })
   end
 
@@ -76,28 +98,18 @@ defmodule TransportWeb.Live.FollowDatasetLive do
 
   @impl true
   def handle_event(
-        "toggle",
+        "follow",
         _,
-        %Phoenix.LiveView.Socket{
-          assigns: %{
-            dataset: %DB.Dataset{} = dataset,
-            contact: %DB.Contact{} = contact,
-            follows_dataset?: follows_dataset?
-          }
-        } = socket
+        %Phoenix.LiveView.Socket{assigns: %{dataset: %DB.Dataset{} = dataset, contact: %DB.Contact{} = contact}} =
+          socket
       ) do
-    if follows_dataset? do
-      DB.DatasetFollower.unfollow!(contact, dataset)
-      delete_notification_subscriptions(contact, dataset)
-    else
-      maybe_promote_reuser_space(contact)
-      DB.DatasetFollower.follow!(contact, dataset, source: :follow_button)
-      create_notification_subscriptions(contact, dataset)
-      # Hide banner after 10s
-      Process.send_after(self(), :hide_banner, 10_000)
-    end
+    maybe_promote_reuser_space(contact)
+    DB.DatasetFollower.follow!(contact, dataset, source: :follow_button)
+    create_notification_subscriptions(contact, dataset)
+    # Hide banner after 10s
+    Process.send_after(self(), :hide_banner, 10_000)
 
-    {:noreply, socket |> assign(:display_banner?, not follows_dataset?) |> set_computed_assigns()}
+    {:noreply, socket |> assign(:display_banner?, true) |> set_computed_assigns()}
   end
 
   @impl true
@@ -161,12 +173,6 @@ defmodule TransportWeb.Live.FollowDatasetLive do
     end
   end
 
-  defp delete_notification_subscriptions(%DB.Contact{id: contact_id}, %DB.Dataset{id: dataset_id}) do
-    DB.NotificationSubscription.base_query()
-    |> where([notification_subscription: ns], ns.contact_id == ^contact_id and ns.dataset_id == ^dataset_id)
-    |> DB.Repo.delete_all()
-  end
-
   # Case where the user is not authenticated
   defp contact(nil = _current_user), do: nil
 
@@ -183,6 +189,15 @@ defmodule TransportWeb.Live.FollowDatasetLive do
     |> DB.Repo.exists?()
   end
 
-  defp heart_class(follows_dataset?: false), do: "fa fa-heart fa-2x icon---animated-heart"
-  defp heart_class(follows_dataset?: true), do: heart_class(follows_dataset?: false) <> " active"
+  defp heart_class(options) do
+    if Keyword.get(options, :producer?) do
+      "fa fa-heart fa-2x producer"
+    else
+      if Keyword.get(options, :follows_dataset?) do
+        heart_class(follows_dataset?: false) <> " active"
+      else
+        "fa fa-heart fa-2x icon---animated-heart"
+      end
+    end
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -693,3 +693,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage your dataset"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Follow this dataset"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage services for this dataset"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -693,3 +693,15 @@ msgstr "Jeu de données ajouté à vos favoris ! Personnalisez vos préférences
 #, elixir-autogen, elixir-format
 msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
 msgstr "<a href=\"%{url}\">Inscrivez-vous ou connectez-vous</a> pour bénéficier des services liés aux jeux de données."
+
+#, elixir-autogen, elixir-format
+msgid "Manage your dataset"
+msgstr "Gérez votre jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "Follow this dataset"
+msgstr "Suivre ce jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "Manage services for this dataset"
+msgstr "Gérez les services liés à ce jeu de données"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -693,3 +693,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "<a href=\"%{url}\">Log in or sign up</a> to benefit from dataset services."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage your dataset"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Follow this dataset"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage services for this dataset"
+msgstr ""


### PR DESCRIPTION
En lien avec #3908.

Gestion de l'affichage et des interactions des coeurs de suivi de datasets sur la page `dataset#details`.

- Si l'utilisateur est connecté et producteur du JDD (ie membre de l'organisation qui publie le JDD), affichage du coeur en bleu, infobulle d'information et lien vers l'espace producteur dans un nouvel onglet.
- Si l'utilisateur est connecté :
  - **Ne suit pas le jeu de données.** Coeur gris, infobulle d'information. Au clic, coeur rouge, infobulle, bandeau d'information et liens vers l'espace réutilisateur dans un nouvel onglet. Inscription à tous les motifs de notification en tant que réutilisateur pour ce JDD. Si première fois que l'action est effectuée, envoi d'un e-mail présentant la fonctionnalité, inscription au suivi quotidien des discussions.
  - **Suit le jeu de données.** Coeur rouge, infobulle d'information. Au clic, ouvre un nouvel onglet vers l'espace réutilisateur.

Comme pour les PRs précédentes, le coeur reste visiblement seulement par les membres de l'organisation du PAN pour le moment.

https://github.com/etalab/transport-site/assets/295709/325500f3-a878-469d-b28f-734dceb4174f

Le fonctionnement du mode déconnecté reste inchangé par rapport à avant (spécifié dans https://github.com/etalab/transport-site/issues/3859), à discuter d'une éventuelle modification avec @cyrilmorin https://github.com/etalab/transport-site/issues/3908#issuecomment-2095447761

