### PR TITLE
Relax constraint on resource_monthly_metrics

### DIFF
--- a/apps/transport/priv/repo/migrations/20240515155123_relax_constraint_on_resource_monthly_metrics.exs
+++ b/apps/transport/priv/repo/migrations/20240515155123_relax_constraint_on_resource_monthly_metrics.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.RelaxConstraintOnResourceMonthlyMetrics do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:resource_monthly_metrics, "resource_monthly_metrics_dataset_datagouv_id_fkey"))
+  end
+
+  def down do
+    alter table(:resource_monthly_metrics) do
+      modify(:dataset_datagouv_id, references(:dataset, column: :datagouv_id, type: :string, on_delete: :delete_all))
+    end
+  end
+end


### PR DESCRIPTION
La contrainte de clef étrangère était trop ambitieuse et ne peut être garanti à l'import des métriques de resources. Enlevons-là.

Cela est désormais cohérent avec l'autre clef (`resource_datagouv_id`) elle aussi non contrainte.

Follow-up de https://github.com/etalab/transport-site/pull/3935. Voir #3931.