### PR TITLE
Transport.GbfsToGeojson : ajout availability

### DIFF
--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -172,7 +172,7 @@ function fillStations (stationsGeojson, bikesAvailable, docksAvailable) {
         pointToLayer: function (geoJsonPoint, latlng) {
             return L.circleMarker(latlng, { stroke: false, color: '#0066db', fillOpacity: 0.8 })
         },
-        onEachFeature: (feature, layer) => setGBFSStationStyle(feature, layer, 'num_bikes_available')
+        onEachFeature: (feature, layer) => setGBFSStationStyle(feature, layer, 'availability')
     }).addTo(bikesAvailable)
 
     L.geoJSON(stationsGeojson, {

--- a/apps/transport/lib/transport/gbfs_to_geojson.ex
+++ b/apps/transport/lib/transport/gbfs_to_geojson.ex
@@ -139,6 +139,7 @@ defmodule Transport.GbfsToGeojson do
           station_status
           |> Enum.find(fn s -> s["station_id"] == station_id end)
           |> Map.delete("station_id")
+          |> add_availability()
 
         put_in(s["properties"]["station_status"], status)
       end)
@@ -147,6 +148,11 @@ defmodule Transport.GbfsToGeojson do
       "type" => "FeatureCollection",
       "features" => features
     }
+  end
+
+  def add_availability(data) do
+    availability = data["num_vehicles_available"] || data["num_bikes_available"]
+    Map.put(data, "availability", availability)
   end
 
   @spec add_free_bike_status(map(), map()) :: map()

--- a/apps/transport/test/transport/gbfs_to_geojson_test.exs
+++ b/apps/transport/test/transport/gbfs_to_geojson_test.exs
@@ -56,7 +56,8 @@ defmodule Transport.GbfsToGeojsonTest do
                        "station_status" => %{
                          "num_bikes_available" => 0,
                          "num_docks_available" => 0,
-                         "a_field" => "coucou"
+                         "a_field" => "coucou",
+                         "availability" => 0
                        }
                      },
                      "type" => "Feature"
@@ -72,7 +73,8 @@ defmodule Transport.GbfsToGeojsonTest do
                        "station_status" => %{
                          "num_bikes_available" => 3,
                          "num_docks_available" => 12,
-                         "num_vehicles_available" => 3
+                         "num_vehicles_available" => 3,
+                         "availability" => 3
                        }
                      },
                      "type" => "Feature"


### PR DESCRIPTION
Fixes #4212

Ajoute un champ `availability` dans la conversion GBFS vers GeoJSON pour gérer le fait que les champs sont nommés différemment selon les versions. Utilise ensuite ce champ dans le code JS.