### PR TITLE
Notifications réutilisateurs : adapte contenu

### DIFF
--- a/apps/transport/priv/gettext/en/LC_MESSAGES/notification_subscription.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/notification_subscription.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "daily_new_comments"
-msgstr "Daily list of new comments"
+msgstr "Comments added to your favorites (daily summary)"
 
 #, elixir-autogen, elixir-format
 msgid "dataset_with_error"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/notification_subscription.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/notification_subscription.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "daily_new_comments"
-msgstr "Commentaires ajoutés quotidiennement"
+msgstr "Commentaires ajoutés à vos favoris (récapitulatif quotidien)"
 
 #, elixir-autogen, elixir-format
 msgid "dataset_with_error"


### PR DESCRIPTION
Fixes #4079

Ajuste la description du motif `daily_new_comments`.

![image](https://github.com/user-attachments/assets/21bfed83-0e28-47f0-940e-fb7ff375d430)
