### PR TITLE
Passage de la pagination à 20 items et bloc de pagination directement sous la liste

### DIFF
--- a/apps/transport/client/stylesheets/components/_shortlist.scss
+++ b/apps/transport/client/stylesheets/components/_shortlist.scss
@@ -2,12 +2,6 @@
   display: flex;
 }
 
-.shortlist__pagination {
-  margin: 1em 0;
-  display: flex;
-  justify-content: flex-end;
-}
-
 .shortlist .side-pane {
   padding: 0;
   margin-right: 2em;
@@ -220,10 +214,6 @@
     flex-direction: column;
   }
 
-  .shortlist__pagination {
-    justify-content: center;
-  }
-
   .shortlist .side-pane {
     order: 2;
     margin-right: 0;
@@ -245,7 +235,7 @@
     flex-direction: column;
   }
 
-  .shortlist__pagination .pagination {
+  .pagination {
     justify-content: center;
   }
 }

--- a/apps/transport/lib/db/repo.ex
+++ b/apps/transport/lib/db/repo.ex
@@ -3,5 +3,5 @@ defmodule DB.Repo do
     otp_app: :transport,
     adapter: Ecto.Adapters.Postgres
 
-  use Scrivener, page_size: 10
+  use Scrivener, page_size: 20
 end

--- a/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
+++ b/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
@@ -11,10 +11,10 @@ defmodule TransportWeb.PaginationHelpers do
         {int, _} -> int
       end
 
-    %Scrivener.Config{page_number: page_number, page_size: 10}
+    %Scrivener.Config{page_number: page_number, page_size: 20}
   end
 
-  def make_pagination_config(_), do: %Scrivener.Config{page_number: 1, page_size: 10}
+  def make_pagination_config(_), do: %Scrivener.Config{page_number: 1, page_size: 20}
 
   def pagination_links(_, %{total_pages: 1}), do: ""
 

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -229,12 +229,13 @@
                 </div>
               </div>
             <% end %>
+            <div>
+              <%= pagination_links(@conn, @datasets) %>
+            </div>
           <% end %>
         </div>
       </div>
-      <div class="shortlist__pagination">
-        <%= pagination_links(@conn, @datasets) %>
-      </div>
+
       <div class="api-link">
         <i class="fas fa-cogs"></i>
         <% # NOTE: the syntax_highlight flag is there just because otherwise we get a match error


### PR DESCRIPTION
Closes #4023 

Cette PR remonte le bloc de liens de la pagination à directement sous la liste de datasets (on ratait facilement la liste à cause du menu à gauche qui faisait scroller).

Elle passe aussi le nombre d’items paginés à 20.

Le PAN a une configuration unique de pagination, cela affecte donc tous les listes paginées suivantes :
- Liste de datasets (recherche)
- Liste de contacts dans le backoffice
- Liste de datasets dans le backoffice
- Liste d’erreurs sur la page de détail d’une resource
- Liste d’erreurs sur la page spécifique de validation (je sais pas si ce template est vraiment utilisé, j’avais vu passer un template inutilisé à un moment)

D’après mes tests manuels, cela n’affecte pas la performance de manière sensible, et le changement de taille de liste est plutôt le bienvenu là où il est réalisé, mais je n’ai pas fait de benchmark automatique de temps de réponse des listes.

![image](https://github.com/etalab/transport-site/assets/15861435/a20ecec2-f9ff-49ad-84b1-e4116c3e3915)
