### PR TITLE
CI : vérifie que le fichier Protobuf GTFS-RT est bien à jour

### DIFF
--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -9,7 +9,7 @@ extra_exclude =
       _ -> [:documentation_links]
     end
   else
-    [:transport_tools, :documentation_links]
+    [:transport_tools, :documentation_links, :external]
   end
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -183,6 +183,21 @@ defmodule Transport.GTFSRTTest do
            } == feed |> GTFSRT.service_alerts_for_display() |> List.first()
   end
 
+  @tag :external
+  test ".proto file is up-to-date" do
+    normalize_whitespace = fn value ->
+      String.trim(Regex.replace(~r/\s*/u, value, ""))
+    end
+
+    remote_content =
+      HTTPoison.get!("https://raw.githubusercontent.com/google/transit/master/gtfs-realtime/proto/gtfs-realtime.proto").body
+
+    local_content = File.read!("#{__DIR__}/../../lib/transport/protobuf/gtfs-realtime.proto")
+
+    assert normalize_whitespace.(remote_content) == normalize_whitespace.(local_content),
+           "Protobuf file seems to have been updated. Consider updating it. See https://github.com/google/transit/tree/master/gtfs-realtime/proto and https://github.com/etalab/transport-site/issues/3891"
+  end
+
   def timerange(start_date, end_date) do
     %TimeRange{start: unix_seconds_delta(start_date), end: unix_seconds_delta(end_date)}
   end


### PR DESCRIPTION
Fixes #3891

Ajoute un test, avec le tag `:external` (non exécuté en local) vérifiant que le fichier Protobuf GTFS-RT de notre app est bien à la même version que celui publié sur le dépôt source.

En cas de changement on aura un fail de ce test. On pourra alors faire une PR pour le mettre à jour, ou ignorer ce test pendant un temps. https://github.com/etalab/transport-site/issues/3891#issuecomment-2072158178