### PR TITLE
ResourcesChangedNotificationJob : récupérer les bons abonnements

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -58,9 +58,11 @@ defmodule DB.NotificationSubscription do
     end
   end
 
-  @spec subscriptions_for_reason_dataset_and_role(atom(), DB.Dataset.t(), Transport.NotificationReason.role()) :: [
-          __MODULE__.t()
-        ]
+  @spec subscriptions_for_reason_dataset_and_role(
+          Transport.NotificationReason.dataset_reason(),
+          DB.Dataset.t(),
+          Transport.NotificationReason.role()
+        ) :: [__MODULE__.t()]
   def subscriptions_for_reason_dataset_and_role(reason, %DB.Dataset{id: dataset_id}, role) do
     base_query()
     |> preload([:contact])
@@ -71,7 +73,10 @@ defmodule DB.NotificationSubscription do
     |> DB.Repo.all()
   end
 
-  @spec subscriptions_for_reason_and_role(atom(), Transport.NotificationReason.role()) :: [__MODULE__.t()]
+  @spec subscriptions_for_reason_and_role(
+          Transport.NotificationReason.platform_reason(),
+          Transport.NotificationReason.role()
+        ) :: [__MODULE__.t()]
   def subscriptions_for_reason_and_role(reason, role) do
     base_query()
     |> preload([:contact])

--- a/apps/transport/lib/jobs/resources_changed_notification_job.ex
+++ b/apps/transport/lib/jobs/resources_changed_notification_job.ex
@@ -24,8 +24,7 @@ defmodule Transport.Jobs.ResourcesChangedNotificationJob do
     dataset = DB.Dataset |> DB.Repo.get!(dataset_id)
     subject = "#{dataset.custom_title} : ressources modifiées"
 
-    @notification_reason
-    |> DB.NotificationSubscription.subscriptions_for_reason_and_role(:reuser)
+    DB.NotificationSubscription.subscriptions_for_reason_dataset_and_role(@notification_reason, dataset, :reuser)
     |> Enum.each(fn %DB.NotificationSubscription{contact: %DB.Contact{} = contact} = subscription ->
       Transport.UserNotifier.resources_changed(contact, subject, dataset)
       |> Transport.Mailer.deliver()

--- a/apps/transport/lib/transport/notification_reason.ex
+++ b/apps/transport/lib/transport/notification_reason.ex
@@ -74,6 +74,8 @@ defmodule Transport.NotificationReason do
     }
   }
 
+  @platform_reasons @reasons_rules |> Map.filter(fn {_, attributes} -> attributes.scope == :platform end) |> Map.keys()
+  @dataset_reasons @reasons_rules |> Map.filter(fn {_, attributes} -> attributes.scope == :dataset end) |> Map.keys()
   @all_reasons @reasons_rules |> Map.keys()
 
   # https://elixirforum.com/t/using-module-attributes-in-typespec-definitions-to-reduce-duplication/42374/2
@@ -81,6 +83,10 @@ defmodule Transport.NotificationReason do
   @type role :: unquote(types)
   types = Enum.reduce(@all_reasons, &{:|, [], [&1, &2]})
   @type reason :: unquote(types)
+  types = Enum.reduce(@platform_reasons, &{:|, [], [&1, &2]})
+  @type platform_reason :: unquote(types)
+  types = Enum.reduce(@dataset_reasons, &{:|, [], [&1, &2]})
+  @type dataset_reason :: unquote(types)
 
   @spec all_reasons :: [reason()]
   def all_reasons, do: @all_reasons
@@ -153,25 +159,11 @@ defmodule Transport.NotificationReason do
     |> Map.keys()
   end
 
-  @spec reasons_related_to_datasets :: [reason()]
-  def reasons_related_to_datasets do
-    @reasons_rules
-    |> Map.filter(fn
-      {_, %{scope: :dataset}} -> true
-      _ -> false
-    end)
-    |> Map.keys()
-  end
+  @spec reasons_related_to_datasets :: [dataset_reason()]
+  def reasons_related_to_datasets, do: @dataset_reasons
 
