### PR TITLE
restore_db.sh: supprimons les jobs par défaut

### DIFF
--- a/restore_db.sh
+++ b/restore_db.sh
@@ -84,6 +84,9 @@ fi
 echo "Truncating contact table"
 sql 'TRUNCATE TABLE contact CASCADE'
 
+echo "Truncating user_feedback table"
+sql 'TRUNCATE TABLE user_feedback CASCADE'
+
 if [ "$should_preserve_oban_jobs" = false ]
 then
   echo "Truncating oban_jobs table"

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -84,9 +84,6 @@ fi
 echo "Truncating contact table"
 sql 'TRUNCATE TABLE contact CASCADE'
 
-echo "Truncating user_feedback table"
-sql 'TRUNCATE TABLE user_feedback CASCADE'
-
 if [ "$should_preserve_oban_jobs" = false ]
 then
   echo "Truncating oban_jobs table"

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -84,8 +84,8 @@ fi
 echo "Truncating contact table"
 sql 'TRUNCATE TABLE contact CASCADE'
 
-echo "Truncating feedback table"
-sql 'TRUNCATE TABLE feedback CASCADE'
+echo "Truncating user_feedback table"
+sql 'TRUNCATE TABLE user_feedback CASCADE'
 
 if [ "$should_preserve_oban_jobs" = false ]
 then

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -54,19 +54,19 @@ while true; do
 done
 
 if test "$#" -eq 1; then
-    DB_NAME="transport_repo"
-    USER_NAME="postgres"
-    BACKUP_PATH=$1
-    HOST="localhost"
-    export PGPASSWORD="postgres"
+  DB_NAME="transport_repo"
+  USER_NAME="postgres"
+  BACKUP_PATH=$1
+  HOST="localhost"
+  export PGPASSWORD="postgres"
 elif test "$#" -eq 5; then
-    DB_NAME=$1
-    HOST=$2
-    USER_NAME=$3
-    export PGPASSWORD=$4
-    BACKUP_PATH=$5
+  DB_NAME=$1
+  HOST=$2
+  USER_NAME=$3
+  export PGPASSWORD=$4
+  BACKUP_PATH=$5
 else
-    usage
+  usage
 fi
 
 function sql() {


### PR DESCRIPTION
Le comportement par défaut change : désormais les jobs Oban du dump sont supprimés sans interroger l'utilisateur.

Pour conserver les jobs il faut désormais utiliser le flag (optionnel) `--preserve-oban-jobs`.

Autre changement : le `truncate table feedback` aurait dû être `truncate table user_feedback`.