### PR TITLE
ImportData : utilise titre d'une ressource pour type documentation

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -547,9 +547,16 @@ defmodule Transport.ImportData do
   false
   iex> documentation?("pdf")
   false
+  iex> documentation?(%{"type" => "main", "title" => "Documentation SIRI"})
+  true
   """
   @spec documentation?(any()) :: boolean()
   def documentation?(%{"type" => "documentation"}), do: true
+
+  def documentation?(%{"title" => resource_title}) do
+    String.match?(resource_title, ~r/\bdocumentation\b/i)
+  end
+
   def documentation?(_), do: false
 
   @doc """


### PR DESCRIPTION
Fixes #4071

Utilise le titre d'une ressource pour déterminer qu'une ressource est en réalité une documentation et non un fichier/API temps réel.

`\b` désigne un [word boundary](https://stackoverflow.com/a/1324756) en regex.