### PR TITLE
Ajout custom_tag pour authentification requise

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -38,13 +38,17 @@ defmodule TransportWeb.CustomTagsLive do
   end
 
   def tags_suggestions do
-    DB.Dataset.base_with_hidden_datasets()
-    |> select([d], fragment("distinct unnest(custom_tags)"))
-    |> DB.Repo.all()
-    |> Enum.sort()
+    tags_in_database =
+      DB.Dataset.base_with_hidden_datasets()
+      |> select([dataset: d], fragment("distinct unnest(custom_tags)"))
+      |> DB.Repo.all()
+
+    documented_tags = Enum.map(tags_documentation(), & &1.name)
+
+    (tags_in_database ++ documented_tags) |> Enum.sort() |> Enum.dedup()
   end
 
-  defp tags_documentation do
+  def tags_documentation do
     [
       %{name: "licence-mobilités", doc: "Applique la licence mobilités pour ce jeu de données"},
       %{
@@ -64,6 +68,10 @@ defmodule TransportWeb.CustomTagsLive do
         name: "masqué",
         doc:
           "Masque ce jeu de données des statistiques, de la recherche et de l'API. Le jeu reste accessible via son URL directe (web et API)."
+      },
+      %{
+        name: "authentification_requise",
+        doc: "Indique sur la page du JDD qu'il est nécessaire de s'authentifier pour accéder aux données."
       }
     ]
   end

--- a/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
@@ -1,0 +1,12 @@
+<p :if={seasonal_warning?(@dataset)} class="notification mt-0">
+  ℹ️ <%= dgettext(
+    "page-dataset-details",
+    "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
+  ) %>
+</p>
+<p :if={authentication_required?(@dataset)} class="notification mt-0">
+  ℹ️ <%= dgettext(
+    "page-dataset-details",
+    "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
+  ) %>
+</p>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -81,12 +81,7 @@
   </div>
   <div class="dataset-infos">
     <section>
-      <p :if={seasonal_warning?(@dataset)} class="notification">
-        ℹ️ <%= dgettext(
-          "page-dataset-details",
-          "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."
-        ) %>
-      </p>
+      <%= render("_banner.html", dataset: @dataset) %>
       <div class="panel">
         <%= description(@dataset) %>
       </div>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -548,7 +548,10 @@ defmodule TransportWeb.DatasetView do
   iex> seasonal_warning?(%DB.Dataset{custom_tags: ["foo"]})
   false
   """
-  def seasonal_warning?(%Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
+  def seasonal_warning?(%DB.Dataset{} = dataset), do: DB.Dataset.has_custom_tag?(dataset, "saisonnier")
+
+  def authentication_required?(%DB.Dataset{} = dataset),
+    do: DB.Dataset.has_custom_tag?(dataset, "authentification_requise")
 
   @doc """
   iex> heart_class(%{42 => :producer}, %DB.Dataset{id: 42})

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -705,3 +705,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -705,3 +705,7 @@ msgstr "Suivre ce jeu de données"
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr "Gérez les services liés à ce jeu de données"
+
+#, elixir-autogen, elixir-format
+msgid "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
+msgstr "Le producteur requiert une authentification pour accéder aux données. En conséquence, certaines fonctionnalités de transport.data.gouv.fr, comme la disponibilité des données, les rapports de validations et les métadonnées sont indisponibles pour ce jeu de données. Veuillez suivre les instructions du producteur pour obtenir l'accès aux données."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -705,3 +705,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Manage services for this dataset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
+msgstr ""

--- a/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
@@ -43,12 +43,17 @@ defmodule TransportWeb.CustomTagsLiveTest do
     assert rendered_view =~ "requestor_ref:OPENDATA"
   end
 
-  test "tags_suggestions" do
+  test "tags_suggestions includes unique tags in the DB + documented tags" do
     insert(:dataset, is_active: true, custom_tags: ["foo"])
     insert(:dataset, is_active: true, custom_tags: ["foo", "bar"])
     insert(:dataset, is_active: true, is_hidden: true, custom_tags: ["baz"])
     insert(:dataset, is_active: false, custom_tags: ["nope"])
 
-    assert ["bar", "baz", "foo"] == TransportWeb.CustomTagsLive.tags_suggestions()
+    suggestions = MapSet.new(TransportWeb.CustomTagsLive.tags_suggestions())
+
+    assert MapSet.new(["bar", "baz", "foo"]) |> MapSet.subset?(suggestions)
+
+    documented_tags = Enum.map(TransportWeb.CustomTagsLive.tags_documentation(), & &1.name)
+    assert MapSet.new(["bar", "baz", "foo"] ++ documented_tags) |> MapSet.equal?(suggestions)
   end
 end


### PR DESCRIPTION
Fixes #4051 

Ajout d'un custom tag `authentification_requise` permettant d'ajouter un bandeau indiquant qu'une authentification est requise pour accéder aux données et que certaines fonctionnalités sur notre plateforme sont indisponibles.

![image](https://github.com/etalab/transport-site/assets/295709/732fcf9b-0219-403c-84dc-af646f6ea0d4)

![image](https://github.com/etalab/transport-site/assets/295709/56eeab94-3b7c-47c5-8411-522ae88d3a2a)
