### PR TITLE
Page JDD : liens vers espaces utilisateurs

### DIFF
--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -11,4 +11,6 @@ defmodule TransportWeb.ReuserSpaceController do
     |> assign(:followed_datasets_ids, followed_datasets_ids)
     |> render("index.html")
   end
+
+  def datasets_edit(%Plug.Conn{} = conn, _), do: text(conn, "Coming later")
 end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -108,6 +108,7 @@ defmodule TransportWeb.Router do
     scope "/espace_reutilisateur" do
       pipe_through([:reuser_space])
       get("/", ReuserSpaceController, :espace_reutilisateur)
+      get("/datasets/:dataset_id", ReuserSpaceController, :datasets_edit)
 
       live_session :reuser_space, session: %{"role" => :reuser}, root_layout: {TransportWeb.LayoutView, :app} do
         live("/notifications", Live.NotificationsLive, :notifications, as: :reuser_space)

--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -60,8 +60,17 @@ defmodule TransportWeb.Session do
 
   At the moment we only allow transport.data.gouv.fr members but we could
   allow specific logged-in users in the future.
+
+  `:force_display_reuser_space` is currently set in a few tests to test things
+  while not being an admin (because being an admin may not be appropriate in the test).
   """
-  def display_reuser_space?(%Plug.Conn{} = conn), do: admin?(conn)
+  def display_reuser_space?(%Plug.Conn{} = conn) do
+    if Mix.env() == :test do
+      get_session(conn, :force_display_reuser_space, false) or admin?(conn)
+    else
+      admin?(conn)
+    end
+  end
 
   @spec set_session_attribute_attribute(Plug.Conn.t(), binary(), boolean()) :: Plug.Conn.t()
   defp set_session_attribute_attribute(%Plug.Conn{} = conn, key, value) do

--- a/apps/transport/lib/transport_web/templates/dataset/_header_links.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_header_links.html.heex
@@ -1,0 +1,34 @@
+<div data-section="dataset-header-links">
+  <%= if TransportWeb.Session.admin?(@conn) do %>
+    <i class="fa fa-external-link-alt"></i>
+    <%= link("Backoffice", to: backoffice_page_path(@conn, :edit, @dataset.id)) %> &middot;
+  <% end %>
+  <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
+    <i class="fa fa-external-link-alt"></i>
+    <%= if @current_user do %>
+      <%= if @is_producer do %>
+        <%= link(dgettext("default", "Producer space"),
+          to: page_path(@conn, :espace_producteur, utm_campaign: "dataset_details"),
+          target: "_blank"
+        ) %>
+      <% else %>
+        <%= if @follows_dataset do %>
+          <%= link(dgettext("default", "Reuser space"),
+            to: reuser_space_path(@conn, :datasets_edit, @dataset.id, utm_campaign: "dataset_details"),
+            target: "_blank"
+          ) %>
+        <% else %>
+          <%= link(dgettext("default", "Reuser space"),
+            to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "dataset_details"),
+            target: "_blank"
+          ) %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= link(dgettext("default", "Reuser space"),
+        to: page_path(@conn, :infos_reutilisateurs, utm_campaign: "dataset_details"),
+        target: "_blank"
+      ) %>
+    <% end %>
+  <% end %>
+</div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -16,13 +16,14 @@
 </div>
 <div class="dataset-title-div" id="dataset-top">
   <%= dgettext("page-dataset-details", "dataset") %>
-  <h1>
-    <%= @dataset.custom_title %>
-  </h1>
-  <%= if TransportWeb.Session.admin?(@conn) do %>
-    <i class="fa fa-external-link-alt"></i>
-    <%= link("backoffice", to: backoffice_page_path(@conn, :edit, @dataset.id)) %>
-  <% end %>
+  <h1><%= @dataset.custom_title %></h1>
+  <%= render("_header_links.html",
+    conn: @conn,
+    dataset: @dataset,
+    current_user: @current_user,
+    is_producer: @is_producer,
+    follows_dataset: @follows_dataset
+  ) %>
 </div>
 <div class="dataset-page">
   <div class="dataset-menu-container">

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -150,3 +150,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Producer space"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -150,3 +150,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Producer space"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -150,3 +150,7 @@ msgstr "Comparer deux GTFS"
 #, elixir-autogen, elixir-format
 msgid "Producer space"
 msgstr "Espace producteur"
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr "Espace réutilisateur"

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -28,4 +28,21 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
     end
   end
+
+  describe "datasets_edit" do
+    test "logged out", %{conn: conn} do
+      conn = conn |> get(reuser_space_path(conn, :datasets_edit, 42))
+      assert redirected_to(conn, 302) == page_path(conn, :infos_reutilisateurs)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vous devez être préalablement connecté"
+    end
+
+    test "logged in", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+      assert conn
+             |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+             |> get(reuser_space_path(conn, :datasets_edit, 42))
+             |> text_response(200) == "Coming later"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3923

Ajout des liens vers les espaces producteur ou réutilisateur en fonction du contexte (connecté ou pas, producteur, suivi du JDD ou non) conformément à ce qui est décrit dans le ticket.

Le lien "Backoffice" reste présent pour les membres de transport.data.gouv.fr.

> En mode connecté + dataset en favori => redirection dans un nouvel onglet vers la page espace_réutilisateur/dataset (à créer)

cette page n'existe pas encore (@cyrilmorin réfléchit et fera un ticket prochainement), je la crée donc dans le router/controller mais elle ne fait rien pour le moment.

## Capture d'écran

Contexte : connecté, admin et producteur

![image](https://github.com/etalab/transport-site/assets/295709/bad6f3fe-540b-4fbe-b357-4d9157bef00c)

