### PR TITLE
Espace réutilisateur : redirection vers page info quand non connecté

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -53,6 +53,11 @@ defmodule TransportWeb.Router do
     plug(:authentication_required, destination_path: "/infos_producteurs")
   end
 
+  pipeline :reuser_space do
+    plug(:browser)
+    plug(:authentication_required, destination_path: "/infos_reutilisateurs")
+  end
+
   scope "/", OpenApiSpex.Plug do
     pipe_through(:browser_no_csp)
 
@@ -101,7 +106,7 @@ defmodule TransportWeb.Router do
     end
 
     scope "/espace_reutilisateur" do
-      pipe_through([:authenticated])
+      pipe_through([:reuser_space])
       get("/", ReuserSpaceController, :espace_reutilisateur)
 
       live_session :reuser_space, session: %{"role" => :reuser}, root_layout: {TransportWeb.LayoutView, :app} do

--- a/apps/transport/lib/transport_web/templates/page/infos_reutilisateurs.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/infos_reutilisateurs.html.heex
@@ -34,7 +34,10 @@ These CSS classes may be removed (soon?) when switching to the DSFR.
               "To log in, you will be redirected to data.gouv.fr, the open platform for French public data"
             ) %>
           </div>
-          <a class="button" href={page_path(@conn, :login, redirect_path: current_path(@conn))}>
+          <a
+            class="button"
+            href={page_path(@conn, :login, redirect_path: reuser_space_path(@conn, :espace_reutilisateur))}
+          >
             <%= dgettext("page-dataset-details", "Log in") %>
           </a>
         </div>

--- a/apps/transport/lib/transport_web/views/page_view.ex
+++ b/apps/transport/lib/transport_web/views/page_view.ex
@@ -1,6 +1,5 @@
 defmodule TransportWeb.PageView do
   use TransportWeb, :view
-  import Phoenix.Controller, only: [current_path: 1]
   import TransportWeb.ResourceView, only: [dataset_creation: 0]
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
   import TransportWeb.DatasetView, only: [upcoming_icon_type_path: 1]

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -220,7 +220,7 @@ defmodule TransportWeb.PageControllerTest do
       {:ok, doc} = Floki.parse_document(body)
       [item] = doc |> Floki.find(".panel-producteurs a.button")
 
-      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Finfos_reutilisateurs"]
+      assert Floki.attribute(item, "href") == ["/login/explanation?redirect_path=%2Fespace_reutilisateur"]
       assert item |> Floki.text() =~ "Identifiez-vous"
     end
 

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -11,7 +11,7 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
   describe "espace_reutilisateur" do
     test "logged out", %{conn: conn} do
       conn = conn |> get(@home_url)
-      assert "/login/explanation?" <> URI.encode_query(redirect_path: @home_url) == redirected_to(conn, 302)
+      assert redirected_to(conn, 302) == page_path(conn, :infos_reutilisateurs)
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
     end
 

--- a/apps/transport/test/transport_web/live_views/notifications_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/notifications_live_test.exs
@@ -24,7 +24,7 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
 
     test "as a reuser", %{conn: conn} do
       conn = conn |> get(@reuser_url)
-      assert redirected_to(conn, 302) == "/login/explanation?" <> URI.encode_query(redirect_path: @reuser_url)
+      assert redirected_to(conn, 302) == page_path(conn, :infos_reutilisateurs)
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
     end
   end


### PR DESCRIPTION
Dernière partie, fixes #3907

Réalise ce qui avait été promis précédemment https://github.com/etalab/transport-site/pull/3916#issuecomment-2106937768. Quand on essaie d'accéder à l'espace réutilisateur en n'étant pas connecté, redirige vers la page d'informations correspondante. Similaire à #3915 pour les producteurs.