### PR TITLE
GBFSMetadata : extraction vehicle_types

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -219,6 +219,7 @@ defmodule Transport.Shared.GBFSMetadata do
         _ -> []
       end
     end
+  end
 
   @spec versions(map()) :: [binary()] | nil
   defp versions(%{"data" => _data} = payload) do

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -141,6 +141,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
           }
         })
       )
+
       json =
         Jason.decode!("""
          {
@@ -152,8 +153,6 @@ defmodule Transport.Shared.GBFSMetadataTest do
               {
                 "name": "vehicle_types",
                 "url": "#{vehicle_types_url}"
-                "name": "system_information",
-                "url": "#{system_information_url}"
               },
               {
                 "name": "station_information",
@@ -206,8 +205,6 @@ defmodule Transport.Shared.GBFSMetadataTest do
           "data": {
             "feeds": [
               {
-                "name": "vehicle_types",
-                "url": "#{vehicle_types_url}"
                 "name": "system_information",
                 "url": "#{system_information_url}"
               },


### PR DESCRIPTION
Fixes #4257

Ajoute des métadonnées sur le type de véhicules présents dans ce flux : vélos, trotinettes, voitures etc