### PR TITLE
Tests manquants sur les éditions de resources

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -118,10 +118,10 @@ defmodule Transport.ImportData do
 
     http_client = Transport.Shared.Wrapper.HTTPoison.impl()
 
+    # We use a direct call with the HTTP client instead of using the datagouv API client module
+    # because of redirects.
     # We'll have to verify the behaviour of hackney/httpoison for follow_redirect: how
     # many redirects are allowed? Is an error raised after a while or not? etc.
-    # Oh this is awful. Really, a direct call with the HTTP client instead of using the datagouv API client module?
-    # Hu, ok, because of redirects.
     response = http_client.get!(url, [], hackney: [follow_redirect: true])
     json = Jason.decode!(response.body)
     {:ok, dataset} = prepare_dataset_from_data_gouv_response(json, type)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -120,6 +120,8 @@ defmodule Transport.ImportData do
 
     # We'll have to verify the behaviour of hackney/httpoison for follow_redirect: how
     # many redirects are allowed? Is an error raised after a while or not? etc.
+    # Oh this is awful. Really, a direct call with the HTTP client instead of using the datagouv API client module?
+    # Hu, ok, because of redirects.
     response = http_client.get!(url, [], hackney: [follow_redirect: true])
     json = Jason.decode!(response.body)
     {:ok, dataset} = prepare_dataset_from_data_gouv_response(json, type)

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -438,7 +438,8 @@ defmodule DB.Factory do
         id \\ nil,
         schema_name \\ nil,
         schema_version \\ nil,
-        filetype \\ nil
+        filetype \\ nil,
+        format \\ nil
       ) do
     [
       %{
@@ -447,7 +448,7 @@ defmodule DB.Factory do
         "id" => id || "resource1_id",
         "type" => "main",
         "filetype" => filetype || "remote",
-        "format" => "zip",
+        "format" => format || "zip",
         "last_modified" => DateTime.utc_now() |> DateTime.add(-1, :hour) |> DateTime.to_iso8601(),
         "schema" => %{"name" => schema_name, "version" => schema_version}
       }

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -338,30 +338,6 @@ defmodule DB.Factory do
     |> DB.Contact.insert!()
   end
 
-  def datagouv_dataset_response(%{} = attributes \\ %{}) do
-    Map.merge(
-      %{
-        "id" => Ecto.UUID.generate(),
-        "title" => "dataset",
-        "created_at" => DateTime.utc_now() |> to_string(),
-        "last_update" => DateTime.utc_now() |> to_string(),
-        "slug" => "dataset-slug",
-        "license" => "lov2",
-        "frequency" => "daily",
-        "tags" => [],
-        "organization" => %{
-          "id" => Ecto.UUID.generate(),
-          "name" => "Org " <> Ecto.UUID.generate(),
-          "badges" => [],
-          "logo" => "https://example.com/img.jpg",
-          "logo_thumbnail" => "https://example.com/img.small.jpg",
-          "slug" => Ecto.UUID.generate()
-        }
-      },
-      attributes
-    )
-  end
-
   def insert_irve_dataset do
     insert(:dataset, %{
       type: "charging-stations",
@@ -426,5 +402,55 @@ defmodule DB.Factory do
         "nbre_pdc" => 3
       }
     })
+  end
+
+  def generate_dataset_payload(datagouv_id, resources \\ nil) do
+    datagouv_dataset_response(%{"id" => datagouv_id, "resources" => resources || generate_resources_payload()})
+  end
+
+  def datagouv_dataset_response(%{} = attributes \\ %{}) do
+    Map.merge(
+      %{
+        "id" => Ecto.UUID.generate(),
+        "title" => "dataset",
+        "created_at" => DateTime.utc_now() |> to_string(),
+        "last_update" => DateTime.utc_now() |> to_string(),
+        "slug" => "dataset-slug",
+        "license" => "lov2",
+        "frequency" => "daily",
+        "tags" => [],
+        "organization" => %{
+          "id" => Ecto.UUID.generate(),
+          "name" => "Org " <> Ecto.UUID.generate(),
+          "badges" => [],
+          "logo" => "https://example.com/img.jpg",
+          "logo_thumbnail" => "https://example.com/img.small.jpg",
+          "slug" => Ecto.UUID.generate()
+        }
+      },
+      attributes
+    )
+  end
+
+  def generate_resources_payload(
+        title \\ nil,
+        url \\ nil,
+        id \\ nil,
+        schema_name \\ nil,
+        schema_version \\ nil,
+        filetype \\ nil
+      ) do
+    [
+      %{
+        "title" => title || "resource1",
+        "url" => url || "http://localhost:4321/resource1",
+        "id" => id || "resource1_id",
+        "type" => "main",
+        "filetype" => filetype || "remote",
+        "format" => "zip",
+        "last_modified" => DateTime.utc_now() |> DateTime.add(-1, :hour) |> DateTime.to_iso8601(),
+        "schema" => %{"name" => schema_name, "version" => schema_version}
+      }
+    ]
   end
 end

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -24,32 +24,6 @@ defmodule Transport.ImportDataTest do
     :ok
   end
 
