### PR TITLE
Uniform validation results display

### DIFF
--- a/apps/transport/client/stylesheets/components/_download_availability.scss
+++ b/apps/transport/client/stylesheets/components/_download_availability.scss
@@ -63,4 +63,14 @@
     color: rgb(199, 18, 18);
     filter: brightness(70%);
   }
+
+  + details {
+    > summary {
+      cursor: pointer;
+    }
+
+    > div {
+      margin-top: 5pt;
+    }
+  }
 }

--- a/apps/transport/lib/transport_web/templates/resource/_download_availability.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_download_availability.html.heex
@@ -17,6 +17,6 @@
   </div>
   <details class="pt-24">
     <summary><%= dgettext("page-dataset-details", "Learn more") %></summary>
-    <%= raw(dgettext("page-dataset-details", "availability-test-explanations")) %>
+    <div><%= raw(dgettext("page-dataset-details", "availability-test-explanations")) %></div>
   </details>
 </div>

--- a/apps/transport/lib/transport_web/templates/resource/_resource_description.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resource_description.html.heex
@@ -1,0 +1,36 @@
+<div>
+  <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %>
+  <strong><%= @resource.title %></strong>
+</div>
+<div>
+  <%= dgettext("resource", "Format:") %> <span class="label"><%= @resource.format %></span>
+</div>
+<div :if={not is_nil(@resource_history) and Map.has_key?(@resource_history.payload, "filesize")}>
+  <%= dgettext("resource", "Size:") %> <%= Map.fetch!(@resource_history.payload, "filesize")
+  |> Sizeable.filesize() %>
+</div>
+<div class="form__group pt-12">
+  <a class="button-outline small secondary" href={DB.Resource.download_url(@resource)}>
+    <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("resource", "Download") %>
+  </a>
+  <a
+    :if={eligible_for_explore?(@resource)}
+    class="button-outline small secondary ml-05-em"
+    href={explore_url(@resource)}
+    target="_blank"
+  >
+    <i class="icon fa fa-external-link-alt" aria-hidden="true"></i><%= dgettext(
+      "resource",
+      "Open with explore.data.gouv.fr"
+    ) %>
+  </a>
+</div>
+<div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
+  <%= description(@resource) %>
+</div>
+<p>
+  <%= dgettext("validations", "This resource file is part of the dataset") %> <%= link(
+    @resource.dataset.custom_title,
+    to: dataset_path(@conn, :details, @resource.dataset.slug)
+  ) %>.
+</p>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -5,42 +5,7 @@
         <%= dgettext("validations", "Resource details") %>
       </h2>
       <div class="panel">
-        <div>
-          <%= dgettext("validations", "File name") %><%= dgettext("helper", ":") %>
-          <strong><%= @resource.title %></strong>
-        </div>
-        <div>
-          <%= dgettext("resource", "Format:") %> <span class="label"><%= @resource.format %></span>
-        </div>
-        <div :if={not is_nil(@resource_history) and Map.has_key?(@resource_history.payload, "filesize")}>
-          <%= dgettext("resource", "Size:") %> <%= Map.fetch!(@resource_history.payload, "filesize")
-          |> Sizeable.filesize() %>
-        </div>
-        <div class="form__group pt-12">
-          <a class="button-outline small secondary" href={DB.Resource.download_url(@resource)}>
-            <i class="icon icon--download" aria-hidden="true"></i><%= dgettext("resource", "Download") %>
-          </a>
-          <a
-            :if={eligible_for_explore?(@resource)}
-            class="button-outline small secondary ml-05-em"
-            href={explore_url(@resource)}
-            target="_blank"
-          >
-            <i class="icon fa fa-external-link-alt" aria-hidden="true"></i><%= dgettext(
-              "resource",
-              "Open with explore.data.gouv.fr"
-            ) %>
-          </a>
-        </div>
-        <div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
-          <%= description(@resource) %>
-        </div>
-        <p>
-          <%= dgettext("validations", "This resource file is part of the dataset") %> <%= link(
-            @resource.dataset.custom_title,
-            to: dataset_path(@conn, :details, @resource.dataset.slug)
-          ) %>.
-        </p>
+        <%= render("_resource_description.html", conn: @conn, resource: @resource, resource_history: @resource_history) %>
       </div>
 
       <%= unless Enum.empty?(@resource.resources_related) do %>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -4,23 +4,11 @@ associated_netex = get_associated_netex(@related_files) %>
 <section>
   <div class="grey-background">
     <div class="container">
-      <h2 class="mt-48"><%= dgettext("validations", "Resource details") %></h2>
+      <h2 class="mt-48">
+        <%= dgettext("validations", "Resource details") %>
+      </h2>
       <div class="panel">
-        <p>
-          <%= dgettext("validations", "File name") %> :
-          <a href={DB.Resource.download_url(@resource)}>
-            <strong><%= @resource.title %></strong>
-          </a>
-        </p>
-        <div :if={should_display_description?(@resource)} class="panel mt-24" lang="fr">
-          <%= description(@resource) %>
-        </div>
-        <p>
-          <%= dgettext("validations", "This resource file is part of the dataset") %> <%= link(
-            @resource.dataset.custom_title,
-            to: dataset_path(@conn, :details, @resource.dataset.slug)
-          ) %>.
-        </p>
+        <%= render("_resource_description.html", conn: @conn, resource: @resource, resource_history: @resource_history) %>
         <%= render("_resources_details.html", conn: @conn, metadata: @metadata, modes: @modes) %>
         <%= if !is_nil(associated_geojson) or !is_nil(associated_netex) do %>
           <div id="other-formats">
@@ -49,6 +37,10 @@ associated_netex = get_associated_netex(@related_files) %>
         <% end %>
       </div>
 
+      <%= unless Enum.empty?(@resource.resources_related) do %>
+        <%= render("_related_resources.html", resource: @resource, conn: @conn) %>
+      <% end %>
+
       <h2 id="download-availability"><%= dgettext("page-dataset-details", "Download availability") %></h2>
       <%= render("_download_availability.html", uptime_per_day: @uptime_per_day, conn: @conn) %>
 
@@ -59,7 +51,8 @@ associated_netex = get_associated_netex(@related_files) %>
         <div class="panel no-padding">
           <div id="resource-geojson-info" class="p-24"></div>
           <div id="resource-geojson"></div>
-          <script src={static_path(@conn, "/js/mapgeojson.js")} />
+          <script src={static_path(@conn, "/js/mapgeojson.js")}>
+          </script>
           <script>
             document.addEventListener("DOMContentLoaded", function() {
               GTFSGeojsonMap(


### PR DESCRIPTION
En travaillant sur le validateur NeTEx j'ai remarqué une petite différence d'affichage entre les ressources GTFS et les autres ressources. Cette PR uniformise l'affiche (bouton de téléchargement) et extrait dans un sous-template ce qui est commun.

Avant :
![image](https://github.com/user-attachments/assets/a7a48bbd-5b31-41db-9fec-72335a70ebba)

Après :
![image](https://github.com/user-attachments/assets/da8b53f7-d5ee-404c-8602-4b638c40acca)

J'ai également changé le curseur au survol "En savoir plus" dans "Disponiblilité au téléchargement" et ajouté la marge quand le panneau de détail est déplié :

![image](https://github.com/user-attachments/assets/a16a12c7-37f2-4142-83d7-70145dcfdf07)

(Le screenshot ne peut illustrer le changement de curseur.)