### PR TITLE
Validateur NeTEx : timeout de 15 minutes

### DIFF
--- a/apps/transport/lib/validators/enroute_chouette_valid_client.ex
+++ b/apps/transport/lib/validators/enroute_chouette_valid_client.ex
@@ -6,7 +6,12 @@ defmodule Transport.EnRouteChouetteValidClient.Wrapper do
 
   @callback create_a_validation(Path.t()) :: binary()
   @callback get_a_validation(binary()) ::
-              :pending | {:successful, binary()} | :warning | :failed | :unexpected_validation_status
+              {:pending, integer()}
+              | {:successful, binary()}
+              | :warning
+              | :failed
+              | :unexpected_validation_status
+              | :unexpected_datetime_format
   @callback get_messages(binary()) :: {binary(), map()}
 
   def impl, do: Application.get_env(:transport, :enroute_validator_client)

--- a/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
+++ b/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
@@ -52,7 +52,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
           "user_status": "pending",
           "started_at": "2024-07-05T14:41:20.680Z",
           "created_at": "2024-07-05T14:41:19.933Z",
-          "updated_at": "2024-07-05T14:41:19.933Z"
+          "updated_at": "2024-07-05T14:45:20.933Z"
         }
         """
 
@@ -63,7 +63,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         %HTTPoison.Response{status_code: 200, body: response_body}
       end)
 
-      assert :pending == EnRouteChouetteValidClient.get_a_validation(validation_id)
+      assert {:pending, 4 * 60 + 1} == EnRouteChouetteValidClient.get_a_validation(validation_id)
     end
 
     test "successful" do

--- a/apps/transport/test/transport/validators/netex_validator_test.exs
+++ b/apps/transport/test/transport/validators/netex_validator_test.exs
@@ -2,7 +2,7 @@ defmodule Transport.Validators.NeTExTest do
   use ExUnit.Case, async: true
   import DB.Factory
   import Mox
-  require Logger
+  import ExUnit.CaptureLog
 
   alias Transport.Validators.NeTEx
 
@@ -143,9 +143,9 @@ defmodule Transport.Validators.NeTExTest do
       resource_url = mk_raw_netex_resource()
 
       validation_id = expect_create_validation()
-      expect_pending_validation(validation_id)
-      expect_pending_validation(validation_id)
-      expect_pending_validation(validation_id)
+      expect_pending_validation(validation_id, 10)
+      expect_pending_validation(validation_id, 20)
+      expect_pending_validation(validation_id, 30)
       expect_failed_validation(validation_id)
 
       expect_get_messages(validation_id, @sample_error_message)
@@ -165,6 +165,19 @@ defmodule Transport.Validators.NeTExTest do
       assert {:ok, %{"validations" => validation_result, "metadata" => %{}}} ==
                NeTEx.validate(resource_url, graceful_retry: false)
     end
+
+    test "timeout" do
+      resource_url = mk_raw_netex_resource()
+
+      validation_id = expect_create_validation()
+      expect_pending_validation(validation_id, 10)
+      expect_pending_validation(validation_id, 4510)
+
+      {result, log} = with_log(fn -> NeTEx.validate(resource_url, graceful_retry: false) end)
+
+      assert result == {:error, "enRoute Chouette Valid: Timeout while fetching results"}
+      assert log =~ "[error] Timeout while fetching result on enRoute Chouette Valid"
+    end
   end
 
   defp expect_create_validation do
@@ -173,8 +186,8 @@ defmodule Transport.Validators.NeTExTest do
     validation_id
   end
 
-  defp expect_pending_validation(validation_id) do
-    expect(Transport.EnRouteChouetteValidClient.Mock, :get_a_validation, fn ^validation_id -> :pending end)
+  defp expect_pending_validation(validation_id, elapsed) do
+    expect(Transport.EnRouteChouetteValidClient.Mock, :get_a_validation, fn ^validation_id -> {:pending, elapsed} end)
   end
 
   defp expect_successful_validation(validation_id) do


### PR DESCRIPTION
Le validateur d'enRoute peut tomber dans un état incohérent et le statut d'une validation rester en pending éternellement. Ce patch implémente un timeout de notre côté. Il est configuré arbitrairement à 15 minutes pour l'instant.

Voir #4153.