### PR TITLE
Dataset#details : répare erreur 500 quand JDD publié par une personne

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -89,7 +89,7 @@ defmodule TransportWeb.DatasetController do
          %DB.Dataset{organization_id: organization_id}
        ) do
     is_producer =
-      if is_nil(current_contact) do
+      if Enum.any?([current_contact, organization_id], &is_nil/1) do
         false
       else
         DB.Contact.base_query()

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -468,6 +468,16 @@ defmodule TransportWeb.DatasetControllerTest do
              "Ce jeu de données a été supprimé de data.gouv.fr"
   end
 
+  test "dataset#details loads when dataset.organization_id is nil", %{conn: conn} do
+    # To be removed when https://github.com/etalab/transport-site/issues/4018
+    # is done and existing datasets have been migrated
+    dataset = insert(:dataset, is_active: true, organization_id: nil)
+
+    mock_empty_history_resources()
+
+    conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
+  end
+
   test "with an archived dataset", %{conn: conn} do
     insert(:dataset, is_active: true, slug: slug = "dataset-slug", archived_at: DateTime.utc_now())
 


### PR DESCRIPTION
Fixes #4017

Cette erreur survenait quand :
- un utilisateur est connecté
- un JDD est publié par une personne et non une organisation (`dataset.organization_id = nil`)
- cet utilisateur visite la page `dataset#details` pour ce JDD

[🐛 Sentry](https://transport-data-gouv-fr.sentry.io/issues/5528852013/?project=6197733)