### PR TITLE
Backoffice : interface pour les notifications pour les contacts

### DIFF
--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notification_subscriptions.html.heex
@@ -7,6 +7,10 @@
 
   <h3>Créer un abonnement</h3>
 
+  <p class="notification">
+    ℹ️ Les abonnements créés depuis le backoffice sont créés avec le rôle de <code><b>producer</b></code>. Les réutilisateurs doivent utiliser l'espace réutilisateur en autonomie.
+  </p>
+
   <h4>Lié à un jeu de données</h4>
 
   <%= form_for @conn, backoffice_notification_subscription_path(@conn, :create), [], fn f -> %>
@@ -83,7 +87,7 @@
             </div>
             <div class="small"><%= dataset.type %></div>
           </td>
-          <td><%= notification_subscription.role %></td>
+          <td><span class={role_class(notification_subscription)}><%= notification_subscription.role %></span></td>
           <td><%= notification_subscription.reason %></td>
           <td><%= notification_subscription.source %></td>
           <td>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/_notifications.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/_notifications.html.heex
@@ -1,0 +1,33 @@
+<div :if={!@creating_contact} class="panel" id="notifications">
+  <h2>Notifications reçues</h2>
+
+  <p :if={Enum.empty?(@notifications)} class="notification">
+    Pas de notifications reçues pour le moment.
+  </p>
+
+  <table :if={Enum.count(@notifications) > 0} class="table dashboard-description">
+    <tr>
+      <th><%= dgettext("backoffice", "Role") %></th>
+      <th><%= dgettext("backoffice", "Notification reason") %></th>
+      <th><%= dgettext("backoffice", "Dataset") %></th>
+      <th><%= dgettext("backoffice", "Datetime") %></th>
+    </tr>
+    <%= for notification <- @notifications do %>
+      <tr>
+        <td><span class={role_class(notification)}><%= notification.role %></span></td>
+        <td lang="en"><%= notification.reason %></td>
+        <td :if={is_nil(notification.dataset_id)}>-</td>
+        <td :if={!is_nil(notification.dataset_id)}>
+          <a href={dataset_path(@conn, :details, notification.dataset.slug)} target="_blank">
+            <i class="fa fa-external-link-alt" aria-hidden="true"></i>
+            <%= notification.dataset.custom_title %>
+          </a>
+        </td>
+        <td><%= Shared.DateTimeDisplay.format_datetime_to_paris(notification.inserted_at, "fr") %></td>
+      </tr>
+    <% end %>
+  </table>
+  <p class="small">
+    Liste les notifications reçues au cours des <%= @notifications_months_limit %> derniers mois.
+  </p>
+</div>

--- a/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/contact/form.html.heex
@@ -95,4 +95,10 @@
     notification_subscriptions: @notification_subscriptions,
     conn: @conn
   ) %>
+  <%= render("_notifications.html",
+    creating_contact: creating_contact,
+    notifications: @notifications,
+    notifications_months_limit: @notifications_months_limit,
+    conn: @conn
+  ) %>
 </div>

--- a/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
+++ b/apps/transport/lib/transport_web/views/backoffice/contact_view.ex
@@ -11,6 +11,10 @@ defmodule TransportWeb.Backoffice.ContactView do
     PaginationHelpers.pagination_links(conn, contacts, kwargs)
   end
 
+  @spec role_class(DB.Notification.t() | DB.NotificationSubscription.t()) :: binary()
+  defp role_class(%{role: :producer}), do: "label"
+  defp role_class(%{role: :reuser}), do: "label label--inactive"
+
   defp dataset_title(%DB.Dataset{custom_title: custom_title, type: type, is_hidden: false}) do
     "#{custom_title} (#{type})"
   end


### PR DESCRIPTION
Fixes #4009, 2ème partie du ticket : adapte l'interface pour la page d'un contact.

- affiche les notifications envoyées pour ce contact au cours des 6 derniers mois
- explicite que l'abonnement à des notifications depuis cette page ne se fait que pour `role = producer`