### PR TITLE
Correctif suivi du nombre de PDC IRVE dans le temps

### DIFF
--- a/livebook/irve-total.livemd
+++ b/livebook/irve-total.livemd
@@ -87,7 +87,7 @@ data =
     task,
     max_concurrency: 25,
     on_timeout: :kill_task,
-    timeout: 25_000
+    timeout: 50_000
   )
   |> Stream.map(fn {:ok, result} -> result end)
   |> Stream.map(fn x -> Map.take(x, ["inserted_at", "row_count"]) end)

--- a/livebook/irve-total.livemd
+++ b/livebook/irve-total.livemd
@@ -28,7 +28,7 @@ opts = [
 {:ok, conn} = Kino.start_child({Postgrex, opts})
 ```
 
-<!-- livebook:{"attrs":{"cache_query":true,"connection":{"type":"postgres","variable":"conn"},"data_frame_alias":"Elixir.Explorer.DataFrame","query":"select id, payload ->> 'permanent_url' as url, inserted_at \nfrom resource_history rh\nwhere rh.resource_id = 79624\norder by inserted_at asc","result_variable":"result","timeout":null},"chunks":null,"kind":"Elixir.KinoDB.SQLCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":{"cache_query":true,"connection":{"type":"postgres","variable":"conn"},"data_frame_alias":"Elixir.Explorer.DataFrame","query":"select id, payload ->> 'permanent_url' as url, inserted_at \nfrom resource_history rh\nwhere rh.resource_id = 81623\norder by inserted_at asc","result_variable":"result","timeout":null},"chunks":null,"kind":"Elixir.KinoDB.SQLCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 result =
@@ -37,7 +37,7 @@ result =
     """
     select id, payload ->> 'permanent_url' as url, inserted_at 
     from resource_history rh
-    where rh.resource_id = 79624
+    where rh.resource_id = 81623
     order by inserted_at asc
     """,
     []

--- a/livebook/irve-total.livemd
+++ b/livebook/irve-total.livemd
@@ -58,14 +58,14 @@ snapshots =
 ```
 
 ```elixir
-path = Path.join(__ENV__.file, "../../scripts/irve/req_custom_cache.exs") |> Path.expand()
+path = Path.join(__ENV__.file, "../../apps/shared/lib/req_custom_cache.ex") |> Path.expand()
 Code.require_file(path)
 
 defmodule Query do
   def cache_dir, do: Path.join(__ENV__.file, "../cache-dir") |> Path.expand()
 
   def cached_get!(url) do
-    req = Req.new() |> CustomCache.attach()
+    req = Req.new() |> Transport.Shared.ReqCustomCache.attach()
     Req.get!(req, url: url, receive_timeout: 100_000, custom_cache_dir: cache_dir())
   end
 end


### PR DESCRIPTION
Suite à question de @stephane-pignal ([discussion Mattermost](https://mattermost.incubateur.net/betagouv/pl/j48yhpqsitrixjmx8g9axiszfy)):

> j'aimerais faire une stat sur l'évolution sur 1 mois du nb de lignes dans le fichier consolidé IRVE. Du coup je pense à metabase. Si c'est le bon outil, j'aurai besoin d'épaulage.

Le notebook présent dans `livebook` permet d'y répondre en instantané, mais avec les inconvénients suivants:
- il faut la base de production sous le coude
- il faut "avaler" l'historique et le ré analyser

On va chercher à rendre cette information plus accessible, voir:
- https://github.com/etalab/transport-site/issues/3963
- https://github.com/etalab/transport-site/issues/3964

(merci @vdegove pour ces tickets)

### Résultat actuel

J'ai fait tourner le tout en local, cela donne:

![CleanShot 2024-05-30 at 11 40 27@2x](https://github.com/etalab/transport-site/assets/10141/5f93619b-37cb-4faf-9e98-b0311b279ba4)
