### PR TITLE
Producteurs : inscription aux notifications lors de la 1ère connexion

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -72,9 +72,11 @@ defmodule DB.NotificationSubscription do
   typed_schema "notification_subscription" do
     field(:reason, Ecto.Enum, values: @all_reasons)
 
-    # Useful to know if the subscription has been created by an admin
-    # from the backoffice (`:admin`) or by the user (`:user`)
-    field(:source, Ecto.Enum, values: [:admin, :user])
+    # The subscription source:
+    # - `:admin`: created by an admin from the backoffice
+    # - `:user`: by the user using self-service tools
+    # - `automation:<slug>`: created by the system, the slug adds more details about the source
+    field(:source, Ecto.Enum, values: [:admin, :user, :"automation:promote_producer_space"])
     field(:role, Ecto.Enum, values: @possible_roles)
 
     belongs_to(:contact, DB.Contact)

--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -101,6 +101,7 @@ defmodule DB.NotificationSubscription do
     |> join(:inner, [notification_subscription: ns], c in DB.Contact, on: ns.contact_id == c.id, as: :contact)
   end
 
+  def insert(%{} = fields), do: %__MODULE__{} |> changeset(fields) |> DB.Repo.insert()
   def insert!(%{} = fields), do: %__MODULE__{} |> changeset(fields) |> DB.Repo.insert!()
 
   def changeset(struct, attrs \\ %{}) do

--- a/apps/transport/lib/jobs/promote_producer_space_job.ex
+++ b/apps/transport/lib/jobs/promote_producer_space_job.ex
@@ -41,7 +41,7 @@ defmodule Transport.Jobs.PromoteProducerSpaceJob do
       # and we leverage the changeset to ignore those.
       DB.NotificationSubscription.insert(%{
         role: :producer,
-        source: :admin,
+        source: :"automation:promote_producer_space",
         reason: reason,
         contact_id: contact_id,
         dataset_id: dataset_id

--- a/apps/transport/lib/jobs/promote_producer_space_job.ex
+++ b/apps/transport/lib/jobs/promote_producer_space_job.ex
@@ -1,0 +1,69 @@
+defmodule Transport.Jobs.PromoteProducerSpaceJob do
+  @moduledoc """
+  This job is executed when a contact logs in on the platform for the first time,
+  for all contacts.
+
+  If the contact is a producer, subscribe them to all producer notifications
+  and send them an email to introduce the producer space.
+
+  If the contact is a reuser, do nothing.
+  """
+  use Oban.Worker, unique: [period: :infinity], max_attempts: 3
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"contact_id" => contact_id}}) do
+    contact =
+      DB.Contact.base_query()
+      |> preload(organizations: :datasets)
+      |> where([contact: c], c.id == ^contact_id)
+      |> DB.Repo.one!()
+
+    datasets = Enum.flat_map(contact.organizations, & &1.datasets)
+
+    unless Enum.empty?(datasets) do
+      create_producer_subscriptions(contact, datasets)
+
+      {:ok, _} =
+        contact.email
+        |> Transport.PromoteProducerSpaceNotifier.promote_producer_space()
+        |> Transport.Mailer.deliver()
+    end
+
+    :ok
+  end
+
+  defp create_producer_subscriptions(%DB.Contact{id: contact_id}, datasets) do
+    reasons = DB.NotificationSubscription.subscribable_reasons_related_to_datasets(:producer)
+
+    for reason <- reasons, %DB.Dataset{id: dataset_id} <- datasets do
+      # Do not use `insert!/1`: we may try to insert duplicates (existing subscriptions)
+      # and we leverage the changeset to ignore those.
+      DB.NotificationSubscription.insert(%{
+        role: :producer,
+        source: :admin,
+        reason: reason,
+        contact_id: contact_id,
+        dataset_id: dataset_id
+      })
+    end
+  end
+end
+
+defmodule Transport.PromoteProducerSpaceNotifier do
+  @moduledoc """
+  Module in charge of building the email.
+  """
+  use Phoenix.Swoosh, view: TransportWeb.EmailView
+
+  def promote_producer_space(email) do
+    contact_email = Application.fetch_env!(:transport, :contact_email)
+
+    new()
+    |> from({"transport.data.gouv.fr", contact_email})
+    |> to(email)
+    |> reply_to(contact_email)
+    |> subject("Bienvenue ! Découvrez votre Espace producteur")
+    |> render_body("promote_producer_space.html", %{contact_email_address: contact_email})
+  end
+end

