### PR TITLE
Import de dataset: résister au recyclage d'URL

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -294,7 +294,7 @@ defmodule Transport.ImportData do
       # Only protect against reuse in the same dataset.
       # See #3976.
       siblings =
-        resource_datagouv_ids |> Enum.reject(fn resource_id -> resource_id == dataset["id"] end)
+        resource_datagouv_ids |> Enum.reject(fn resource_id -> resource_id == resource["id"] end)
 
       existing_resource = get_existing_resource(resource, dataset["id"], siblings) || %{}
 

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -51,10 +51,10 @@ defmodule Transport.ImportData do
     {:ok, _result} = Repo.query("REFRESH MATERIALIZED VIEW places;")
   end
 
-  def generate_import_logs!(
-        %Dataset{id: dataset_id, datagouv_id: datagouv_id},
-        options
-      ) do
+  defp generate_import_logs!(
+         %Dataset{id: dataset_id, datagouv_id: datagouv_id},
+         options
+       ) do
     success = options |> Keyword.fetch!(:success)
     msg = options |> Keyword.get(:msg)
 
@@ -276,13 +276,27 @@ defmodule Transport.ImportData do
 
   @spec get_resources(map(), binary()) :: [map()]
   def get_resources(dataset, type) do
-    dataset
-    |> get_valid_resources(type)
-    |> Enum.concat(get_community_resources(dataset))
-    |> Enum.uniq_by(fn resource -> resource["url"] end)
+    resources =
+      dataset
+      |> get_valid_resources(type)
+      |> Enum.concat(get_community_resources(dataset))
+      |> Enum.uniq_by(fn resource -> resource["url"] end)
+
+    resource_datagouv_ids =
+      resources |> Enum.map(fn resource -> resource["id"] end)
+
+    resources
     |> Enum.map_reduce(0, fn resource, display_position ->
       is_community_resource = resource["is_community_resource"] == true
-      existing_resource = get_existing_resource(resource, dataset["id"]) || %{}
+
+      # List of sibling resources to avoid collisions when some resource URL is
+      # reused for a new one.
+      # Only protect against reuse in the same dataset.
+      # See #3976.
+      siblings =
+        resource_datagouv_ids |> Enum.reject(fn resource_id -> resource_id == dataset["id"] end)
+
+      existing_resource = get_existing_resource(resource, dataset["id"], siblings) || %{}
 
       resource =
         resource
@@ -841,10 +855,10 @@ defmodule Transport.ImportData do
   def get_title(%{"title" => title}) when not is_nil(title), do: title
   def get_title(%{"url" => url}), do: Helpers.filename_from_url(url)
 
-  @spec get_existing_resource(map(), binary()) :: Resource.t() | nil
+  @spec get_existing_resource(map(), binary(), list()) :: Resource.t() | nil
   # ODS CSV resources are identified only with their URL, as their resource datagouv id is not unique.
   # For regular resources, we can identify them by resource datagouv id or by their url.
-  defp get_existing_resource(%{"is_ods_csv" => true, "url" => url}, dataset_datagouv_id) do
+  defp get_existing_resource(%{"is_ods_csv" => true, "url" => url}, dataset_datagouv_id, _) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
     |> where([r], r.url == ^url)
@@ -853,10 +867,19 @@ defmodule Transport.ImportData do
     |> Repo.one()
   end
 
-  defp get_existing_resource(%{"url" => url, "id" => datagouv_id}, dataset_datagouv_id) do
+  defp get_existing_resource(
+         %{"url" => url, "id" => resource_datagouv_id},
+         dataset_datagouv_id,
+         siblings
+       ) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r, _d], r.datagouv_id == ^datagouv_id or r.url == ^url)
+    |> where(
+      [r, _d],
+      # Support URL reuse without collision. See #3976.
+      r.datagouv_id == ^resource_datagouv_id or
+        (r.datagouv_id not in ^siblings and r.url == ^url)
+    )
     |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id]))
     |> Repo.one()

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -282,6 +282,10 @@ defmodule Transport.ImportData do
       |> Enum.concat(get_community_resources(dataset))
       |> Enum.uniq_by(fn resource -> resource["url"] end)
 
+    # List of resources to avoid collisions when some resource URL is
+    # reused for a new one.
+    # Only protect against reuse in the same dataset.
+    # See #3976.
     resource_datagouv_ids =
       resources |> Enum.map(fn resource -> resource["id"] end)
 
