### PR TITLE
Mise à jour CSP pour Dailymotion

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -48,7 +48,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           frame-ancestors 'none';
           img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
-          frame-src https://www.dailymotion.com/;
+          frame-src https://*.dailymotion.com;
           style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
           report-uri #{Application.fetch_env!(:sentry, :csp_url)}
           """
@@ -62,7 +62,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
             frame-ancestors 'none';
             img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
-            frame-src https://www.dailymotion.com/;
+            frame-src https://*.dailymotion.com;
             style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
             report-uri #{Application.fetch_env!(:sentry, :csp_url)}
           """


### PR DESCRIPTION
Fixes #4282

Dailymotion semble avoir ajouté un domaine supplémentaire utilisé lors de la diffusion d'une vidéo, intégrée via une iframe.

L'erreur donnée est :

> Refused to frame 'https://geo.dailymotion.com/' because it violates the following Content Security Policy directive: "frame-src https://www.dailymotion.com/".

Je n'ai pas trouvé de recommendation claire de Dailymotion/d'autres personnes pour une CSP acceptable. La modification effectuée corrige le problème et permet l'affichage de l'iframe/la lecture en local.