### PR TITLE
Dataset : force la présence d'une organisation

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -528,7 +528,8 @@ defmodule DB.Dataset do
       :legal_owner_company_siren,
       :custom_logo,
       :custom_full_logo,
-      :custom_logo_changed_at
+      :custom_logo_changed_at,
+      :organization_id
     ])
     |> update_change(:custom_title, &String.trim/1)
     |> cast_aom(params)
@@ -543,6 +544,7 @@ defmodule DB.Dataset do
     |> set_is_hidden()
     |> validate_organization_type()
     |> add_organization(params)
+    |> validate_required([:organization_id])
     |> maybe_set_custom_logo_changed_at()
     |> put_assoc(:legal_owners_aom, legal_owners_aom)
     |> put_assoc(:legal_owners_region, legal_owners_region)
@@ -566,6 +568,9 @@ defmodule DB.Dataset do
       DB.Organization.changeset(DB.Repo.get(DB.Organization, id) || %DB.Organization{}, org)
     )
     |> put_change(:organization, name)
+    # `put_assoc` already sets `organization_id` but we set it again
+    # to pass `validate_required([:organization_id])`
+    |> put_change(:organization_id, id)
   end
 
   defp add_organization(%Ecto.Changeset{} = changeset, _), do: changeset

--- a/apps/transport/lib/jobs/import_dataset_followers_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_followers_job.ex
@@ -71,8 +71,6 @@ defmodule Transport.Jobs.ImportDatasetFollowersJob do
     end
   end
 
-  def contact_is_producer?({_, %{organization_ids: _}}, %DB.Dataset{organization_id: nil}), do: false
-
   def contact_is_producer?({_, %{organization_ids: contact_org_ids}}, %DB.Dataset{organization_id: dataset_org_id}) do
     dataset_org_id in contact_org_ids
   end

--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -129,8 +129,6 @@ defmodule TransportWeb.DiscussionsLive do
     end
   end
 
-  defp organization_info(%DB.Dataset{organization_id: nil}), do: :no_organization
-
   defp organization_info(%DB.Dataset{organization_id: organization_id}) when is_binary(organization_id) do
     Datagouvfr.Client.Organization.Wrapper.get(organization_id, restrict_fields: true)
   end

--- a/apps/transport/priv/repo/migrations/20240726065227_dataset_organization_id_not_null.exs
+++ b/apps/transport/priv/repo/migrations/20240726065227_dataset_organization_id_not_null.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.DatasetOrganizationIdNotNull do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER TABLE dataset ALTER COLUMN organization_id SET NOT NULL")
+  end
+
+  def down do
+    execute("ALTER TABLE dataset ALTER COLUMN organization_id DROP NOT NULL")
+  end
+end

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -231,11 +231,6 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
   end
 
   describe "contacts_in_org" do
-    test "org is not set" do
-      dataset = insert(:dataset, organization_id: nil)
-      assert [] == PageController.contacts_in_org(dataset |> DB.Repo.preload(organization_object: :contacts))
-    end
-
     test "dataset is nil" do
       assert [] == PageController.contacts_in_org(nil)
     end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -472,16 +472,6 @@ defmodule TransportWeb.DatasetControllerTest do
              "Ce jeu de données a été supprimé de data.gouv.fr"
   end
 
-  test "dataset#details loads when dataset.organization_id is nil", %{conn: conn} do
-    # To be removed when https://github.com/etalab/transport-site/issues/4018
-    # is done and existing datasets have been migrated
-    dataset = insert(:dataset, is_active: true, organization_id: nil)
-
-    mock_empty_history_resources()
-
-    conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
-  end
-
   test "with an archived dataset", %{conn: conn} do
     insert(:dataset, is_active: true, slug: slug = "dataset-slug", archived_at: DateTime.utc_now())
 

--- a/apps/transport/test/transport_web/live_views/discussions_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/discussions_live_test.exs
@@ -92,32 +92,6 @@ defmodule Transport.TransportWeb.DiscussionsLiveTest do
     assert render(view) =~ ""
   end
 
-  test "renders even if there is no organization", %{conn: conn} do
-    dataset = insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), organization_id: nil)
-
-    Datagouvfr.Client.Discussions.Mock |> expect(:get, 1, fn ^datagouv_id -> discussions() end)
-
-    # No organization mock: shouldn’t be called.
-
-    {:ok, view, _html} =
-      live_isolated(conn, TransportWeb.DiscussionsLive,
-        session: %{
-          "dataset_datagouv_id" => datagouv_id,
-          "current_user" => %{"email" => "fc@tdg.fr"},
-          "dataset" => dataset,
-          "locale" => "fr",
-          "csp_nonce_value" => Ecto.UUID.generate()
-        }
-      )
-
-    parsed_content = view |> render() |> Floki.parse_document!()
-
-    discussion_title_text =
-      parsed_content |> Floki.find(".discussion-title h4") |> Floki.text()
-
-    assert discussion_title_text =~ "Le titre de la question"
-  end
-
   test "answer and answer and close buttons", %{conn: conn} do
     dataset =
       insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), organization_id: org_id = Ecto.UUID.generate())


### PR DESCRIPTION
Fixes #4018

Empêche le référencement d'un JDD sans organisation (publié par une personne et non une organisation). Il [n'y a plus de JDD sans organisation en prod](https://github.com/etalab/transport-site/issues/4018#issuecomment-2250339589).

- Ajoute une contrainte not null sur `dataset.organization_id`.
- Ajuste `DB.Dataset.changeset/2`
- Supprime le code et les tests qui géraient la possibilité d'avoir `dataset.organization_id = null`