### PR TITLE
Espace réutilisateur : améliorations UX

### DIFF
--- a/apps/transport/client/stylesheets/reuser_space.scss
+++ b/apps/transport/client/stylesheets/reuser_space.scss
@@ -50,3 +50,7 @@ form.search-followed-datasets {
     display: inline-block;
   }
 }
+
+.align-right {
+  text-align: right;
+}

--- a/apps/transport/lib/transport_web/live/followed_datasets_live.ex
+++ b/apps/transport/lib/transport_web/live/followed_datasets_live.ex
@@ -38,6 +38,7 @@ defmodule TransportWeb.Live.FollowedDatasetsLive do
               <div class="dataset__infos">
                 <h3 class="dataset__title">
                   <a href={dataset_path(@socket, :details, dataset.slug)} target="_blank">
+                    <i class="fa fa-external-link-alt" aria-hidden="true"></i>
                     <%= dataset.custom_title %>
                   </a>
                 </h3>
@@ -66,7 +67,7 @@ defmodule TransportWeb.Live.FollowedDatasetsLive do
           </div>
           <div class="panel__extra">
             <a href={reuser_space_path(@socket, :datasets_edit, dataset.id)} class="no-bg">
-              <button class="button-outline primary small"><%= dgettext("reuser-space", "Edit") %></button>
+              <button class="button-outline primary small"><%= dgettext("reuser-space", "Manage") %></button>
             </a>
           </div>
         </div>

--- a/apps/transport/lib/transport_web/templates/reuser_space/datasets_edit.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/datasets_edit.html.heex
@@ -3,38 +3,69 @@
 </section>
 <section class="reuser-space-section">
   <div class="container pt-24">
+    <h2 class="mb-0"><%= @dataset.custom_title %></h2>
+    <div class="align-right pb-24">
+      <a href="#modal" class="button warning">
+        <i class="icon fas fa-trash"></i>
+        <%= dgettext("reuser-space", "Remove from favorites") %>
+      </a>
+    </div>
     <div class="panel">
-      <h2><%= @dataset.custom_title %></h2>
-      <a href="#modal" class="button warning"><%= dgettext("reuser-space", "Remove from favorites") %></a>
-      <div class="modal__backdrop" id="modal">
-        <div class="modal">
-          <p>
-            Here we will have soon a few words highlighting how dangerous this action is. We also offer a complimentary escape option.
-          </p>
-          <%= form_for %{}, reuser_space_path(@conn, :unfavorite, @dataset.id), [class: "no-margin", method: "post"], fn _ -> %>
-            <div class="form__group button__group">
-              <button
-                class="button warning"
-                type="submit"
-                data-tracking-category="reuser_space"
-                data-tracking-action="confirm_unfavorite_dataset"
-              >
-                <%= dgettext("reuser-space", "Remove from favorites") %>
-              </button>
-              <a
-                href="#"
-                class="button secondary"
-                data-tracking-category="reuser_space"
-                data-tracking-action="abort_unfavorite_dataset"
-              >
-                <%= dgettext("reuser-space", "Cancel") %>
-              </a>
-            </div>
-          <% end %>
-        </div>
+      <h3><%= dgettext("reuser-space", "Manage notifications") %></h3>
+      <p class="notification">
+        <%= dgettext("reuser-space", "This feature is coming soon!") %>
+      </p>
+    </div>
+    <div class="panel">
+      <h3><%= dgettext("reuser-space", "Improved data sharing") %></h3>
+      <p class="notification">
+        <%= dgettext("reuser-space", "This feature is coming soon!") %>
+      </p>
+    </div>
+    <div class="panel">
+      <h3><%= dgettext("reuser-space", "Discussions") %></h3>
+      <p class="notification">
+        <%= dgettext("reuser-space", "This feature is coming soon!") %>
+      </p>
+    </div>
+    <div class="modal__backdrop" id="modal">
+      <div class="modal">
+        <p>
+          <%= dgettext(
+            "reuser-space",
+            ~s|Warning, you are going to remove "%{dataset_title}" from your favorites. You will lose any settings or actions you previously performed on this dataset.|,
+            dataset_title: @dataset.custom_title
+          ) %>
+        </p>
+        <%= form_for %{}, reuser_space_path(@conn, :unfavorite, @dataset.id), [class: "no-margin", method: "post"], fn _ -> %>
+          <div class="form__group button__group">
+            <button
+              class="button warning"
+              type="submit"
+              data-tracking-category="reuser_space"
+              data-tracking-action="confirm_unfavorite_dataset"
+            >
+              <i class="icon fas fa-trash"></i>
+              <%= dgettext("reuser-space", "Remove from favorites") %>
+            </button>
+            <a
+              href="#"
+              class="button secondary"
+              data-tracking-category="reuser_space"
+              data-tracking-action="abort_unfavorite_dataset"
+            >
+              <%= dgettext("reuser-space", "Cancel") %>
+            </a>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
 </section>
