### PR TITLE
Backoffice : pouvoir éditer un JDD inactif

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -101,6 +101,7 @@ defmodule DB.Dataset do
     from(d in DB.Dataset, as: :dataset, where: d.is_active and not d.is_hidden)
   end
 
+  def all_datasets, do: from(d in DB.Dataset, as: :dataset)
   def archived, do: base_query() |> where([dataset: d], not is_nil(d.archived_at))
   def inactive, do: from(d in DB.Dataset, as: :dataset, where: not d.is_active)
   def hidden, do: from(d in DB.Dataset, as: :dataset, where: d.is_active and d.is_hidden)
@@ -130,7 +131,7 @@ defmodule DB.Dataset do
   Returns a list of resources, with their last resource_history preloaded
   """
   def last_resource_history(dataset_id) do
-    DB.Dataset.base_with_hidden_datasets()
+    DB.Dataset.all_datasets()
     |> where([dataset: d], d.id == ^dataset_id)
     |> join(:left, [dataset: d], r in DB.Resource, on: d.id == r.dataset_id, as: :resource)
     |> join(:left, [resource: r], rh in DB.ResourceHistory,

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -32,6 +32,10 @@ defmodule TransportWeb.EditDatasetLive do
         </div>
       <% end %>
 
+      <p :if={not is_nil(@dataset) and not @dataset.is_active} class="notification warning">
+        Ce jeu de données a été supprimé de data.gouv.fr. Il faudrait probablement remplacer son URL source ou le déréférencer.
+      </p>
+
       <div class="pt-24">
         <%= InputHelpers.text_input(f, :url,
           placeholder: dgettext("backoffice", "Dataset's url"),

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -154,6 +154,20 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
              "Ainsi que 2 abonnements de 1 réutilisateur."
   end
 
+  test "can edit a dataset, even when it's not active", %{conn: conn} do
+    dataset = insert(:dataset, is_active: false)
+
+    doc =
+      conn
+      |> setup_admin_in_session()
+      |> get(Routes.backoffice_page_path(conn, :edit, dataset.id))
+      |> html_response(200)
+      |> Floki.parse_document!()
+
+    assert doc |> Floki.find(".notification.warning") |> Floki.text() =~
+             "Ce jeu de données a été supprimé de data.gouv.fr"
+  end
+
   test "notifications_sent sort order and grouping works" do
     dataset = insert(:dataset, is_active: true, datagouv_id: Ecto.UUID.generate(), slug: Ecto.UUID.generate())
 


### PR DESCRIPTION
Fixes #4088

Permet de pouvoir éditer un JDD inactif dans le backoffice, dans le but de choisir une nouvelle URL source data.gouv.fr ou de le déréférencer.

![image](https://github.com/user-attachments/assets/f305243b-b775-4e97-bdf0-5919f3ccadd8)
