### PR TITLE
Correctif sur la disponibilité de la seule ressource hébergée sur Google Drive

### DIFF
--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -58,11 +58,12 @@ defmodule Transport.AvailabilityChecker do
     # Google Drive content (1 instance at time of writing) returns a 303, and by default `hackney` only allows
     # POST method for this, but here HEAD/GET are supported and required. By using `force_redirection` in `hackney`
     # options, this indicated `hackney` that the redirect should still occur.
-    options = if URI.parse(url).host == "drive.google.com" do
-      options |> Keyword.merge(hackney: [force_redirect: true])
-    else
-      options
-    end
+    options =
+      if URI.parse(url).host == "drive.google.com" do
+        options |> Keyword.merge(hackney: [force_redirect: true])
+      else
+        options
+      end
 
     case http_client().head(url, [], options) do
       # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -41,6 +41,7 @@ defmodule Transport.AvailabilityChecker do
       # https://github.com/edgurgel/httpoison/issues/171#issuecomment-244029927
       # https://github.com/etalab/transport-site/issues/3463
       {:error, %HTTPoison.Error{reason: {:invalid_redirection, _}}} ->
+        # NOTE: this does not actually verifies that the target is available at the moment!
         true
 
       _ ->

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -55,9 +55,9 @@ defmodule Transport.AvailabilityChecker do
     # Least intrusive fix, only pass `force_redirection` to `HTTPoison` if the param value is true, else
     # do not specify it, to avoid side-effect.
     # See: https://github.com/benoitc/hackney/blob/eca5fbb1ff2d84facefb2a633e00f6ca16e7ddfd/src/hackney_stream.erl#L173
-    # Google Drive content (1 instance at time of writing) returns a 303, and by default `hackney` only allows POST method
-    # for this, but here HEAD/GET are supported and required. By using `force_redirection` in `hackney` options, this
-    # indicated `hackney` that the redirect should still occur.
+    # Google Drive content (1 instance at time of writing) returns a 303, and by default `hackney` only allows
+    # POST method for this, but here HEAD/GET are supported and required. By using `force_redirection` in `hackney`
+    # options, this indicated `hackney` that the redirect should still occur.
     options = if URI.parse(url).host == "drive.google.com" do
       options |> Keyword.merge(hackney: [force_redirect: true])
     else

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -67,6 +67,14 @@ defmodule Transport.AvailabilityCheckerTest do
     test_fallback_to_stream(403)
   end
 
+  test "redirection for Google Drive" do
+    expect(Transport.HTTPoison.Mock, :head, fn _url, [], [follow_redirect: true, hackney: [force_redirect: true]] ->
+      {:ok, %HTTPoison.Response{status_code: 200}}
+    end)
+
+    assert AvailabilityChecker.available?("GTFS", "https://drive.google.com/test_url")
+  end
+
   defp mock_head_with_status(status_code) do
     expect(Transport.HTTPoison.Mock, :head, fn _url, [], [follow_redirect: true] ->
       {:ok, %HTTPoison.Response{status_code: status_code}}


### PR DESCRIPTION
Voir:
- #4122
- #3464 (souci similaire, mais actuellement non "traversé" par les ressources que j'ai pu tester)

J'ai implémenté un hot-fix de la manière la moins intrusive possible, en ne touchant pas les options sauf si on est vraiment sur Google Drive.

### Solutions plus élaborées à envisager

- Passer à `Req` qui ne présente pas ce problème
- Ouvrir un ticket dans `hackney` pour traiter correctement "303 + GET" (ce qui n'est pas géré actuellement et cause le problème)

### Tâches restantes

- [x] Ajouter un test dans `availability_checker_test.exs`
- [ ] Déployer
- [ ] Corriger les statistiques de la ressource considérée (id=81575), pour ne pas biaiser leur affichage

### Bouts de code qui m'ont servi en mise au point

```elixir
resources = DB.Resource
|> DB.Repo.all
|> Enum.filter(fn(x) -> x.id == 81575 end)

resources
|> Enum.with_index()
|> Enum.each(fn({r, index}) ->
  IO.puts "Processing #{index}/#{resources |> length()}"
  url = DB.Resource.download_url(r)
  IO.puts url
  # Req.head!(url) |> IO.inspect(IEx.inspect_opts)
  Transport.AvailabilityChecker.available?(r.format, DB.Resource.download_url(r))
  |> IO.inspect
end)
```

Vérification du comportement d'hackney (pourrait servir pour un bug report):

```elixir
# url = "https://drive.google.com/uc?export=download&id=1JPmGimO4tfQpzL8A0ixYnYrPDehYILWn"

# #{:ok, status_code, headers, client_ref} =
#   :hackney.get(url, [], "", [follow_redirect: true, force_redirect: true, max_redirect: 5]) |> IO.inspect(IEx.inspect_opts)
```