-
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "reuser_space"}
+  ) %>
+</section>
 <script defer type="text/javascript" src={static_path(@conn, "/js/app.js")} />

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -116,9 +116,25 @@ msgid "Cancel"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Edit"
+msgid "Remove from favorites"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Remove from favorites"
+msgid "Discussions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Improved data sharing"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This feature is coming soon!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Warning, you are going to remove \"%{dataset_title}\" from your favorites. You will lose any settings or actions you previously performed on this dataset."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -116,9 +116,25 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #, elixir-autogen, elixir-format
-msgid "Edit"
-msgstr "Éditer"
+msgid "Remove from favorites"
+msgstr "Supprimer de vos favoris"
 
 #, elixir-autogen, elixir-format
-msgid "Remove from favorites"
-msgstr "Retirer de vos favoris"
+msgid "Discussions"
+msgstr "Discussions"
+
+#, elixir-autogen, elixir-format
+msgid "Improved data sharing"
+msgstr "Repartage des données améliorées"
+
+#, elixir-autogen, elixir-format
+msgid "Manage"
+msgstr "Gérer"
+
+#, elixir-autogen, elixir-format
+msgid "This feature is coming soon!"
+msgstr "Cette fonctionnalité arrive bientôt !"
+
+#, elixir-autogen, elixir-format
+msgid "Warning, you are going to remove \"%{dataset_title}\" from your favorites. You will lose any settings or actions you previously performed on this dataset."
+msgstr "Attention, vous allez supprimer le jeu de données \"%{dataset_title}\" de vos favoris. Vous allez perdre tous les paramétrages ou actions que vous avez réalisés précédemment sur ce jeu de données."

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -116,9 +116,25 @@ msgid "Cancel"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Edit"
+msgid "Remove from favorites"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Remove from favorites"
+msgid "Discussions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Improved data sharing"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Manage"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This feature is coming soon!"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Warning, you are going to remove \"%{dataset_title}\" from your favorites. You will lose any settings or actions you previously performed on this dataset."
 msgstr ""

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -59,7 +59,7 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
              |> get(reuser_space_path(conn, :datasets_edit, dataset.id))
              |> html_response(200)
              |> Floki.parse_document!()
-             |> Floki.find("h2")
+             |> Floki.find(".reuser-space-section h2")
              |> Floki.text() == dataset.custom_title
     end
   end


### PR DESCRIPTION
Gère une bonne partie des éléments d'améliorations UX décrits dans #3983

À venir dans une PR qui suit : la gestion des notifications pour ce JDD sur la page `reuser_space/datasets_edit`. Ceci requiert une LiveView donc j'ai choisi de découper en 2 PRs.

## Captures d'écran

![image](https://github.com/etalab/transport-site/assets/295709/36bb4418-6a69-450c-9349-5c02340a4a55)

![localhost_5000_espace_reutilisateur_datasets_700](https://github.com/etalab/transport-site/assets/295709/3fa19fd2-71cb-4907-87db-dae97d93f90e)
