### PR TITLE
NewDatagouvDatasetsJob : e-mail par catégorie de données

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -75,6 +75,9 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
              formats: MapSet.new([])
            }
          ]
+         # Check that all rules:
+         # - have the required attributes
+         # - the specified schemas (`etalab/schema-irve-statique` for example) exist
          |> Enum.map(fn %{category: category, schemas: schemas, tags: %MapSet{}, formats: %MapSet{}} = rule ->
            if Mix.env() == :prod do
              unless Enum.all?(schemas, &(&1 in Map.keys(Schemas.transport_schemas()))) do

--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -8,58 +8,102 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
   import Ecto.Query
   alias Transport.Shared.Schemas.Wrapper, as: Schemas
 
-  @relevant_tags MapSet.new([
-                   "autopartage",
-                   "bus",
-                   "covoiturage",
-                   "cyclable",
-                   "deplacements",
-                   "déplacements",
-                   "freefloating",
-                   "horaires",
-                   "mobilite",
-                   "mobilité",
-                   "parking",
-                   "stationnement",
-                   "temps-reel",
-                   "transport",
-                   "transports",
-                   "trottinette",
-                   "velo",
-                   "vls",
-                   "vélo",
-                   "zfe"
-                 ])
-  @relevant_formats MapSet.new(["gtfs", "netex", "gbfs", "gtfs-rt", "gtfsrt", "siri", "ssim"])
+  @rules [
+           %{
+             category: "Transport en commun",
+             schemas: MapSet.new([]),
+             tags:
+               MapSet.new([
+                 "bus",
+                 "deplacements",
+                 "déplacements",
+                 "horaires",
+                 "mobilite",
+                 "mobilité",
+                 "temps-reel",
+                 "temps-réel",
+                 "transport",
+                 "transports"
+               ]),
+             formats: MapSet.new(["gtfs", "netex", "gtfs-rt", "gtfsrt", "siri", "ssim"])
+           },
+           %{
+             category: "Freefloating",
+             schemas: MapSet.new([]),
+             tags:
+               MapSet.new([
+                 "autopartage",
+                 "freefloating",
+                 "trottinette",
+                 "vls",
+                 "scooter",
+                 "libre-service",
+                 "libre service",
+                 "scooter"
+               ]),
+             formats: MapSet.new(["gbfs"])
+           },
+           %{
+             category: "Vélo et stationnements",
+             schemas: [
+               "etalab/schema-amenagements-cyclables",
+               "etalab/schema-stationnement-cyclable",
+               "etalab/schema-stationnement",
+               "etalab/schema-comptage-mobilites"
+             ],
+             tags: MapSet.new(["cyclable", "parking", "stationnement", "velo", "vélo"]),
+             formats: MapSet.new([])
+           },
+           %{
+             category: "Covoiturage et ZFE",
+             schemas: ["etalab/schema-lieux-covoiturage", "etalab/schema-zfe"],
+             tags: MapSet.new(["covoiturage", "zfe"]),
+             formats: MapSet.new([])
+           },
+           %{
+             category: "IRVE",
+             schemas: ["etalab/schema-irve-statique", "etalab/schema-irve-dynamique"],
+             tags:
+               MapSet.new([
+                 "infrastructure de recharge",
+                 "borne de recharge",
+                 "irve",
+                 "sdirve",
+                 "électrique",
+                 "electrique"
+               ]),
+             formats: MapSet.new([])
+           }
+         ]
+         |> Enum.map(fn %{category: category, schemas: schemas, tags: %MapSet{}, formats: %MapSet{}} = rule ->
+           if Mix.env() == :prod do
+             unless Enum.all?(schemas, &(&1 in Map.keys(Schemas.transport_schemas()))) do
+               raise "`#{category}` has invalid schemas: #{inspect(schemas)}"
+             end
+           end
+
+           rule
+         end)
 
   @impl Oban.Worker
   def perform(%Oban.Job{inserted_at: %DateTime{} = inserted_at}) do
-    %HTTPoison.Response{status_code: 200, body: body} =
-      Transport.Shared.Wrapper.HTTPoison.impl().get!(
-        Path.join(Application.fetch_env!(:transport, :datagouvfr_site), "/api/1/datasets/?sort=-created&page_size=500"),
-        [],
-        timeout: 30_000,
-        recv_timeout: 30_000
-      )
-
-    %{"data" => datasets} = Jason.decode!(body)
-    datasets = filtered_datasets(datasets, inserted_at)
-
-    unless Enum.empty?(datasets) do
-      duration = window(DateTime.to_date(inserted_at)) * -24
-      Transport.Mailer.deliver(Transport.AdminNotifier.new_datagouv_datasets(datasets, duration))
-    end
-
-    :ok
+    filtered_datasets(datagouv_datasets(), inserted_at)
+    |> match_for_rules()
+    |> send_emails(inserted_at)
   end
+
+  def rules, do: @rules
 
   def filtered_datasets(datasets, %DateTime{} = inserted_at) do
     dataset_ids = DB.Dataset.base_query() |> select([dataset: d], d.datagouv_id) |> DB.Repo.all()
 
     Enum.filter(datasets, fn dataset ->
-      dataset["id"] not in dataset_ids and
-        after_datetime?(get_in(dataset, ["internal", "created_at_internal"]), starting_date(inserted_at)) and
-        dataset_is_relevant?(dataset)
+      not_on_platform = dataset["id"] not in dataset_ids
+
+      created_recently =
+        after_datetime?(get_in(dataset, ["internal", "created_at_internal"]), starting_date(inserted_at))
+
+      not_on_platform and created_recently
     end)
   end
 
@@ -100,60 +144,106 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
 
   def ignore_dataset?(%{}), do: false
 
-  def dataset_is_relevant?(%{} = dataset) do
+  def dataset_is_relevant?(%{} = dataset, rule) do
     if ignore_dataset?(dataset) do
       false
     else
       match_on_dataset =
-        [&tags_is_relevant?/1, &description_is_relevant?/1, &title_is_relevant?/1]
-        |> Enum.map(& &1.(dataset))
+        [tags_is_relevant?(dataset, rule), description_is_relevant?(dataset, rule), title_is_relevant?(dataset, rule)]
         |> Enum.any?()
 
       match_on_resources =
-        dataset
-        |> Map.fetch!("resources")
-        |> Enum.map(&resource_is_relevant?/1)
-        |> Enum.any?()
+        dataset |> Map.fetch!("resources") |> Enum.any?(&resource_is_relevant?(&1, rule))
 
       match_on_dataset or match_on_resources
     end
   end
 
-  defp title_is_relevant?(%{"title" => title}), do: string_matches?(title)
-  defp description_is_relevant?(%{"description" => description}), do: string_matches?(description)
+  defp datagouv_datasets do
+    url =
+      Path.join(Application.fetch_env!(:transport, :datagouvfr_site), "/api/1/datasets/?sort=-created&page_size=500")
 
-  defp string_matches?(nil), do: false
+    %HTTPoison.Response{status_code: 200, body: body} =
+      Transport.Shared.Wrapper.HTTPoison.impl().get!(url, [], timeout: 30_000, recv_timeout: 30_000)
 
-  defp string_matches?(str) when is_binary(str) do
+    body |> Jason.decode!() |> Map.fetch!("data")
+  end
+
+  defp match_for_rules(datasets) do
+    for dataset <- datasets, rule <- @rules, dataset_is_relevant?(dataset, rule) do
+      {rule.category, dataset}
+    end
+  end
+
+  defp send_emails([], %DateTime{}), do: :ok
+
+  defp send_emails(matches, inserted_at) do
+    duration = window(DateTime.to_date(inserted_at)) * -24
+
+    matches
+    |> Enum.group_by(fn {category, _} -> category end, fn {_, dataset} -> dataset end)
+    |> Enum.each(fn {category, datasets} ->
+      rule = Enum.find(@rules, &(&1.category == category))
+
+      Transport.AdminNotifier.new_datagouv_datasets(category, datasets, rule_explanation(rule), duration)
+      |> Transport.Mailer.deliver()
+    end)
+  end
+
+  def rule_explanation(%{schemas: schemas, tags: tags, formats: formats}) do
+    join_or_empty = fn values ->
+      if Enum.empty?(values) do
+        "<vide>"
+      else
+        Enum.join(values, ", ")
+      end
+    end
+
+    """
+    <p>Règles utilisées pour identifier ces jeux de données :</p>
+    <ul>
+      <li>Formats : #{join_or_empty.(formats)}</li>
+      <li>Schémas : #{join_or_empty.(schemas)}</li>
+      <li>Mots-clés/tags : #{join_or_empty.(tags)}</li>
+    </ul>
+    """
+  end
+
+  defp title_is_relevant?(%{"title" => title}, rule), do: string_matches?(title, rule)
+  defp description_is_relevant?(%{"description" => description}, rule), do: string_matches?(description, rule)
+
+  defp string_matches?(nil, _rule), do: false
+
+  defp string_matches?(str, %{formats: formats, tags: tags} = _rule) when is_binary(str) do
     str
     |> String.downcase()
     |> String.split(" ")
     |> MapSet.new()
-    |> MapSet.intersection(MapSet.union(@relevant_formats, @relevant_tags))
+    |> MapSet.intersection(MapSet.union(formats, tags))
     |> MapSet.size() > 0
   end
 
-  defp tags_is_relevant?(%{"tags" => tags}) do
-    tags |> Enum.map(&string_matches?(String.downcase(&1))) |> Enum.any?()
+  defp tags_is_relevant?(%{"tags" => tags} = _dataset, rule) do
+    tags |> Enum.map(&string_matches?(String.downcase(&1), rule)) |> Enum.any?()
   end
 
-  defp resource_is_relevant?(%{} = resource) do
-    [&resource_format_is_relevant?/1, &resource_schema_is_relevant?/1, &description_is_relevant?/1]
-    |> Enum.map(& &1.(resource))
-    |> Enum.any?()
+  defp resource_is_relevant?(%{} = resource, rule) do
+    Enum.any?([
+      resource_format_is_relevant?(resource, rule),
+      resource_schema_is_relevant?(resource, rule),
+      description_is_relevant?(resource, rule)
+    ])
   end
 
-  defp resource_format_is_relevant?(%{"format" => nil}), do: false
+  defp resource_format_is_relevant?(%{"format" => nil}, _rule), do: false
 
-  defp resource_format_is_relevant?(%{"format" => format}) do
-    MapSet.member?(@relevant_formats, String.downcase(format))
+  defp resource_format_is_relevant?(%{"format" => format}, %{formats: formats} = _rule) do
+    MapSet.member?(formats, String.downcase(format))
   end
 
-  defp resource_schema_is_relevant?(%{"schema" => %{"name" => "etalab/schema-irve-statique"}}), do: false
-
-  defp resource_schema_is_relevant?(%{"schema" => %{"name" => schema_name}}) do
-    schema_name in Map.keys(Schemas.transport_schemas())
+  defp resource_schema_is_relevant?(%{"schema" => %{"name" => schema_name}}, %{schemas: schemas} = _rule) do
+    schema_name in schemas
   end
 
-  defp resource_schema_is_relevant?(%{}), do: false
+  defp resource_schema_is_relevant?(%{}, _rule), do: false
 end

--- a/apps/transport/lib/mailer/admin_notifier.ex
+++ b/apps/transport/lib/mailer/admin_notifier.ex
@@ -63,9 +63,9 @@ defmodule Transport.AdminNotifier do
     |> render_body("datasets_climate_resilience_bill_inappropriate_licence.html", %{datasets: datasets})
   end
 
-  def new_datagouv_datasets(datagouv_datasets, duration) do
+  def new_datagouv_datasets(category, datagouv_datasets, rule_explanation, duration) do
     notify_bidzev()
-    |> subject("Nouveaux jeux de données à référencer - data.gouv.fr")
+    |> subject("Nouveaux jeux de données #{category} à référencer - data.gouv.fr")
     |> html_body("""
     <p>Bonjour,</p>
 
@@ -76,7 +76,8 @@ defmodule Transport.AdminNotifier do
     </ul>
     <br/>
     <hr>
-    <p>Vous pouvez consulter et modifier <a href="https://github.com/etalab/transport-site/blob/master/apps/transport/lib/jobs/new_datagouv_datasets_job.ex">les règles de cette tâche</a>.</p>
+    #{rule_explanation}
+    <p>Vous pouvez modifier <a href="https://github.com/etalab/transport-site/blob/master/apps/transport/lib/jobs/new_datagouv_datasets_job.ex">les règles de cette tâche</a>.</p>
     """)
   end
 


### PR DESCRIPTION
Fixes #4159 

Adapte le job en charge de suggérer aux @etalab/transport-bizdev les jeux de données récemment ajoutés sur data.gouv.fr qui pourraient être pertinents à référencer sur le PAN.

- Adapte les règles
- Introduit plusieurs catégories de données, chacune avec ses problèmes règles de pertinence
- Envoi de plusieurs e-mails de JDDs à référencer, en groupant par catégorie de données
- Adapte les tests
- Un peu de refactor

🔜 Le changement d'adresse e-mail destinataire de `deploiement@` à `contact@` sera effectué dans une PR à venir.