### PR TITLE
Meilleur affichage de la "couverture calendaire"

### DIFF
--- a/apps/transport/client/stylesheets/components/_resource-details.scss
+++ b/apps/transport/client/stylesheets/components/_resource-details.scss
@@ -14,7 +14,7 @@
 
 .networks-start-end {
   display: grid;
-  grid-template-columns: minmax(0, 200px) repeat(4, max-content);
+  grid-template-columns: max-content repeat(4, max-content);
   column-gap: 10px;
   row-gap: 3px;
   .outdated {


### PR DESCRIPTION
Lors de tests de non-régression du validateur GTFS j'ai remarqué que l'affichage des lignes pour la metadata "couverture calendaire" n'était pas assez généreux en largeur.

<details>
<summary>Avant :</summary>
<img src=https://github.com/user-attachments/assets/00873e9d-4f3d-4040-a1d9-fb25f4b0847e/>
</details>

<details>
<summary>Après :</summary>
<img src=https://github.com/user-attachments/assets/a90261b0-5fe0-46dd-9fd4-8fbc4f3972dd/>
</details>