### PR TITLE
Helper pour déterminer affichage espace réutilisateur

### DIFF
--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -58,7 +58,7 @@ defmodule TransportWeb.Session do
   A temporary helper method to determine if we should display "reuser space features".
   Convenient method to find various entrypoints in the codebase.
 
-  At the moment we only allow transport.data.gouv.fr's member but we could
+  At the moment we only allow transport.data.gouv.fr members but we could
   allow specific logged-in users in the future.
   """
   def display_reuser_space?(%Plug.Conn{} = conn), do: admin?(conn)

--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -54,6 +54,15 @@ defmodule TransportWeb.Session do
     DB.Dataset.base_query() |> where([dataset: d], d.organization_id in ^org_ids) |> DB.Repo.exists?()
   end
 
+  @doc """
+  A temporary helper method to determine if we should display "reuser space features".
+  Convenient method to find various entrypoints in the codebase.
+
+  At the moment we only allow transport.data.gouv.fr's member but we could
+  allow specific logged-in users in the future.
+  """
+  def display_reuser_space?(%Plug.Conn{} = conn), do: admin?(conn)
+
   @spec set_session_attribute_attribute(Plug.Conn.t(), binary(), boolean()) :: Plug.Conn.t()
   defp set_session_attribute_attribute(%Plug.Conn{} = conn, key, value) do
     current_user = current_user(conn)

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -238,7 +238,7 @@
   </div>
   <div class="dataset-metas">
     <div class="panel">
-      <%= if TransportWeb.Session.admin?(@conn) do %>
+      <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
         <%= live_render(@conn, TransportWeb.Live.FollowDatasetLive,
           session: %{"current_user" => @current_user, "dataset_id" => @dataset.id}
         ) %>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -196,7 +196,7 @@
                     </div>
                   </div>
                   <div class="dataset__type">
-                    <%= if TransportWeb.Session.admin?(@conn) do %>
+                    <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
                       <i class={heart_class(@dataset_heart_values, dataset)}></i>
                     <% end %>
                     <%= unless is_nil(icon_type_path(dataset)) do %>


### PR DESCRIPTION
Un rapide refactor visant à utiliser un helper spécifique pour déterminer si on doit afficher des éléments spécifiques à l'espace réutilisateur, que l'on cache pour le moment.

Permet de faire moins d'erreurs, être plus explicite et retrouver les différents endroits à adapter ensuite.