### PR TITLE
Gestion des notifications : mise à jour du DOM

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -114,6 +114,9 @@
       margin-right: 5px;
     }
   }
+  form.full-width {
+    max-width: 100%;
+  }
 }
 
 a.filler {

--- a/apps/transport/lib/transport_web/live/notifications_live.html.heex
+++ b/apps/transport/lib/transport_web/live/notifications_live.html.heex
@@ -33,8 +33,8 @@ display_error = is_producer and not is_nil(@error) %>
     <div :if={!display_error} class="panel mt-24">
       <div :if={is_reuser} data-content="platform-wide-notifications">
         <h3><%= dgettext("reuser-space", "Global notifications") %></h3>
-        <table class="table">
-          <.form :let={f} for={%{}}>
+        <.form :let={f} for={%{}} class="full-width">
+          <table class="table">
             <%= for reason <- @platform_wide_reasons do %>
               <% subscribed = reason in @subscribed_platform_wide_reasons %>
               <tr>
@@ -64,13 +64,13 @@ display_error = is_producer and not is_nil(@error) %>
                 </td>
               </tr>
             <% end %>
-          </.form>
-        </table>
+          </table>
+        </.form>
       </div>
 
       <h3 :if={is_reuser}><%= dgettext("reuser-space", "Notifications by dataset") %></h3>
-      <table class="table" data-content="dataset-notifications">
-        <.form :let={f} for={%{}}>
+      <.form :let={f} for={%{}} class="full-width">
+        <table class="table" data-content="dataset-notifications">
           <tr>
             <td><strong><%= dgettext("espace-producteurs", "All notifications") %></strong></td>
             <td>
@@ -146,8 +146,8 @@ display_error = is_producer and not is_nil(@error) %>
               </tr>
             <% end %>
           <% end %>
-        </.form>
-      </table>
+        </table>
+      </.form>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/4105

Je ne suis pas absolument certain du problème mais il semble que le précédent DOM causait des problèmes dans certaines situations avec LiveView, en faisant disparaitre des blocs au rerender  (après une action) avec LiveView.

https://stackoverflow.com/a/5967613 indique que le DOM correct est `form > table` et non `table > form`.

J'ai fait plusieurs tests pour vérifier que les données dans `LiveView.Socket.assigns` sont bien correctes.

J'ai ajouté plusieurs tests pour vérifier que les notifications générales sont bien présentes et correctes quand on change les abonnements spécifiques à un JDD.

https://github.com/user-attachments/assets/5567b747-2a24-415b-8ae4-781772af8641

