### PR TITLE
Espace réutilisateur : sortie publique

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -56,6 +56,7 @@ defmodule TransportWeb.Router do
   pipeline :reuser_space do
     plug(:browser)
     plug(:authentication_required, destination_path: "/infos_reutilisateurs")
+    plug(:check_reuser_space_enabled)
   end
 
   scope "/", OpenApiSpex.Plug do
@@ -391,6 +392,17 @@ defmodule TransportWeb.Router do
 
       _ ->
         conn
+    end
+  end
+
+  def check_reuser_space_enabled(%Plug.Conn{} = conn, _) do
+    if TransportWeb.Session.display_reuser_space?(conn) do
+      conn
+    else
+      conn
+      |> put_flash(:info, dgettext("alert", "This feature is currently not available."))
+      |> redirect(to: "/")
+      |> halt()
     end
   end
 

--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -62,18 +62,11 @@ defmodule TransportWeb.Session do
   A temporary helper method to determine if we should display "reuser space features".
   Convenient method to find various entrypoints in the codebase.
 
-  At the moment we only allow transport.data.gouv.fr members but we could
-  allow specific logged-in users in the future.
-
-  `:force_display_reuser_space` is currently set in a few tests to test things
-  while not being an admin (because being an admin may not be appropriate in the test).
+  Enable it for everybody but keep a "kill switch" to disable it quickly
+  by setting an environment variable and rebooting the app.
   """
-  def display_reuser_space?(%Plug.Conn{} = conn) do
-    if Mix.env() == :test do
-      get_session(conn, :force_display_reuser_space, false) or admin?(conn)
-    else
-      admin?(conn)
-    end
+  def display_reuser_space?(%Plug.Conn{}) do
+    not Application.fetch_env!(:transport, :disable_reuser_space)
   end
 
   @spec set_session_attribute_attribute(Plug.Conn.t(), binary(), boolean()) :: Plug.Conn.t()

--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -60,13 +60,19 @@ defmodule TransportWeb.Session do
 
   @doc """
   A temporary helper method to determine if we should display "reuser space features".
-  Convenient method to find various entrypoints in the codebase.
+  Convenient method to find various entrypoints in the codebase:
+  - links and buttons to the reuser space
+  - follow dataset hearts (search results, dataset pages)
+  - reuser space
 
   Enable it for everybody but keep a "kill switch" to disable it quickly
   by setting an environment variable and rebooting the app.
+
+  transport.data.gouv.fr admins get access no matter what.
   """
-  def display_reuser_space?(%Plug.Conn{}) do
-    not Application.fetch_env!(:transport, :disable_reuser_space)
+  def display_reuser_space?(%Plug.Conn{} = conn) do
+    feature_disabled = Application.fetch_env!(:transport, :disable_reuser_space)
+    admin?(conn) or not feature_disabled
   end
 
   @spec set_session_attribute_attribute(Plug.Conn.t(), binary(), boolean()) :: Plug.Conn.t()

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -196,7 +196,7 @@
                     </div>
                   </div>
                   <div class="dataset__type">
-                    <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
+                    <%= if not is_nil(@current_user) and TransportWeb.Session.display_reuser_space?(@conn) do %>
                       <i class={heart_class(@dataset_heart_values, dataset)}></i>
                     <% end %>
                     <%= unless is_nil(icon_type_path(dataset)) do %>

--- a/apps/transport/priv/gettext/alert.pot
+++ b/apps/transport/priv/gettext/alert.pot
@@ -29,3 +29,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This feature is currently not available."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
@@ -29,3 +29,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This feature is currently not available."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -29,3 +29,7 @@ msgstr "Une erreur a eu lieu lors de la récupération de vos ressources"
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr "Impossible de récupérer ce jeu de données pour le moment"
+
+#, elixir-autogen, elixir-format
+msgid "This feature is currently not available."
+msgstr "La fonctionnalité n'est pas disponible pour le moment."

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule TransportWeb.ReuserSpaceControllerTest do
-  use TransportWeb.ConnCase, async: true
+  # `async: false` because we change the app config in a test
+  use TransportWeb.ConnCase, async: false
   import DB.Factory
 
   @home_url reuser_space_path(TransportWeb.Endpoint, :espace_reutilisateur)
@@ -26,6 +27,17 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
 
       # Feedback form is displayed
       refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
+    end
+
+    test "reuser space disabled by killswitch", %{conn: conn} do
+      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
+      Application.put_env(:transport, :disable_reuser_space, true)
+      conn = Plug.Test.init_test_session(conn, %{current_user: %{}})
+      refute TransportWeb.Session.display_reuser_space?(conn)
+      conn = conn |> get(@home_url)
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "La fonctionnalité n'est pas disponible pour le moment"
+      Application.put_env(:transport, :disable_reuser_space, old_value)
     end
   end
 

--- a/apps/transport/test/transport_web/session_test.exs
+++ b/apps/transport/test/transport_web/session_test.exs
@@ -1,5 +1,6 @@
 defmodule TransportWeb.SessionTest do
-  use ExUnit.Case, async: true
+  # `async: false` because we change the app config in a test
+  use ExUnit.Case, async: false
   import DB.Factory
   import TransportWeb.Session
   doctest TransportWeb.Session, import: true
@@ -51,6 +52,24 @@ defmodule TransportWeb.SessionTest do
                |> Plug.Test.init_test_session(%{current_user: %{}})
                |> set_is_producer([build(:dataset), build(:dataset)])
                |> Plug.Conn.get_session(:current_user)
+    end
+  end
+
+  describe "display_reuser_space?" do
+    test "killswitch can disable the reuser space" do
+      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
+      Application.put_env(:transport, :disable_reuser_space, true)
+      conn = Plug.Test.init_test_session(%Plug.Conn{}, %{})
+      refute TransportWeb.Session.display_reuser_space?(conn)
+      Application.put_env(:transport, :disable_reuser_space, old_value)
+    end
+
+    test "admins get access when killswitch is enabled" do
+      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
+      Application.put_env(:transport, :disable_reuser_space, true)
+      conn = Plug.Test.init_test_session(%Plug.Conn{}, %{current_user: %{"is_admin" => true}})
+      assert TransportWeb.Session.display_reuser_space?(conn)
+      Application.put_env(:transport, :disable_reuser_space, old_value)
     end
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -37,8 +37,9 @@ webserver = webserver == "1"
 config :transport,
   worker: worker,
   webserver: webserver,
-  # kill switch
-  disable_national_gtfs_map: System.get_env("DISABLE_NATIONAL_GTFS_MAP") == "1"
+  # kill switches: set specific variable environments to disable features
+  disable_reuser_space: System.get_env("DISABLE_REUSER_SPACE") in ["1", "true"],
+  disable_national_gtfs_map: System.get_env("DISABLE_NATIONAL_GTFS_MAP") in ["1", "true"]
 
 config :unlock,
   enforce_ttl: webserver


### PR DESCRIPTION
- Rend disponible l'espace réutilisateur pour tout le monde.
- Adapte les quelques tests nécessaires suite à ce changement.
- Ajoute un "kill switch" permettant de fermer rapidement la fonctionnalité en cas de besoin.

Je vais me coordonner avec @cyrilmorin pour la sortie de cette PR, en faisant un tour ensemble avant.