### PR TITLE
PutLocale : vérifie que la locale est bien supportée

### DIFF
--- a/apps/transport/lib/transport_web/plugs/put_locale.ex
+++ b/apps/transport/lib/transport_web/plugs/put_locale.ex
@@ -11,9 +11,18 @@ defmodule TransportWeb.Plugs.PutLocale do
   def call(conn, _opts) do
     locale = conn.params["locale"] || get_session(conn, :locale) || preferred_accept_language(conn)
 
-    Gettext.put_locale(locale)
-    conn |> put_session(:locale, locale)
+    if locale in @supported_locales do
+      Gettext.put_locale(locale)
+      conn |> put_session(:locale, locale)
+    else
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(400, "Locale is not supported.")
+      |> halt()
+    end
   end
+
+  def supported_locales, do: @supported_locales
 
   @doc """
   Determines the locale to use using the `accept-language` HTTP header.

--- a/apps/transport/test/transport_web/routing/put_locale_test.exs
+++ b/apps/transport/test/transport_web/routing/put_locale_test.exs
@@ -1,4 +1,38 @@
 defmodule TransportWeb.Plugs.PutLocaleTest do
-  use ExUnit.Case, async: true
+  use TransportWeb.ConnCase, async: true
   doctest TransportWeb.Plugs.PutLocale, import: true
+
+  @path page_path(TransportWeb.Endpoint, :missions)
+
+  test "uses the locale query parameter", %{conn: conn} do
+    conn = get(conn, @path)
+
+    assert Plug.Conn.get_session(conn, :locale) == "fr"
+
+    conn = get(conn, @path, locale: "en")
+    assert Plug.Conn.get_session(conn, :locale) == "en"
+  end
+
+  test "uses the locale in the session", %{conn: conn} do
+    conn = conn |> Plug.Test.init_test_session(%{locale: "en"}) |> get(@path)
+    assert Plug.Conn.get_session(conn, :locale) == "en"
+  end
+
+  test "uses the accept-language header", %{conn: conn} do
+    conn = conn |> Plug.Conn.put_req_header("accept-language", "en-CA;q=0.9, *;q=0.5") |> get(@path)
+
+    assert Plug.Conn.get_session(conn, :locale) == "en"
+  end
+
+  test "400 if the locale is not supported", %{conn: conn} do
+    assert conn |> get(@path, locale: "es") |> text_response(400) == "Locale is not supported."
+  end
+
+  test "locale is switched in Gettext", %{conn: conn} do
+    TransportWeb.Plugs.PutLocale.supported_locales()
+    |> Enum.each(fn locale ->
+      html = conn |> get(@path, locale: locale) |> html_response(200)
+      assert html |> Floki.parse_document!() |> Floki.attribute("html", "lang") == [locale]
+    end)
+  end
 end


### PR DESCRIPTION
Fixes #4142

- Vérifie lors d'un changement de locale que celle-ci est bien supportée.
- Ajoute de nombreux tests pour vérifier le bon fonctionnement du plug existant (prise en compte des différentes possibilités de modification de la locale, impact sur la configuration).