### PR TITLE
Notifications : ajuste clés étrangères pour gérer suppression abonnements et contacts

### DIFF
--- a/apps/transport/priv/repo/migrations/20240730130026_notifications_adjust_foreign_keys.exs
+++ b/apps/transport/priv/repo/migrations/20240730130026_notifications_adjust_foreign_keys.exs
@@ -1,0 +1,15 @@
+defmodule DB.Repo.Migrations.NotificationsAdjustForeignKeys do
+  use Ecto.Migration
+
+  def change do
+    # Review foreign key settings previously set in
+    # 20240604121342_notifications_add_columns.exs
+    alter table(:notifications) do
+      modify(:notification_subscription_id, references(:notification_subscription, on_delete: :nilify_all),
+        from: references(:notification_subscription, on_delete: :nothing)
+      )
+
+      modify(:contact_id, references(:contact, on_delete: :nilify_all), from: references(:contact, on_delete: :nothing))
+    end
+  end
+end

--- a/apps/transport/test/db/contact_test.exs
+++ b/apps/transport/test/db/contact_test.exs
@@ -269,6 +269,25 @@ defmodule DB.ContactTest do
     assert [admin_contact.datagouv_user_id] == DB.Contact.admin_datagouv_ids()
   end
 
+  test "delete a contact attached to a notification" do
+    contact = insert_contact()
+
+    ns =
+      insert(:notification_subscription, %{
+        reason: :daily_new_comments,
+        source: :admin,
+        contact_id: contact.id,
+        role: :producer
+      })
+      |> DB.Repo.preload(:contact)
+
+    %DB.Notification{} = notification = DB.Notification.insert!(ns, %{})
+
+    DB.Repo.delete!(contact)
+
+    %DB.Notification{contact_id: nil} = DB.Repo.reload!(notification)
+  end
+
   defp list_inactive_contact_ids(datetime) do
     DB.Contact.list_inactive_contacts(datetime)
     |> Enum.map(fn %DB.Contact{id: contact_id} -> contact_id end)

--- a/apps/transport/test/db/notification_subscription_test.exs
+++ b/apps/transport/test/db/notification_subscription_test.exs
@@ -118,4 +118,23 @@ defmodule DB.NotificationSubscriptionTest do
                dataset_id: nil
              })
   end
+
+  test "delete a subscription attached to a notification" do
+    contact = insert_contact()
+
+    ns =
+      insert(:notification_subscription, %{
+        reason: :daily_new_comments,
+        source: :admin,
+        contact_id: contact.id,
+        role: :producer
+      })
+      |> DB.Repo.preload(:contact)
+
+    %DB.Notification{} = notification = DB.Notification.insert!(ns, %{})
+
+    DB.Repo.delete!(ns)
+
+    %DB.Notification{notification_subscription_id: nil} = DB.Repo.reload!(notification)
+  end
 end


### PR DESCRIPTION
Fixes #4102

Ajuste la migration initiale pour ne pas lever une exception quand on tente de supprimer un `notification_subscription` ou `contact`, référencé par `notifications`.