### PR TITLE
Gère validation à nil pour flux GBFS

### DIFF
--- a/apps/shared/lib/validation/gbfs_validator.ex
+++ b/apps/shared/lib/validation/gbfs_validator.ex
@@ -47,7 +47,8 @@ defmodule Shared.Validation.GBFSValidator do
 
     def validate(url) do
       with {:ok, %{status_code: 200, body: response}} <- call_api(url),
-           {:ok, json} <- Jason.decode(response) do
+           {:ok, json} <- Jason.decode(response),
+           {:has_errors_count, true} <- {:has_errors_count, is_integer(json["summary"]["errorsCount"])} do
         {:ok,
          %Summary{
            has_errors: json["summary"]["hasErrors"],

--- a/apps/transport/lib/transport_web/templates/resource/_errors_warnings_count.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_errors_warnings_count.html.heex
@@ -1,4 +1,4 @@
-<p>
+<p :if={!is_nil(@nb_errors)}>
   <b>
     <%= if @nb_errors + @nb_warnings == 0 do %>
       <span class="icon--validation">✅</span><%= dgettext("validations", "No error detected") %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -285,6 +285,8 @@ defmodule TransportWeb.DatasetView do
       when is_integer(errors_count) and errors_count >= 0,
       do: errors_count
 
+  def errors_count(%DB.MultiValidation{}), do: nil
+
   def availability_number_days, do: 30
   def max_nb_history_resources, do: 25
   def days_notifications_sent, do: 90

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -401,6 +401,23 @@ defmodule TransportWeb.DatasetControllerTest do
     assert conn |> html_response(200) =~ "1 erreur"
   end
 
+  test "GBFS with a nil validation", %{conn: conn} do
+    dataset = insert(:dataset)
+    resource = insert(:resource, %{dataset_id: dataset.id, format: "gbfs", url: "url"})
+    %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource.id})
+
+    insert(:multi_validation, %{
+      resource_history_id: resource_history_id,
+      validator: Transport.Validators.GBFSValidator.validator_name(),
+      result: nil,
+      metadata: nil
+    })
+
+    mock_empty_history_resources()
+
+    assert conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
+  end
+
   test "show NeTEx number of errors", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset, %{slug: slug = "dataset-slug", aom: build(:aom)})
 

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -104,6 +104,22 @@ defmodule TransportWeb.ResourceControllerTest do
     assert conn |> html_response(200) =~ "1 erreur"
   end
 
+  test "GBFS resource with nil validation sends back 200", %{conn: conn} do
+    resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "3")
+    assert DB.Resource.gbfs?(resource)
+
+    insert(:multi_validation, %{
+      resource_history: insert(:resource_history, %{resource_id: resource.id}),
+      validator: Transport.Validators.GBFSValidator.validator_name(),
+      result: nil,
+      metadata: %DB.ResourceMetadata{metadata: %{}}
+    })
+
+    Transport.Shared.Schemas.Mock |> expect(:transport_schemas, fn -> %{} end)
+
+    assert conn |> get(resource_path(conn, :details, resource.id)) |> html_response(200)
+  end
+
   test "resource has its description displayed", %{conn: conn} do
     resource = DB.Resource |> DB.Repo.get_by(datagouv_id: "1")
 


### PR DESCRIPTION
Fixes #4296

- Ne stocke pas une validation complète quand le validateur GBFS renvoie un rapport avec les différents champs à `nil`
- Vérifie que les pages `dataset#details` et `resource#details` chargent correctement quand la validation GBFS est `nil`