--- a/apps/transport/lib/transport_web/templates/email/promote_producer_space.html.md
+++ b/apps/transport/lib/transport_web/templates/email/promote_producer_space.html.md
@@ -1,0 +1,11 @@
+Bonjour,
+
+Bienvenue sur le Point d’Accès National aux données de transport, [transport.data.gouv.fr](https://transport.data.gouv.fr) !
+
+Rendez-vous sur votre <%= link_for_espace_producteur(:promote_producer_space) %> pour mettre à jour vos données ou paramétrer vos notifications en cas de péremption, d’indisponibilité ou d’erreurs bloquantes pour les données que vous gérez.
+
+Si vous avez des questions, n’hésitez pas à contacter notre équipe à l’adresse : <%= @contact_email_address %>.
+
+À bientôt,
+
+L’équipe transport.data.gouv.fr

--- a/apps/transport/test/transport/jobs/promote_producer_space_job_test.exs
+++ b/apps/transport/test/transport/jobs/promote_producer_space_job_test.exs
@@ -1,0 +1,85 @@
+defmodule Transport.Test.Transport.Jobs.PromoteProducerSpaceJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  import DB.Factory
+  import Ecto.Query
+  import Swoosh.TestAssertions
+  alias Transport.Jobs.PromoteProducerSpaceJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "perform" do
+    test "does nothing if you're a reuser" do
+      contact = insert_contact()
+      insert(:dataset)
+
+      assert :ok == perform_job(PromoteProducerSpaceJob, %{contact_id: contact.id})
+
+      assert DB.NotificationSubscription |> DB.Repo.all() |> Enum.empty?()
+      refute_email_sent()
+    end
+
+    test "for a producer" do
+      organization = insert(:organization)
+
+      %DB.Contact{id: contact_id, email: contact_email} =
+        insert_contact(%{organizations: [organization |> Map.from_struct()]})
+
+      dataset = insert(:dataset, organization_id: organization.id)
+      # Another dataset, should be ignored: contact is not a producer for it
+      insert(:dataset)
+
+      # An existing notification subscription in the DB before executing the job
+      insert(:notification_subscription,
+        dataset_id: dataset.id,
+        reason: :expiration,
+        role: :producer,
+        contact_id: contact_id,
+        source: :admin
+      )
+
+      assert :ok == perform_job(PromoteProducerSpaceJob, %{contact_id: contact_id})
+
+      # The contact has been subscribed to all producer reasons for the dataset.
+      # The existing subscription did not interfere.
+      subscriptions =
+        DB.NotificationSubscription.base_query()
+        |> select([notification_subscription: ns], %{
+          dataset_id: ns.dataset_id,
+          role: ns.role,
+          contact_id: ns.contact_id,
+          reason: ns.reason
+        })
+        |> DB.Repo.all()
+
+      expected_subscriptions =
+        DB.NotificationSubscription.subscribable_reasons_related_to_datasets(:producer)
+        |> MapSet.new(fn reason ->
+          %{dataset_id: dataset.id, role: :producer, contact_id: contact_id, reason: reason}
+        end)
+
+      assert Enum.count(subscriptions) == subscriptions |> MapSet.new() |> Enum.count()
+      assert expected_subscriptions == MapSet.new(subscriptions)
+
+      assert_email_sent(fn %Swoosh.Email{} = sent ->
+        assert %Swoosh.Email{
+                 from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
+                 to: [{"", ^contact_email}],
+                 reply_to: {"", "contact@transport.data.gouv.fr"},
+                 subject: "Bienvenue ! Découvrez votre Espace producteur",
+                 text_body: nil,
+                 html_body: html_body
+               } = sent
+
+        assert html_body =~ "Bienvenue sur le Point d’Accès National aux données de transport"
+
+        assert html_body =~
+                 ~s(Rendez-vous sur votre <a href="http://127.0.0.1:5100/espace_producteur?utm_source=transactional_email&amp;utm_medium=email&amp;utm_campaign=promote_producer_space">Espace Producteur</a> pour mettre à jour vos données ou paramétrer vos notifications)
+      end)
+
+      assert DB.Notification |> DB.Repo.all() |> Enum.empty?()
+    end
+  end
+end

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -68,10 +68,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset with a region and AOM", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     {conn, logs} =
       use_cassette "dataset/dataset-region-ao.json" do
@@ -89,16 +86,15 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset without a region nor aom", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
-
     dataset = @dataset |> Map.put("region_id", nil) |> Map.put("insee", nil)
 
     {conn, logs} =
       use_cassette "dataset/dataset-no-region-nor-ao.json" do
-        with_log(fn -> post(conn, backoffice_dataset_path(conn, :post), %{"form" => dataset}) end)
+        with_log(fn ->
+          conn
+          |> setup_admin_in_session()
+          |> post(backoffice_dataset_path(conn, :post), %{"form" => dataset})
+        end)
       end
 
     assert logs =~ "Vous devez remplir soit une région soit une AOM soit utiliser les zones data.gouv"
@@ -112,11 +108,6 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to a region", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
-
     dataset_datagouv_id = "12"
 
     dataset =
@@ -171,7 +162,7 @@ defmodule TransportWeb.BackofficeControllerTest do
        ]}
     end)
 
