### PR TITLE
Import: Résister au recyclage d'URL de ressources

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -862,19 +862,26 @@ defmodule Transport.ImportData do
   # ODS CSV resources are identified only with their URL, as their resource datagouv id is not unique.
   # For regular resources, we can identify them by resource datagouv id or by their url.
   defp get_existing_resource(%{"is_ods_csv" => true, "url" => url}, dataset_datagouv_id) do
+    get_existing_resource_by_url(url, dataset_datagouv_id)
+  end
+
+  defp get_existing_resource(%{"url" => url, "id" => resource_datagouv_id}, dataset_datagouv_id) do
+    get_existing_resource_by_datagouv_id(resource_datagouv_id, dataset_datagouv_id) ||
+      get_existing_resource_by_url(url, dataset_datagouv_id)
+  end
+
+  defp get_existing_resource_by_url(url, dataset_datagouv_id) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r], r.url == ^url)
-    |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
+    |> where([r, d], r.url == ^url and d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id]))
     |> Repo.one()
   end
 
-  defp get_existing_resource(%{"url" => url, "id" => datagouv_id}, dataset_datagouv_id) do
+  defp get_existing_resource_by_datagouv_id(resource_datagouv_id, dataset_datagouv_id) do
     Resource
     |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
-    |> where([r, _d], r.datagouv_id == ^datagouv_id or r.url == ^url)
-    |> where([_r, d], d.datagouv_id == ^dataset_datagouv_id)
+    |> where([r, d], r.datagouv_id == ^resource_datagouv_id and d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id]))
     |> Repo.one()
   end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -872,7 +872,7 @@ defmodule Transport.ImportData do
 
   defp get_existing_resource_by_url(url, dataset_datagouv_id) do
     Resource
-    |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
+    |> join(:inner, [r], d in Dataset, on: r.dataset_id == d.id)
     |> where([r, d], r.url == ^url and d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id]))
     |> Repo.one()
@@ -880,7 +880,7 @@ defmodule Transport.ImportData do
 
   defp get_existing_resource_by_datagouv_id(resource_datagouv_id, dataset_datagouv_id) do
     Resource
-    |> join(:left, [r], d in Dataset, on: r.dataset_id == d.id)
+    |> join(:inner, [r], d in Dataset, on: r.dataset_id == d.id)
     |> where([r, d], r.datagouv_id == ^resource_datagouv_id and d.datagouv_id == ^dataset_datagouv_id)
     |> select([r], map(r, [:id]))
     |> Repo.one()

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -24,36 +24,20 @@ defmodule Transport.ImportDataTest do
     :ok
   end
 
-  def generate_resources_payload(
-        title \\ nil,
-        url \\ nil,
-        id \\ nil,
-        schema_name \\ nil,
-        schema_version \\ nil,
-        filetype \\ nil
-      ) do
-    [
-      generate_resource_payload(title, url, id, schema_name, schema_version, filetype)
-    ]
+  def generate_resources_payload(opts \\ []) do
+    [generate_resource_payload(opts)]
   end
 
-  def generate_resource_payload(
-        title \\ nil,
-        url \\ nil,
-        id \\ nil,
-        schema_name \\ nil,
-        schema_version \\ nil,
-        filetype \\ nil
-      ) do
+  def generate_resource_payload(opts \\ []) do
     %{
-      "title" => title || "resource1",
-      "url" => url || "http://localhost:4321/resource1",
-      "id" => id || "resource1_id",
+      "title" => Keyword.get(opts, :title, "resource1"),
+      "url" => Keyword.get(opts, :url, "http://localhost:4321/resource1"),
+      "id" => Keyword.get(opts, :id, "resource1_id"),
       "type" => "main",
-      "filetype" => filetype || "remote",
+      "filetype" => Keyword.get(opts, :filetype, "remote"),
       "format" => "zip",
       "last_modified" => DateTime.utc_now() |> DateTime.add(-1, :hour) |> DateTime.to_iso8601(),
-      "schema" => %{"name" => schema_name, "version" => schema_version}
+      "schema" => %{"name" => Keyword.get(opts, :schema_name), "version" => Keyword.get(opts, :schema_version)}
     }
   end
 
