### PR TITLE
Corrige un lien erronné vers la doc

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
@@ -115,7 +115,7 @@
                 <h4 class="with-link"><%= dgettext("espace-producteurs", "Publish a dataset") %></h4>
               </div>
               <div>
-                <a href="https://doc.transport.data.gouv.fr/reutilisations-des-donnees/reutilisation-des-donnees">
+                <a href="https://doc.transport.data.gouv.fr/administration-des-donnees">
                   <%= dgettext("espace-producteurs", "Adding a dataset guidelines") %>
                 </a>
               </div>

--- a/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/infos_producteurs.html.heex
@@ -50,10 +50,7 @@
             </div>
           </div>
           <div class="presentation-action pt-24">
-            <a
-              href="https://doc.transport.data.gouv.fr/reutilisations-des-donnees/reutilisation-des-donnees"
-              class="button-outline primary"
-            >
+            <a href="https://doc.transport.data.gouv.fr/administration-des-donnees" class="button-outline primary">
               <%= dgettext("page-producteurs", "Data publishing guidelines") %>
             </a>
           </div>


### PR DESCRIPTION
Adapte le lien utilisé pour indiquer comment publier ses données sur la page "infos producteur" et dans l'espace producteur.

Voir [discussion sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/9c6nctpndfd1pnyqtrn118surc).