### PR TITLE
Liste les jeux de donnée d’une organisation

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -372,6 +372,13 @@ defmodule DB.Dataset do
   defp filter_by_licence(query, %{"licence" => licence}), do: where(query, [d], d.licence == ^licence)
   defp filter_by_licence(query, _), do: query
 
+  @spec filter_by_organization(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  defp filter_by_organization(query, %{"organization_id" => organization_id}) do
+    where(query, [d], d.organization_id == ^organization_id)
+  end
+
+  defp filter_by_organization(query, _), do: query
+
   @spec list_datasets(map()) :: Ecto.Query.t()
   def list_datasets(%{} = params) do
     params
@@ -394,6 +401,7 @@ defmodule DB.Dataset do
       |> filter_by_licence(params)
       |> filter_by_climate_resilience_bill(params)
       |> filter_by_custom_tag(params)
+      |> filter_by_organization(params)
       |> filter_by_fulltext(params)
       |> select([dataset: d], d.id)
 

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -253,7 +253,7 @@
       <div class="pt-12">
         <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "Data published by") %></span>
         <div class="dataset-type-info">
-          <b><%= @dataset.organization %></b>
+          <b><%= link(@dataset.organization, to: dataset_path(@conn, :index, organization_id: @dataset.organization_id)) %></b>
         </div>
       </div>
       <div class="pt-12">

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -253,7 +253,9 @@
       <div class="pt-12">
         <span class="dataset-metas-info-title"><%= dgettext("page-dataset-details", "Data published by") %></span>
         <div class="dataset-type-info">
-          <b><%= link(@dataset.organization, to: dataset_path(@conn, :index, organization_id: @dataset.organization_id)) %></b>
+          <b>
+            <%= link(@dataset.organization, to: dataset_path(@conn, :index, organization_id: @dataset.organization_id)) %>
+          </b>
         </div>
       </div>
       <div class="pt-12">

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -219,6 +219,9 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   test "search for datasets published by an organization" do
     %DB.Organization{id: org_id} = insert(:organization)
     %Dataset{id: dataset_id} = insert(:dataset, organization_id: org_id, is_active: true)
+    # other dataset by another org, shouldn’t be found
+    %DB.Organization{id: other_org_id} = insert(:organization)
+    %Dataset{id: _other_dataset_id} = insert(:dataset, organization_id: other_org_id, is_active: true)
 
     assert [%Dataset{id: ^dataset_id}] =
              %{"organization_id" => to_string(org_id)} |> Dataset.list_datasets() |> Repo.all()

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -216,6 +216,14 @@ defmodule TransportWeb.DatasetSearchControllerTest do
              %{"aom" => to_string(aom2.id)} |> Dataset.list_datasets() |> Repo.all()
   end
 
+  test "search for datasets published by an organization" do
+    %DB.Organization{id: org_id} = insert(:organization)
+    %Dataset{id: dataset_id} = insert(:dataset, organization_id: org_id, is_active: true)
+
+    assert [%Dataset{id: ^dataset_id}] =
+             %{"organization_id" => to_string(org_id)} |> Dataset.list_datasets() |> Repo.all()
+  end
+
   test "a dataset labelled as base nationale published by us is first without filters" do
     %{id: base_nationale_dataset_id} =
       insert(:dataset,


### PR DESCRIPTION
Closes #3957

Cette PR rajoute un lien dans l’oreille de la page d’un jeu de données sur le nom du producteur, ce lien renvoie à la page de recherche dataset avec un nouveau filtre sur l’organisation (dans l’URL, paramètre GET : `/datasets?organization_id=org_id`). La pagination marche si la liste des jeux de données publiée est longue.

J’ai fait simple, ce lien sur la page d’un jeu de données est le seul moyen d’accéder à cette liste. En particulier, n’ont pas été implémentés :
- La recherche texte libre par organisation, sur la homepage ou la page de résultats de recherche. Si on met le nom d’une organisation, on ne retrouvera (toujours pas) les JDD de cette organisation.
- Un filtre latéral (ce qui aurait impliqué d’avoir une recherche au sein du filtre).
- Une page indexée par les moteurs de recherche : l’URL de cette page est juste /datasets, avec des paramètres, et non une page dédiée au producteur (pas de page `/organization/{id}/datasets/` ou similaire donc).

![Capture d’écran du 2024-06-17 17-20-29](https://github.com/etalab/transport-site/assets/15861435/417ba357-dc86-4354-884d-ec1191b08591)

![image](https://github.com/etalab/transport-site/assets/15861435/2394c6af-6846-404d-8f5d-8038d347603f)

D’un point de vue performance, on est bons puisqu’il y a déjà un index sur la colonne organization_id de la table dataset, et que le filtre va juste regarder dans cette colonne sans jointure, extrait de `structure.sql` :

```
--
-- Name: dataset_organization_id_index; Type: INDEX; Schema: public; Owner: -
--

CREATE INDEX dataset_organization_id_index ON public.dataset USING btree (organization_id);
```
