### PR TITLE
Consolidation BNLC : gère CSV avec BOM

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -333,7 +333,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
                                       %{@download_path_key => tmp_path, @separator_key => separator} = resource_details
                                     } ->
       tmp_path
-      |> File.stream!()
+      |> File.stream!([:trim_bom, encoding: :utf8])
       |> CSV.decode!(headers: true, field_transform: &String.trim/1, separator: separator)
       # Keep only columns that are present in the BNLC, ignore extra columns
       |> Stream.filter(&Map.take(&1, bnlc_headers))

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -328,8 +328,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
     Transport.HTTPoison.Mock
     |> expect(:get, fn ^url, [], [follow_redirect: true] ->
+      # A CSV with BOM (byte order mark)
       body = """
-      foo,bar,baz,insee,id_local
+      \uFEFFfoo,bar,baz,insee,id_local
       1,2,3,21231,1
       4,5,6,21231,2
       """
@@ -533,8 +534,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       Transport.HTTPoison.Mock
       |> expect(:get, fn ^bar_url, [], [follow_redirect: true] ->
+        # A CSV with BOM (byte order mark)
         body = """
-        foo,bar,baz,insee,id_local,extra_col,id_lieu
+        \uFEFFfoo,bar,baz,insee,id_local,extra_col,id_lieu
         1,2,3,21231,3,is_ignored,is_generated_again
         """
 


### PR DESCRIPTION
Fixes #3925

Le job ne gérait pas les fichiers CSV comportant un BOM (byte order mark) en début de fichier CSV, ce qui est _okay-ish_ pour nous. Survenait avec [Lieux de covoiturage - Département du Calvados](https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-departement-du-calvados/).