### PR TITLE
ResourceHistoryJob : améliore détection d'un ZIP

### DIFF
--- a/apps/transport/lib/zip.ex
+++ b/apps/transport/lib/zip.ex
@@ -1,12 +1,24 @@
 defmodule Transport.ZipMetaDataExtractor do
   @moduledoc """
-  A module to extract the metadata out of a zip file on disk. It relies on `unzip`
+  A module to extract the metadata out of a ZIP file on disk. It relies on `unzip`
   which is able to stream the content of each file, allowing us to easily compute a
   SHA256 for each entry.
   """
 
-  def extract!(file) do
-    zip_file = Unzip.LocalFile.open(file)
+  @doc """
+  Checks if a file stored on disk is a valid ZIP file.
+  The file should exist, otherwise an exception will be raised.
+  """
+  @spec zip?(binary()) :: boolean()
+  def zip?(filepath) do
+    case filepath |> Unzip.LocalFile.open() |> Unzip.new() do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  def extract!(filepath) do
+    zip_file = Unzip.LocalFile.open(filepath)
     {:ok, unzip} = Unzip.new(zip_file)
     # NOTE: `unzip.cd_list` contains crc + filenames & more info, if needed
     unzip

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -245,20 +245,31 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
   end
 
   describe "upload_filename" do
-    test "it works" do
+    test "GTFS, ZIP file" do
       resource_id = 42
 
       assert "#{resource_id}/#{resource_id}.20211202.130534.393187.zip" ==
                ResourceHistoryJob.upload_filename(
                  %DB.Resource{id: resource_id, format: "GTFS"},
+                 @gtfs_path,
                  ~U[2021-12-02 13:05:34.393187Z]
                )
+    end
+
+    test "CSV file" do
+      resource_id = 42
+      filepath = Path.join(System.tmp_dir!(), Ecto.UUID.generate())
+
+      File.write!(filepath, "foo")
 
       assert "#{resource_id}/#{resource_id}.20211202.130534.393187.csv" ==
                ResourceHistoryJob.upload_filename(
                  %DB.Resource{id: resource_id, format: "csv"},
+                 filepath,
                  ~U[2021-12-02 13:05:34.393187Z]
                )
+
+      File.rm!(filepath)
     end
   end
 

--- a/apps/transport/test/zip_test.exs
+++ b/apps/transport/test/zip_test.exs
@@ -1,9 +1,32 @@
 defmodule Transport.ZipMetaDataExtractorTest do
   use ExUnit.Case, async: true
+  @zip_path "#{__DIR__}/../../shared/test/validation/gtfs.zip"
+
+  describe "zip?" do
+    test "file does not exist" do
+      assert_raise MatchError, fn ->
+        Transport.ZipMetaDataExtractor.zip?("/tmp/#{Ecto.UUID.generate()}")
+      end
+    end
+
+    test "ZIP file" do
+      assert Transport.ZipMetaDataExtractor.zip?(@zip_path)
+    end
+
+    test "regular file" do
+      filepath = Path.join(System.tmp_dir!(), Ecto.UUID.generate())
+
+      try do
+        File.write!(filepath, "foo")
+        refute Transport.ZipMetaDataExtractor.zip?(filepath)
+      after
+        File.rm!(filepath)
+      end
+    end
+  end
 
   test "extract! with a valid zip" do
-    path = "#{__DIR__}/../../shared/test/validation/gtfs.zip"
-    results = Transport.ZipMetaDataExtractor.extract!(path)
+    results = Transport.ZipMetaDataExtractor.extract!(@zip_path)
 
     assert 9 == Enum.count(results)
 


### PR DESCRIPTION
Fixes #4120

Revoit la méthode pour détecter qu'un fichier local est bien un fichier ZIP. Utilise [la librairie `unzip`](https://hexdocs.pm/unzip/Unzip.html#new/1) pour s'assurer que le fichier sur le disque est bien un ZIP.