### PR TITLE
GBFSMetadata : ajuste first_feed pour GBFS v3.0

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -175,8 +175,15 @@ defmodule Transport.Shared.GBFSMetadata do
     end
   end
 
-  def first_feed(%{"data" => data} = payload) do
-    (data["en"] || data["fr"] || data[payload |> languages() |> Enum.at(0)])["feeds"]
+  def first_feed(%{"data" => data, "version" => version} = payload) do
+    # From GBFS 1.1 until GBFS 2.3
+    if String.starts_with?(version, ["1.", "2."]) do
+      first_language = payload |> languages() |> Enum.at(0)
+      (data["en"] || data["fr"] || data[first_language])["feeds"]
+      # From GBFS 3.0 onwards
+    else
+      data["feeds"]
+    end
   end
 
   defp languages(%{"data" => data}) do

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -96,6 +96,33 @@ defmodule Transport.Shared.GBFSMetadataTest do
     end
   end
 
+  describe "feeds" do
+    test "3.0 feed" do
+      json =
+        Jason.decode!("""
+         {
+          "last_updated": "2023-07-17T13:34:13+02:00",
+          "ttl": 0,
+          "version": "3.0",
+          "data": {
+            "feeds": [
+              {
+                "name": "system_information",
+                "url": "https://www.example.com/gbfs/1/system_information"
+              },
+              {
+                "name": "station_information",
+                "url": "https://www.example.com/gbfs/1/station_information"
+              }
+            ]
+          }
+        }
+        """)
+
+      assert ["system_information", "station_information"] == feeds(json)
+    end
+  end
+
   defp setup_validation_result(summary \\ nil) do
     Shared.Validation.GBFSValidator.Mock
     |> expect(:validate, fn url ->

--- a/apps/transport/test/transport/gbfs_to_geojson_test.exs
+++ b/apps/transport/test/transport/gbfs_to_geojson_test.exs
@@ -200,7 +200,8 @@ defmodule Transport.GbfsToGeojsonTest do
         "fr" => %{
           "feeds" => feeds
         }
-      }
+      },
+      "version" => "2.3"
     }
     |> Jason.encode!()
   end


### PR DESCRIPTION
Fixes #4208

Ajuste la méthode `Transport.Shared.GBFSMetadata.first_feed/1` pour gérer la payload de `gbfs.json` à partir de la version 3.0 qui ne contient plus de `language`.