### PR TITLE
Menu personnel : ajout espace réutilisateur

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -90,6 +90,11 @@
                       to: page_path(@conn, :espace_producteur, utm_campaign: "menu_dropdown")
                     ) %>
                   <% end %>
+                  <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
+                    <%= link(gettext("Reuser space"),
+                      to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "menu_dropdown")
+                    ) %>
+                  <% end %>
                   <a
                     class="navigation__link nagivation__link--logout"
                     href={session_path(@conn, :delete, redirect_path: current_path(@conn))}


### PR DESCRIPTION
En lien avec #3914

Traite un point qui est déjà certain :
> Ajouter le menu « Espace réutilisateur » sous « Espace producteur » depuis le menu personnel

Ceci reste visiblement uniquement par les membres de notre équipe, pour quelques jours encore, tant que ceci n'est pas mis à disposition du grand public.

Le reste des changements est encore en discussion.