### PR TITLE
Opendatasoft.UrlExtractor : documente et teste 1 match par ligne

### DIFF
--- a/apps/transport/test/transport/url_extractor_test.exs
+++ b/apps/transport/test/transport/url_extractor_test.exs
@@ -1,8 +1,8 @@
-defmodule Transport.UrlExtractorDocTest do
+defmodule Transport.UrlExtractorTest do
   use ExUnit.Case, async: true
   alias Opendatasoft.UrlExtractor
   import Mox
-  doctest UrlExtractor
+  doctest UrlExtractor, import: true
 
   setup :verify_on_exit!
 


### PR DESCRIPTION
En traitant #4149, j'ai (re ?)découvert que `Opendatasoft.UrlExtractor` (le module en charge de trouver des ressources par le biais d'URL présentes dans un export de tableur provenant d'OpenDataSoft) ne trouvait qu'au plus 1 match par ligne.

Si un fichier CSV dispose de plusieurs colonnes qui sont dans notre liste de candidats, seule la première colonne qui matche sera utilisée pour trouver l'URL.

J'ai documenté et testé ce fonctionnement et fait en sorte que ce match soit non sensible à la casse.

J'ai positionné la colonne `url` en premier dans la liste, j'ai constaté que ce nom de colonne était le plus commun quand un producteur renseigne une URL externe, ce qui est ce qu'on cherche en priorité. `fichier` est également très commun mais correspond à un dépôt de fichier sur OpenDataSoft, qui est moins souhaitable qu'une URL externe, que l'on espère stable.