### PR TITLE
Correction affichage ressource GTFS

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -103,7 +103,8 @@ associated_netex = get_associated_netex(@related_files) %>
                 issues: @issues,
                 conn: @conn,
                 data_vis: @data_vis,
-                token: nil
+                token: nil,
+                validator: Transport.Validators.GTFSTransport
               ) %>
             </nav>
             <div class="main-pane">


### PR DESCRIPTION
La validation NeTEx a fait quelques changements cassants dans un template utilisé pour l'affichage des ressources. Je n'avais pas retesté ce cas (pourtant fort banal).

Fixes #4196.