### PR TITLE
Abonnement aux notifications : valeur champ source quand créé par le système

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -76,7 +76,10 @@ defmodule DB.NotificationSubscription do
     # - `:admin`: created by an admin from the backoffice
     # - `:user`: by the user using self-service tools
     # - `automation:<slug>`: created by the system, the slug adds more details about the source
-    field(:source, Ecto.Enum, values: [:admin, :user, :"automation:promote_producer_space"])
+    field(:source, Ecto.Enum,
+      values: [:admin, :user, :"automation:promote_producer_space", :"automation:migrate_from_reuser_to_producer"]
+    )
+
     field(:role, Ecto.Enum, values: @possible_roles)
 
     belongs_to(:contact, DB.Contact)

--- a/apps/transport/lib/jobs/notification_subscription_producer_job.ex
+++ b/apps/transport/lib/jobs/notification_subscription_producer_job.ex
@@ -44,7 +44,9 @@ defmodule Transport.Jobs.NotificationSubscriptionProducerJob do
   defp create_subscriptions(%{contact_id: _, dataset_id: _} = attrs) do
     DB.NotificationSubscription.subscribable_reasons_related_to_datasets(:producer)
     |> Enum.each(fn reason ->
-      DB.NotificationSubscription.insert!(Map.merge(%{role: :producer, source: :admin, reason: reason}, attrs))
+      DB.NotificationSubscription.insert!(
+        Map.merge(%{role: :producer, source: :"automation:migrate_from_reuser_to_producer", reason: reason}, attrs)
+      )
     end)
   end
 end

--- a/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
+++ b/apps/transport/test/transport/jobs/notification_subscription_producer_job_test.exs
@@ -70,13 +70,13 @@ defmodule Transport.Test.Transport.Jobs.NotificationSubscriptionProducerJobTest 
              %DB.NotificationSubscription{
                role: :producer,
                reason: :dataset_with_error,
-               source: :admin,
+               source: :"automation:migrate_from_reuser_to_producer",
                contact_id: ^producer_id,
                dataset_id: ^dataset_id
              },
              %DB.NotificationSubscription{
                reason: :expiration,
-               source: :admin,
+               source: :"automation:migrate_from_reuser_to_producer",
                role: :producer,
                contact_id: ^producer_id,
                dataset_id: ^dataset_id
@@ -90,7 +90,7 @@ defmodule Transport.Test.Transport.Jobs.NotificationSubscriptionProducerJobTest 
              },
              %DB.NotificationSubscription{
                reason: :resource_unavailable,
-               source: :admin,
+               source: :"automation:migrate_from_reuser_to_producer",
                role: :producer,
                contact_id: ^producer_id,
                dataset_id: ^dataset_id


### PR DESCRIPTION
Fixes #3943

J'ai revu le code existant pour adapter la valeur de la colonne `source` et l'adapter si jamais l'abonnement a été créé par du code dans le but d'avoir de meilleures statistiques (connaitre la source de création d'un abonnement).