### PR TITLE
Résultats de recherche : uniformise titre de page

### DIFF
--- a/apps/transport/lib/db/region.ex
+++ b/apps/transport/lib/db/region.ex
@@ -20,4 +20,6 @@ defmodule DB.Region do
     has_many(:departements, Departement, foreign_key: :region_insee, references: :insee)
     has_one(:datasets, Dataset)
   end
+
+  def national, do: DB.Repo.get_by!(DB.Region, nom: "National")
 end

--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -232,7 +232,7 @@ defmodule TransportWeb.PageController do
 
   defmodule Tile do
     @enforce_keys [:link, :icon, :title, :count]
-    defstruct [:link, :icon, :title, :count, :type, :documentation_url, :mode]
+    defstruct [:link, :icon, :title, :count, :type, :documentation_url]
   end
 
   def home_tiles(conn) do
@@ -248,22 +248,19 @@ defmodule TransportWeb.PageController do
       },
       %Tile{
         # 14 is the region « National » We defined coaches as buses not bound to a region or AOM
-        mode: "bus",
-        link: dataset_path(conn, :by_region, 14, %{"modes" => ["bus"]}),
+        link: dataset_path(conn, :by_region, 14, "modes[]": "bus"),
         icon: icon_type_path("long-distance-coach"),
         title: dgettext("page-index", "Long distance coach"),
         count: Keyword.fetch!(counts, :count_coach)
       },
       %Tile{
-        mode: "rail",
-        link: dataset_path(conn, :index, %{"modes" => ["rail"]}),
+        link: dataset_path(conn, :index, "modes[]": "rail"),
         icon: icon_type_path("train"),
         title: dgettext("page-index", "Rail transport"),
         count: Keyword.fetch!(counts, :count_train)
       },
       %Tile{
-        mode: "ferry",
-        link: dataset_path(conn, :index, %{"modes" => ["ferry"]}),
+        link: dataset_path(conn, :index, "modes[]": "ferry"),
         icon: icon_type_path("boat"),
         title: dgettext("page-index", "Sea and river transport"),
         count: Keyword.fetch!(counts, :count_boat)
@@ -292,17 +289,6 @@ defmodule TransportWeb.PageController do
         count: Keyword.fetch!(counts, :count_paris2024)
       }
     ]
-    |> check_mode_is_set!()
-  end
-
-  defp check_mode_is_set!(tiles) do
-    Enum.each(tiles, fn %Tile{link: link, mode: mode} = tile ->
-      if String.contains?(link, "modes") and is_nil(mode) do
-        raise "mode attribute should be filled for #{inspect(tile)}"
-      end
-    end)
-
-    tiles
   end
 
   defp climate_resilience_bill_type_tile(%Plug.Conn{} = conn, %{count: count, type: type}) do


### PR DESCRIPTION
Fixes #4115

Permet d'avoir des titres de catégories de données quand ce n'est pas simplement `type=:type` mais aussi avec des modes ou des tags.

Utilise la configuration des tuiles sur la page d'accueil pour s'assurer de la cohérence entre les paramètres et le titre des données.

![image](https://github.com/user-attachments/assets/fcc4226d-2b12-4179-981b-f3917d6ab756)
![image](https://github.com/user-attachments/assets/85b0cede-6464-45aa-8113-3a65c1e649ad)
