### PR TITLE
Email : fix liste des datasets avec commentaires

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.heex
@@ -1,0 +1,15 @@
+<p>Bonjour,</p>
+
+<p>
+  Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.
+</p>
+
+<ul>
+  <%= for dataset <- @datasets do %>
+    <li><%= link_for_dataset_section(dataset, :discussion) %></li>
+  <% end %>
+</ul>
+
+<p>
+  L’équipe transport.data.gouv.fr
+</p>

--- a/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.md
+++ b/apps/transport/lib/transport_web/templates/email/new_comments_reuser.html.md
@@ -1,9 +1,0 @@
-Bonjour,
-
-Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.
-
-<%= for dataset <- @datasets do %>
-- <%= link_for_dataset_section(dataset, :discussion) %>
-<% end %>
-
-L’équipe transport.data.gouv.fr

--- a/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_comments_notification_job_test.exs
@@ -146,28 +146,33 @@ defmodule Transport.Test.Transport.Jobs.NewCommentsNotificationJobTest do
     %DB.Contact{id: contact_id, email: email} = insert_contact()
     other_followed_dataset = insert(:dataset)
 
-    %DB.Dataset{id: dataset_id} =
-      dataset =
+    %DB.Dataset{id: dataset1_id} =
+      dataset1 =
+      insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z])
+
+    %DB.Dataset{id: dataset2_id} =
+      dataset2 =
       insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z])
 
     %DB.Dataset{id: other_dataset_id} =
       insert(:dataset, latest_data_gouv_comment_timestamp: ~U[2024-03-29 10:00:00.00Z])
 
     # Identifies two datasets as relevant
-    assert [%DB.Dataset{id: ^dataset_id}, %DB.Dataset{id: ^other_dataset_id}] =
+    assert [%DB.Dataset{id: ^dataset1_id}, %DB.Dataset{id: ^dataset2_id}, %DB.Dataset{id: ^other_dataset_id}] =
              ~U[2024-04-01 09:00:00.00Z]
              |> NewCommentsNotificationJob.relevant_datasets_query()
              |> DB.Repo.all()
              |> Enum.sort_by(& &1.id)
 
-    insert(:dataset_follower, dataset_id: dataset_id, contact_id: contact_id, source: :datagouv)
+    insert(:dataset_follower, dataset_id: dataset1_id, contact_id: contact_id, source: :datagouv)
+    insert(:dataset_follower, dataset_id: dataset2_id, contact_id: contact_id, source: :datagouv)
     insert(:dataset_follower, dataset_id: other_followed_dataset.id, contact_id: contact_id, source: :datagouv)
 
     # Perform the job for a single contact
     assert :ok ==
              perform_job(NewCommentsNotificationJob, %{
                "contact_id" => contact_id,
-               "dataset_ids" => [dataset_id, other_dataset_id]
+               "dataset_ids" => [dataset1_id, dataset2_id, other_dataset_id]
              })
 
     # Email has been sent
@@ -180,25 +185,31 @@ defmodule Transport.Test.Transport.Jobs.NewCommentsNotificationJobTest do
                            html_body: html_body
                          } ->
       assert remove_whitespace(html_body) == remove_whitespace(~s|
+      <p>Bonjour,</p>
+
       <p>
-      Bonjour,</p>
-      <p>
-      Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.</p>
-      <p>
+        Des discussions ont eu lieu sur certains jeux de données que vous suivez. Vous pouvez prendre connaissance de ces échanges.
       </p>
+
       <ul>
         <li>
-        <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}#dataset-discussions">#{dataset.custom_title}</a>
+        <a href="http://127.0.0.1:5100/datasets/#{dataset1.slug}#dataset-discussions">#{dataset1.custom_title}</a>
         </li>
-        </ul>
-      <p>
-      L’équipe transport.data.gouv.fr</p>|)
+        <li>
+        <a href="http://127.0.0.1:5100/datasets/#{dataset2.slug}#dataset-discussions">#{dataset2.custom_title}</a>
+        </li>
+      </ul>
+
+      <p>L’équipe transport.data.gouv.fr</p>|)
     end)
 
-    # Notification has been saved
-    assert [%DB.Notification{reason: :daily_new_comments, dataset_id: ^dataset_id, email: ^email}] =
+    # Notifications have been saved
+    assert [
+             %DB.Notification{reason: :daily_new_comments, dataset_id: ^dataset1_id, email: ^email},
+             %DB.Notification{reason: :daily_new_comments, dataset_id: ^dataset2_id, email: ^email}
+           ] =
              DB.Notification |> DB.Repo.all()
   end
 
-  defp remove_whitespace(value), do: value |> String.replace(" ", "") |> String.trim()
+  defp remove_whitespace(value), do: value |> String.replace(~r/\s/, "") |> String.trim()
 end


### PR DESCRIPTION
Le rendu markdown d‘une liste de liens est capricieux. Un template html simple fera aussi bien l‘affaire.

Les tests couvrent ce cas désormais.

Closes #3989.