### PR TITLE
Import des contact points depuis l'API de data.gouv.fr

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -15,7 +15,13 @@ defmodule DB.NotificationSubscription do
     # - `:user`: by the user using self-service tools
     # - `automation:<slug>`: created by the system, the slug adds more details about the source
     field(:source, Ecto.Enum,
-      values: [:admin, :user, :"automation:promote_producer_space", :"automation:migrate_from_reuser_to_producer"]
+      values: [
+        :admin,
+        :user,
+        :"automation:promote_producer_space",
+        :"automation:migrate_from_reuser_to_producer",
+        :"automation:import_contact_point"
+      ]
     )
 
     field(:role, Ecto.Enum, values: possible_roles())

--- a/apps/transport/lib/jobs/import_dataset_contact_points_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_contact_points_job.ex
@@ -1,0 +1,161 @@
+defmodule Transport.Jobs.ImportDatasetContactPointsJob do
+  @moduledoc """
+  Import dataset contact points coming from the data.gouv.fr's API.
+
+  Producers can specify a contact point for a dataset on their open data
+  platform or directly on data.gouv.fr.
+
+  We reuse this data to find or create a contact and subscribe this contact
+  to producer subscriptions for this dataset.
+
+  When a contact point was previously set and has been removed,
+  we delete old subscriptions.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+  require Logger
+
+  # The number of workers to run in parallel
+  @task_concurrency 5
+  # The notification subscription source when creating/deleting subscriptions
+  @notification_subscription_source "automation:import_contact_point"
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    dataset_datagouv_ids()
+    |> Task.async_stream(
+      &import_contact_point/1,
+      max_concurrency: @task_concurrency,
+      on_timeout: :kill_task,
+      timeout: 10_000
+    )
+    |> Stream.run()
+  end
+
+  def dataset_datagouv_ids do
+    DB.Dataset.base_query() |> select([dataset: d], d.datagouv_id) |> DB.Repo.all()
+  end
+
+  def import_contact_point(datagouv_id) do
+    dataset = DB.Repo.get_by!(DB.Dataset, datagouv_id: datagouv_id)
+
+    case Datagouvfr.Client.Datasets.get(datagouv_id) do
+      {:ok, %{"contact_point" => contact_point}} ->
+        update_contact_point(dataset, contact_point)
+
+      other ->
+        Logger.error("#{inspect(__MODULE__)} unexpected HTTP response for dataset##{datagouv_id}: #{inspect(other)}")
+    end
+  end
+
+  @doc """
+  iex> guess_identity("John DOE")
+  %{first_name: "John", last_name: "DOE", mailing_list_title: nil}
+  iex> guess_identity("DOE John")
+  %{first_name: "John", last_name: "DOE", mailing_list_title: nil}
+  iex> guess_identity("John Doe")
+  %{first_name: "John", last_name: "Doe", mailing_list_title: nil}
+  iex> guess_identity("Service géomatique open data")
+  %{first_name: nil, last_name: nil, mailing_list_title: "Service géomatique open data"}
+  iex> guess_identity("")
+  %{first_name: nil, last_name: nil, mailing_list_title: "Inconnu"}
+  """
+  @spec guess_identity(binary() | nil) :: %{
+          first_name: binary() | nil,
+          last_name: binary() | nil,
+          mailing_list_title: binary() | nil
+        }
+  def guess_identity(name) do
+    cond do
+      private_individual?(name) ->
+        guess_first_and_last_name(name) |> Map.put(:mailing_list_title, nil)
+
+      name not in ["", nil] ->
+        %{first_name: nil, last_name: nil, mailing_list_title: name}
+
+      true ->
+        %{first_name: nil, last_name: nil, mailing_list_title: "Inconnu"}
+    end
+  end
+
+  defp update_contact_point(%DB.Dataset{id: dataset_id}, nil = _contact_points) do
+    DB.NotificationSubscription.base_query()
+    |> where(
+      [notification_subscription: ns],
+      ns.dataset_id == ^dataset_id and ns.role == :producer and ns.source == ^@notification_subscription_source
+    )
+    |> DB.Repo.delete_all()
+  end
+
+  defp update_contact_point(%DB.Dataset{} = dataset, %{"email" => _, "name" => _} = contact_point) do
+    contact = find_or_create_contact(contact_point)
+    create_contact_point_subscriptions(dataset, contact)
+    delete_other_contact_points_subscriptions(dataset, contact)
+  end
+
+  defp create_contact_point_subscriptions(%DB.Dataset{id: dataset_id}, %DB.Contact{id: contact_id}) do
+    existing_reasons =
+      DB.NotificationSubscription.base_query()
+      |> where(
+        [notification_subscription: ns],
+        ns.dataset_id == ^dataset_id and ns.role == :producer and ns.contact_id == ^contact_id
+      )
+      |> select([notification_subscription: ns], ns.reason)
+      |> DB.Repo.all()
+      |> MapSet.new()
+
+    Transport.NotificationReason.subscribable_reasons_related_to_datasets(:producer)
+    |> MapSet.new()
+    |> MapSet.difference(existing_reasons)
+    |> Enum.each(fn reason ->
+      DB.NotificationSubscription.insert!(%{
+        role: :producer,
+        source: @notification_subscription_source,
+        reason: reason,
+        contact_id: contact_id,
+        dataset_id: dataset_id
+      })
+    end)
+  end
+
+  defp delete_other_contact_points_subscriptions(%DB.Dataset{id: dataset_id}, %DB.Contact{id: contact_id}) do
+    DB.NotificationSubscription.base_query()
+    |> where([notification_subscription: ns], ns.dataset_id == ^dataset_id and ns.contact_id != ^contact_id)
+    |> where([notification_subscription: ns], ns.role == :producer and ns.source == ^@notification_subscription_source)
+    |> DB.Repo.delete_all()
+  end
+
+  defp find_or_create_contact(%{"email" => email, "name" => name}) do
+    case DB.Repo.get_by(DB.Contact, email_hash: String.downcase(email)) do
+      %DB.Contact{} = contact ->
+        contact
+
+      nil ->
+        Map.merge(guess_identity(name), %{email: email})
+        |> DB.Contact.insert!()
+    end
+  end
+
+  defp private_individual?(nil), do: false
+
+  defp private_individual?(name) do
+    String.split(name, " ") |> Enum.count() == 2
+  end
+
+  defp guess_first_and_last_name(name) do
+    [first, second] = values = String.split(name, " ")
+
+    case Enum.map(values, &upcase?/1) do
+      [false, true] ->
+        %{first_name: first, last_name: second}
+
+      [true, false] ->
+        %{first_name: second, last_name: first}
+
+      _ ->
+        %{first_name: first, last_name: second}
+    end
+  end
+
+  defp upcase?(value), do: value == String.upcase(value)
+end

--- a/apps/transport/test/transport/jobs/import_dataset_contact_points_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_contact_points_job_test.exs
@@ -1,0 +1,201 @@
+defmodule Transport.Test.Transport.Jobs.ImportDatasetContactPointsJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Ecto.Query
+  import Mox
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.ImportDatasetContactPointsJob
+
+  doctest ImportDatasetContactPointsJob, import: true
+
+  @producer_reasons Transport.NotificationReason.subscribable_reasons_related_to_datasets(:producer)
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "import_contact_point" do
+    test "removes a previously existing contact point" do
+      other_producer = insert_contact()
+      contact_point = insert_contact()
+      %DB.Dataset{datagouv_id: datagouv_id} = dataset = insert(:dataset)
+
+      other_ns =
+        insert(:notification_subscription,
+          dataset_id: dataset.id,
+          contact_id: other_producer.id,
+          role: :producer,
+          reason: :expiration,
+          source: :user
+        )
+
+      contact_point_ns =
+        insert(:notification_subscription,
+          dataset_id: dataset.id,
+          contact_id: contact_point.id,
+          role: :producer,
+          reason: :expiration,
+          source: :"automation:import_contact_point"
+        )
+
+      Datagouvfr.Client.Datasets.Mock
+      |> expect(:get, 1, fn ^datagouv_id -> {:ok, %{"contact_point" => nil}} end)
+
+      ImportDatasetContactPointsJob.import_contact_point(datagouv_id)
+
+      # The contact point's subscription has been deleted and the other one
+      # is untouched.
+      assert [other_ns, nil] == DB.Repo.reload([other_ns, contact_point_ns])
+
+      # The contact point still exists
+      refute DB.Repo.reload(contact_point) |> is_nil()
+    end
+
+    test "removes contact point with nothing in the database" do
+      other_producer = insert_contact()
+      %DB.Dataset{datagouv_id: datagouv_id} = dataset = insert(:dataset)
+
+      other_ns =
+        insert(:notification_subscription,
+          dataset_id: dataset.id,
+          contact_id: other_producer.id,
+          role: :producer,
+          reason: :expiration,
+          source: :user
+        )
+
+      Datagouvfr.Client.Datasets.Mock
+      |> expect(:get, 1, fn ^datagouv_id -> {:ok, %{"contact_point" => nil}} end)
+
+      ImportDatasetContactPointsJob.import_contact_point(datagouv_id)
+
+      assert other_ns == DB.Repo.reload(other_ns)
+    end
+
+    test "creates producer subscriptions for an existing contact with a subscription" do
+      %DB.Contact{id: contact_id} = contact_point = insert_contact()
+      %DB.Dataset{datagouv_id: datagouv_id, id: dataset_id} = dataset = insert(:dataset)
+
+      insert(:notification_subscription,
+        dataset_id: dataset.id,
+        contact_id: contact_point.id,
+        role: :producer,
+        reason: :expiration,
+        source: :user
+      )
+
+      Datagouvfr.Client.Datasets.Mock
+      |> expect(:get, 1, fn ^datagouv_id ->
+        {:ok, %{"contact_point" => %{"email" => contact_point.email, "name" => DB.Contact.display_name(contact_point)}}}
+      end)
+
+      ImportDatasetContactPointsJob.import_contact_point(datagouv_id)
+
+      assert MapSet.new(@producer_reasons) ==
+               DB.NotificationSubscription.base_query()
+               |> where(
+                 [notification_subscription: ns],
+                 ns.dataset_id == ^dataset_id and ns.role == :producer and ns.contact_id == ^contact_id
+               )
+               |> select([notification_subscription: ns], ns.reason)
+               |> DB.Repo.all()
+               |> MapSet.new()
+
+      assert [
+               %{count: Enum.count(@producer_reasons) - 1, source: :"automation:import_contact_point"},
+               %{count: 1, source: :user}
+             ] ==
+               DB.NotificationSubscription.base_query()
+               |> where(
+                 [notification_subscription: ns],
+                 ns.dataset_id == ^dataset_id and ns.role == :producer and ns.contact_id == ^contact_id
+               )
+               |> select([notification_subscription: ns], %{source: ns.source, count: count(ns.id)})
+               |> group_by([notification_subscription: ns], ns.source)
+               |> DB.Repo.all()
+    end
+
+    test "creates a new contact and producer subscriptions, deletes the previous contact point subscriptions" do
+      %DB.Dataset{datagouv_id: datagouv_id} = dataset = insert(:dataset)
+      previous_contact_point = insert_contact()
+
+      previous_contact_point_ns =
+        insert(:notification_subscription,
+          dataset_id: dataset.id,
+          contact_id: previous_contact_point.id,
+          role: :producer,
+          reason: :expiration,
+          source: :"automation:import_contact_point"
+        )
+
+      email = "john@example.fr"
+
+      Datagouvfr.Client.Datasets.Mock
+      |> expect(:get, 1, fn ^datagouv_id ->
+        {:ok, %{"contact_point" => %{"email" => email, "name" => "John DOE"}}}
+      end)
+
+      ImportDatasetContactPointsJob.import_contact_point(datagouv_id)
+
+      %DB.Contact{first_name: "John", email: ^email} = contact = DB.Repo.get_by(DB.Contact, last_name: "DOE")
+
+      assert nil == DB.Repo.reload(previous_contact_point_ns)
+      assert MapSet.new(@producer_reasons) == subscribed_reasons(dataset, contact)
+    end
+  end
+
+  test "perform" do
+    %DB.Dataset{datagouv_id: d1_datagouv_id} = d1 = insert(:dataset)
+    %DB.Dataset{datagouv_id: d2_datagouv_id} = d2 = insert(:dataset)
+    contact_point = insert_contact()
+    email = "john@example.com"
+    insert(:dataset, is_active: false)
+    insert(:dataset, is_active: true, is_hidden: true)
+
+    assert MapSet.new([d1_datagouv_id, d2_datagouv_id]) ==
+             ImportDatasetContactPointsJob.dataset_datagouv_ids() |> MapSet.new()
+
+    setup_http_responses([
+      {d1_datagouv_id,
+       %{"contact_point" => %{"email" => contact_point.email, "name" => DB.Contact.display_name(contact_point)}}},
+      {d2_datagouv_id, %{"contact_point" => %{"email" => email, "name" => "DOE John"}}}
+    ])
+
+    assert :ok == perform_job(ImportDatasetContactPointsJob, %{})
+
+    %DB.Contact{email: ^email, first_name: "John"} = created_contact = DB.Repo.get_by(DB.Contact, last_name: "DOE")
+
+    assert MapSet.new(@producer_reasons) == subscribed_reasons(d1, contact_point)
+    assert MapSet.new([]) == subscribed_reasons(d2, contact_point)
+
+    assert MapSet.new(@producer_reasons) == subscribed_reasons(d2, created_contact)
+    assert MapSet.new([]) == subscribed_reasons(d1, created_contact)
+  end
+
+  defp subscribed_reasons(%DB.Dataset{id: dataset_id}, %DB.Contact{id: contact_id}) do
+    DB.NotificationSubscription.base_query()
+    |> where(
+      [notification_subscription: ns],
+      ns.dataset_id == ^dataset_id and ns.role == :producer and ns.contact_id == ^contact_id and
+        ns.source == :"automation:import_contact_point"
+    )
+    |> select([notification_subscription: ns], ns.reason)
+    |> DB.Repo.all()
+    |> MapSet.new()
+  end
+
+  defp setup_http_responses(data) when is_list(data) do
+    responses =
+      Enum.into(data, %{}, fn {datagouv_id, response} ->
+        {datagouv_id, response}
+      end)
+
+    # HTTP requests order is not important
+    Datagouvfr.Client.Datasets.Mock
+    |> expect(:get, Enum.count(responses), fn datagouv_id ->
+      {:ok, Map.fetch!(responses, datagouv_id)}
+    end)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -152,6 +152,7 @@ oban_prod_crontab = [
   # The job will make sure that it's executed only on the first Monday of these months
   {"15 8 * 3,6,11 1", Transport.Jobs.PeriodicReminderProducersNotificationJob},
   {"15 5 * * *", Transport.Jobs.ImportDatasetFollowersJob},
+  {"20 5 * * *", Transport.Jobs.ImportDatasetContactPointsJob},
   {"30 5 * * *", Transport.Jobs.ImportDatasetMonthlyMetricsJob},
   {"45 5 * * *", Transport.Jobs.ImportResourceMonthlyMetricsJob},
   {"0 8 * * *", Transport.Jobs.WarnUserInactivityJob},


### PR DESCRIPTION
Fixes #3897

Cette PR ajoute un job permettant de reprendre les informations des points de contact depuis l'API de data.gouv.fr. Les producteurs peuvent désigner une personne référente pour un JDD sur leur plateforme open data ou depuis data.gouv.fr.

L'objectif est de reprendre cette information et d'inscrire aux notifications producteur pour le JDD.

Ce job réalise ceci pour tout notre catalogue, gère l'ajout/la suppression/le passage d'un contact à un autre.