### PR TITLE
DataChecker : adapte erreur vers Sentry

### DIFF
--- a/apps/transport/lib/transport/data_checker.ex
+++ b/apps/transport/lib/transport/data_checker.ex
@@ -86,24 +86,24 @@ defmodule Transport.DataChecker do
         {:archived, datetime}
 
       {:error, %HTTPoison.Error{} = error} ->
-        Sentry.capture_message(
-          "Unable to get Dataset status from data.gouv.fr",
-          extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
-        )
-
+        log_sentry_event(datagouv_id, error)
         :ignore
 
       {:error, reason} when reason in [:not_found, :gone] ->
         :inactive
 
       {:error, error} ->
-        Sentry.capture_message(
-          "Unable to get Dataset status from data.gouv.fr",
-          extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
-        )
-
+        log_sentry_event(datagouv_id, error)
         :ignore
     end
+  end
+
+  defp log_sentry_event(datagouv_id, error) do
+    Sentry.capture_message(
+      "Unable to get dataset status for Dataset##{datagouv_id} from data.gouv.fr",
+      fingerprint: ["#{__MODULE__}:dataset_status:error"],
+      extra: %{dataset_datagouv_id: datagouv_id, error_reason: inspect(error)}
+    )
   end
 
   def outdated_data do

--- a/config/config.exs
+++ b/config/config.exs
@@ -183,8 +183,19 @@ config :transport,
   transport_tools_folder: Path.absname("transport-tools/")
 
 # Disable sending events to Sentry by default.
+# Sentry events are only sent when `dsn` is not nil
+# https://hexdocs.pm/sentry/upgrade-10-x.html#stop-using-included_environments
 # Events are sent in production and staging, configured in `prod.exs`
-config :sentry, dsn: nil
+config :sentry,
+  dsn: nil,
+  environment_name: "SENTRY_ENV" |> System.get_env(to_string(config_env())) |> String.to_atom(),
+  enable_source_code_context: true,
+  # https://hexdocs.pm/sentry/Sentry.html#module-configuration
+  # > a list of paths to the root of your application's source code.
+  # > For umbrella apps, you should set this to all the application paths in your umbrella
+  # Caveat: https://github.com/getsentry/sentry-elixir/issues/638
+  root_source_code_paths: [File.cwd!() |> Path.join("apps")],
+  filter: Transport.Shared.SentryExceptionFilter
 
 # For now, never send session data (containing sensitive data in our case) nor params,
 # even if this means less useful information.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,18 +15,8 @@ config :transport,
 # Configure Sentry for production and staging.
 # Check out https://sentry.io/settings/transport-data-gouv-fr/projects/transport-site/install/elixir/
 config :sentry,
-  # Sentry events are only sent when `dsn` is not nil
-  # https://hexdocs.pm/sentry/upgrade-10-x.html#stop-using-included_environments
   dsn: System.get_env("SENTRY_DSN"),
-  csp_url: System.get_env("SENTRY_CSP_URL"),
-  environment_name: "SENTRY_ENV" |> System.get_env(to_string(config_env())) |> String.to_atom(),
-  enable_source_code_context: true,
-  # https://hexdocs.pm/sentry/Sentry.html#module-configuration
-  # > a list of paths to the root of your application's source code.
-  # > For umbrella apps, you should set this to all the application paths in your umbrella
-  # Caveat: https://github.com/getsentry/sentry-elixir/issues/638
-  root_source_code_paths: [File.cwd!() |> Path.join("apps")],
-  filter: Transport.Shared.SentryExceptionFilter
+  csp_url: System.get_env("SENTRY_CSP_URL")
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
Fixes #4178

## Symptome

Un warning est visible lors de l'exécution des tests, provenant de `Transport.DataChecker`

```
[warning] Event dropped due to being a duplicate of a previously-captured event.
```

## Pourquoi

Le warning est visible depuis peu, parce que est Sentry en test mode en `test` (commit https://github.com/etalab/transport-site/commit/344a4d0ddd3daa895de62719cb245ef063c1310c), avant c'était juste silencieux. Mais le warning est intéressant, il dit qu'avec la conf/le code actuel seul le premier event aurait été envoyé. Donc en cas d'erreur d'un appel sur data.gouv.fr on aurait eu 1 seul event comportant le dataset ID et pas les suivants. Le code d'envoi vers Sentry visé est là depuis de nombreux mois.

## Que faire

Il semble qu'il est souhaitable d'envoyer plusieurs événements vers Sentry afin de disposer des différents `datagouv_id` des jeux de données. Il faut donc faire en sorte que l'événement ne soit pas considéré comme un doublon par Sentry.

## Documentation de Sentry

Le code qui n'envoie pas un événement en cas de doublon dans le SDK Elixir Sentry est le suivant

https://github.com/getsentry/sentry-elixir/blob/b8e40d793a7d45f6d1a1965120ce3a586793ce69/lib/sentry/client.ex#L107-L119

`Sentry.Dedupe.insert` a le code suivant

https://github.com/getsentry/sentry-elixir/blob/b8e40d793a7d45f6d1a1965120ce3a586793ce69/lib/sentry/dedupe.ex#L18-L27

Le hash d'un événement est calculé de la façon suivante 

https://github.com/getsentry/sentry-elixir/blob/b8e40d793a7d45f6d1a1965120ce3a586793ce69/lib/sentry/event.ex#L479-L489

Il se repose sur l'exception, le message, le level et la fingerprint. Mais **pas** `extra`, qui comporte le `datagouv_id`.

[Fingerprint](https://docs.sentry.io/platforms/javascript/enriching-events/fingerprinting/) permet de grouper des événements.

> All events have a fingerprint. Events with the same fingerprint are grouped together into an issue.

## Décision

Avec ces éléments, je choisis de spécifier une fingerprint et de faire varier le message pour grouper les événements et ne pas être considéré comme un doublon.

## Correction

Le warning n'est plus visible dans l'exécution des tests après le changement effectué.