### PR TITLE
Validateur GTFS : ajoute erreur NegativeStopDuration

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_negative_stop_duration_issue.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_negative_stop_duration_issue.html.heex
@@ -1,0 +1,19 @@
+<p>
+  <%= dgettext("validations-explanations", "Impacted file:") %> <tt>stop_times.txt</tt>
+</p>
+<p>
+  <%= dgettext("validations-explanations", "NegativeStopDuration") %>
+</p>
+<table class="table">
+  <tr>
+    <th><%= dgettext("validations-explanations", "Trip ID") %></th>
+    <th><%= dgettext("page-dataset-details", "Details") %></th>
+  </tr>
+
+  <%= for issue <- @issues do %>
+    <tr>
+      <td><%= issue["object_id"] %></td>
+      <td><%= issue["details"] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -43,7 +43,8 @@ defmodule TransportWeb.ResourceView do
         "InvalidShapeId" => "_invalid_shape_id_issue.html",
         "MissingId" => "_missing_id_issue.html",
         "MissingName" => "_missing_name_issue.html",
-        "SubFolder" => "_subfolder_issue.html"
+        "SubFolder" => "_subfolder_issue.html",
+        "NegativeStopDuration" => "_negative_stop_duration_issue.html"
       },
       issue_type(issues.entries),
       "_generic_issue.html"

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -224,7 +224,8 @@ defmodule Transport.Validators.GTFSTransport do
       "IdNotAscii" => dgettext("gtfs-transport-validator", "ID is not ASCII-encoded"),
       "InvalidShapeId" => dgettext("gtfs-transport-validator", "Invalid shape ID"),
       "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID"),
-      "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder")
+      "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder"),
+      "NegativeStopDuration" => dgettext("gtfs-transport-validator", "Negative stop duration")
     }
 
   @spec gtfs_outdated?(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -170,3 +170,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Files in a subfolder"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Negative stop duration"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -126,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "SubFolder"
 msgstr ".txt files are in subfolder (%{folder}). Files must reside at the root level directly, not in a subfolder."
+
+#, elixir-autogen, elixir-format
+msgid "NegativeStopDuration"
+msgstr "The departure time at a stop is earlier than its arrival time."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -170,3 +170,7 @@ msgstr "Doublon de stop_sequence dans un trajet"
 #, elixir-autogen, elixir-format
 msgid "Files in a subfolder"
 msgstr "Fichiers dans un sous-dossier"
+
+#, elixir-autogen, elixir-format
+msgid "Negative stop duration"
+msgstr "Temps d'arrêt négatif"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -126,3 +126,7 @@ msgstr "Arrêts associés"
 #, elixir-autogen, elixir-format
 msgid "SubFolder"
 msgstr "Les fichiers .txt sont dans un sous-dossier (%{folder}). Les fichiers doivent être à la racine de l'archive ZIP et non dans un sous-dossier."
+
+#, elixir-autogen, elixir-format
+msgid "NegativeStopDuration"
+msgstr "L'heure de départ d'un arrêt (departure_time) est antérieure à son heure d'arrivée (arrival_time)."

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -169,3 +169,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Files in a subfolder"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Negative stop duration"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -125,3 +125,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "SubFolder"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "NegativeStopDuration"
+msgstr ""


### PR DESCRIPTION
Fixes #4098

Ajoute un nouveau template/description d'erreurs pour une nouvelle règle de validation GTFS.