### PR TITLE
OpsTests : mise à jour des IPs de Clever Cloud

### DIFF
--- a/ops_tests/ops_tests.exs
+++ b/ops_tests/ops_tests.exs
@@ -3,7 +3,7 @@
 ExUnit.start()
 
 Mix.install([
-  {:req, "~> 0.4.8"},
+  {:req, "~> 0.5.4"},
   {:dns, "~> 2.4.0"}
 ])
 
@@ -13,10 +13,15 @@ defmodule Transport.OpsTests do
   # See https://developers.clever-cloud.com/doc/administrate/domain-names/#your-application-runs-in-the-europeparis-par-zone
   @domain_name "transport.data.gouv.fr"
   @clever_cloud_ip_addresses [
-    {46, 252, 181, 103},
-    {46, 252, 181, 104},
-    {185, 42, 117, 108},
-    {185, 42, 117, 109}
+    {91, 208, 207, 214},
+    {91, 208, 207, 215},
+    {91, 208, 207, 216},
+    {91, 208, 207, 217},
+    {91, 208, 207, 218},
+    {91, 208, 207, 220},
+    {91, 208, 207, 221},
+    {91, 208, 207, 222},
+    {91, 208, 207, 223}
   ]
 
   test "correct DOMAIN_NAME for prod-worker" do


### PR DESCRIPTION
Les IPs des loads balancers de Clever Cloud changent https://developers.clever-cloud.com/changelog/2024-06-28-new-ip-list-paris/.

[Voir sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/q5yxxs1uwfg63p6jntk5knzyoa).

Adapte les tests pour refléter les changements effectués dans les enregistrements DNS
- https://github.com/etalab/transport-deploy/commit/ddb0de09651a96093584958c476717d1f7f6c0b3
- https://github.com/etalab/transport-deploy/commit/7f894e8d0a44ba202c49060dc0cbfeef9cf0ad26