### PR TITLE
Dénombrer les réutilisateurs abonnés à un dataset

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -176,7 +176,7 @@ defmodule TransportWeb.Backoffice.PageController do
   end
 
   def load_dataset(dataset_id) do
-    Dataset
+    DB.Dataset
     |> preload([
       :aom,
       :notification_subscriptions,

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -153,6 +153,16 @@ defmodule TransportWeb.Backoffice.PageController do
         dataset -> assign(conn, :dataset, dataset)
       end
 
+    reuser_subscriptions =
+      conn.assigns[:dataset].notification_subscriptions
+      |> Enum.filter(fn sub -> sub.role == :reuser end)
+
+    reusers =
+      reuser_subscriptions
+      |> Enum.sort_by(&{&1.contact.last_name, &1.reason})
+      |> Enum.group_by(& &1.contact)
+      |> Enum.count()
+
     conn
     |> assign(:dataset_id, dataset_id)
     |> assign(:dataset_types, Dataset.types())
@@ -162,6 +172,8 @@ defmodule TransportWeb.Backoffice.PageController do
     |> assign(:resources_with_history, DB.Dataset.last_resource_history(dataset_id))
     |> assign(:contacts_datalist, contacts_datalist())
     |> assign(:contacts_in_org, contacts_in_org(conn.assigns[:dataset]))
+    |> assign(:reusers, reusers)
+    |> assign(:reuser_subscriptions, reuser_subscriptions |> Enum.count())
     |> assign(
       :import_logs,
       LogsImport

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -157,7 +157,7 @@ defmodule TransportWeb.Backoffice.PageController do
       conn.assigns[:dataset].notification_subscriptions
       |> Enum.filter(fn sub -> sub.role == :reuser end)
 
-    reusers =
+    reusers_count =
       reuser_subscriptions
       |> Enum.sort_by(&{&1.contact.last_name, &1.reason})
       |> Enum.group_by(& &1.contact)
@@ -172,8 +172,8 @@ defmodule TransportWeb.Backoffice.PageController do
     |> assign(:resources_with_history, DB.Dataset.last_resource_history(dataset_id))
     |> assign(:contacts_datalist, contacts_datalist())
     |> assign(:contacts_in_org, contacts_in_org(conn.assigns[:dataset]))
-    |> assign(:reusers, reusers)
-    |> assign(:reuser_subscriptions, reuser_subscriptions |> Enum.count())
+    |> assign(:reusers_count, reusers_count)
+    |> assign(:reuser_subscriptions_count, reuser_subscriptions |> Enum.count())
     |> assign(
       :import_logs,
       LogsImport

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -54,7 +54,7 @@
   <h3><%= dgettext("backoffice", "Existing subscriptions") %></h3>
 
   <p :if={Enum.empty?(@notification_subscriptions)} class="notification">
-    <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>
+    <%= dgettext("backoffice", "There are no notification subscriptions for this contact.") %>
   </p>
 
   <table :if={Enum.count(subscriptions_with_dataset) > 0} class="table mt-48 dashboard-description">

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -51,10 +51,10 @@
     <%= submit("Mettre à jour les abonnements") %>
   <% end %>
 
-  <h3>Abonnements existants</h3>
+  <h3><%= dgettext("backoffice", "Existing subscriptions") %></h3>
 
   <p :if={Enum.empty?(@notification_subscriptions)} class="notification">
-    Il n'y a pas d'abonnements à des notifications pour ce contact.
+    <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>
   </p>
 
   <table :if={Enum.count(subscriptions_with_dataset) > 0} class="table mt-48 dashboard-description">

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -165,7 +165,7 @@
       <p :if={Enum.count(@dataset.notification_subscriptions) > 0} class="small">
         Cette liste ne concerne que les producteurs.
       </p>
-      <p :if={@reusers_count > 0}>
+      <p :if={@reusers_count > 0} id="reuser_subscriptions">
         <%= dngettext(
           "backoffice",
           "reuser-subscription-count",

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <div class="dashboard-description mt-48">
+    <div id="resource_historization" class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Resource historization") %></h3>
 
       <%= if Dataset.should_skip_history?(@dataset) do %>
@@ -85,7 +85,7 @@
           </div>
           <div :if={Enum.count(@contacts_in_org) > 0}>
             <p>
-              Producteurs s'étant déjà connectés au PAN
+              Producteurs s’étant déjà connectés au PAN
             </p>
             <ul>
               <%= for contact <- @contacts_in_org do %>
@@ -123,7 +123,7 @@
 
         <%= submit("Créer un abonnement") %>
       <% end %>
-      <h4><%= dgettext("backoffice", "Existing subscriptions") %></h4>
+      <h4 id="existing_subscriptions"><%= dgettext("backoffice", "Existing subscriptions") %></h4>
       <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="table">
         <tr>
           <th>Contact</th>
@@ -191,7 +191,7 @@
         ) %>
       </div>
     </div>
-    <div :if={Enum.count(@notifications_sent) > 0} class="dashboard-description mt-48">
+    <div :if={Enum.count(@notifications_sent) > 0} id="notifications_sent" class="dashboard-description mt-48">
       <h3><%= dgettext("backoffice", "Notifications sent") %></h3>
 
       <p>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -162,6 +162,9 @@
           <% end %>
         <% end %>
       </table>
+      <p :if={Enum.count(@dataset.notification_subscriptions) > 0} class="small">
+        Cette liste ne concerne que les producteurs.
+      </p>
       <p :if={@reusers_count > 0}>
         <%= dngettext(
           "backoffice",

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -131,8 +131,8 @@
           <th>Source</th>
           <th>Actions</th>
         </tr>
-        <%= for {contact, notification_subscriptions} <- @dataset.notification_subscriptions |> Enum.sort_by(&{&1.contact.last_name, &1.reason}) |> Enum.group_by(& &1.contact) do %>
-          <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions |> Enum.filter(fn sub -> sub.role == :producer end)) do %>
+        <%= for {contact, notification_subscriptions} <- @subscriptions_by_producer do %>
+          <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
             <tr>
               <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
                 <a href={backoffice_contact_path(@conn, :edit, contact.id)}>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -162,11 +162,21 @@
           <% end %>
         <% end %>
       </table>
-      <p :if={@reusers > 0}>
-        <%= dngettext("backoffice", "reuser-subscription-count", "reuser-subscriptions-count", @reuser_subscriptions,
-          reuser_subscriptions: @reuser_subscriptions
+      <p :if={@reusers_count > 0}>
+        <%= dngettext(
+          "backoffice",
+          "reuser-subscription-count",
+          "reuser-subscriptions-count",
+          @reuser_subscriptions_count,
+          reuser_subscriptions_count: @reuser_subscriptions_count
         ) %>
-        <%= dngettext("backoffice", "reuser-count", "reusers-count", @reusers, reusers: @reusers) %>
+        <%= dngettext(
+          "backoffice",
+          "reuser-count",
+          "reusers-count",
+          @reusers_count,
+          reusers_count: @reusers_count
+        ) %>
       </p>
       <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
         <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -123,7 +123,7 @@
 
         <%= submit("Créer un abonnement") %>
       <% end %>
-      <h4>Abonnements existants</h4>
+      <h4><%= dgettext("backoffice", "Existing subscriptions") %></h4>
       <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="table">
         <tr>
           <th>Contact</th>
@@ -165,7 +165,7 @@
         <% end %>
       </table>
       <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
-        Il n'y a pas d'abonnements à des notifications pour ce jeu de données.
+        <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>
       </p>
       <div :if={Enum.count(@dataset.notification_subscriptions) > 0}>
         <%= live_render(@conn, TransportWeb.Live.SendNowOnNAPNotificationView,

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -179,7 +179,7 @@
         ) %>
       </p>
       <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
-        <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>
+        <%= dgettext("backoffice", "There are no notification subscriptions for this contact.") %>
       </p>
       <div :if={Enum.count(@dataset.notification_subscriptions) > 0}>
         <%= live_render(@conn, TransportWeb.Live.SendNowOnNAPNotificationView,

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -124,7 +124,7 @@
         <%= submit("Créer un abonnement") %>
       <% end %>
       <h4 id="existing_subscriptions"><%= dgettext("backoffice", "Existing subscriptions") %></h4>
-      <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="table">
+      <table :if={Enum.count(@dataset.notification_subscriptions) > 0} id="existing_subscriptions_table" class="table">
         <tr>
           <th>Contact</th>
           <th><%= dgettext("backoffice", "Notification reason") %></th>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -127,13 +127,12 @@
       <table :if={Enum.count(@dataset.notification_subscriptions) > 0} class="table">
         <tr>
           <th>Contact</th>
-          <th><%= dgettext("backoffice", "Role") %></th>
           <th><%= dgettext("backoffice", "Notification reason") %></th>
           <th>Source</th>
           <th>Actions</th>
         </tr>
         <%= for {contact, notification_subscriptions} <- @dataset.notification_subscriptions |> Enum.sort_by(&{&1.contact.last_name, &1.reason}) |> Enum.group_by(& &1.contact) do %>
-          <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions) do %>
+          <%= for {notification_subscription, index} <- Enum.with_index(notification_subscriptions |> Enum.filter(fn sub -> sub.role == :producer end)) do %>
             <tr>
               <td :if={index == 0} rowspan={Enum.count(notification_subscriptions)}>
                 <a href={backoffice_contact_path(@conn, :edit, contact.id)}>
@@ -149,7 +148,6 @@
                   <% end %>
                 </div>
               </td>
-              <td><%= notification_subscription.role %></td>
               <td><%= notification_subscription.reason %></td>
               <td><%= notification_subscription.source %></td>
               <td>
@@ -164,6 +162,12 @@
           <% end %>
         <% end %>
       </table>
+      <p :if={@reusers > 0}>
+        <%= dngettext("backoffice", "reuser-subscription-count", "reuser-subscriptions-count", @reuser_subscriptions,
+          reuser_subscriptions: @reuser_subscriptions
+        ) %>
+        <%= dngettext("backoffice", "reuser-count", "reusers-count", @reusers, reusers: @reusers) %>
+      </p>
       <p :if={Enum.empty?(@dataset.notification_subscriptions)} class="mt-48 notification">
         <%= dgettext("backoffice", "There's no notification subscriptions for this contact.") %>
       </p>

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -322,3 +322,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Existing subscriptions"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "reuser-subscription-count"
+msgid_plural "reuser-subscriptions-count"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "reuser-count"
+msgid_plural "reusers-count"
+msgstr[0] ""
+msgstr[1] ""

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -316,7 +316,7 @@ msgid "Dataset"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "There's no notification subscriptions for this contact."
+msgid "There are no notification subscriptions for this contact."
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -314,3 +314,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "There's no notification subscriptions for this contact."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Existing subscriptions"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -322,3 +322,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Existing subscriptions"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "reuser-subscription-count"
+msgid_plural "reuser-subscriptions-count"
+msgstr[0] "Along with %{reuser_subscriptions} subscription from"
+msgstr[1] "Along with %{reuser_subscriptions} subscriptions from"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "reuser-count"
+msgid_plural "reusers-count"
+msgstr[0] "%{reusers} reuser."
+msgstr[1] "%{reusers} reusers."

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -326,11 +326,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "reuser-subscription-count"
 msgid_plural "reuser-subscriptions-count"
-msgstr[0] "Along with %{reuser_subscriptions} subscription from"
-msgstr[1] "Along with %{reuser_subscriptions} subscriptions from"
+msgstr[0] "Along with %{reuser_subscriptions_count} subscription from"
+msgstr[1] "Along with %{reuser_subscriptions_count} subscriptions from"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reuser-count"
 msgid_plural "reusers-count"
-msgstr[0] "%{reusers} reuser."
-msgstr[1] "%{reusers} reusers."
+msgstr[0] "%{reusers_count} reuser."
+msgstr[1] "%{reusers_count} reusers."

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -316,7 +316,7 @@ msgid "Dataset"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "There's no notification subscriptions for this contact."
+msgid "There are no notification subscriptions for this contact."
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -314,3 +314,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "There's no notification subscriptions for this contact."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Existing subscriptions"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -326,11 +326,11 @@ msgstr "Abonnements existants"
 #, elixir-autogen, elixir-format
 msgid "reuser-subscription-count"
 msgid_plural "reuser-subscriptions-count"
-msgstr[0] "Ainsi que %{reuser_subscriptions} abonnement de"
-msgstr[1] "Ainsi que %{reuser_subscriptions} abonnements de"
+msgstr[0] "Ainsi que %{reuser_subscriptions_count} abonnement de"
+msgstr[1] "Ainsi que %{reuser_subscriptions_count} abonnements de"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reuser-count"
 msgid_plural "reusers-count"
-msgstr[0] "%{reusers} réutilisateur."
-msgstr[1] "%{reusers} réutilisateurs."
+msgstr[0] "%{reusers_count} réutilisateur."
+msgstr[1] "%{reusers_count} réutilisateurs."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -316,7 +316,7 @@ msgid "Dataset"
 msgstr "Jeu de données"
 
 #, elixir-autogen, elixir-format
-msgid "There's no notification subscriptions for this contact."
+msgid "There are no notification subscriptions for this contact."
 msgstr "Il n’y a pas d’abonnements à des notifications pour ce contact."
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -314,3 +314,11 @@ msgstr "Rôle"
 #, elixir-autogen, elixir-format
 msgid "Dataset"
 msgstr "Jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "There's no notification subscriptions for this contact."
+msgstr "Il n’y a pas d’abonnements à des notifications pour ce contact."
+
+#, elixir-autogen, elixir-format
+msgid "Existing subscriptions"
+msgstr "Abonnements existants"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -322,3 +322,15 @@ msgstr "Il n’y a pas d’abonnements à des notifications pour ce contact."
 #, elixir-autogen, elixir-format
 msgid "Existing subscriptions"
 msgstr "Abonnements existants"
+
+#, elixir-autogen, elixir-format
+msgid "reuser-subscription-count"
+msgid_plural "reuser-subscriptions-count"
+msgstr[0] "Ainsi que %{reuser_subscriptions} abonnement de"
+msgstr[1] "Ainsi que %{reuser_subscriptions} abonnements de"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "reuser-count"
+msgid_plural "reusers-count"
+msgstr[0] "%{reusers} réutilisateur."
+msgstr[1] "%{reusers} réutilisateurs."

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -97,13 +97,15 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     insert_notification(%{dataset: dataset, email: "user1@example.fr", reason: :expiration})
     insert_notification(%{dataset: dataset, email: "user2@example.fr", reason: :expiration})
 
-    response =
+    doc =
       conn
       |> setup_admin_in_session()
       |> get(Routes.backoffice_page_path(conn, :edit, dataset.id))
       |> html_response(200)
+      |> Floki.parse_document!()
 
-    assert response =~ "user1@example.fr, user2@example.fr"
+    assert "user1@example.fr, user2@example.fr" ==
+             doc |> Floki.find("#notifications_sent table td:nth-child(3)") |> Floki.text()
   end
 
   test "notifications_sent sort order and grouping works" do

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -108,6 +108,27 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
              doc |> Floki.find("#notifications_sent table td:nth-child(3)") |> Floki.text()
   end
 
+  test "notification subscriptions", %{conn: conn} do
+    organization = insert(:organization)
+
+    dataset =
+      insert(:dataset,
+        is_active: true,
+        datagouv_id: Ecto.UUID.generate(),
+        slug: Ecto.UUID.generate(),
+        organization_id: organization.id
+      )
+
+    doc =
+      conn
+      |> setup_admin_in_session()
+      |> get(Routes.backoffice_page_path(conn, :edit, dataset.id))
+      |> html_response(200)
+      |> Floki.parse_document!()
+
+    assert doc |> Floki.find("#existing_subscriptions_table tr td:nth-child(1)") |> Floki.text() =~ "User One"
+  end
+
   test "notifications_sent sort order and grouping works" do
     dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate(), slug: Ecto.UUID.generate())
 

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -94,8 +94,8 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
         organization_id: organization.id
       )
 
-    insert_notification(%{dataset: dataset, email: "foo@example.fr", reason: :expiration})
-    insert_notification(%{dataset: dataset, email: "bar@example.fr", reason: :expiration})
+    insert_notification(%{dataset: dataset, email: "user1@example.fr", reason: :expiration})
+    insert_notification(%{dataset: dataset, email: "user2@example.fr", reason: :expiration})
 
     response =
       conn
@@ -103,7 +103,7 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
       |> get(Routes.backoffice_page_path(conn, :edit, dataset.id))
       |> html_response(200)
 
-    assert response =~ "bar@example.fr, foo@example.fr"
+    assert response =~ "user1@example.fr, user2@example.fr"
   end
 
   test "notifications_sent sort order and grouping works" do
@@ -112,10 +112,10 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
     now = DateTime.utc_now()
     five_hours_ago = DateTime.add(now, -5, :hour)
 
-    insert_notification_at_datetime(%{dataset: dataset, email: "foo@example.fr", reason: :expiration}, now)
-    insert_notification_at_datetime(%{dataset: dataset, email: "bar@example.fr", reason: :expiration}, now)
-    insert_notification_at_datetime(%{dataset: dataset, email: "bar@example.fr", reason: :expiration}, five_hours_ago)
-    insert_notification_at_datetime(%{dataset: dataset, email: "baz@example.fr", reason: :expiration}, five_hours_ago)
+    insert_notification_at_datetime(%{dataset: dataset, email: "user1@example.fr", reason: :expiration}, now)
+    insert_notification_at_datetime(%{dataset: dataset, email: "user2@example.fr", reason: :expiration}, now)
+    insert_notification_at_datetime(%{dataset: dataset, email: "user2@example.fr", reason: :expiration}, five_hours_ago)
+    insert_notification_at_datetime(%{dataset: dataset, email: "user3@example.fr", reason: :expiration}, five_hours_ago)
 
     now_truncated = %{DateTime.truncate(now, :second) | second: 0}
     five_hours_ago_truncated = %{DateTime.truncate(five_hours_ago, :second) | second: 0}
@@ -125,8 +125,8 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
              {{:expiration, ^five_hours_ago_truncated}, emails_2}
            ] = PageController.notifications_sent(dataset)
 
-    assert emails_1 |> Enum.sort() == ["bar@example.fr", "foo@example.fr"]
-    assert emails_2 |> Enum.sort() == ["bar@example.fr", "baz@example.fr"]
+    assert emails_1 |> Enum.sort() == ["user1@example.fr", "user2@example.fr"]
+    assert emails_2 |> Enum.sort() == ["user2@example.fr", "user3@example.fr"]
   end
 
   test "can download the resources CSV", %{conn: conn} do


### PR DESCRIPTION
Les abonnements avec le rôle reuser ne sont plus affichés, et l'on a une idée du volume après la liste des producteurs abonnés :

![image](https://github.com/etalab/transport-site/assets/346377/b73acf32-38e3-4ea7-b546-89c16018f00f)

Voir #4009.