### PR TITLE
DiscussionsLive : répare erreur de syntaxe JS

### DIFF
--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -18,7 +18,7 @@ defmodule TransportWeb.DiscussionsLive do
             "discussion"
           )
         )
-        # scroll to the right place after discussions have been loaded
+        // Scroll to the right place after discussions have been loaded
         if (location.hash) location.href = location.hash;
       })
     </script>


### PR DESCRIPTION
Correction d'une erreur JS introduite dans #3909. La syntaxe du commentaire n'est pas bonne comme c'est du JavaScript. Pas facile à spotter car c'est du LiveView et on a un mélange de langages…

Détecté en navigant sur le site web. On n'a pas de Sentry pour le JS actuellement.

![image](https://github.com/etalab/transport-site/assets/295709/5f7e3b2d-5f69-49bd-8bb7-ec55493fa3e9)
