### PR TITLE
NewDatagouvDatasetsJob : corrige liste des schémas

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -49,7 +49,9 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
         "etalab/schema-amenagements-cyclables",
         "etalab/schema-stationnement-cyclable",
         "etalab/schema-stationnement",
-        "etalab/schema-comptage-mobilites"
+        "etalab/schema-comptage-mobilites-channel",
+        "etalab/schema-comptage-mobilites-measure",
+        "etalab/schema-comptage-mobilites-site"
       ],
       tags: MapSet.new(["cyclable", "parking", "stationnement", "velo", "vélo"]),
       formats: MapSet.new([])


### PR DESCRIPTION
Certains schémas spécifiés dans la catégorie "Vélo et stationnements" sont invalides. En réalité [c'est un data package](https://schema.data.gouv.fr/etalab/schema-comptage-mobilites/) qui contient 3 schémas, il faut donc spécifier les 3 schémas et non indiquer le nom du data package.

Il y a [du code défensif](https://github.com/etalab/transport-site/blob/5fef8b9af50c5e22c9981989843f5eb36ec41637/apps/transport/lib/jobs/new_datagouv_datasets_job.ex#L81-L91) qui détecte ça, une exception était levée sur Sentry.

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/5818985600/)