-  def generate_resources_payload(
-        title \\ nil,
-        url \\ nil,
-        id \\ nil,
-        schema_name \\ nil,
-        schema_version \\ nil,
-        filetype \\ nil
-      ) do
-    [
-      %{
-        "title" => title || "resource1",
-        "url" => url || "http://localhost:4321/resource1",
-        "id" => id || "resource1_id",
-        "type" => "main",
-        "filetype" => filetype || "remote",
-        "format" => "zip",
-        "last_modified" => DateTime.utc_now() |> DateTime.add(-1, :hour) |> DateTime.to_iso8601(),
-        "schema" => %{"name" => schema_name, "version" => schema_version}
-      }
-    ]
-  end
-
-  def generate_dataset_payload(datagouv_id, resources \\ nil) do
-    datagouv_dataset_response(%{"id" => datagouv_id, "resources" => resources || generate_resources_payload()})
-  end
-
   def insert_national_dataset(datagouv_id) do
     insert(:dataset, datagouv_id: datagouv_id, aom: nil, region_id: DB.Repo.get_by!(DB.Region, nom: "National").id)
   end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -728,22 +728,8 @@ defmodule TransportWeb.ResourceControllerTest do
     dataset_datagouv_id = "dataset_datagouv_id"
 
     Datagouvfr.Client.Datasets.Mock
-    |> expect(:get, 1, fn _ ->
-      {:ok,
-       %{
-         "id" => dataset_datagouv_id,
-         "resources" => [
-           %{
-             "filetype" => "remote",
-             "format" => "csv",
-             "id" => resource_datagouv_id,
-             "title" => "bnlc.csv",
-             "type" => "main",
-             "url" => "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/main/bnlc-.csv"
-           }
-         ],
-         "title" => "Base Nationale des Lieux de Covoiturage"
-       }}
+    |> expect(:get, 1, fn ^dataset_datagouv_id ->
+      dataset_datagouv_get_response(dataset_datagouv_id, resource_datagouv_id)
     end)
 
     html = conn |> get(resource_path(conn, :form, dataset_datagouv_id, resource_datagouv_id)) |> html_response(200)
@@ -759,23 +745,7 @@ defmodule TransportWeb.ResourceControllerTest do
     dataset_datagouv_id = "dataset_datagouv_id"
 
     Datagouvfr.Client.Datasets.Mock
-    |> expect(:get, 1, fn _ ->
-      {:ok,
-       %{
-         "id" => dataset_datagouv_id,
-         "resources" => [
-           %{
-             "filetype" => "remote",
-             "format" => "csv",
-             "id" => "resource_datagouv_id",
-             "title" => "bnlc.csv",
-             "type" => "main",
-             "url" => "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/main/bnlc-.csv"
-           }
-         ],
-         "title" => "Base Nationale des Lieux de Covoiturage"
-       }}
-    end)
+    |> expect(:get, 1, fn ^dataset_datagouv_id -> dataset_datagouv_get_response(dataset_datagouv_id) end)
 
     html = conn |> get(resource_path(conn, :form, dataset_datagouv_id)) |> html_response(200)
     assert html =~ "Nouvelle ressource"
@@ -855,5 +825,23 @@ defmodule TransportWeb.ResourceControllerTest do
     html = html_response(conn, 404)
     assert html =~ "Page non disponible"
     assert Phoenix.Flash.get(conn.assigns.flash, :error) == "La ressource n'est pas disponible sur le serveur distant"
+  end
+
+  defp dataset_datagouv_get_response(dataset_datagouv_id, resource_datagouv_id \\ nil) do
+    {:ok,
+     datagouv_dataset_response(%{
+       "id" => dataset_datagouv_id,
+       "title" => "Base Nationale des Lieux de Covoiturage",
+       "resources" =>
+         generate_resources_payload(
+           "bnlc.csv",
+           "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/main/bnlc-.csv",
+           resource_datagouv_id,
+           nil,
+           nil,
+           nil,
+           "csv"
+         )
+     })}
   end
 end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -802,9 +802,24 @@ defmodule TransportWeb.ResourceControllerTest do
     # We would just check that import_data works correctly, while this is already tested elsewhere.
   end
 
-  # test "we can show the delete confirmation page", %{conn: conn} do
-  # TODO
-  # end
+  test "we can show the delete confirmation page", %{conn: conn} do
+    conn = conn |> init_test_session(%{current_user: %{}})
+    resource_datagouv_id = "resource_dataset_id"
+    dataset_datagouv_id = "dataset_datagouv_id"
+
+    Datagouvfr.Client.Datasets.Mock
+    |> expect(:get, 1, fn ^dataset_datagouv_id ->
+      dataset_datagouv_get_response(dataset_datagouv_id, resource_datagouv_id)
+    end)
+
+    html =
+      conn
+      |> get(resource_path(conn, :delete_resource_confirmation, dataset_datagouv_id, resource_datagouv_id))
+      |> html_response(200)
+
+    assert html =~ "bnlc.csv"
+    assert html =~ "Souhaitez-vous mettre à jour la ressource ou la supprimer définitivement ?"
+  end
 
   # test "we can delete a resource", %{conn: conn} do
   # TODO

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -755,7 +755,7 @@ defmodule TransportWeb.ResourceControllerTest do
     assert html =~ "Ajouter une nouvelle ressource"
   end
 
-  test "we can add a new resource with an URL", %{conn: conn} do
+  test "we can add a new resource with a URL", %{conn: conn} do
     %DB.Dataset{datagouv_id: dataset_datagouv_id} = insert(:dataset)
     conn = conn |> init_test_session(%{current_user: %{}})
 


### PR DESCRIPTION
Suite de #4064, fait une partie de #4069, préalable de #4053.

J’ai fini de tester l’essentiel des routes, il y a quelques trous volontaires :
- Je ne teste pas la route de liste de resources, puisqu’elle sautera dans #4053
- Je ne teste pas l’upload de fichier, trop ennuyant, donc je ne teste que le cas d’une URL remote
- Le cas de mise à jour de resource est très (très) similaire au cas de nouvelle resource (d’ailleurs, c’est la même route de contrôleur, et la même action du client API), donc je ne l’ai pas testée.