### PR TITLE
Affichage de la carte pour tous les GeoJSONs

### DIFF
--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -338,7 +338,7 @@ function createMap (id, resourceUrl, resourceFormat, lang = 'fr') {
         createCSVmap(id, resourceUrl)
     } else if (resourceFormat === 'gbfs' || resourceUrl.endsWith('gbfs.json')) {
         createGBFSmap(id, resourceUrl, lang)
-    } else if (resourceUrl.endsWith('.geojson') || resourceUrl.endsWith('.json')) {
+    } else if (resourceFormat === 'geojson' || resourceUrl.endsWith('.geojson') || resourceUrl.endsWith('.json')) {
         createGeojsonMap(id, resourceUrl)
     } else {
         removeViz(`vizualisation of the resource ${resourceUrl} has failed : not recognized file extension`)


### PR DESCRIPTION
Le format n'est-il pas un meilleur indice que l'URL de la resource ?

Ceci a le mérite d'afficher la visualisation GeoJSON si l'url est formattée différemment, comme dans le cas de la [ZFE Strasbourg](https://transport.data.gouv.fr/datasets/zone-a-faibles-emissions-mobilite/) pour laquelle l'url est au format `https://somewhere.org/path/to/resource/export/geojson`.

Fixes #2301.