-    conn = post(conn, backoffice_dataset_path(conn, :post), %{"form" => dataset})
+    conn = conn |> setup_admin_in_session() |> post(backoffice_dataset_path(conn, :post), %{"form" => dataset})
 
     assert redirected_to(conn, 302) == backoffice_page_path(conn, :index)
     assert Resource |> where([r], not r.is_community_resource) |> Repo.all() |> length() == 1
@@ -180,10 +171,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to aom", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     dataset = %{@dataset | "region_id" => nil}
 
@@ -222,10 +210,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to cities", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     dataset =
       @dataset_with_zones
@@ -244,10 +229,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to cities and to the country", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     dataset =
       @dataset_with_zones
@@ -275,10 +257,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to an AO and with an empty territory name", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     dataset =
       @dataset_with_zones
@@ -313,10 +292,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset linked to a region and to the country", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     dataset =
       @dataset
@@ -338,10 +314,7 @@ defmodule TransportWeb.BackofficeControllerTest do
   end
 
   test "Add a dataset twice", %{conn: conn} do
-    conn =
-      conn
-      |> init_test_session(redirect_path: "/datasets")
-      |> get(session_path(conn, :create, %{"code" => "secret"}))
+    conn = conn |> setup_admin_in_session()
 
     resource_url = "http://www.metromobilite.fr/data/Horaires/SEM-GTFS.zip"
     dataset = %{@dataset | "region_id" => nil}


### PR DESCRIPTION
Dernière partie, fixes #3896.

Quand un producteur se connecte la première fois chez nous avec son compte data.gouv.fr, abonne la personne à toutes les notifications pour les jeux de données que la personne gère. [voir consignes](https://github.com/etalab/transport-site/issues/3896#issuecomment-2098541927).

Cette PR dispatch un job dans `SessionController` quand un contact se connecte la première fois chez nous, ce nouveau job Oban est en charge de déterminer si le contact est producteur ou réutilisateur (rien à faire), créer les abonnements pertinents et envoyer un e-mail souhaitant la bienvenue et présentant l'Espace producteur.

@cyrilmorin doit encore valider le contenu de l'e-mail, le reste de la PR ne changera pas.