### PR TITLE
TableSchemaValidator : enregistrements de compteurs sur AppSignal

### DIFF
--- a/apps/shared/lib/validation/tableschema_validator.ex
+++ b/apps/shared/lib/validation/tableschema_validator.ex
@@ -36,9 +36,17 @@ defmodule Shared.Validation.TableSchemaValidator do
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
            http_client().get(api_url, [], recv_timeout: @timeout),
          {:ok, json} <- Jason.decode(body) do
+      Appsignal.increment_counter("validata.success", 1)
       build_report(json)
     else
-      _ -> nil
+      _ ->
+        Appsignal.increment_counter("validata.failed", 1, %{
+          schema_name: schema_name,
+          schema_version: schema_version,
+          url: url
+        })
+
+        nil
     end
   end
 


### PR DESCRIPTION
Fixes #3501

Enregistrement de [metrics](https://docs.appsignal.com/metrics/custom.html) sur AppSignal pour suivre le volume de validations sur Validata. Je verrai pour ajouter une alerte en cas d'erreurs et commencer à investiguer.