### PR TITLE
Content Security Policy : ajout directive frame ancestors

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -44,6 +44,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           default-src 'none';
           connect-src *;
           font-src *;
+          frame-ancestors 'none';
           img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
           frame-src https://www.dailymotion.com/;
@@ -57,6 +58,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
             default-src 'none';
             connect-src *;
             font-src *;
+            frame-ancestors 'none';
             img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
             frame-src https://www.dailymotion.com/;

--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -10,12 +10,13 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
   def call(conn, _opts) do
     nonce = generate_nonce()
     csp_headers = csp_headers(Application.fetch_env!(:transport, :app_env), nonce)
+    headers = Map.merge(csp_headers, %{"x-frame-options" => "DENY"})
 
     conn
     # used by the phoenix LivedDashboard to allow secure inlined CSS
     |> Plug.Conn.assign(:csp_nonce_value, nonce)
     |> Plug.Conn.put_session(:csp_nonce_value, nonce)
-    |> Phoenix.Controller.put_secure_browser_headers(csp_headers)
+    |> Phoenix.Controller.put_secure_browser_headers(headers)
   end
 
   @doc """

--- a/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
+++ b/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
@@ -9,7 +9,7 @@ defmodule TransportWeb.HeadersAndCookiesTest do
     assert get_resp_header(conn, "referrer-policy") == ["strict-origin-when-cross-origin"]
     assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
     assert get_resp_header(conn, "x-download-options") == ["noopen"]
-    assert get_resp_header(conn, "x-frame-options") == ["SAMEORIGIN"]
+    assert get_resp_header(conn, "x-frame-options") == ["DENY"]
     assert get_resp_header(conn, "x-permitted-cross-domain-policies") == ["none"]
 
     [header] = get_resp_header(conn, "set-cookie")


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-deploy/issues/74

Améliore notre CSP en indiquant que le PAN ne peut pas être mis dans une `iframe`. Voir [OWASP - Clickjacking defense](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html#defending-with-content-security-policy-csp-frame-ancestors-directive).

Nous avions déjà `x-frame-options: sameorigin` dans notre codebase pour toutes nos réponses. https://github.com/etalab/transport-site/blob/22162d63b100d9a1efd940096fef8613de307555/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs#L12

J'adapte en passant à `DENY`, on ne met pas d'iframe de notre propre site.