### PR TITLE
Backoffice : ajout bouton pour consolider BNZFE

### DIFF
--- a/apps/transport/lib/jobs/consolidate_lez_job.ex
+++ b/apps/transport/lib/jobs/consolidate_lez_job.ex
@@ -45,8 +45,9 @@ defmodule Transport.Jobs.ConsolidateLEZsJob do
   }
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
+  def perform(%Oban.Job{id: job_id}) do
     consolidate() |> update_files()
+    Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
     :ok
   end
 

--- a/apps/transport/lib/transport_web/live/start_consolidate_job_view.ex
+++ b/apps/transport/lib/transport_web/live/start_consolidate_job_view.ex
@@ -1,4 +1,4 @@
-defmodule TransportWeb.Live.SendConsolidateBNLCView do
+defmodule TransportWeb.Live.SendConsolidateJobView do
   # Very similar to `TransportWeb.Live.SendNowOnNAPNotificationView`
   use Phoenix.LiveView
   @button_disabled [:dispatched, :sent]
@@ -13,7 +13,12 @@ defmodule TransportWeb.Live.SendConsolidateBNLCView do
 
   def mount(
         _params,
-        %{"button_texts" => button_texts, "button_default_class" => button_default_class, "job_args" => job_args},
+        %{
+          "button_texts" => button_texts,
+          "button_default_class" => button_default_class,
+          "job_module" => job_module,
+          "job_args" => job_args
+        },
         socket
       ) do
     socket =
@@ -21,6 +26,7 @@ defmodule TransportWeb.Live.SendConsolidateBNLCView do
       |> assign(
         button_texts: button_texts,
         button_default_class: button_default_class,
+        job_module: job_module,
         job_args: job_args
       )
       |> assign_step(:first)
@@ -33,9 +39,9 @@ defmodule TransportWeb.Live.SendConsolidateBNLCView do
     {:noreply, socket}
   end
 
-  def handle_info(:dispatch, %Phoenix.LiveView.Socket{assigns: %{job_args: job_args}} = socket) do
+  def handle_info(:dispatch, %Phoenix.LiveView.Socket{assigns: %{job_args: job_args, job_module: job_module}} = socket) do
     new_socket =
-      case job_args |> Transport.Jobs.ConsolidateBNLCJob.new() |> Oban.insert() do
+      case job_args |> job_module.new() |> Oban.insert() do
         {:ok, %Oban.Job{id: job_id}} ->
           send(self(), {:wait_for_completion, job_id})
           assign_step(socket, :dispatched)

--- a/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/index.html.heex
@@ -91,7 +91,7 @@
 
   <h2>Consolidation BNLC</h2>
   <div>
-    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView,
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateJobView,
       session: %{
         "button_texts" => %{
           sent: "Rapport disponible par e-mail",
@@ -99,12 +99,13 @@
           default: "🧪 Consolider à blanc"
         },
         "button_default_class" => "button",
+        "job_module" => Transport.Jobs.ConsolidateBNLCJob,
         "job_args" => %{}
       }
     ) %>
   </div>
   <div>
-    <%= live_render(@conn, TransportWeb.Live.SendConsolidateBNLCView,
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateJobView,
       session: %{
         "button_texts" => %{
           sent: "Fichier mis à jour et rapport envoyé",
@@ -112,7 +113,24 @@
           default: "📥 Consolider et remplacer sur data.gouv.fr"
         },
         "button_default_class" => "button warning-light",
+        "job_module" => Transport.Jobs.ConsolidateBNLCJob,
         "job_args" => %{"action" => "datagouv_update"}
+      }
+    ) %>
+  </div>
+
+  <h2>Consolidation ZFE</h2>
+  <div>
+    <%= live_render(@conn, TransportWeb.Live.SendConsolidateJobView,
+      session: %{
+        "button_texts" => %{
+          sent: "Fichiers mis à jour",
+          dispatched: "Consolidation en cours",
+          default: "📥 Consolider et remplacer sur data.gouv.fr"
+        },
+        "button_default_class" => "button warning-light",
+        "job_module" => Transport.Jobs.ConsolidateLEZsJob,
+        "job_args" => %{}
       }
     ) %>
   </div>


### PR DESCRIPTION
Fixes #4235

Permet de lancer une consolidation BNZFE depuis le backoffice. Reprend une LiveView existante qui permet de consolider la BNLC et la rend plus générique.