### PR TITLE
restore_db: Option pour tronquer les jobs Oban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ apps/transport/client/yarn-error.log
 .miniorc
 livebook/cache-dir
 apps/transport/priv/repo/structure.sql
+
+pg.list

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -11,7 +11,7 @@
 # ./restore_db.sh --skip-extensions <path_to_backup>
 #
 # With the flag `--truncate-jobs`, you can skip the prompt and automatically truncate Oban jobs. Example:
-# ./restore_db.sh --preserve-oban-jobs <path_to_backup>
+# ./restore_db.sh --truncate-jobs <path_to_backup>
 #
 # The flags must be the first args.
 

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -9,7 +9,11 @@
 # With the flag `--skip-extensions`, you can also skip extensions restoration as those might require administrative
 # rights your pg user doesn't have. Example:
 # ./restore_db.sh --skip-extensions <path_to_backup>
-# The flag must be the first arg.
+#
+# With the flag `--truncate-jobs`, you can skip the prompt and automatically truncate Oban jobs. Example:
+# ./restore_db.sh --preserve-oban-jobs <path_to_backup>
+#
+# The flags must be the first args.
 
 VALID_ARGS=$(getopt --options=h --longoptions=help,skip-extensions,truncate-jobs --name "$0" -- "$@") || exit 1
 

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -11,13 +11,42 @@
 # ./restore_db.sh --skip-extensions <path_to_backup>
 # The flag must be the first arg.
 
-skip_extensions=false
+VALID_ARGS=$(getopt --options=h --longoptions=help,skip-extensions,truncate-jobs --name "$0" -- "$@") || exit 1
 
-if [ "$1" = "--skip-extensions" ]
-then
-  skip_extensions=true
-  shift 1
-fi
+eval set -- "$VALID_ARGS"
+
+should_skip_extensions=false
+should_truncate_jobs=false
+
+function usage() {
+  echo "Usage:"
+  echo " $0 (-h|--help) -- this message"
+  echo " $0 [--skip-extensions] [--truncate-jobs] <absolute_path_to_backup>"
+  echo " $0 [--skip-extensions] [--truncate-jobs] <db_name> <host> <user_name> <password> <absolute_path_to_backup>"
+  exit 1
+}
+
+while true; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+
+    --skip-extensions)
+      should_skip_extensions=true
+      shift 1
+      ;;
+
+    --truncate-jobs)
+      should_truncate_jobs=true
+      shift 1
+      ;;
+
+    --) shift;
+      break
+      ;;
+  esac
+done
 
 if test "$#" -eq 1; then
     DB_NAME="transport_repo"
@@ -32,11 +61,14 @@ elif test "$#" -eq 5; then
     export PGPASSWORD=$4
     BACKUP_PATH=$5
 else
-    echo "Usage: ./restore_db.sh (--skip-extensions) <db_name> <host> <user_name> <password> <absolute_path_to_backup>"
-    exit 1
+    usage
 fi
 
-if [ "$skip_extensions" = true ]
+function sql() {
+  psql -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" -c "$1"
+}
+
+if [ "$should_skip_extensions" = true ]
 then
   pg_restore -l "$BACKUP_PATH" -f ./pg.list
   pg_restore -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" --format=c --no-owner --clean --use-list ./pg.list --no-acl "$BACKUP_PATH"
@@ -44,24 +76,33 @@ else
   pg_restore -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" --format=c --no-owner --clean --no-acl "$BACKUP_PATH"
 fi
 
+function truncate_jobs() {
+  sql 'TRUNCATE TABLE oban_jobs'
+}
 
 echo "Truncating contact table"
-psql -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" -c 'TRUNCATE TABLE contact CASCADE'
-echo "Truncating feedback table"
-psql -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" -c 'TRUNCATE TABLE feedback CASCADE'
+sql 'TRUNCATE TABLE contact CASCADE'
 
-# https://stackoverflow.com/a/1885534
-read -p "Do you want to remove already enqueued Oban jobs? [y/N] " -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
+echo "Truncating feedback table"
+sql 'TRUNCATE TABLE feedback CASCADE'
+
+if [ "$should_truncate_jobs" = true ]
 then
-    psql -h "$HOST" -U "$USER_NAME" -d "$DB_NAME" -c 'DELETE from oban_jobs'
+  truncate_jobs
+else
+  # https://stackoverflow.com/a/1885534
+  read -p "Do you want to remove already enqueued Oban jobs? [y/N] " -n 1 -r
+  echo    # (optional) move to a new line
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    truncate_jobs
+  fi
 fi
 
 # Don't let database files hang around
 rm "$BACKUP_PATH"
 
-if [ "$skip_extensions" = true ]
+if [ "$should_skip_extensions" = true ]
 then
   rm ./pg.list
 fi


### PR DESCRIPTION
Nouveau flag `--truncate-jobs` pour automatiquement tronquer les jobs Oban au restore. Le comportement par défaut est inchangé : la question reste posée si le flag n'est pas mis.

Autres changements :
- la gestion d'arguments a été revue pour supporter plus d'options. Le message d'usage est enrichi en conséquence.
- les flags classiques `-h` et `--help` sont ajoutés pour rappeler l'usage.
- helper pour les commandes SQL