@@ -289,14 +293,7 @@ defmodule Transport.ImportData do
     |> Enum.map_reduce(0, fn resource, display_position ->
       is_community_resource = resource["is_community_resource"] == true
 
-      # List of sibling resources to avoid collisions when some resource URL is
-      # reused for a new one.
-      # Only protect against reuse in the same dataset.
-      # See #3976.
-      siblings =
-        resource_datagouv_ids |> Enum.reject(fn resource_id -> resource_id == resource["id"] end)
-
-      existing_resource = get_existing_resource(resource, dataset["id"], siblings) || %{}
+      existing_resource = get_existing_resource(resource, dataset["id"], resource_datagouv_ids) || %{}
 
       resource =
         resource

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -283,7 +283,6 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :id) == Map.get(resource, :id)
     assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
     assert Map.get(resource_updated, :url) == "http://localhost:4321/resource1"
-    # IO.inspect({resource, resource_updated}, label: "URL recycling")
   end
 
   test "resist collisions upon resource URL update" do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -309,7 +309,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource, :display_position) == 0
     assert Map.get(resource, :url) == "http://localhost:4321/resource1"
 
-    # import 2: somebody changed the resource1's URL and use the previous URL
+    # import 2: somebody changed the resource1's URL and used the previous URL
     # for a new resource
     payload_2 =
       generate_dataset_payload(

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -345,7 +345,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :url) == "http://localhost:4321/resource1/bis"
     assert Map.get(new_resource, :url) == "http://localhost:4321/resource1"
 
-    # import 3: Second's resource has been recreated with a the same URL
+    # import 3: Second resource has been recreated with the same URL
     payload_3 =
       generate_dataset_payload(
         datagouv_id,

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -249,9 +249,14 @@ defmodule Transport.ImportDataTest do
     assert db_count(DB.Resource) == 1
 
     [
-    %DB.Resource{title: "resource1", filetype: "remote", type: "main", display_position: 0, url: "http://localhost:4321/resource1"}
+      %DB.Resource{
+        title: "resource1",
+        filetype: "remote",
+        type: "main",
+        display_position: 0,
+        url: "http://localhost:4321/resource1"
+      } = resource
     ] = DB.Resource |> DB.Repo.all()
-
 
     # import 2: the original resources has been dropped and recreated with the
     # same URL

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -231,6 +231,61 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :id) == resource_id
   end
 
+  test "recycled resource URL" do
+    insert_national_dataset(datagouv_id = "dataset1_id")
+
+    assert db_count(DB.Dataset) == 1
+    assert db_count(DB.Resource) == 0
+
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id), head: http_head_mock() do
+      with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
+        with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
+          ImportData.import_all_datasets()
+        end
+      end
+    end
+
+    assert db_count(DB.Dataset) == 1
+    assert db_count(DB.Resource) == 1
+
+    [resource] = DB.Resource |> DB.Repo.all()
+    assert Map.get(resource, :title) == "resource1"
+    assert Map.get(resource, :filetype) == "remote"
+    assert Map.get(resource, :type) == "main"
+    assert Map.get(resource, :display_position) == 0
+    assert Map.get(resource, :url) == "http://localhost:4321/resource1"
+
+    # import 2: the original resources has been droped and recreated with the
+    # same URL
+    payload_2 =
+      generate_dataset_payload(
+        datagouv_id,
+        generate_resources_payload(
+          "new title !!! fresh !!!",
+          "http://localhost:4321/resource1",
+          new_datagouv_id = "resource2_id"
+        )
+      )
+
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id, payload_2), head: http_head_mock() do
+      with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
+        with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
+          ImportData.import_all_datasets()
+        end
+      end
+    end
+
+    assert db_count(DB.Dataset) == 1
+    assert db_count(DB.Resource) == 1
+
+    [resource_updated] = DB.Resource |> DB.Repo.all()
+    # assert that we reuse the previous resource
+    assert Map.get(resource_updated, :id) == Map.get(resource, :id)
+    assert Map.get(resource_updated, :datagouv_id) == new_datagouv_id
+    assert Map.get(resource_updated, :url) == "http://localhost:4321/resource1"
+    # IO.inspect({resource, resource_updated}, label: "URL recycling")
+  end
+
   test "resist collisions upon resource URL update" do
     insert_national_dataset(datagouv_id = "dataset1_id")
 