-  @spec platform_wide_reasons :: [reason()]
-  def platform_wide_reasons do
-    @reasons_rules
-    |> Map.filter(fn
-      {_, %{scope: :platform}} -> true
-      _ -> false
-    end)
-    |> Map.keys()
-  end
+  @spec platform_wide_reasons :: [platform_reason()]
+  def platform_wide_reasons, do: @platform_reasons
 
   @doc """
   iex> subscribable_reasons_related_to_datasets(:reuser) != subscribable_reasons_related_to_datasets(:producer)

--- a/apps/transport/test/transport/jobs/resources_changed_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/resources_changed_notification_job_test.exs
@@ -137,41 +137,53 @@ defmodule Transport.Test.Transport.Jobs.ResourcesChangedNotificationJobTest do
              all_enqueued()
   end
 
-  test "perform with a dataset_id" do
-    %DB.Dataset{id: dataset_id} = dataset = insert(:dataset, custom_title: "Super JDD")
-    %DB.Contact{id: contact_id, email: email} = contact = insert_contact()
+  describe "perform with a dataset_id" do
+    test "with a subscription" do
+      %DB.Dataset{id: dataset_id} = dataset = insert(:dataset, custom_title: "Super JDD")
+      %DB.Contact{id: contact_id, email: email} = contact = insert_contact()
 
-    %DB.NotificationSubscription{id: ns_id} =
-      insert(:notification_subscription, %{
-        reason: :resources_changed,
-        source: :admin,
-        role: :reuser,
-        contact_id: contact_id
-      })
+      %DB.NotificationSubscription{id: ns_id} =
+        insert(:notification_subscription, %{
+          dataset_id: dataset_id,
+          reason: :resources_changed,
+          source: :admin,
+          role: :reuser,
+          contact_id: contact_id
+        })
 
-    assert :ok == perform_job(ResourcesChangedNotificationJob, %{"dataset_id" => dataset_id})
+      assert :ok == perform_job(ResourcesChangedNotificationJob, %{"dataset_id" => dataset_id})
 
-    # Logs have been saved
-    assert [
-             %DB.Notification{
-               contact_id: ^contact_id,
-               email: ^email,
-               reason: :resources_changed,
-               dataset_id: ^dataset_id,
-               role: :reuser,
-               notification_subscription_id: ^ns_id,
-               payload: %{"job_id" => _}
-             }
-           ] = DB.Notification |> DB.Repo.all()
+      # Logs have been saved
+      assert [
+               %DB.Notification{
+                 contact_id: ^contact_id,
+                 email: ^email,
+                 reason: :resources_changed,
+                 dataset_id: ^dataset_id,
+                 role: :reuser,
+                 notification_subscription_id: ^ns_id,
+                 payload: %{"job_id" => _}
+               }
+             ] = DB.Notification |> DB.Repo.all()
 
-    assert_email_sent(
-      from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-      to: {DB.Contact.display_name(contact), email},
-      reply_to: {"", "contact@transport.data.gouv.fr"},
-      subject: "Super JDD : ressources modifiées",
-      text_body: nil,
-      html_body:
-        ~r(Les ressources du jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a> viennent d’être modifiées)
-    )
+      assert_email_sent(
+        from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
+        to: {DB.Contact.display_name(contact), email},
+        reply_to: {"", "contact@transport.data.gouv.fr"},
+        subject: "Super JDD : ressources modifiées",
+        text_body: nil,
+        html_body:
+          ~r(Les ressources du jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a> viennent d’être modifiées)
+      )
+    end
+  end
+
+  test "without subscriptions" do
+    dataset = insert(:dataset)
+
+    assert :ok == perform_job(ResourcesChangedNotificationJob, %{"dataset_id" => dataset.id})
+
+    assert [] = DB.Notification |> DB.Repo.all()
+    assert_no_email_sent()
   end
 end


### PR DESCRIPTION
Fixes #4042

Le job et les tests associés faisaient comme si l'abonnement était platform-wide (dataset_id = nil) alors que ce motif est spécifique à un jeu de données.

Étend ce qui a été fait dans #4036 pour avoir un typespec spécifique aux motifs de la plateforme et aux motifs spécifiques aux JDDs.

@vdegove, je pense que tu es la bonne personne pour review ça.