### PR TITLE
Espace producteur : mise à jour lien pour modifier une ressource

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -155,7 +155,6 @@ defmodule TransportWeb.Router do
         pipe_through([:authenticated])
 
         scope "/datasets/:dataset_id/resources" do
-          get("/", ResourceController, :resources_list)
           post("/", ResourceController, :post_file)
           get("/_new_resource/", ResourceController, :form)
           get("/:resource_id/", ResourceController, :form)

--- a/apps/transport/lib/transport_web/templates/resource/form.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/form.html.heex
@@ -36,7 +36,7 @@
                   dgettext(
                     "resource",
                     ~s(This option allows you to add the resource on data.gouv.fr, directly from here. Do you want to publish a more up-to-date version of a resource? <a href="%{url}">Update the resource</a> instead.),
-                    url: resource_path(@conn, :resources_list, @dataset["id"])
+                    url: espace_producteur_path(@conn, :edit_dataset, @db_dataset.id)
                   )
                 ) %>
               </p>


### PR DESCRIPTION
Fixes #4132

Répare un lien cassé sur l'espace producteur.

Lors d'un refactor récent, la méthode `:resources_list` a été supprimée du controller mais pas du router https://github.com/etalab/transport-site/pull/4053#discussion_r1725131505 On référençait ainsi cet ancien lien, ce qui causait une erreur 500. Je suis surpris/déçu que Phoenix permette d'avoir des méthodes inexistantes dans un controller alors que c'est référencé dans un router :cry:

Le lien est désormais vers la page d'édition du dataset, ce qui permet de choisir la ressource à éditer.