### PR TITLE
Configuration dev du validator GTFS

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -73,9 +73,7 @@ config :transport,
     on_demand_validation: "on-demand-validation-dev",
     gtfs_diff: "gtfs-diff-dev",
     logos: "logos-dev"
-  },
-  # by default, use the production validator. This can be overriden with dev.secret.exs
-  gtfs_validator_url: "https://validation.transport.data.gouv.fr"
+  }
 
 config :oauth2, Datagouvfr.Authentication,
   site: datagouvfr_site,


### PR DESCRIPTION
En voulant tester des refactorings du validateur GTFS faits dans le cadre de #4153, je me suis pris les pieds dans la config locale. Cette PR corrige ce petit _hiccup_. Il est possible que j'ai loupé quelque chose d'évident.

Il était inutile de redéfinir dans dev.exs, et cette redéfinition supprimait la lecture de l'environnement comme valeur par défaut, rendant ce dernier inopérent.

Il est toujours possible de surcharger dans dev.secret.exs si l'on juge cela nécessaire.