### PR TITLE
Resources GTFS: filesize porté par l‘historique

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -40,7 +40,6 @@ defmodule DB.Resource do
     # (this is done for OpenDataSoft)
     field(:datagouv_id, :string)
 
-    field(:filesize, :integer)
     # Can be `remote` or `file`. `file` are for files uploaded and hosted
     # on data.gouv.fr
     field(:filetype, :string)
@@ -109,7 +108,6 @@ defmodule DB.Resource do
         :community_resource_publisher,
         :original_resource_url,
         :description,
-        :filesize,
         :filetype,
         :type,
         :display_position

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -251,6 +251,16 @@ defmodule TransportWeb.API.DatasetController do
 
   defp get_metadata(_), do: nil
 
+  defp get_payload(%Resource{format: "GTFS", resource_history: resource_history}) do
+    resource_history
+    |> Enum.at(0)
+    |> Map.get(:payload)
+  rescue
+    _ -> nil
+  end
+
+  defp get_payload(_), do: nil
+
   @spec transform_resource(Resource.t()) :: map()
   defp transform_resource(resource) do
     metadata = get_metadata(resource)
@@ -260,6 +270,8 @@ defmodule TransportWeb.API.DatasetController do
         %{metadata: metadata_content} -> metadata_content
         _ -> nil
       end
+
+    payload = get_payload(resource)
 
     %{
       "page_url" => TransportWeb.Router.Helpers.resource_url(TransportWeb.Endpoint, :details, resource.id),
@@ -274,10 +286,10 @@ defmodule TransportWeb.API.DatasetController do
       "start_calendar_validity" => metadata_content && Map.get(metadata, "start_date"),
       "type" => resource.type,
       "format" => resource.format,
+      "filesize" => payload && Map.get(payload, "filesize"),
       "community_resource_publisher" => resource.community_resource_publisher,
       "metadata" => metadata_content,
       "original_resource_url" => resource.original_resource_url,
-      "filesize" => resource.filesize,
       "modes" => metadata && Map.get(metadata, :modes),
       "features" => metadata && Map.get(metadata, :features),
       "schema_name" => resource.schema_name,


### PR DESCRIPTION
Le champ `filesize` n‘est plus lu de la base de données pour les ressources.

L‘API est adaptée pour lire l‘historique (pour les resources GTFS en l‘état de la PR). Pour les autres types de ressources le filesize est `null` (pour l‘instant).

La colonne n'est pas supprimée mais n'est plus connue de la couche de persistence.

See #2432.