### PR TITLE
Modifications accueil et menu

### DIFF
--- a/apps/transport/client/images/icons/validate.svg
+++ b/apps/transport/client/images/icons/validate.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <ellipse style="stroke: rgb(0, 0, 0); fill: rgb(232, 244, 250); stroke-width: 0px;" cx="256" cy="256" rx="244.522" ry="245.935"/>
+  <path d="M 373.885 122.857 L 202.212 290.418 L 138.049 227.816 L 87.457 277.243 L 202.147 389.143 L 216.968 374.746 L 424.543 172.219 L 373.885 122.857 Z" fill="#41ad49" style=""/>
+</svg>

--- a/apps/transport/client/stylesheets/home.scss
+++ b/apps/transport/client/stylesheets/home.scss
@@ -189,6 +189,9 @@ a.tile:hover {
       font-size: 1.5em;
       font-weight: normal;
     }
+    .button.reuser-space {
+      background-color: var(--primary-color-producer)
+    }
   }
   .home-search {
     flex-basis: 50%;

--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -54,7 +54,7 @@ nav.navigation input {
 }
 
 .nav__username {
-  margin-right: 1em;
+  margin-left: 1em;
 }
 
 .navbar__logo-mariane {

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -79,6 +79,7 @@
             <li class="nav__item">
               <div class="dropdown">
                 <div class="user-name-display">
+                  <img :if={avatar_url(@conn)} src={avatar_url(@conn)} alt="Avatar" class="nav__avatar" />
                   <span class="nav__username">
                     <%= if assigns[:current_user]["first_name"] && assigns[:current_user]["last_name"] do %>
                       <%= assigns[:current_user]["first_name"] %> <%= assigns[:current_user]["last_name"] %>
@@ -86,9 +87,6 @@
                       <%= gettext("My account") %>
                     <% end %>
                   </span>
-                  <%= if assigns[:current_user]["avatar_thumbnail"] do %>
-                    <img src={assigns[:current_user]["avatar_thumbnail"]} alt="" class="nav__avatar" />
-                  <% end %>
                 </div>
                 <div class="dropdown-content">
                   <%= if TransportWeb.Session.admin?(@conn) do %>

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -18,6 +18,16 @@
         </a>
         <ul class="nav__links top-nav-links">
           <li class="nav__item">
+            <div class="dropdown">
+              <%= gettext("Data") %>
+              <div class="dropdown-content">
+                <%= link(gettext("Datasets"), to: dataset_path(@conn, :index)) %>
+                <%= link(gettext("Exploration map"), to: explore_path(@conn, :index)) %>
+                <%= link(gettext("National GTFS stops map"), to: explore_path(@conn, :gtfs_stops)) %>
+              </div>
+            </div>
+          </li>
+          <li class="nav__item">
             <%= link(gettext("Documentation"), to: "https://doc.transport.data.gouv.fr") %>
           </li>
           <li class="nav__item">
@@ -31,15 +41,14 @@
                   to: live_path(@conn, TransportWeb.Live.GTFSDiffSelectLive)
                 ) %>
                 <%= link(gettext("SIRI query generator"), to: live_path(@conn, TransportWeb.Live.SIRIQuerierLive)) %>
-                <%= link(gettext("Exploration map"), to: explore_path(@conn, :index)) %>
-                <%= link(gettext("National GTFS stops map"), to: explore_path(@conn, :gtfs_stops)) %>
+
                 <%= link(gettext("Accèslibre Mobilités"), to: "https://mtes-mct.github.io/alm-docs/", target: "_blank") %>
                 <%= link(gettext("Service status"), to: "https://stats.uptimerobot.com/q7nqyiO9yQ", target: "_blank") %>
               </div>
             </div>
           </li>
           <li class="nav__item">
-            <%= link(gettext("Producer infos"), to: page_path(@conn, :infos_producteurs)) %>
+            <%= link(gettext("Statistics"), to: stats_path(@conn, :index)) %>
           </li>
           <li class="nav__item">
             <div class="dropdown">

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -4,6 +4,17 @@
       <div class="home-title">
         <h1><%= dgettext("page-index", "title") %></h1>
         <h2><%= dgettext("page-index", "subtitle") %></h2>
+        <a href={page_path(@conn, :espace_producteur, utm_campaign: "home_button")} class="button">
+          <%= dgettext("page-index", "Producer space") %>
+        </a>
+        <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
+          <a
+            href={reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "home_button")}
+            class="button reuser-space"
+          >
+            <%= dgettext("page-index", "Reuser space") %>
+          </a>
+        <% end %>
       </div>
       <div class="home-search">
         <div class="searchBar">
@@ -27,9 +38,9 @@
           <h4><%= dgettext("page-index", "You can also") %></h4>
           <div class="home-other-search-methods">
             <div class="search-method">
-              <a href={stats_path(@conn, :index)}>
-                <img src={static_path(@conn, "/images/icons/map.png")} alt="Cartes" />
-                <%= dgettext("page-index", "Use the map") %>
+              <a href={live_path(@conn, TransportWeb.Live.OnDemandValidationSelectLive)}>
+                <img src={static_path(@conn, "/images/icons/validate.svg")} alt="Validation" />
+                <%= dgettext("page-index", "Validate your data") %>
               </a>
             </div>
             <div class="search-method">
