### PR TITLE
ConsolidateLEZsJob : adapte publisher pour Ville de Paris

### DIFF
--- a/apps/transport/lib/jobs/consolidate_lez_job.ex
+++ b/apps/transport/lib/jobs/consolidate_lez_job.ex
@@ -17,7 +17,7 @@ defmodule Transport.Jobs.ConsolidateLEZsJob do
   @schema_name "etalab/schema-zfe"
   @lez_dataset_type "low-emission-zones"
   @dataset_org_to_publisher %{
-    "Mairie de Paris" => %{
+    "Ville de Paris" => %{
       "nom" => "Ville de Paris",
       "siren" => "217500016",
       "forme_juridique" => "Autre collectivité territoriale"

--- a/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
@@ -195,7 +195,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJobTest do
     end
 
     test "without an AOM" do
-      dataset = insert(:dataset, type: "low-emission-zones", organization: "Mairie de Paris", aom: nil)
+      dataset = insert(:dataset, type: "low-emission-zones", organization: "Ville de Paris", aom: nil)
 
       zfe_aire =
         insert(:resource,


### PR DESCRIPTION
La consolidation ZFE ajoute un champ `publisher` détaillant la collectivité qui publie la donnée et ajoute l'identifiant de la ZFE. Quand le JDD est attaché à une AOM c'est immédiat grâce aux informations en BDD. Quand ce n'est pas rattaché à une AOM, il faut mapper l'organisation data.gouv.fr à des données.

Le nom de l'organisation de Paris a été renommé ("Mairie de Paris" vers "Ville de Paris") et casse la consolidation.

Cette PR répare le bug immédiat, tout en gardant en tête qu'il faudrait avoir un mécanisme plus robuste ou au moins une alerte quand une incohérence est détectée pour éviter de découvrir ça quand on dispatch le job à la main (ce process ne tourne pas automatiquement pour le moment).

Voir [échec de job Oban en prod du jour](https://transport.data.gouv.fr/backoffice/jobs?worker=ConsolidateLEZsJob)

`(KeyError) key "ville de paris" not found in: %{…}`