### PR TITLE
Clarification du code custom Telemetry AppSignal Ecto

### DIFF
--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -50,7 +50,7 @@ defmodule Transport.Application do
     :ok = Transport.Jobs.ObanLogger.setup()
 
     :ok = Transport.Telemetry.setup()
-    :ok = Transport.EctoTelemetry.setup()
+    :ok = Transport.AppSignal.EctoTelemetry.setup()
 
     opts = [strategy: :one_for_one, name: Transport.Supervisor]
     Supervisor.start_link(children, opts)

--- a/apps/transport/lib/transport/appsignal_ecto_telemetry.ex
+++ b/apps/transport/lib/transport/appsignal_ecto_telemetry.ex
@@ -1,4 +1,4 @@
-defmodule Transport.EctoTelemetry do
+defmodule Transport.AppSignal.EctoTelemetry do
   require Logger
 
   @moduledoc """
@@ -42,7 +42,6 @@ defmodule Transport.EctoTelemetry do
     case measurements do
       %{queue_time: queue_time} ->
         Appsignal.add_distribution_value("ecto.queue_time", System.convert_time_unit(queue_time, :native, :millisecond))
-
       _ ->
         nil
     end
@@ -71,7 +70,7 @@ defmodule Transport.EctoTelemetry do
       "transport-appsignal-ecto",
       # NOTE: the first two params are I believe mapped to `DB.Repo`
       [:db, :repo, :query],
-      &Transport.EctoTelemetry.handle_event/4,
+      &Transport.AppSignal.EctoTelemetry.handle_event/4,
       nil
     )
   end

--- a/apps/transport/lib/transport/appsignal_ecto_telemetry.ex
+++ b/apps/transport/lib/transport/appsignal_ecto_telemetry.ex
@@ -42,6 +42,7 @@ defmodule Transport.AppSignal.EctoTelemetry do
     case measurements do
       %{queue_time: queue_time} ->
         Appsignal.add_distribution_value("ecto.queue_time", System.convert_time_unit(queue_time, :native, :millisecond))
+
       _ ->
         nil
     end

--- a/apps/transport/lib/transport/ecto_telemetry.ex
+++ b/apps/transport/lib/transport/ecto_telemetry.ex
@@ -12,7 +12,7 @@ defmodule Transport.EctoTelemetry do
   * https://github.com/appsignal/appsignal-elixir/issues/887 (which ensures calls are fast & mostly safe)
 
   A few notes extracted from the doc (with extra comments):
-  * `:idle_time` - the time the connection spent waiting before being checked out for the query. 
+  * `:idle_time` - the time the connection spent waiting before being checked out for the query.
                  the higher the better ; if this gets low (close to 0), the pool is over-used (not good).
   * `:queue_time` - the time spent waiting to check out a database connection.
                   the lower the better. if this gets too high, the pool is over-used (not good).

--- a/apps/transport/lib/transport/ecto_telemetry.ex
+++ b/apps/transport/lib/transport/ecto_telemetry.ex
@@ -65,7 +65,7 @@ defmodule Transport.EctoTelemetry do
   end
 
   def setup do
-    Logger.info("Setting up telemetry for AppSignal + Ecto")
+    Logger.info("Setting up telemetry for our custom AppSignal's Ecto integration")
 
     :telemetry.attach(
       "transport-ecto",

--- a/apps/transport/lib/transport/ecto_telemetry.ex
+++ b/apps/transport/lib/transport/ecto_telemetry.ex
@@ -68,7 +68,7 @@ defmodule Transport.EctoTelemetry do
     Logger.info("Setting up telemetry for our custom AppSignal's Ecto integration")
 
     :telemetry.attach(
-      "transport-ecto",
+      "transport-appsignal-ecto",
       # NOTE: the first two params are I believe mapped to `DB.Repo`
       [:db, :repo, :query],
       &Transport.EctoTelemetry.handle_event/4,


### PR DESCRIPTION
En lien avec:
- #4279

Et vu que c'était peu clair pour moi, je clarifie le code sur les points suivants:
- le handler ne sert en fait qu'à AppSignal (pour l'intégration Ecto) et non à "AppSignal + Ecto" 
- le module ne sert actuellement qu'à AppSignal, le côté dynamique du handler n'a pa été exploité à ce stade, donc je prends note de cet état de fait et je renomme le module pour que ça soit plus clair

Vu que le code correspondant n'est pas testé et pas simple à tester en pratique, j'ai testé en local à la main (dans `handle_event`) avec un `IO.inspect(measurements, IEx.inspect_opts())`, aucun souci détecté, ce qui veut dire que le handler est bien enregistré et fonctionne (point important car ceci n'est pas testé à ma connaissance actuellement).