### PR TITLE
NewDatagouvDatasetsJob : ajuste information vide

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -199,7 +199,7 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
   def rule_explanation(%{schemas: schemas, tags: tags, formats: formats}) do
     join_or_empty = fn values ->
       if Enum.empty?(values) do
-        "<vide>"
+        "(vide)"
       else
         Enum.join(values, ", ")
       end

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -152,7 +152,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
   end
 
   test "rule_explanation" do
-    assert "<p>Règles utilisées pour identifier ces jeux de données :</p>\n<ul>\n  <li>Formats : netex</li>\n  <li>Schémas : <vide></li>\n  <li>Mots-clés/tags : cassis, kir</li>\n</ul>\n" ==
+    assert "<p>Règles utilisées pour identifier ces jeux de données :</p>\n<ul>\n  <li>Formats : netex</li>\n  <li>Schémas : (vide)</li>\n  <li>Mots-clés/tags : cassis, kir</li>\n</ul>\n" ==
              NewDatagouvDatasetsJob.rule_explanation(%{
                schemas: MapSet.new([]),
                tags: MapSet.new(["kir", "cassis"]),


### PR DESCRIPTION
Lié à #4159 

`<vide>` était interprété comme un tag HTML non existant et non rendu à l'écran [dans Front](https://app.frontapp.com/open/cnv_197ucs9i?key=Yhvgrw_74csEeCpQgjC5zz1_8FWrhrjo) (voir dans "View source").

Change le texte en conséquence.

![image](https://github.com/user-attachments/assets/282f3a7f-96a5-4382-aedd-a984853df51f)