@@ -40,7 +51,7 @@
             </div>
             <div class="search-method">
               <a href={dataset_path(@conn, :index, order_by: "most_recent")}>
-                <img src={static_path(@conn, "/images/icons/recently-added-datasets.png")} alt="API" />
+                <img src={static_path(@conn, "/images/icons/recently-added-datasets.png")} alt="Data" />
                 <%= dgettext("page-index", "See newly added datasets") %>
               </a>
             </div>

--- a/apps/transport/lib/transport_web/views/layout_view.ex
+++ b/apps/transport/lib/transport_web/views/layout_view.ex
@@ -10,6 +10,23 @@ defmodule TransportWeb.LayoutView do
 
   def has_flash(%Plug.Conn{} = conn), do: not Enum.empty?(conn.assigns.flash)
 
+  @doc """
+  The current user's avatar URL.
+  If the logged-in user has a custom avatar, use its URL.
+  Otherwise use the data.gouv.fr pixels for this user.
+  """
+  def avatar_url(%Plug.Conn{assigns: %{current_user: %{"avatar_thumbnail" => avatar_thumbnail}}})
+      when is_binary(avatar_thumbnail) do
+    avatar_thumbnail
+  end
+
+  def avatar_url(%Plug.Conn{assigns: %{current_user: %{"id" => datagouv_id}}}) do
+    # https://doc.data.gouv.fr/api/reference/#/avatars/avatars
+    "https://www.data.gouv.fr/api/1/avatars/#{datagouv_id}/50"
+  end
+
+  def avatar_url(%Plug.Conn{}), do: nil
+
   def add_locale_to_url(conn, locale) do
     query_params = conn.query_params |> Map.put("locale", locale) |> Plug.Conn.Query.encode()
     "#{conn.request_path}?#{query_params}"

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -84,10 +84,6 @@ msgid "Producer informations"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Producer infos"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "My account"
 msgstr ""
 
@@ -157,4 +153,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Accèslibre Mobilités"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Datasets"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Statistics"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -84,10 +84,6 @@ msgid "Producer informations"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Producer infos"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "My account"
 msgstr ""
 
@@ -157,4 +153,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Accèslibre Mobilités"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Datasets"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Statistics"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -159,10 +159,6 @@ msgid "Use our APIs"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Use the map"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "You can also"
 msgstr ""
 
@@ -204,4 +200,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Learn more about our missions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Producer space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Validate your data"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -84,10 +84,6 @@ msgid "Producer informations"
 msgstr "Voir les infos producteurs"
 
 #, elixir-autogen, elixir-format
-msgid "Producer infos"
-msgstr "Infos producteurs"
-
-#, elixir-autogen, elixir-format
 msgid "My account"
 msgstr "Mon compte"
 
@@ -158,3 +154,15 @@ msgstr "Espace réutilisateur"
 #, elixir-autogen, elixir-format
 msgid "Accèslibre Mobilités"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Data"
+msgstr "Données"
+
+#, elixir-autogen, elixir-format
+msgid "Datasets"
+msgstr "Toutes les données"
+
+#, elixir-autogen, elixir-format
+msgid "Statistics"
+msgstr "Statistiques"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -159,10 +159,6 @@ msgid "Use our APIs"
 msgstr "Utiliser nos API"
 
 #, elixir-autogen, elixir-format
-msgid "Use the map"
-msgstr "Rechercher sur la carte"
-
-#, elixir-autogen, elixir-format
 msgid "You can also"
 msgstr "Vous pouvez également"
 
@@ -205,3 +201,15 @@ msgstr "Ils nous aident dans notre mission"
 #, elixir-autogen, elixir-format
 msgid "Learn more about our missions"
 msgstr "Découvrez les missions que nous menons"
+
+#, elixir-autogen, elixir-format
+msgid "Producer space"
+msgstr "Espace producteur"
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr "Espace réutilisateur"
+
+#, elixir-autogen, elixir-format
+msgid "Validate your data"
+msgstr "Valider ses données"

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -159,10 +159,6 @@ msgid "Use our APIs"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Use the map"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "You can also"
 msgstr ""
 
@@ -204,4 +200,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Learn more about our missions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Producer space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuser space"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Validate your data"
 msgstr ""


### PR DESCRIPTION
Fixes #3914

Implémente les changements détaillés dans https://github.com/etalab/transport-site/issues/3914#issuecomment-2181097607

Le bouton pour l'espace réutilisateur reste masqué tant qu'il n'est pas sorti pour le grand public. Tenter d'accéder aux espaces utilisateurs sans être connecté amène sur une landing page d'information, présentant la fonctionnalité et demandant de se connecter.


![image](https://github.com/etalab/transport-site/assets/295709/23cfcf1a-1579-41e8-b139-df7ba9b388c9)
![Screenshot 2024-06-21 at 11 24 37](https://github.com/etalab/transport-site/assets/295709/bbc5c5e7-5ea0-4071-9b95-2e43764515de)
