### PR TITLE
Validateur NeTEx : validation du XSD

### DIFF
--- a/apps/transport/lib/validators/enroute_chouette_valid_client.ex
+++ b/apps/transport/lib/validators/enroute_chouette_valid_client.ex
@@ -30,6 +30,7 @@ defmodule Transport.EnRouteChouetteValidClient do
       {:multipart,
        [
          {"validation[rule_set]", "french"},
+         {"validation[include_schema]", "true"},
          make_file_part("validation[file]", filepath)
        ]}
 

--- a/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
+++ b/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
@@ -17,6 +17,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         "id": "d8e2b6c2-b1e5-4890-84d4-9b761a445882",
         "rule_set": "french",
         "user_status": "pending",
+        "include_schema": true,
         "created_at": "2024-07-05T14:41:19.933Z",
         "updated_at": "2024-07-05T14:41:19.933Z"
       }
@@ -31,6 +32,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
 
       assert [
                {"validation[rule_set]", "french"},
+               {"validation[include_schema]", "true"},
                {:file, tmp_file, {"form-data", [{:name, "validation[file]"}, {:filename, Path.basename(tmp_file)}]}, []}
              ] == parts
 
@@ -50,6 +52,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
           "id": "#{validation_id}",
           "rule_set": "french",
           "user_status": "pending",
+          "include_schema": true,
           "started_at": "2024-07-05T14:41:20.680Z",
           "created_at": "2024-07-05T14:41:19.933Z",
           "updated_at": "2024-07-05T14:41:20.933Z"
@@ -75,6 +78,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
           "id": "#{validation_id}",
           "rule_set": "french",
           "user_status": "successful",
+          "include_schema": true,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:25.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",
@@ -101,6 +105,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
           "id": "#{validation_id}",
           "rule_set": "french",
           "user_status": "warning",
+          "include_schema": true,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:24.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",
@@ -127,6 +132,7 @@ defmodule Transport.EnRouteChouetteValidClientTest do
           "id": "#{validation_id}",
           "rule_set": "french",
           "user_status": "failed",
+          "include_schema": true,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:28.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",


### PR DESCRIPTION
A court terme c'est probablement la fonctionnalité la plus utile pour les AOM en attendant qu'on implémente le profil FR correctement.

Voir #4153.