### PR TITLE
Resource#details: link to explore.data.gouv.fr

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -6,14 +6,31 @@
       </h2>
       <div class="panel">
         <div>
-          <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %><a href={
-            DB.Resource.download_url(@resource)
-          }>
-            <strong><%= @resource.title %></strong>
-          </a>
+          <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %>
+          <strong><%= @resource.title %></strong>
         </div>
         <div>
           <%= dgettext("resource", "Format:") %> <span class="label"><%= @resource.format %></span>
+        </div>
+        <div :if={not is_nil(@resource_history) and Map.has_key?(@resource_history.payload, "filesize")}>
+          <%= dgettext("resource", "Size:") %> <%= Map.fetch!(@resource_history.payload, "filesize")
+          |> Sizeable.filesize() %>
+        </div>
+        <div class="form__group pt-12">
+          <a class="button-outline small secondary" href={DB.Resource.download_url(@resource)}>
+            <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("resource", "Download") %>
+          </a>
+          <a
+            :if={eligible_for_explore?(@resource)}
+            class="button-outline small secondary ml-05-em"
+            href={explore_url(@resource)}
+            target="_blank"
+          >
+            <i class="icon fa fa-external-link-alt" aria-hidden="true"></i><%= dgettext(
+              "resource",
+              "Open with explore.data.gouv.fr"
+            ) %>
+          </a>
         </div>
         <div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
           <%= description(@resource) %>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -327,4 +327,15 @@ defmodule TransportWeb.ResourceView do
   def yes_no_icon(nil), do: ""
   def yes_no_icon(value) when value > 0, do: "✅"
   def yes_no_icon(_), do: "❌"
+
+  def eligible_for_explore?(%DB.Resource{format: format}) do
+    format in ["geojson", "csv", "ods", "xlsx", "xls"]
+  end
+
+  def explore_url(%DB.Resource{
+        datagouv_id: resource_datagouv_id,
+        dataset: %DB.Dataset{datagouv_id: dataset_datagouv_id}
+      }) do
+    "https://explore.data.gouv.fr/fr/datasets/#{dataset_datagouv_id}/#/resources/#{resource_datagouv_id}"
+  end
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -164,3 +164,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "The resource has been deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Open with explore.data.gouv.fr"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Size:"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -164,3 +164,15 @@ msgstr "Souhaitez-vous mettre à jour la ressource ou la supprimer définitiveme
 #, elixir-autogen, elixir-format
 msgid "The resource has been deleted"
 msgstr "La ressource a été supprimée"
+
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr "Télécharger"
+
+#, elixir-autogen, elixir-format
+msgid "Open with explore.data.gouv.fr"
+msgstr "Ouvrir dans explore.data.gouv.fr"
+
+#, elixir-autogen, elixir-format
+msgid "Size:"
+msgstr "Taille :"

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -164,3 +164,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "The resource has been deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Open with explore.data.gouv.fr"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Size:"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -855,6 +855,17 @@ defmodule TransportWeb.ResourceControllerTest do
     # We would just check that import_data works correctly, while this is already tested elsewhere.
   end
 
+  test "resource size and link to explore.data.gouv.fr are displayed", %{conn: conn} do
+    resource = insert(:resource, format: "csv", dataset: insert(:dataset, is_active: true))
+    insert(:resource_history, resource_id: resource.id, payload: %{"filesize" => "1024"})
+
+    html_response = conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
+    assert html_response =~ "Taille : 1 KB"
+
+    assert TransportWeb.ResourceView.eligible_for_explore?(resource)
+    assert html_response =~ "https://explore.data.gouv.fr"
+  end
+
   defp test_remote_download_error(%Plug.Conn{} = conn, mock_status_code) do
     resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "2")
     refute DB.Resource.can_direct_download?(resource)


### PR DESCRIPTION
Fixes #4162

- Taille du fichier
- Bouton de téléchargement
- Ajoute un lien vers explore.data.gouv.fr pour ressources pertinentes

![image](https://github.com/user-attachments/assets/4f3a47ab-f7c9-4549-93c5-94badf264d38)

