### PR TITLE
Logo personnalisé d'un JDD : ajout timestamp dans nom de fichier

### DIFF
--- a/apps/transport/lib/jobs/custom_logo_conversion_job.ex
+++ b/apps/transport/lib/jobs/custom_logo_conversion_job.ex
@@ -7,13 +7,14 @@ defmodule Transport.Jobs.CustomLogoConversionJob do
   use Oban.Worker, max_attempts: 3
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"datagouv_id" => datagouv_id, "path" => path}}) do
+  def perform(%Oban.Job{args: %{"datagouv_id" => datagouv_id, "path" => path}, inserted_at: %DateTime{} = inserted_at}) do
     %DB.Dataset{datagouv_id: datagouv_id} = DB.Repo.get_by!(DB.Dataset, datagouv_id: datagouv_id)
     local_path = Path.join(System.tmp_dir!(), path)
     extension = local_path |> Path.extname() |> String.downcase()
+    timestamp = DateTime.to_unix(inserted_at)
 
-    logo_filename = "#{datagouv_id}#{extension}"
-    full_logo_filename = "#{datagouv_id}_full#{extension}"
+    logo_filename = "#{datagouv_id}.#{timestamp}#{extension}"
+    full_logo_filename = "#{datagouv_id}_full.#{timestamp}#{extension}"
     logo_path = Path.join(System.tmp_dir!(), logo_filename)
     full_logo_path = Path.join(System.tmp_dir!(), full_logo_filename)
 


### PR DESCRIPTION
Ajoute un timestamp dans les URLs des logos personnalisés envoyés par les producteurs pour leur de données.

Ceci permet d'éviter un problème de cache de l'image lors de la mise à jour. En effet l'URL précédente était de la forme `https://example.com/:dataset_id.png` avec un cache de plusieurs jours. En cas de remplacement d'un logo qui était déjà personnalisé, le producteur ou les visiteurs peuvent voir l'ancienne version pendant quelques jours.

```
$ curl -I https://transport-data-gouv-fr-logos-prod.cellar-c2.services.clever-cloud.com/60e324396e9514171898339c.png
HTTP/1.1 200 OK
content-length: 3124
accept-ranges: bytes
last-modified: Fri, 05 Jul 2024 06:47:44 GMT
x-rgw-object-type: Normal
ETag: "a67d2a8cea40ab807917b3ae79a4f07c-1"
cache-control: public, max-age=604800
x-amz-request-id: tx000000000000008a98767-006687bf07-261b3ae8-default
content-type: application/octet-stream
date: Fri, 05 Jul 2024 09:38:15 GMT
```

L'ajout d'un timestamp UNIX permet d'avoir une URL unique, qui changera lors du remplacement du logo.

📧 🐛 Voir [un ticket](https://app.frontapp.com/open/msg_28amemza?key=2MtYaYcQypfOvrivGxgoWaRxMRgaQh_B) où un producteur a été confus.