### PR TITLE
NeTEx : Meilleur affichage résumé des erreurs

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
@@ -3,7 +3,7 @@
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
     <% {severity, count} = NeTEx.count_max_severity(@validation.result) %>
     <a href={link}>
-      <span class={summary_class(%{severity: severity, count_errors: count})}>
+      <span class={summary_class(%{severity: String.capitalize(severity), count_errors: count})}>
         <%= if NeTEx.no_error?(severity) do %>
           <%= dgettext("page-dataset-details", "No error detected") %>
         <% else %>


### PR DESCRIPTION
Comment remarqué dans https://github.com/etalab/transport-site/pull/4227#issuecomment-2391242989, la classe CSS appliquée au résumé des validations interpole directement le niveau de validation maximal et malheureusement la sémantique diffère entre GTFS et NeTEx. Cette PR corrige ceci de façon assez superficielle, à défaut d'uniformiser les codes d'erreurs entre tous les validateurs.

Avant 
![image](https://github.com/user-attachments/assets/fb5b994f-8eb1-4a1d-a251-36e21999dfa5)

Après
![image](https://github.com/user-attachments/assets/9981319c-a3d6-46aa-9a7a-0a88226dc4d4)
