### PR TITLE
Calcul de statistiques pour les flux GBFS

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -99,7 +99,7 @@ defmodule Transport.Shared.GBFSMetadata do
     if is_nil(feed_name) do
       feed_ttl(payload["ttl"])
     else
-      payload |> first_feed() |> feed_url_by_name(feed_name) |> feed_ttl()
+      payload |> feed_url_by_name(feed_name) |> feed_ttl()
     end
   end
 
@@ -177,7 +177,7 @@ defmodule Transport.Shared.GBFSMetadata do
   end
 
   def stations_statistics(%{"data" => _data} = payload) do
-    feed_url = payload |> first_feed() |> feed_url_by_name(:station_status)
+    feed_url = feed_url_by_name(payload, :station_status)
 
     with {:feed_exists, true} <- {:feed_exists, not is_nil(feed_url)},
          {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
@@ -205,7 +205,7 @@ defmodule Transport.Shared.GBFSMetadata do
   end
 
   def vehicle_statistics(%{"data" => _data} = payload) do
-    feed_url = payload |> first_feed() |> feed_url_by_name(:vehicle_status)
+    feed_url = feed_url_by_name(payload, :vehicle_status)
 
     with {:feed_exists, true} <- {:feed_exists, not is_nil(feed_url)},
          {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
@@ -237,7 +237,7 @@ defmodule Transport.Shared.GBFSMetadata do
   defp vehicles_available(%{"num_bikes_available" => num_bikes_available}), do: num_bikes_available
 
   def system_details(%{"data" => _data} = payload) do
-    feed_url = payload |> first_feed() |> feed_url_by_name(:system_information)
+    feed_url = feed_url_by_name(payload, :system_information)
 
     if not is_nil(feed_url) do
       with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
@@ -276,17 +276,8 @@ defmodule Transport.Shared.GBFSMetadata do
 
   defp localized_string?(_), do: false
 
-  def first_feed(%{"data" => data} = payload) do
-    if before_v3?(payload) do
-      first_language = payload |> languages() |> Enum.at(0)
-      (data["en"] || data["fr"] || data[first_language])["feeds"]
-    else
-      data["feeds"]
-    end
-  end
-
   def vehicle_types(%{"data" => _data} = payload) do
-    feed_url = payload |> first_feed() |> feed_url_by_name(:vehicle_types)
+    feed_url = feed_url_by_name(payload, :vehicle_types)
 
     if is_nil(feed_url) do
       # https://gbfs.org/specification/reference/#vehicle_typesjson
@@ -306,7 +297,7 @@ defmodule Transport.Shared.GBFSMetadata do
     if before_v3?(payload) do
       Map.keys(data)
     else
-      feed_url = payload |> first_feed() |> feed_url_by_name(:system_information)
+      feed_url = feed_url_by_name(payload, :system_information)
 
       with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
            {:ok, json} <- Jason.decode(body) do
@@ -319,7 +310,7 @@ defmodule Transport.Shared.GBFSMetadata do
 
   @spec versions(map()) :: [binary()] | nil
   def versions(%{"data" => _data} = payload) do
-    versions_url = payload |> first_feed() |> feed_url_by_name(:gbfs_versions)
+    versions_url = feed_url_by_name(payload, :gbfs_versions)
 
     if is_nil(versions_url) do
       [Map.get(payload, "version", "1.0")]
@@ -333,9 +324,24 @@ defmodule Transport.Shared.GBFSMetadata do
     end
   end
 
-  @spec feed_url_by_name(list(), feed_name()) :: binary() | nil
-  def feed_url_by_name(feeds, name) do
-    Enum.find(feeds, fn map -> feed_is_named?(map, name) end)["url"]
+  @doc """
+  Finds the main list of sub-feeds from a `gbfs.json`.
+
+  Before v3 the order is: English first, then French otherwise the first language.
+  As-of v3 there is only a single list of feeds.
+  """
+  def main_feeds(%{"data" => data} = payload) do
+    if before_v3?(payload) do
+      first_language = payload |> languages() |> Enum.at(0)
+      (data["en"] || data["fr"] || data[first_language])["feeds"]
+    else
+      data["feeds"]
+    end
+  end
+
+  @spec feed_url_by_name(map(), feed_name()) :: binary() | nil
+  def feed_url_by_name(%{"data" => _} = payload, name) do
+    (payload |> main_feeds() |> Enum.find(&feed_is_named?(&1, name)))["url"]
   end
 
   @spec feed_is_named?(map(), feed_name()) :: boolean()
@@ -365,7 +371,7 @@ defmodule Transport.Shared.GBFSMetadata do
   def feeds(%{"data" => _data} = payload) do
     # Remove potential ".json" at the end of feed names as people
     # often make this mistake
-    payload |> first_feed() |> Enum.map(fn feed -> String.replace(feed["name"], ".json", "") end)
+    payload |> main_feeds() |> Enum.map(fn feed -> String.replace(feed["name"], ".json", "") end)
   end
 
   @doc """

--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -56,6 +56,7 @@ defmodule Transport.Shared.GBFSMetadata do
       vehicle_types: vehicle_types(json),
       types: types(json),
       ttl: ttl(json),
+      stats: stats(json),
       feed_timestamp_delay: feed_timestamp_delay
     }
   rescue
@@ -173,6 +174,72 @@ defmodule Transport.Shared.GBFSMetadata do
       nil -> nil
     end
   end
+
+  def stats(%{"data" => _data} = payload) do
+    stations_statistics(payload)
+    |> Map.merge(vehicle_statistics(payload))
+    |> Map.merge(%{version: 1})
+  end
+
+  def stations_statistics(%{"data" => _data} = payload) do
+    feed_url = payload |> first_feed() |> feed_url_by_name(:station_status)
+
+    with {:feed_exists, true} <- {:feed_exists, not is_nil(feed_url)},
+         {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
+         {:ok, json} <- Jason.decode(body) do
+      stations = json["data"]["stations"]
+
+      %{
+        nb_stations: Enum.count(stations),
+        nb_installed_stations: Enum.count(stations, & &1["is_installed"]),
+        nb_renting_stations: Enum.count(stations, & &1["is_renting"]),
+        nb_returning_stations: Enum.count(stations, & &1["is_returning"]),
+        nb_docks_available: stations |> Enum.map(& &1["num_docks_available"]) |> non_nil_sum(),
+        nb_docks_disabled: stations |> Enum.map(& &1["num_docks_disabled"]) |> non_nil_sum(),
+        nb_vehicles_available_stations: stations |> Enum.map(&vehicles_available/1) |> non_nil_sum(),
+        nb_vehicles_disabled_stations: stations |> Enum.map(& &1["num_vehicles_disabled"]) |> non_nil_sum()
+      }
+    else
+      {:feed_exists, false} ->
+        %{}
+
+      e ->
+        Logger.error("Cannot get GBFS station_status details: #{inspect(e)}")
+        %{}
+    end
+  end
+
+  def vehicle_statistics(%{"data" => _data} = payload) do
+    feed_url = payload |> first_feed() |> feed_url_by_name(:vehicle_status)
+
+    with {:feed_exists, true} <- {:feed_exists, not is_nil(feed_url)},
+         {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
+         {:ok, json} <- Jason.decode(body) do
+      vehicles = json["data"]["vehicles"] || json["data"]["bikes"]
+      nb_vehicles = Enum.count(vehicles)
+      nb_docked_vehicles = Enum.count(vehicles, &Map.has_key?(&1, "station_id"))
+
+      %{
+        nb_vehicles: nb_vehicles,
+        nb_disabled_vehicles: Enum.count(vehicles, & &1["is_disabled"]),
+        nb_reserved_vehicles: Enum.count(vehicles, & &1["is_reserved"]),
+        nb_docked_vehicles: nb_docked_vehicles,
+        nb_freefloating_vehicles: nb_vehicles - nb_docked_vehicles
+      }
+    else
+      {:feed_exists, false} ->
+        %{}
+
+      e ->
+        Logger.error("Cannot get GBFS vehicle_status details: #{inspect(e)}")
+        %{}
+    end
+  end
+
+  # As of 3.0
+  defp vehicles_available(%{"num_vehicles_available" => num_vehicles_available}), do: num_vehicles_available
+  # Before 3.0
+  defp vehicles_available(%{"num_bikes_available" => num_bikes_available}), do: num_bikes_available
 
   def system_details(%{"data" => _data} = payload) do
     feed_url = payload |> first_feed() |> feed_url_by_name(:system_information)
@@ -304,6 +371,18 @@ defmodule Transport.Shared.GBFSMetadata do
     # Remove potential ".json" at the end of feed names as people
     # often make this mistake
     payload |> first_feed() |> Enum.map(fn feed -> String.replace(feed["name"], ".json", "") end)
+  end
+
+  @doc """
+  iex> non_nil_sum([1, 3])
+  4
+  iex> non_nil_sum([1, nil])
+  1
+  iex> non_nil_sum([nil])
+  0
+  """
+  def non_nil_sum(values) do
+    values |> Enum.reject(&is_nil/1) |> Enum.sum()
   end
 
   defp before_v3?(%{"version" => version}), do: String.starts_with?(version, ["1.", "2."])

--- a/apps/shared/test/fixtures/gbfs/free_bike_status.2.2.json
+++ b/apps/shared/test/fixtures/gbfs/free_bike_status.2.2.json
@@ -1,0 +1,28 @@
+{
+  "last_updated":1609866247,
+  "ttl":0,
+  "version":"2.2",
+  "data":{
+    "bikes":[
+      {
+        "bike_id":"ghi789",
+        "last_reported":1609866109,
+        "lat":12.34,
+        "lon":56.78,
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"abc123"
+      },
+      {
+        "bike_id":"jkl012",
+        "last_reported":1609866204,
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"def456",
+        "current_range_meters":6543,
+        "station_id":"86",
+        "pricing_plan_id":"plan3"
+      }
+    ]
+  }
+}

--- a/apps/shared/test/fixtures/gbfs/gbfs.2.2.json
+++ b/apps/shared/test/fixtures/gbfs/gbfs.2.2.json
@@ -1,0 +1,19 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "en": {
+      "feeds": [
+        {
+          "name": "station_status",
+          "url": "https://example.com/gbfs/station_status"
+        },
+        {
+          "name": "free_bike_status",
+          "url": "https://example.com/gbfs/free_bike_status"
+        }
+      ]
+    }
+  }
+}

--- a/apps/shared/test/fixtures/gbfs/gbfs.3.0.json
+++ b/apps/shared/test/fixtures/gbfs/gbfs.3.0.json
@@ -1,0 +1,17 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "feeds": [
+      {
+        "name": "station_status",
+        "url": "https://example.com/gbfs/station_status"
+      },
+      {
+        "name": "vehicle_status",
+        "url": "https://example.com/gbfs/vehicle_status"
+      }
+    ]
+  }
+}

--- a/apps/shared/test/fixtures/gbfs/station_status.2.2.json
+++ b/apps/shared/test/fixtures/gbfs/station_status.2.2.json
@@ -1,0 +1,55 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "station 1",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1609866125,
+        "num_docks_available": 3,
+        "vehicle_docks_available": [{
+          "vehicle_type_ids": ["abc123"],
+          "count": 2
+        }, {
+          "vehicle_type_ids": ["def456"],
+          "count": 1
+        }],
+        "num_bikes_available": 1,
+        "vehicle_types_available": [{
+          "vehicle_type_id": "abc123",
+          "count": 1
+        }, {
+          "vehicle_type_id": "def456",
+          "count": 0
+        }]
+      }, {
+        "station_id": "station 2",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": 1609866106,
+        "num_docks_available": 8,
+        "num_docks_disabled": 1,
+        "vehicle_docks_available": [{
+          "vehicle_type_ids": ["abc123"],
+          "count": 6
+        }, {
+          "vehicle_type_ids": ["def456"],
+          "count": 2
+        }],
+        "num_bikes_available": 6,
+        "vehicle_types_available": [{
+          "vehicle_type_id": "abc123",
+          "count": 2
+        }, {
+          "vehicle_type_id": "def456",
+          "count": 4
+        }]
+      }
+    ]
+  }
+}

--- a/apps/shared/test/fixtures/gbfs/station_status.3.0.json
+++ b/apps/shared/test/fixtures/gbfs/station_status.3.0.json
@@ -1,0 +1,71 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "stations": [
+      {
+        "station_id": "station1",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "num_docks_available": 3,
+        "num_docks_disabled" : 1,
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123", "def456" ],
+            "count": 2
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 1
+          }
+        ],
+        "num_vehicles_available": 1,
+        "num_vehicles_disabled": 2,
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 1
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 0
+          }
+        ]
+      },
+      {
+        "station_id": "station2",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "num_docks_available": 8,
+        "num_docks_disabled" : 1,
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123" ],
+            "count": 6
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 2
+          }
+        ],
+        "num_vehicles_available": 6,
+        "num_vehicles_disabled": 1,
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 2
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 4
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/shared/test/fixtures/gbfs/vehicle_status.3.0.json
+++ b/apps/shared/test/fixtures/gbfs/vehicle_status.3.0.json
@@ -1,0 +1,32 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl":0,
+  "version":"3.0",
+  "data":{
+    "vehicles":[
+      {
+        "vehicle_id":"973a5c94-c288-4a2b-afa6-de8aeb6ae2e5",
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "lat":12.345678,
+        "lon":56.789012,
+        "is_reserved":false,
+        "is_disabled":true,
+        "vehicle_type_id":"abc123",
+        "rental_uris": {
+          "android": "https://www.example.com/app?vehicle_id=973a5c94-c288-4a2b-afa6-de8aeb6ae2e5&platform=android&",
+          "ios": "https://www.example.com/app?vehicle_id=973a5c94-c288-4a2b-afa6-de8aeb6ae2e5&platform=ios"
+        }
+      },
+      {
+        "vehicle_id":"987fd100-b822-4347-86a4-b3eef8ca8b53",
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "is_reserved":true,
+        "is_disabled":false,
+        "vehicle_type_id":"def456",
+        "current_range_meters":6543.0,
+        "station_id":"86",
+        "pricing_plan_id":"plan3"
+      }
+    ]
+  }
+}

--- a/apps/shared/test/gbfs_metadata_test.exs
+++ b/apps/shared/test/gbfs_metadata_test.exs
@@ -573,7 +573,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
 
       assert has_feed?(payload, :vehicle_status)
 
-      assert payload |> first_feed() |> feed_url_by_name(:vehicle_status) == feed_url
+      assert payload |> feed_url_by_name(:vehicle_status) == feed_url
 
       assert has_feed?(
                %{"version" => "2.3", "data" => %{"en" => %{"feeds" => [%{"name" => "free_bike_status.json"}]}}},
@@ -592,7 +592,7 @@ defmodule Transport.Shared.GBFSMetadataTest do
       }
 
       assert has_feed?(payload, :vehicle_status)
-      assert payload |> first_feed() |> feed_url_by_name(:vehicle_status) == feed_url
+      assert payload |> feed_url_by_name(:vehicle_status) == feed_url
     end
   end
 

--- a/apps/transport/lib/transport/gbfs_to_geojson.ex
+++ b/apps/transport/lib/transport/gbfs_to_geojson.ex
@@ -234,7 +234,7 @@ defmodule Transport.GbfsToGeojson do
 
   @spec feed_url_from_payload(map(), feed_name()) :: binary() | nil
   defp feed_url_from_payload(payload, feed_name) do
-    payload |> GBFSMetadata.first_feed() |> GBFSMetadata.feed_url_by_name(feed_name)
+    GBFSMetadata.feed_url_by_name(payload, feed_name)
   end
 
   defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()


### PR DESCRIPTION
Fixes #4258

Calcule des statistiques pour les flux GBFS pour les stations et les véhicules. Le code est adapté pour les différentes versions de GBFS de 1.1 à 3.0.

J'ai exécuté le code sur les différents flux que l'on a chez nous, sans rencontrer d'erreurs.

Il est possible qu'on calcule plus de statistiques plus tard, par exemple distinguer le nombre de véhicules par type (vélo VS trottinette quand un flux comporte les 2) mais il est utile d'envoyer déjà ceci en production, faire un peu de refactor et d'éventuellement ajouter des choses ensuite. On en discutera avec @stephane-pignal.

## Exemple de payload

Une payload complète pour un flux GBFS. La clé ajoutée par cette PR est `stats`

```
%{
 cors_header_value: nil,
 feed_timestamp_delay: 0,
 feeds: ["vehicle_types", "gbfs_versions", "geofencing_zones",
  "station_information", "station_status", "system_alerts",
  "system_information", "system_pricing_plans", "system_regions",
  "vehicle_status"],
 languages: ["fr"],
 stats: %{
   nb_disabled_vehicles: 0,
   nb_docked_vehicles: 31,
   nb_docks_available: 74,
   nb_docks_disabled: 0,
   nb_freefloating_vehicles: 6,
   nb_installed_stations: 5,
   nb_renting_stations: 5,
   nb_reserved_vehicles: 0,
   nb_returning_stations: 5,
   nb_stations: 5,
   nb_vehicles: 37,
   nb_vehicles_available_stations: 32,
   nb_vehicles_disabled_stations: 0,
   version: 1
 },
 system_details: %{
   "email" => "support@ecovelo.com",
   "feed_contact_email" => "gbfs@ecovelo.com",
   "languages" => ["fr"],
   "manifest_url" => "https://api.gbfs.ecovelo.mobi/manifest.json",
   "name" => "VélYcéo",
   "opening_hours" => "24/7",
   "phone_number" => "+33974591314",
   "purchase_url" => "https://velyceo.ecovelo.mobi/#/forfaits",
   "rental_apps" => %{
     "android" => %{
       "discovery_uri" => "com.ecovelo.velyceo://",
       "store_uri" => "https://play.google.com/store/apps/details?id=com.ecovelo.velyceo&hl=fr&gl=US"
     },
     "ios" => %{
       "discovery_uri" => "com.ecovelo.velyceo://",
       "store_uri" => "https://apps.apple.com/us/app/v%C3%A9lyc%C3%A9o-libre-service/id1561329566"
     }
   },
   "start_date" => "2020-08-20",
   "system_id" => "velyceo",
   "terms_last_updated" => "2022-04-01",
   "terms_url" => "https://velyceo.ecovelo.mobi/#/cgu",
   "timezone" => "Europe/Paris",
   "url" => "https://velyceo.ecovelo.mobi"
 },
 ttl: 300,
 types: ["free_floating", "stations"],
 validation: %Shared.Validation.GBFSValidator.Summary{
   has_errors: false,
   errors_count: 0,
   version_detected: "3.0",
   version_validated: "3.0",
   validator_version: "1.0.12",
   validator: Shared.Validation.GBFSValidator.HTTPValidatorClient
 },
 vehicle_types: ["bicycle", "scooter"],
 versions: ["3.0", "2.2"]
}}
```