### PR TITLE
Corrige attribution OpenStreetMap

### DIFF
--- a/apps/transport/client/javascripts/mapbox-credentials.js
+++ b/apps/transport/client/javascripts/mapbox-credentials.js
@@ -1,7 +1,7 @@
 export const Mapbox = {
     url: 'https://api.mapbox.com/styles/v1/transport-pan/clj8j9fla009701pie4nrfo62/tiles/{tileSize}/{z}/{x}/{y}?access_token={accessToken}',
     accessToken: 'pk.eyJ1IjoidHJhbnNwb3J0LXBhbiIsImEiOiJjbGo4anJodWUxOXY0M3BxeWo3bHlrMXoxIn0.qFfjiswVf2TaLQ2YmB-Mnw',
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors <a href="https://spdx.org/licenses/ODbL-1.0.html">ODbL</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
     maxZoom: 20,
     tileSize: 512,
     zoomOffset: -1


### PR DESCRIPTION
Fixes #4074

Indique la bonne URL d'attribution pour OSM