### PR TITLE
Datasets expérimentaux

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -25,6 +25,7 @@ defmodule DB.Dataset do
   @licences_ouvertes ["fr-lo", "lov2"]
   @licence_mobilités_tag "licence-mobilités"
   @hidden_dataset_custom_tag_value "masqué"
+  @experimental_tag "experimental"
 
   typed_schema "dataset" do
     field(:datagouv_id, :string)
@@ -1125,4 +1126,9 @@ defmodule DB.Dataset do
   @spec full_logo(__MODULE__.t()) :: binary()
   def full_logo(%__MODULE__{full_logo: full_logo, custom_full_logo: custom_full_logo}),
     do: custom_full_logo || full_logo
+
+  def reject_experimental_datasets(queryable) do
+    queryable
+    |> where([d], @experimental_tag not in d.tags)
+  end
 end

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -1127,6 +1127,14 @@ defmodule DB.Dataset do
   def full_logo(%__MODULE__{full_logo: full_logo, custom_full_logo: custom_full_logo}),
     do: custom_full_logo || full_logo
 
+  @doc """
+  iex> experimental?(%DB.Dataset{custom_tags: ["experimental", "foo"]})
+  true
+  iex> experimental?(%DB.Dataset{custom_tags: ["foo"]})
+  false
+  """
+  def experimental?(%__MODULE__{} = dataset), do: has_custom_tag?(dataset, @experimental_tag)
+
   def reject_experimental_datasets(queryable) do
     queryable
     |> where([d], @experimental_tag not in d.tags)

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -79,6 +79,7 @@ defmodule TransportWeb.API.DatasetController do
   def by_id(%Plug.Conn{} = conn, %{"id" => datagouv_id}) do
     dataset =
       Dataset
+      |> Dataset.reject_experimental_datasets()
       |> preload([:resources, :aom, :region, :communes, :legal_owners_aom, :legal_owners_region])
       |> Repo.get_by(datagouv_id: datagouv_id)
 
@@ -95,6 +96,7 @@ defmodule TransportWeb.API.DatasetController do
   @spec geojson_by_id(Plug.Conn.t(), map) :: Plug.Conn.t()
   def geojson_by_id(%Plug.Conn{} = conn, %{"id" => id}) do
     Dataset
+    |> Dataset.reject_experimental_datasets()
     |> Repo.get_by(datagouv_id: id)
     |> Repo.preload([:aom, :region, :communes])
     |> case do
@@ -374,6 +376,7 @@ defmodule TransportWeb.API.DatasetController do
 
     %{}
     |> Dataset.list_datasets()
+    |> Dataset.reject_experimental_datasets()
     |> preload([:resources, :aom, :region, :communes, :legal_owners_aom, :legal_owners_region])
     |> Repo.all()
     |> Enum.map(fn dataset ->

--- a/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/custom_tags_live.ex
@@ -72,6 +72,10 @@ defmodule TransportWeb.CustomTagsLive do
       %{
         name: "authentification_requise",
         doc: "Indique sur la page du JDD qu'il est nécessaire de s'authentifier pour accéder aux données."
+      },
+      %{
+        name: "experimental",
+        doc: "Ajoute sur la page du JDD une bannière indiquant que le jeu est expérimental"
       }
     ]
   end

--- a/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
@@ -1,3 +1,9 @@
+<p :if={experimental?(@dataset)} class="notification warning mt-0">
+  ⚠️ <%= dgettext(
+    "page-dataset-details",
+    "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
+  ) %>
+</p>
 <p :if={seasonal_warning?(@dataset)} class="notification mt-0">
   ℹ️ <%= dgettext(
     "page-dataset-details",
@@ -8,11 +14,5 @@
   ℹ️ <%= dgettext(
     "page-dataset-details",
     "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
-  ) %>
-</p>
-<p :if={experimental?(@dataset)} class="notification mt-0">
-  ℹ️ <%= dgettext(
-    "page-dataset-details",
-    "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
   ) %>
 </p>

--- a/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_banner.html.heex
@@ -10,3 +10,9 @@
     "The producer requires authentication to access the data. Consequently, some features on transport.data.gouv.fr, such as data availability, validations, and metadata, are unavailable for this dataset. Please follow the producer's instructions to gain access to the data."
   ) %>
 </p>
+<p :if={experimental?(@dataset)} class="notification mt-0">
+  ℹ️ <%= dgettext(
+    "page-dataset-details",
+    "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
+  ) %>
+</p>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -8,6 +8,7 @@ defmodule TransportWeb.DatasetView do
   # ~H expects a variable named `assigns`, so wrapping the calls to `~H` inside
   # a helper function would be cleaner and more future-proof to avoid conflicts at some point.
   import Phoenix.Component, only: [sigil_H: 2, live_render: 3]
+  import DB.Dataset, only: [experimental?: 1]
   import DB.MultiValidation, only: [get_metadata_info: 2, get_metadata_info: 3]
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -717,3 +717,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Data under the responsibility of"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -717,3 +717,7 @@ msgstr "Le producteur requiert une authentification pour accéder aux données. 
 #, elixir-autogen, elixir-format
 msgid "Data under the responsibility of"
 msgstr "Données sous la responsabilité de"
+
+#, elixir-autogen, elixir-format
+msgid "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
+msgstr "Ce jeu de données non officiel est publié à titre expérimental. Veuillez à ne pas le réutiliser à des fins d'information voyageur."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -717,3 +717,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Data under the responsibility of"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This unofficial dataset is provided experimentally. Do not use it for travel information purpose."
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -679,7 +679,7 @@ defmodule TransportWeb.DatasetControllerTest do
            ] == content |> Floki.find("#quality-indicators table")
   end
 
-  describe "information banners are displayed" do
+  describe "information & warning banners are displayed" do
     test "a seasonal dataset", %{conn: conn} do
       dataset = insert(:dataset, is_active: true, custom_tags: ["saisonnier", "foo"])
       assert TransportWeb.DatasetView.seasonal_warning?(dataset)
@@ -700,6 +700,17 @@ defmodule TransportWeb.DatasetControllerTest do
         conn,
         dataset,
         "Le producteur requiert une authentification pour accéder aux données"
+      )
+    end
+
+    test "an experimental dataset", %{conn: conn} do
+      dataset = insert(:dataset, is_active: true, custom_tags: ["experimental", "foo"])
+      assert DB.Dataset.experimental?(dataset)
+
+      dataset_has_banner_with_text(
+        conn,
+        dataset,
+        "Ce jeu de données non officiel est publié à titre expérimental. Veuillez à ne pas le réutiliser à des fins d'information voyageur."
       )
     end
   end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/657289cb-4ada-4a8f-9846-c85880060bbc)

Voir #4275.

Je n'ai pas trouvé d'icone d'avertissement ; en attendant le caractère unicode fait office de substitut.