### PR TITLE
Espace producteur : uniformisation du fil d'ariane

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -184,7 +184,7 @@ defmodule TransportWeb.ResourceController do
          # Resource and resource_id may be nil in case of a new resource
          resource <- assign_resource_from_dataset_payload(dataset, params["resource_id"]) do
       conn
-      |> assign(:dataset, dataset)
+      |> assign_datasets(dataset)
       |> assign(:resource, resource)
       |> render("form.html")
     else
@@ -204,7 +204,7 @@ defmodule TransportWeb.ResourceController do
          # Resource and resource_id may be nil in case of a new resource
          resource when not is_nil(resource) <- assign_resource_from_dataset_payload(dataset, resource_id) do
       conn
-      |> assign(:dataset, dataset)
+      |> assign_datasets(dataset)
       |> assign(:resource, resource)
       |> render("delete_resource_confirmation.html")
     else
@@ -337,6 +337,12 @@ defmodule TransportWeb.ResourceController do
         |> put_flash(:error, dgettext("resource", "Unable to upload file"))
         |> form(params)
     end
+  end
+
+  defp assign_datasets(%Plug.Conn{} = conn, %{"id" => dataset_id} = dataset) do
+    conn
+    |> assign(:db_dataset, DB.Repo.get_by!(DB.Dataset, datagouv_id: dataset_id))
+    |> assign(:dataset, dataset)
   end
 
   defp assign_resource_from_dataset_payload(dataset, resource_id) do

--- a/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/delete_resource_confirmation.html.heex
@@ -2,12 +2,12 @@
 resource_id = Map.fetch!(@conn.params, "resource_id") %>
 <section class="pt-48 pb-24">
   <div class="container">
-    <%= breadcrumbs([@conn, :delete_resource]) %>
+    <%= breadcrumbs([@conn, :delete_resource, @db_dataset.custom_title, @db_dataset.id]) %>
   </div>
 </section>
 <section class="espace-producteur-section">
   <div class="container pt-24">
-    <strong><%= @dataset["title"] %> > <%= @resource["title"] %></strong>
+    <strong><%= @db_dataset.custom_title %> > <%= @resource["title"] %></strong>
     <%= form_for @conn, resource_path(@conn, :delete, dataset_id, resource_id), [method: "delete", class: "pt-48"], fn _ -> %>
       <p class="notification warning">
         <%= dgettext("resource", "Do you want to update the resource or delete it definitely?") %>

--- a/apps/transport/lib/transport_web/templates/resource/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.heex
@@ -3,15 +3,15 @@
   <section class="pt-48 pb-24">
     <div class="container">
       <%= if new_resource do %>
-        <%= breadcrumbs([@conn, :new_resource]) %>
+        <%= breadcrumbs([@conn, :new_resource, @db_dataset.custom_title, @db_dataset.id]) %>
       <% else %>
-        <%= breadcrumbs([@conn, :update_resource]) %>
+        <%= breadcrumbs([@conn, :update_resource, @db_dataset.custom_title, @db_dataset.id]) %>
       <% end %>
     </div>
   </section>
   <section class="choose-file">
     <div class="container pt-24">
-      <strong><%= @dataset["title"] %><span :if={!new_resource}> > <%= @resource["title"] %></span></strong>
+      <strong><%= @db_dataset.custom_title %><span :if={!new_resource}> > <%= @resource["title"] %></span></strong>
       <div class="pt-24">
         <h2><%= title(@conn) %></h2>
       </div>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -18,13 +18,6 @@ defmodule TransportWeb.BreadCrumbs do
     [{dgettext("reuser-space", "Reuser space"), reuser_space_path(conn, :espace_reutilisateur)}]
   end
 
-  def crumbs(conn, :new_resource) do
-    crumbs(conn, :espace_producteur) ++
-      [
-        {dgettext("espace-producteurs", "New resource"), nil}
-      ]
-  end
-
   def crumbs(conn, :contacts) do
     [{"Contacts", backoffice_contact_path(conn, :index)}]
   end
@@ -54,30 +47,27 @@ defmodule TransportWeb.BreadCrumbs do
       ]
   end
 
-  def crumbs(conn, :delete_resource) do
-    # Same than below, can’t really link to edit dataset page
-    crumbs(conn, :espace_producteur) ++
-      [
-        {dgettext("espace-producteurs", "Delete a resource"), nil}
-      ]
-  end
-
-  def crumbs(conn, :update_resource) do
-    # Ideally this should link to the edit_dataset crumb instead of the espace_producteur
-    # but on the update resource page, we don’t have the DB dataset, but a datagouv API dataset
-    # So can’t have reliably the same title and DB id than on the dataset edit page
-    crumbs(conn, :espace_producteur) ++
-      [
-        {dgettext("espace-producteurs", "Update a resource"), nil}
-      ]
-  end
-
   def crumbs(conn, :datasets_edit, dataset_custom_title) do
     crumbs(conn, :reuser_space) ++ [{dataset_custom_title, nil}]
   end
 
   def crumbs(conn, :edit_dataset, dataset_custom_title, id) do
     crumbs(conn, :espace_producteur) ++ [{dataset_custom_title, espace_producteur_path(conn, :edit_dataset, id)}]
+  end
+
+  def crumbs(conn, :delete_resource, dataset_custom_title, id) do
+    crumbs(conn, :edit_dataset, dataset_custom_title, id) ++
+      [{dgettext("espace-producteurs", "Delete a resource"), nil}]
+  end
+
+  def crumbs(conn, :new_resource, dataset_custom_title, id) do
+    crumbs(conn, :edit_dataset, dataset_custom_title, id) ++
+      [{dgettext("espace-producteurs", "New resource"), nil}]
+  end
+
+  def crumbs(conn, :update_resource, dataset_custom_title, id) do
+    crumbs(conn, :edit_dataset, dataset_custom_title, id) ++
+      [{dgettext("espace-producteurs", "Update a resource"), nil}]
   end
 
   def render_crumbs(crumbs_element) do


### PR DESCRIPTION
Fixes #4117

Uniformise le fil d'ariane / breadcrumb dans l'espace producteur suite à l'ajout d'une page d'édition de JDD.

![image](https://github.com/user-attachments/assets/1b2e7a68-f577-4bc0-ae58-472928cdfa7f)
![image](https://github.com/user-attachments/assets/6d335fa5-b3e2-4416-a4f3-a4c002e04ad7)