@@ -199,9 +183,9 @@ defmodule Transport.ImportDataTest do
       generate_dataset_payload(
         datagouv_id,
         generate_resources_payload(
-          new_title = "new title !!! fresh !!!",
-          "http://localhost:4321/resource1",
-          new_datagouv_id = "resource2_id"
+          title: new_title = "new title !!! fresh !!!",
+          url: "http://localhost:4321/resource1",
+          id: new_datagouv_id = "resource2_id"
         )
       )
 
@@ -231,9 +215,9 @@ defmodule Transport.ImportDataTest do
       generate_dataset_payload(
         datagouv_id,
         generate_resources_payload(
-          new_title,
-          _new_url = "https://example.com/" <> Ecto.UUID.generate(),
-          new_datagouv_id
+          title: new_title,
+          url: "https://example.com/" <> Ecto.UUID.generate(),
+          id: new_datagouv_id
         )
       )
 
@@ -268,14 +252,14 @@ defmodule Transport.ImportDataTest do
     payload_1 =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource1",
-          "resource1"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource1",
+          id: "resource1"
         ),
         generate_resource_payload(
-          "Resource 2",
-          "http://localhost:4321/resource2",
-          "resource2"
+          title: "Resource 2",
+          url: "http://localhost:4321/resource2",
+          id: "resource2"
         )
       ])
 
@@ -288,9 +272,9 @@ defmodule Transport.ImportDataTest do
     payload_2 =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource1",
-          "resource1"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource1",
+          id: "resource1"
         )
       ])
 
@@ -310,19 +294,19 @@ defmodule Transport.ImportDataTest do
     setup_payload =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource1",
-          "resource1"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource1",
+          id: "resource1"
         ),
         generate_resource_payload(
-          "Resource 2",
-          "http://localhost:4321/resource2",
-          "resource2"
+          title: "Resource 2",
+          url: "http://localhost:4321/resource2",
+          id: "resource2"
         ),
         generate_resource_payload(
-          "Resource 3",
-          "http://localhost:4321/resource3",
-          "resource3"
+          title: "Resource 3",
+          url: "http://localhost:4321/resource3",
+          id: "resource3"
         )
       ])
 
@@ -340,14 +324,14 @@ defmodule Transport.ImportDataTest do
     payload_1 =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource2",
-          "resource1"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource2",
+          id: "resource1"
         ),
         generate_resource_payload(
-          "Resource 3",
-          "http://localhost:4321/resource3",
-          "resource3"
+          title: "Resource 3",
+          url: "http://localhost:4321/resource3",
+          id: "resource3"
         )
       ])
 
@@ -361,19 +345,19 @@ defmodule Transport.ImportDataTest do
     payload_2 =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource2",
-          "resource1"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource2",
+          id: "resource1"
         ),
         generate_resource_payload(
-          "Resource 3",
-          "http://localhost:4321/resource3",
-          "resource3"
+          title: "Resource 3",
+          url: "http://localhost:4321/resource3",
+          id: "resource3"
         ),
         generate_resource_payload(
-          "Resource 4",
-          "http://localhost:4321/resource1",
-          "resource4"
+          title: "Resource 4",
+          url: "http://localhost:4321/resource1",
+          id: "resource4"
         )
       ])
 
@@ -393,14 +377,14 @@ defmodule Transport.ImportDataTest do
     payload_3 =
       generate_dataset_payload(datagouv_id, [
         generate_resource_payload(
-          "Resource 3",
-          "http://localhost:4321/resource3",
-          "resource3"
+          title: "Resource 3",
+          url: "http://localhost:4321/resource3",
+          id: "resource3"
         ),
         generate_resource_payload(
-          "Resource 1",
-          "http://localhost:4321/resource2",
-          "resource4"
+          title: "Resource 1",
+          url: "http://localhost:4321/resource2",
+          id: "resource4"
         )
       ])
 
@@ -431,11 +415,11 @@ defmodule Transport.ImportDataTest do
         get: fn _ ->
           {:ok,
            generate_resources_payload(
-             community_resource_title,
-             "http://example.com/file",
-             "1",
-             schema_name,
-             schema_version
+             title: community_resource_title,
+             url: "http://example.com/file",
+             id: "1",
+             schema_name: schema_name,
+             schema_version: schema_version
            )}
         end do
         with_mock HTTPStreamV2, fetch_status_and_hash: http_stream_mock() do


### PR DESCRIPTION
Nouvelle tentative de corriger #3978, avec cette fois une couverture de test plus solide.

Fixe également #4057 (testé avec un dump de la semaine passée et data.gouv de prod).