### PR TITLE
PeriodicReminderProducers : conserve uniquement les JDD abonnés en tant que producteur

### DIFF
--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -138,7 +138,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
     |> Enum.filter(&(&1.role == :producer))
     |> Enum.map(& &1.dataset)
     |> Enum.uniq()
-    |> Enum.sort_by(& &1.custom_title)
+    |> Enum.sort_by(fn %DB.Dataset{custom_title: custom_title} -> custom_title end)
   end
 
   @spec subscribed_as_producer?(DB.Contact.t()) :: boolean()
@@ -147,8 +147,8 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
   end
 
   @spec other_producers_subscribers(DB.Contact.t()) :: [DB.Contact.t()]
-  def other_producers_subscribers(%DB.Contact{id: contact_id, notification_subscriptions: subscriptions}) do
-    dataset_ids = subscriptions |> Enum.map(& &1.dataset_id) |> Enum.uniq()
+  def other_producers_subscribers(%DB.Contact{id: contact_id} = contact) do
+    dataset_ids = contact |> datasets_subscribed_as_producer() |> Enum.map(& &1.id)
 
     dataset_ids
     |> DB.NotificationSubscription.producer_subscriptions_for_datasets(contact_id)

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -107,6 +107,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
     %DB.Contact{id: producer_2_id} = producer_2 = insert_contact()
     reuser = insert_contact()
     dataset = insert(:dataset)
+    other_dataset = insert(:dataset)
 
     # Should be ignored, the contact of a member of the transport.data.gouv.fr's org
     admin_producer =
@@ -123,9 +124,22 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       )
     end)
 
+    # Subscribed as a reuser to another dataset and a producer has notifications enabled.
+    # Should not list the other producer.
+    [{producer_1, :reuser}, {producer_2, :producer}]
+    |> Enum.each(fn {%DB.Contact{} = current_contact, role} ->
+      insert(:notification_subscription,
+        source: :admin,
+        role: role,
+        reason: :expiration,
+        dataset: other_dataset,
+        contact: current_contact
+      )
+    end)
+
     assert [%DB.Contact{id: ^producer_2_id}] =
              producer_1
-             |> DB.Repo.preload(:notification_subscriptions)
+             |> DB.Repo.preload(notification_subscriptions: [:dataset])
              |> PeriodicReminderProducersNotificationJob.other_producers_subscribers()
   end
 

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -160,8 +160,10 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
   test "send mail to producer with subscriptions" do
     %DB.Contact{email: email} = producer_1 = insert_contact()
     producer_2 = insert_contact(%{first_name: "Marina", last_name: "Loiseau"})
+    producer_3 = insert_contact(%{first_name: "Foo", last_name: "Baz"})
     reuser = insert_contact()
     dataset = insert(:dataset, custom_title: "Super JDD")
+    other_dataset = insert(:dataset)
 
     %DB.Contact{id: admin_producer_id} =
       admin_producer =
@@ -174,6 +176,19 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
         role: role,
         reason: :expiration,
         dataset: dataset,
+        contact: contact
+      )
+    end)
+
+    # Subscribed as a reuser to another dataset and a producer has notifications enabled.
+    # Should not list the other producer.
+    [{producer_1, :reuser}, {producer_3, :producer}]
+    |> Enum.each(fn {%DB.Contact{} = contact, role} ->
+      insert(:notification_subscription,
+        source: :admin,
+        role: role,
+        reason: :expiration,
+        dataset: other_dataset,
         contact: contact
       )
     end)


### PR DESCRIPTION
Bug constaté : l'e-mail envoyé listait des producteurs inscrit aux notifications pour les JDDs à tort. On listait les producteurs des jeux de données pour des abonnements à des JDDs en tant que réutilisateur.

J'ai du mal à le phraser de manière simple 😅 Je peux vous partager un exemple d'e-mail reçu avec un contenu inapproprié. Je ne partage pas ici car contient quelques données personnelles.

## Exemple

- utilisateurs A et B
- JDD 1
- utilisateur A n'est pas producteur du JDD 1
- utilisateur A abonné aux notifications pour JDD 1 en tant que réutilisateur
- utilisateur B abonné aux notifications pour JDD 1 en tant que producteur

On envoyait à tort, le texte suivant, à l'utilisateur A :
> Les autres personnes inscrites à ces notifications sont : utilisateur B

Mis en évidence dans le premier commit https://github.com/etalab/transport-site/commit/adad44c05de682070d91b39d46a477c0c03fbcd8