### PR TITLE
Discussions : ajout badge pour membres du PAN

### DIFF
--- a/apps/transport/client/stylesheets/components/_discussions.scss
+++ b/apps/transport/client/stylesheets/components/_discussions.scss
@@ -47,7 +47,7 @@
     padding-bottom: 5vh;
   }
 
-  .label--producer {
+  .label--role {
     margin-left: 1em;
   }
 }

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -282,7 +282,7 @@ defmodule DB.Contact do
   end
 
   @doc """
-  A list of contact_ids for contacts who are members of the transport.data.gouv.fr's organization.
+  A list of contact IDs for contacts who are members of the transport.data.gouv.fr's organization.
 
   This list is cached because it is very stable over time and we need it for multiple
   Oban jobs executed in parallel or one after another.
@@ -295,6 +295,20 @@ defmodule DB.Contact do
       to_string(__MODULE__) <> ":admin_contact_ids",
       fn -> Enum.map(admin_contacts(), & &1.id) end,
       :timer.seconds(60)
+    )
+  end
+
+  @doc """
+  A list of datagouv user IDs for contacts who are members of the transport.data.gouv.fr's organization.
+
+  This list is cached because it is very stable over time.
+  """
+  @spec admin_datagouv_ids() :: [binary()]
+  def admin_datagouv_ids do
+    Transport.Cache.fetch(
+      to_string(__MODULE__) <> ":admin_datagouv_ids",
+      fn -> Enum.map(admin_contacts(), & &1.datagouv_user_id) end,
+      :timer.minutes(60)
     )
   end
 

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -31,6 +31,7 @@ defmodule TransportWeb.DiscussionsLive do
             current_user: @current_user,
             socket: @socket,
             dataset: @dataset,
+            admin_member_ids: @admin_member_ids,
             org_member_ids: @org_member_ids,
             org_logo_thumbnail: @org_logo_thumbnail,
             locale: @locale
@@ -83,7 +84,12 @@ defmodule TransportWeb.DiscussionsLive do
 
     socket =
       socket
-      |> assign(discussions: discussions, org_member_ids: org_member_ids, org_logo_thumbnail: org_logo_thumbnail)
+      |> assign(
+        discussions: discussions,
+        org_member_ids: org_member_ids,
+        org_logo_thumbnail: org_logo_thumbnail,
+        admin_member_ids: DB.Contact.admin_datagouv_ids()
+      )
       |> push_event("discussions-loaded", %{
         ids: discussions |> Enum.filter(&discussion_should_be_closed?/1) |> Enum.map(& &1["id"])
       })
@@ -92,9 +98,11 @@ defmodule TransportWeb.DiscussionsLive do
   end
 
   @doc """
-    Decides if a discussion coming from data.gouv.fr API should be dislayed as closed for a less cluttered UI
-    A discussion is closed if it has a "closed" key with a value (same behaviour than on data.gouv.fr)
-    or if the last comment inside the discussion is older than 2 months (because people often forget to close discussions)
+  Decides if a discussion coming from data.gouv.fr API should be displayed as closed for a less cluttered UI.
+
+  A discussion is closed if:
+  - it has a "closed" key with a value (same behaviour than on data.gouv.fr)
+  - if the last comment inside the discussion is older than 2 months (because people often forget to close discussions)
   """
   def discussion_should_be_closed?(%{"closed" => closed}) when not is_nil(closed), do: true
 

--- a/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_discussion.html.heex
@@ -10,6 +10,7 @@
   <div id={"comments-discussion-#{@discussion["id"]}"}>
     <%= for comment <- @discussion["discussion"] do %>
       <% is_producer = comment["posted_by"]["id"] in @org_member_ids %>
+      <% is_admin = comment["posted_by"]["id"] in @admin_member_ids %>
       <% avatar_src =
         cond do
           user_avatar = comment["posted_by"]["avatar_thumbnail"] -> user_avatar
@@ -24,8 +25,11 @@
         <div>
           <div class="discussion-comment__header">
             <a href={comment["posted_by"]["page"]}><%= commenter_full_name %></a>
-            <span :if={is_producer} class="label label--producer">
+            <span :if={is_producer} class="label label--role">
               <%= dgettext("page-dataset-details", "data producer") %>
+            </span>
+            <span :if={is_admin} class="label label--role">
+              transport.data.gouv.fr
             </span>
             <span class="discussion-date">
               <%= dgettext("page-dataset-details", "Posted on %{datetime}",

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -259,6 +259,16 @@ defmodule DB.ContactTest do
     assert [] == list_inactive_contact_ids(date2)
   end
 
+  test "admin_contact* methods" do
+    admin_org = build(:organization, name: "Point d'Accès National transport.data.gouv.fr")
+    %DB.Contact{id: admin_id} = admin_contact = insert_contact(%{organizations: [Map.from_struct(admin_org)]})
+    insert_contact()
+
+    assert [%DB.Contact{id: ^admin_id}] = DB.Contact.admin_contacts()
+    assert [admin_id] == DB.Contact.admin_contact_ids()
+    assert [admin_contact.datagouv_user_id] == DB.Contact.admin_datagouv_ids()
+  end
+
   defp list_inactive_contact_ids(datetime) do
     DB.Contact.list_inactive_contacts(datetime)
     |> Enum.map(fn %DB.Contact{id: contact_id} -> contact_id end)


### PR DESCRIPTION
Utilise et étend ce qui a été fait dans #3533

Ajoute un badge :label: `transport.data.gouv.fr` pour les membres du PAN qui répondent dans les discussions. Ceci permet de mieux nous identifier.

## Captures d'écran

Cas d'un échange entre PAN et producteur
![image](https://github.com/etalab/transport-site/assets/295709/10b8026a-45c3-4ef8-a7d3-771f83db8e49)

Réponse d'un membre du PAN pour un JDD que l'on produit (2 badges)
![image](https://github.com/etalab/transport-site/assets/295709/9d7c6d12-d088-4b71-acef-53fb2afea5eb)
