### PR TITLE
NewDatagouvDatasetsJob: check that rules have valid schemas using CRON

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -77,7 +77,7 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
   ]
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"check_rules" => _}}) do
+  def perform(%Oban.Job{args: %{"check_rules" => true}}) do
     # Check that all rules:
     # - have the required attributes
     # - the specified schemas (`etalab/schema-irve-statique` for example) exist

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -130,6 +130,7 @@ oban_prod_crontab = [
   # https://github.com/etalab/transport-site/issues/3492
   # {"0 20 * * *", Transport.Jobs.ResourceHistoryValidataJSONJob},
   {"15 */3 * * *", Transport.Jobs.ResourceHistoryTableSchemaValidationJob},
+  {"0 6 * * 1-5", Transport.Jobs.NewDatagouvDatasetsJob, args: %{check_rules: true}},
   {"5 6 * * 1-5", Transport.Jobs.NewDatagouvDatasetsJob},
   {"0 6 * * *", Transport.Jobs.NewDatasetNotificationsJob},
   {"30 6 * * *", Transport.Jobs.ExpirationNotificationJob},

--- a/config/test.exs
+++ b/config/test.exs
@@ -148,3 +148,6 @@ config :transport, Transport.Mailer, adapter: Swoosh.Adapters.Test
 # avoid logging
 config :os_mon,
   start_memsup: false
+
+# See https://hexdocs.pm/sentry/Sentry.Test.html
+config :sentry, test_mode: true


### PR DESCRIPTION
Suite de #4163

La méthode précédente pour vérifier que les règles avaient des schémas existants ne convenait pas. On en [avait discuté un peu](https://github.com/etalab/transport-site/pull/4163#discussion_r1745403468) mais en réalité au déploiement en production on a une erreur de compilation, à ce stade Cachex, qui est appelé pour la liste des schémas, n'est pas encore démarré.

Stacktrace résultante.

```
2024-09-05T15:33:31.900Z == Compilation error in file lib/jobs/new_datagouv_datasets_job.ex ==
2024-09-05T15:33:31.900Z ** (ArgumentError) errors were found at the given arguments:
2024-09-05T15:33:31.900Z   * 1st argument: the table identifier does not refer to an existing ETS table
2024-09-05T15:33:31.900Z     (stdlib 4.3.1.3) :ets.lookup(:cachex_overseer_table, Shared.Cachex)
2024-09-05T15:33:31.900Z     (cachex 3.6.0) lib/cachex/services/overseer.ex:91: Cachex.Services.Overseer.retrieve/1
2024-09-05T15:33:31.900Z     (cachex 3.6.0) lib/cachex.ex:690: Cachex.fetch/4
2024-09-05T15:33:31.900Z     (shared 0.1.0) lib/schemas.ex:114: Transport.Shared.Schemas.cache_fetch/3
2024-09-05T15:33:31.900Z     lib/jobs/new_datagouv_datasets_job.ex:83: anonymous fn/1 in :elixir_compiler_46.__MODULE__/1
2024-09-05T15:33:31.900Z     (elixir 1.16.2) lib/enum.ex:4199: Enum.predicate_list/3
2024-09-05T15:33:31.900Z     lib/jobs/new_datagouv_datasets_job.ex:83: anonymous fn/1 in :elixir_compiler_46.__MODULE__/1
2024-09-05T15:33:31.900Z     (elixir 1.16.2) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
```

Je bouge cette vérification dans une clause de `perform`, exécutée au même rythme que le job normal (1 fois par jour, du lundi au vendredi inclus) et lève une exception dans Sentry en cas de problème. C'est la 1ère fois dans cette codebase qu'on vérifie les événements Sentry levés d'ailleurs.