### PR TITLE
Meilleur fix pour le calcul d'inactivité

### DIFF
--- a/apps/transport/lib/jobs/warn_user_inactivity_job.ex
+++ b/apps/transport/lib/jobs/warn_user_inactivity_job.ex
@@ -22,7 +22,11 @@ defmodule Transport.Jobs.WarnUserInactivityJob do
   defp pruning_threshold(now), do: DateTime.add(now, -30 * 25, :day)
 
   defp warn_inactive_contact(%DateTime{} = pruning_dt, %DB.Contact{} = contact) do
-    days_until_pruning = DateTime.diff(contact.last_login_at, pruning_dt, :day)
+    days_until_pruning =
+      Date.diff(
+        DateTime.to_date(contact.last_login_at),
+        DateTime.to_date(pruning_dt)
+      )
 
     case days_until_pruning do
       30 ->


### PR DESCRIPTION
Le calcul de durée d'inactivité (en jours) est désormais fait sur les dates et non plus les datetime. Ainsi peu importe l'heure à laquelle le job tournera, et éviterait des ambiguïtés de calcul qu'un utilisateur scrupuleux pourrait relever.

Ceci a également le mérite de stabiliser les tests.

Vrai fix de ce que #3945 essayait de corriger.