### PR TITLE
Carte exploration : couleur layer ZFE

### DIFF
--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -173,7 +173,7 @@ function updateIRVELayer (geojson) {
 
 function trackEvent (layer) {
     // https://matomo.org/faq/reports/implement-event-tracking-with-matomo/#how-to-set-up-matomo-event-tracking-with-javascript
-    // `windown._paq` is only defined in production (in templates/layout/app.html.heex)
+    // `window._paq` is only defined in production (in templates/layout/app.html.heex)
     if (window._paq) {
         window._paq.push(['trackEvent', 'explore-map', 'enable-layer', layer])
     }

--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -173,14 +173,17 @@ function updateIRVELayer (geojson) {
 
 function trackEvent (layer) {
     // https://matomo.org/faq/reports/implement-event-tracking-with-matomo/#how-to-set-up-matomo-event-tracking-with-javascript
-    window._paq.push(['trackEvent', 'explore-map', 'enable-layer', layer])
+    // `windown._paq` is only defined in production (in templates/layout/app.html.heex)
+    if (window._paq) {
+        window._paq.push(['trackEvent', 'explore-map', 'enable-layer', layer])
+    }
 }
 
 function createPointsLayer (geojson, id) {
     const fillColor = {
         'bnlc-layer': [255, 174, 0, 100],
         'parkings_relais-layer': [0, 33, 70, 100],
-        'zfe-layer': [155, 89, 182, 100],
+        'zfe-layer': [52, 8, 143, 100],
         'irve-layer': [245, 40, 145, 100]
     }[id]
 
@@ -192,6 +195,7 @@ function createPointsLayer (geojson, id) {
         filled: true,
         extruded: false,
         pointType: 'circle',
+        opacity: 1,
         getFillColor: fillColor,
         getPointRadius: 1000,
         pointRadiusUnits: 'meters',

--- a/apps/transport/client/stylesheets/components/_explore.scss
+++ b/apps/transport/client/stylesheets/components/_explore.scss
@@ -17,7 +17,7 @@
     background-color: rgb(0, 33, 70);
   }
   #zfe-check:checked {
-    background-color: rgb(155, 89, 182);
+    background-color: rgb(52, 8, 143);
   }
   #irve-check:checked {
     background-color: rgb(245, 40, 145);


### PR DESCRIPTION
Fixes #4012

Ajuste la couleur du layer des ZFE pour le rendre plus visible. J'ai tenté de jouer avec [`fillOpacity`](https://leafletjs.com/reference.html#path) en passant de 0.2 à 1 mais il n'y avait pas de différence.

J'ai choisi un violet plus foncé.