@@ -290,6 +345,42 @@ defmodule Transport.ImportDataTest do
     assert Map.get(new_resource, :datagouv_id) == new_datagouv_id
     assert Map.get(resource_updated, :url) == "http://localhost:4321/resource1/bis"
     assert Map.get(new_resource, :url) == "http://localhost:4321/resource1"
+
+    # import 3: Second's resource has been recreated with a the same URL
+    payload_3 =
+      generate_dataset_payload(
+        datagouv_id,
+        generate_resources_payload(
+          "new title !!! fresh !!!",
+          "http://localhost:4321/resource1/bis",
+          "resource1_id"
+        ) ++
+          generate_resources_payload(
+            "new title !!! fresh !!!",
+            "http://localhost:4321/resource1",
+            recreated_datagouv_id = "resource3_id"
+          )
+      )
+
+    with_mock HTTPoison, get!: http_get_mock_200(datagouv_id, payload_3), head: http_head_mock() do
+      with_mock Datagouvfr.Client.CommunityResources, get: fn _ -> {:ok, []} end do
+        with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do
+          ImportData.import_all_datasets()
+        end
+      end
+    end
+
+    assert db_count(DB.Dataset) == 1
+    assert db_count(DB.Resource) == 2
+
+    [resource_updated_bis, new_resource_bis] = DB.Resource |> DB.Repo.all()
+    # assert that the resources URLs have been updated without collisions
+    assert Map.get(resource_updated_bis, :id) == Map.get(resource, :id)
+    assert Map.get(resource_updated_bis, :datagouv_id) == existing_datagouv_id
+    assert Map.get(new_resource_bis, :datagouv_id) == recreated_datagouv_id
+    assert Map.get(new_resource_bis, :id) == Map.get(new_resource, :id)
+    assert Map.get(resource_updated_bis, :url) == "http://localhost:4321/resource1/bis"
+    assert Map.get(new_resource_bis, :url) == "http://localhost:4321/resource1"
   end
 
   test "import dataset with a community resource" do

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -285,6 +285,7 @@ defmodule Transport.ImportDataTest do
 
     [resource_updated, new_resource] = DB.Resource |> DB.Repo.all()
     # assert that the resources URLs have been updated without collisions
+    assert Map.get(resource_updated, :id) == Map.get(resource, :id)
     assert Map.get(resource_updated, :datagouv_id) == existing_datagouv_id
     assert Map.get(new_resource, :datagouv_id) == new_datagouv_id
     assert Map.get(resource_updated, :url) == "http://localhost:4321/resource1/bis"

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -255,7 +255,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource, :display_position) == 0
     assert Map.get(resource, :url) == "http://localhost:4321/resource1"
 
-    # import 2: the original resources has been droped and recreated with the
+    # import 2: the original resources has been dropped and recreated with the
     # same URL
     payload_2 =
       generate_dataset_payload(

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -231,7 +231,7 @@ defmodule Transport.ImportDataTest do
     assert Map.get(resource_updated, :id) == resource_id
   end
 
-  test "resist collisions upon ressource URL update" do
+  test "resist collisions upon resource URL update" do
     insert_national_dataset(datagouv_id = "dataset1_id")
 
     assert db_count(DB.Dataset) == 1

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -248,12 +248,10 @@ defmodule Transport.ImportDataTest do
     assert db_count(DB.Dataset) == 1
     assert db_count(DB.Resource) == 1
 
-    [resource] = DB.Resource |> DB.Repo.all()
-    assert Map.get(resource, :title) == "resource1"
-    assert Map.get(resource, :filetype) == "remote"
-    assert Map.get(resource, :type) == "main"
-    assert Map.get(resource, :display_position) == 0
-    assert Map.get(resource, :url) == "http://localhost:4321/resource1"
+    [
+    %DB.Resource{title: "resource1", filetype: "remote", type: "main", display_position: 0, url: "http://localhost:4321/resource1"}
+    ] = DB.Resource |> DB.Repo.all()
+
 
     # import 2: the original resources has been dropped and recreated with the
     # same URL


### PR DESCRIPTION
Il arrive qu'une ressource soit ajoutée à un dataset avec l'URL d'une ressource préexistante. Ceci est malheureux et sans doute un usage détourné de data.gouv.fr mais la réalité est têtue et quand cela se produit des actions correctives manuelles sont requises.

Ce changement vise à résister à un tel recyclage d'URL.

Closes #3976