### PR TITLE
Skip d'un test qui échoue sur Mac M1

### DIFF
--- a/apps/transport/test/build_test.exs
+++ b/apps/transport/test/build_test.exs
@@ -25,6 +25,10 @@ defmodule TransportWeb.BuildTest do
     version
   end
 
+  # Skip next test on Mac M1, where it will always (currently) fail
+  # See https://github.com/etalab/transport-site/issues/2520
+  if Transport.Platform.apple_silicon?(), do: @tag(:pending)
+
   test "rambo rust wrapper compiles and runs" do
     {:ok, %{out: "hello\n"}} = Rambo.run("echo", ["hello"])
   end

--- a/apps/transport/test/support/platform.ex
+++ b/apps/transport/test/support/platform.ex
@@ -1,0 +1,9 @@
+defmodule Transport.Platform do
+  # NOTE: duplicate from `mix.exs`, good enough for now
+  def apple_silicon? do
+    :system_architecture
+    |> :erlang.system_info()
+    |> List.to_string()
+    |> String.starts_with?("aarch64-apple-darwin")
+  end
+end

--- a/apps/transport/test/support/platform.ex
+++ b/apps/transport/test/support/platform.ex
@@ -1,5 +1,5 @@
 defmodule Transport.Platform do
-  # NOTE: duplicate from `mix.exs`, good enough for now
+  # NOTE: duplicate from `mix.exs`, a bit complicated to DRY apparently
   def apple_silicon? do
     :system_architecture
     |> :erlang.system_info()

--- a/apps/transport/test/support/platform.ex
+++ b/apps/transport/test/support/platform.ex
@@ -1,5 +1,9 @@
 defmodule Transport.Platform do
-  # NOTE: duplicate from `mix.exs`, a bit complicated to DRY apparently
+  @moduledoc """
+  A little heuristic to determine if the code is running on a Mac M1.
+
+  Duplicate from `mix.exs`, a bit complicated to DRY apparently.
+  """
   def apple_silicon? do
     :system_architecture
     |> :erlang.system_info()


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-site/issues/2520
- https://github.com/jayjun/rambo/pull/13
- https://github.com/jayjun/rambo/issues/23
- https://github.com/jayjun/rambo/issues/21 (bloque une nouvelle release)

Le test qui vérifie la bonne exécution de Rambo échoue en systématique sur Mac M1.

Je le "skippe" (pending) explicitement via cette PR car ça pollue le résultat chez moi.

```
..sh: /Users/thbar/git/transport/transport-site/_build/test/lib/rambo/priv/rambo-macarm: No such file or directory
sh: line 0: exec: /Users/thbar/git/transport/transport-site/_build/test/lib/rambo/priv/rambo-macarm: cannot execute: No such file or directory


  1) test rambo rust wrapper compiles and runs (TransportWeb.BuildTest)
     apps/transport/test/build_test.exs:30
     ** (MatchError) no match of right hand side value: {:error, "rambo exited with 126"}
     code: {:ok, %{out: "hello\n"}} = Rambo.run("echo", ["hello"])
     stacktrace:
       test/build_test.exs:31: (test)
```