### PR TITLE
Temporaire : désactivation validation NeTEx

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -12,8 +12,7 @@ defmodule TransportWeb.ResourceController do
                         Transport.Validators.GTFSRT,
                         Transport.Validators.GBFSValidator,
                         Transport.Validators.TableSchema,
-                        Transport.Validators.EXJSONSchema,
-                        Transport.Validators.NeTEx
+                        Transport.Validators.EXJSONSchema
                       ])
 
   def details(conn, %{"id" => id} = params) do

--- a/apps/transport/lib/validators/validator_selection.ex
+++ b/apps/transport/lib/validators/validator_selection.ex
@@ -33,7 +33,7 @@ defmodule Transport.ValidatorsSelection.Impl do
   def validators(%{format: "GTFS"}), do: [Validators.GTFSTransport]
   def validators(%{format: "gtfs-rt"}), do: [Validators.GTFSRT]
   def validators(%{format: "gbfs"}), do: [Validators.GBFSValidator]
-  def validators(%{format: "NeTEx"}), do: [Validators.NeTEx]
+  def validators(%{format: "NeTEx"}), do: []
 
   def validators(%{schema_name: schema_name}) when not is_nil(schema_name) do
     cond do

--- a/apps/transport/test/transport/validators/validator_selection_test.exs
+++ b/apps/transport/test/transport/validators/validator_selection_test.exs
@@ -22,9 +22,7 @@ defmodule Transport.ValidatorsSelectionTest do
 
       resource_history = insert(:resource_history, payload: %{"format" => "NeTEx"})
 
-      assert ValidatorsSelection.validators(resource_history) == [
-               Transport.Validators.NeTEx
-             ]
+      assert ValidatorsSelection.validators(resource_history) == []
     end
 
     test "for a ResourceHistory with a schema" do

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -445,53 +445,53 @@ defmodule TransportWeb.ResourceControllerTest do
            |> html_response(200) =~ "couverture calendaire par réseau"
   end
 
-  test "NeTEx validation is shown", %{conn: conn} do
-    %{id: dataset_id} = insert(:dataset)
-
-    %{id: resource_id} =
-      insert(:resource, %{
-        dataset_id: dataset_id,
-        format: "NeTEx",
-        url: "https://example.com/file"
-      })
-
-    conn1 = conn |> get(resource_path(conn, :details, resource_id))
-    assert conn1 |> html_response(200) =~ "Pas de validation disponible"
-
-    %{id: resource_history_id} =
-      insert(:resource_history, %{
-        resource_id: resource_id,
-        payload: %{"permanent_url" => permanent_url = "https://example.com/#{Ecto.UUID.generate()}"}
-      })
-
-    insert(:multi_validation, %{
-      resource_history_id: resource_history_id,
-      validator: Transport.Validators.NeTEx.validator_name(),
-      result: %{
-        "xsd-1871" => [
-          %{
-            "code" => "xsd-1871",
-            "message" =>
-              "Element '{http://www.netex.org.uk/netex}OppositeDIrectionRef': This element is not expected. Expected is ( {http://www.netex.org.uk/netex}OppositeDirectionRef ).",
-            "criticity" => "error"
-          }
-        ]
-      },
-      max_error: "error",
-      metadata: %DB.ResourceMetadata{
-        metadata: %{"elapsed_seconds" => 42},
-        modes: [],
-        features: []
-      },
-      validation_timestamp: ~U[2022-10-28 14:12:29.041243Z]
-    })
-
-    content = conn |> get(resource_path(conn, :details, resource_id)) |> html_response(200)
-    assert content =~ "Rapport de validation"
-
-    assert content =~
-             ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le fichier NeTEx en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
-  end
+  # test "NeTEx validation is shown", %{conn: conn} do
+  #   %{id: dataset_id} = insert(:dataset)
+  #
+  #   %{id: resource_id} =
+  #     insert(:resource, %{
+  #       dataset_id: dataset_id,
+  #       format: "NeTEx",
+  #       url: "https://example.com/file"
+  #     })
+  #
+  #   conn1 = conn |> get(resource_path(conn, :details, resource_id))
+  #   assert conn1 |> html_response(200) =~ "Pas de validation disponible"
+  #
+  #   %{id: resource_history_id} =
+  #     insert(:resource_history, %{
+  #       resource_id: resource_id,
+  #       payload: %{"permanent_url" => permanent_url = "https://example.com/#{Ecto.UUID.generate()}"}
+  #     })
+  #
+  #   insert(:multi_validation, %{
+  #     resource_history_id: resource_history_id,
+  #     validator: Transport.Validators.NeTEx.validator_name(),
+  #     result: %{
+  #       "xsd-1871" => [
+  #         %{
+  #           "code" => "xsd-1871",
+  #           "message" =>
+  #             "Element '{http://www.netex.org.uk/netex}OppositeDIrectionRef': This element is not expected. Expected is ( {http://www.netex.org.uk/netex}OppositeDirectionRef ).",
+  #           "criticity" => "error"
+  #         }
+  #       ]
+  #     },
+  #     max_error: "error",
+  #     metadata: %DB.ResourceMetadata{
+  #       metadata: %{"elapsed_seconds" => 42},
+  #       modes: [],
+  #       features: []
+  #     },
+  #     validation_timestamp: ~U[2022-10-28 14:12:29.041243Z]
+  #   })
+  #
+  #   content = conn |> get(resource_path(conn, :details, resource_id)) |> html_response(200)
+  #   assert content =~ "Rapport de validation"
+  #
+  #   assert content =~
+  #            ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le fichier NeTEx en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
+  # end
 
   test "GTFS-RT validation is shown", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset)

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -490,7 +490,8 @@ defmodule TransportWeb.ResourceControllerTest do
   #   assert content =~ "Rapport de validation"
   #
   #   assert content =~
-  #            ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le fichier NeTEx en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
+  #            ~s{Validation effectuée en utilisant <a href="#{permanent_url}">le
+  #            fichier NeTEx en vigueur</a> le 28/10/2022 à 16h12 Europe/Paris}
   # end
 
   test "GTFS-RT validation is shown", %{conn: conn} do


### PR DESCRIPTION
Actuellement le job est bloquant et sature la queue des validations, bloquant tout le reste et n'utilisant pas la pleine capacité d'enRoute.

Un meilleur fix arrivera dans un second temps.