### PR TITLE
E-mails : changement adresse destinataire pour bizdevs

### DIFF
--- a/apps/transport/lib/mailer/admin_notifier.ex
+++ b/apps/transport/lib/mailer/admin_notifier.ex
@@ -121,7 +121,9 @@ defmodule Transport.AdminNotifier do
   defp notify_bidzev do
     new()
     |> from({"transport.data.gouv.fr", Application.fetch_env!(:transport, :contact_email)})
-    |> to(Application.fetch_env!(:transport, :bizdev_email))
+    # Uses the contact@ email address but method is kept if we need
+    # to route differently in the future.
+    |> to(Application.fetch_env!(:transport, :contact_email))
     |> reply_to(Application.fetch_env!(:transport, :contact_email))
   end
 

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -27,7 +27,7 @@ defmodule Transport.DataCheckerTest do
 
       assert_email_sent(
         from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-        to: "deploiement@transport.data.gouv.fr",
+        to: "contact@transport.data.gouv.fr",
         subject: "Jeux de données supprimés ou archivés",
         text_body: nil,
         html_body: ~r/Certains jeux de données disparus sont réapparus sur data.gouv.fr/
@@ -81,7 +81,7 @@ defmodule Transport.DataCheckerTest do
 
       assert_email_sent(
         from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-        to: "deploiement@transport.data.gouv.fr",
+        to: "contact@transport.data.gouv.fr",
         subject: "Jeux de données supprimés ou archivés",
         text_body: nil,
         html_body: ~r/Certains jeux de données ont disparus de data.gouv.fr/
@@ -108,7 +108,7 @@ defmodule Transport.DataCheckerTest do
 
       assert_email_sent(
         from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-        to: "deploiement@transport.data.gouv.fr",
+        to: "contact@transport.data.gouv.fr",
         subject: "Jeux de données supprimés ou archivés",
         text_body: nil,
         html_body: ~r/Certains jeux de données sont indiqués comme archivés/
@@ -239,7 +239,7 @@ defmodule Transport.DataCheckerTest do
 
       assert_email_sent(fn %Swoosh.Email{
                              from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                             to: [{"", "deploiement@transport.data.gouv.fr"}],
+                             to: [{"", "contact@transport.data.gouv.fr"}],
                              subject: "Jeux de données arrivant à expiration",
                              text_body: nil,
                              html_body: body

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -864,7 +864,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   defp assert_ok_email_sent do
     assert_email_sent(fn %Swoosh.Email{
                            from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                           to: [{"", "deploiement@transport.data.gouv.fr"}],
+                           to: [{"", "contact@transport.data.gouv.fr"}],
                            subject: "[OK] Rapport de consolidation de la BNLC",
                            html_body: html_body
                          } ->
@@ -878,7 +878,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   defp assert_ko_email_sent do
     assert_email_sent(fn %Swoosh.Email{
                            from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                           to: [{"", "deploiement@transport.data.gouv.fr"}],
+                           to: [{"", "contact@transport.data.gouv.fr"}],
                            subject: "[ERREUR] Rapport de consolidation de la BNLC",
                            html_body: html_body
                          } ->

--- a/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_climate_resilience_bill_not_lo_licence_job_test.exs
@@ -24,7 +24,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetsClimateResilienceBillNotLOLicenc
 
     assert_email_sent(
       from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-      to: "deploiement@transport.data.gouv.fr",
+      to: "contact@transport.data.gouv.fr",
       subject: "Jeux de données article 122 avec licence inappropriée",
       text_body: nil,
       html_body:

--- a/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/datasets_without_gtfs_rt_related_resources_notification_job_test.exs
@@ -58,7 +58,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNot
 
     assert_email_sent(fn %Swoosh.Email{
                            from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                           to: [{"", "deploiement@transport.data.gouv.fr"}],
+                           to: [{"", "contact@transport.data.gouv.fr"}],
                            reply_to: {"", "contact@transport.data.gouv.fr"},
                            subject: "Jeux de données GTFS-RT sans ressources liées",
                            text_body: nil,

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -237,7 +237,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
       assert_email_sent(fn %Swoosh.Email{
                              from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                             to: [{"", "deploiement@transport.data.gouv.fr"}],
+                             to: [{"", "contact@transport.data.gouv.fr"}],
                              subject: "Nouveaux jeux de données Freefloating à référencer - data.gouv.fr",
                              text_body: nil,
                              html_body: body
@@ -247,7 +247,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
       assert_email_sent(fn %Swoosh.Email{
                              from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                             to: [{"", "deploiement@transport.data.gouv.fr"}],
+                             to: [{"", "contact@transport.data.gouv.fr"}],
                              subject: "Nouveaux jeux de données Transport en commun à référencer - data.gouv.fr",
                              text_body: nil,
                              html_body: body
@@ -295,7 +295,7 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
 
     assert_email_sent(fn %Swoosh.Email{
                            from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-                           to: [{"", "deploiement@transport.data.gouv.fr"}],
+                           to: [{"", "contact@transport.data.gouv.fr"}],
                            subject: "Nouveaux jeux de données Transport en commun à référencer - data.gouv.fr",
                            text_body: nil,
                            html_body: body

--- a/config/config.exs
+++ b/config/config.exs
@@ -178,7 +178,6 @@ config :transport,
   nb_days_to_keep_validations: 60,
   join_our_slack_link: "https://join.slack.com/t/transportdatagouvfr/shared_invite/zt-2n1n92ye-sdGQ9SeMh5BkgseaIzV8kA",
   contact_email: "contact@transport.data.gouv.fr",
-  bizdev_email: "deploiement@transport.data.gouv.fr",
   tech_email: "tech@transport.data.gouv.fr",
   security_email: "contact@transport.data.gouv.fr",
   transport_tools_folder: Path.absname("transport-tools/")


### PR DESCRIPTION
Les bizdevs ont exprimé leur souhait d'avoir les e-mails de pilotage adressés à `contact@` et non `deploiement@`. Voir #4145 et #4159.

Cette PR change ceci.