### PR TITLE
Unification des APIs des validateurs GTFS & NeTEx

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -106,7 +106,7 @@
             <%= if severity == "NoError" do %>
               <%= dgettext("page-dataset-details", "No error detected") %>
             <% else %>
-              <%= "#{count} #{String.downcase(GTFSTransport.severities(severity)[:text])}" %>
+              <%= "#{count} #{String.downcase(GTFSTransport.severity(severity)[:text])}" %>
             <% end %>
           </span>
         </a>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
@@ -3,7 +3,7 @@
     <%= for {severity, issues} <- @validation_summary do %>
       <%= if Map.get(@severities_count, severity, 0) > 0 do %>
         <div class="validation-issue">
-          <h4><%= @severities_count[severity] %> <%= severities(severity).text %></h4>
+          <h4><%= @severities_count[severity] %> <%= severity(severity).text %></h4>
           <ul>
             <%= for {key, issue} <- issues do %>
               <li>

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -74,8 +74,8 @@ defmodule Transport.Validators.GTFSTransport do
       "Information" => %{level: 3, text: dgettext("gtfs-transport-validator", "Informations")}
     }
 
-  @spec severities(binary()) :: %{level: integer(), text: binary()}
-  def severities(key), do: severities_map()[key]
+  @spec severity(binary()) :: %{level: integer(), text: binary()}
+  def severity(key), do: severities_map()[key]
 
   @doc """
   Get issues from validation results. For a specific issue type if specified, or the most severe.
@@ -99,7 +99,7 @@ defmodule Transport.Validators.GTFSTransport do
   def get_issues(%{} = validation_result, _) do
     validation_result
     |> Map.values()
-    |> Enum.sort_by(fn [%{"severity" => severity} | _] -> severities(severity).level end)
+    |> Enum.sort_by(fn [%{"severity" => severity} | _] -> severity(severity).level end)
     |> List.first([])
   end
 
@@ -128,7 +128,7 @@ defmodule Transport.Validators.GTFSTransport do
     end)
     |> Map.new()
     |> Enum.group_by(fn {_, issue} -> issue.severity end)
-    |> Enum.sort_by(fn {severity, _} -> severities(severity).level end)
+    |> Enum.sort_by(fn {severity, _} -> severity(severity).level end)
   end
 
   @doc """
@@ -167,7 +167,7 @@ defmodule Transport.Validators.GTFSTransport do
   def count_max_severity(%{} = validation_result) do
     validation_result
     |> count_by_severity()
-    |> Enum.min_by(fn {severity, _count} -> severity |> severities() |> Map.get(:level) end)
+    |> Enum.min_by(fn {severity, _count} -> severity |> severity() |> Map.get(:level) end)
   end
 
   @spec mine?(any) :: boolean()


### PR DESCRIPTION
Certains commentaires pris en compte sur le validateur NeTEx sont backportés sur le validateur GTFS pour plus tard pouvoir utiliser les deux un peu plus génériquement.

Motivé par #4153.