### PR TITLE
Ajout d'une bannière pour annoncer NeTEx parkings

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
@@ -1,0 +1,14 @@
+<p :if={parking_profile_warning?(@dataset)} class="notification mt-0 error">
+  <%= raw(
+    dgettext(
+      "page-dataset-details",
+      ~s(Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href="https://normes.transport.data.gouv.fr/normes/netex/parkings/" target="_blank">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024.)
+    )
+  ) %>
+</p>
+<p :if={seasonal_warning?(@dataset)} class="notification mt-0">
+  ℹ️ <%= dgettext(
+    "page-dataset-details",
+    "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+  ) %>
+</p>

--- a/apps/transport/lib/transport_web/templates/dataset/_custom_message.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_custom_message.html.heex
@@ -1,4 +1,12 @@
 <div class="container container_max_700px">
+  <div :if={parking_profile_warning?(@conn)} class="notification mt-0 error">
+    <%= raw(
+      dgettext(
+        "page-dataset-details",
+        ~s(Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href="https://normes.transport.data.gouv.fr/normes/netex/parkings/" target="_blank">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024.)
+      )
+    ) %>
+  </div>
   <div class="panel mb-24" id="custom-message">
     <%= markdown_to_safe_html!(@msg) %>
   </div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -81,12 +81,7 @@
   </div>
   <div class="dataset-infos">
     <section>
-      <p :if={seasonal_warning?(@dataset)} class="notification">
-        ℹ️ <%= dgettext(
-          "page-dataset-details",
-          "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
-        ) %>
-      </p>
+      <%= render("_banner.html", dataset: @dataset) %>
       <div class="panel">
         <%= description(@dataset) %>
       </div>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -550,12 +550,19 @@ defmodule TransportWeb.DatasetView do
   """
   def seasonal_warning?(%Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
 
+  @doc """
+  Should we display a banner highlighting that the NeTEx profile for parkings will be the standard soon.
+
+  https://github.com/etalab/transport-site/issues/4043
+  """
+  @spec parking_profile_warning?(DB.Dataset.t() | Plug.Conn.t()) :: boolean()
   def parking_profile_warning?(%DB.Dataset{type: "private-parking", datagouv_id: datagouv_id}) do
-    # See https://github.com/etalab/transport-site/issues/4043
     datagouv_id in ["5ea1add4a5a7dac3af82310a", "63692c99da0527c2b541e02b"]
   end
 
-  def parking_profile_warning?(%DB.Dataset{}), do: false
+  def parking_profile_warning?(%Plug.Conn{params: %{"type" => "private-parking"}}), do: true
+
+  def parking_profile_warning?(_), do: false
 
   @doc """
   iex> heart_class(%{42 => :producer}, %DB.Dataset{id: 42})

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -550,6 +550,13 @@ defmodule TransportWeb.DatasetView do
   """
   def seasonal_warning?(%Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
 
+  def parking_profile_warning?(%DB.Dataset{type: "private-parking", datagouv_id: datagouv_id}) do
+    # See https://github.com/etalab/transport-site/issues/4043
+    datagouv_id in ["5ea1add4a5a7dac3af82310a", "63692c99da0527c2b541e02b"]
+  end
+
+  def parking_profile_warning?(%DB.Dataset{}), do: false
+
   @doc """
   iex> heart_class(%{42 => :producer}, %DB.Dataset{id: 42})
   "fa fa-heart producer"

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -705,3 +705,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -708,4 +708,4 @@ msgstr "Gérez les services liés à ce jeu de données"
 
 #, elixir-autogen, elixir-format
 msgid "Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024."
-msgstr "En raison de la publication du profil France Parkings de la norme NeTEx disponible sur <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, les base nationales des lieux de stationnements hors voirie et des parcs relais seront supprimées le 1er septembre 2024."
+msgstr "En raison de la publication du profil France Parkings de la norme NeTEx disponible sur <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, les bases nationales des lieux de stationnements hors voirie et des parcs relais seront supprimées le 1er septembre 2024."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -705,3 +705,7 @@ msgstr "Suivre ce jeu de données"
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr "Gérez les services liés à ce jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024."
+msgstr "En raison de la publication du profil France Parkings de la norme NeTEx disponible sur <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, les base nationales des lieux de stationnements hors voirie et des parcs relais seront supprimées le 1er septembre 2024."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -705,3 +705,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Due to the release of the French profile “Parkings” applicable to NeTEx, available on <a href=\"https://normes.transport.data.gouv.fr/normes/netex/parkings/\" target=\"_blank\">normes.transport.data.gouv.fr</a>, the national datasets related to car parks and park-and-ride will be deleted on September 1st 2024."
+msgstr ""

--- a/apps/transport/priv/search_custom_messages.yml
+++ b/apps/transport/priv/search_custom_messages.yml
@@ -95,19 +95,8 @@
   msg:
     fr: |
         Les données concernant le stationnement hors-voirie en France sont produites par différentes collectivités et gestionnaires de parking.
-
-        Ces données, lorsqu’elles sont normalisées, sont assemblées et consolidées dans un jeu de données national : [la Base Nationale des Lieux de Stationnement (BNLS)](https://transport.data.gouv.fr/datasets/base-nationale-des-lieux-de-stationnement/).
-
-        Cette base ne référence que les parkings accessibles au public dont l’accès est limité par une barrière ; certaines bases locales référencées ici ont une définition plus larges et comprennent des parkings pour lesquelles l’accès est libre, sans barrière.
-
     en: |
-        This category aims to describe the location of car-parks across France, and provide general traveller information (such as access information or an estimate of parking fees for each car-park).
-
         Data for private car-parks in France are produced by different local authorities or parking operators.
-
-        These data, when published in a normalized format described [here](https://schema.data.gouv.fr/etalab/schema-stationnement/latest.html), are aggregated into a national dataset called [Base Nationale des Lieux de Stationnement (BNLS)](https://transport.data.gouv.fr/datasets/base-nationale-des-lieux-de-stationnement/).
-
-        This dataset only describes parking spaces accessible to the general public, with barrier entrance. Other datasets referenced here can have a broader definition and might include freely accessible car-parks, (ie. with no entrance barrier), in addition to the parking spaces with barrier entrance included in the “Base Nationale des Lieux de Stationnement” (BNLS).
 
 - category: carpooling-areas
   search_params:

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -653,14 +653,34 @@ defmodule TransportWeb.DatasetControllerTest do
 
     assert TransportWeb.DatasetView.seasonal_warning?(dataset)
 
-    [{"p", [{"class", "notification"}], [content]}] =
+    content =
       conn
       |> get(dataset_path(conn, :details, dataset.slug))
       |> html_response(200)
       |> Floki.parse_document!()
       |> Floki.find(".notification")
+      |> Floki.text()
 
     assert content =~ "Le service de transport de ce jeu de donnée ne fonctionne pas toute l'année"
+  end
+
+  test "banner for parking datasets", %{conn: conn} do
+    # See https://github.com/etalab/transport-site/issues/4043
+    # This datagouv_id is for a target parking dataset
+    dataset = insert(:dataset, is_active: true, type: "private-parking", datagouv_id: "5ea1add4a5a7dac3af82310a")
+    mock_empty_history_resources()
+
+    assert TransportWeb.DatasetView.parking_profile_warning?(dataset)
+
+    content =
+      conn
+      |> get(dataset_path(conn, :details, dataset.slug))
+      |> html_response(200)
+      |> Floki.parse_document!()
+      |> Floki.find(".notification")
+      |> Floki.text()
+
+    assert content =~ "En raison de la publication du profil France Parkings de la norme NeTEx"
   end
 
   test "custom logo is displayed when set", %{conn: conn} do

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -322,4 +322,17 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
     refute hidden_dataset.id in (%{} |> DB.Dataset.list_datasets() |> DB.Repo.all() |> Enum.map(& &1.id))
   end
+
+  test "NeTEx profile banner for private parking", %{conn: conn} do
+    content =
+      conn
+      |> get(dataset_path(conn, :index), %{type: "private-parking"})
+      |> html_response(200)
+      |> Floki.parse_document!()
+      |> Floki.find(".notification.error")
+      |> Floki.text()
+
+    assert content =~
+             "En raison de la publication du profil France Parkings de la norme NeTEx disponible sur normes.transport.data.gouv.fr"
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/4043. Voir le ticket pour les specs détaillées et les clarifications apportées.

- Ajout d'une bannière sur 2 JDDs parkings ciblés
- Modification description catégorie `private-parking`

![image](https://github.com/etalab/transport-site/assets/295709/d69c63a4-2447-4c77-a84b-a10e1dfd979a)
![image](https://github.com/etalab/transport-site/assets/295709/88a5fc30-ed97-4249-9e82-24e82bdb2df2)

