### PR TITLE
Cartes : utilise des tuiles IGN

### DIFF
--- a/apps/transport/client/javascripts/dataset-map.js
+++ b/apps/transport/client/javascripts/dataset-map.js
@@ -1,15 +1,9 @@
 import L from 'leaflet'
-import { Mapbox } from './mapbox-credentials'
+import { IGN } from './map-config'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
-    L.tileLayer(Mapbox.url, {
-        accessToken: Mapbox.accessToken,
-        attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
-        tileSize: Mapbox.tileSize,
-        zoomOffset: Mapbox.zoomOffset
-    }).addTo(map)
+    L.tileLayer(IGN.url, IGN.config).addTo(map)
 
     const fg = L.featureGroup().addTo(map)
     return { map, fg }

--- a/apps/transport/client/javascripts/explore.js
+++ b/apps/transport/client/javascripts/explore.js
@@ -4,7 +4,7 @@ import { LeafletLayer } from 'deck.gl-leaflet'
 import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers'
 
 import { MapView } from '@deck.gl/core'
-import { Mapbox } from './mapbox-credentials'
+import { Mapbox } from './map-config'
 
 const socket = new Socket('/socket', { params: { token: window.userToken } })
 socket.connect()

--- a/apps/transport/client/javascripts/gtfs.js
+++ b/apps/transport/client/javascripts/gtfs.js
@@ -3,18 +3,12 @@ import { LeafletLayer } from 'deck.gl-leaflet'
 import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers'
 
 import { MapView } from '@deck.gl/core'
-import { Mapbox } from './mapbox-credentials'
+import { IGN } from './map-config'
 
 const metropolitanFranceBounds = [[51.1, -4.9], [41.2, 9.8]]
 const map = Leaflet.map('map', { renderer: Leaflet.canvas() })
 
-Leaflet.tileLayer(Mapbox.url, {
-    accessToken: Mapbox.accessToken,
-    attribution: Mapbox.attribution,
-    maxZoom: Mapbox.maxZoom,
-    tileSize: Mapbox.tileSize,
-    zoomOffset: Mapbox.zoomOffset
-}).addTo(map)
+Leaflet.tileLayer(IGN.url, IGN.config).addTo(map)
 
 const deckGLLayer = new LeafletLayer({
     views: [new MapView({ repeat: true })],

--- a/apps/transport/client/javascripts/map-config.js
+++ b/apps/transport/client/javascripts/map-config.js
@@ -6,3 +6,14 @@ export const Mapbox = {
     tileSize: 512,
     zoomOffset: -1
 }
+
+export const IGN = {
+    url: 'https://data.geopf.fr/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+    config: {
+        minZoom: 0,
+        maxZoom: 18,
+        attribution: 'IGN-F/Géoportail',
+        tileSize: 256,
+        className: 'ign-tile'
+    }
+}

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -1,15 +1,9 @@
 import L from 'leaflet'
-import { Mapbox } from './mapbox-credentials'
+import { IGN } from './map-config'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
-    L.tileLayer(Mapbox.url, {
-        accessToken: Mapbox.accessToken,
-        attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
-        tileSize: Mapbox.tileSize,
-        zoomOffset: Mapbox.zoomOffset
-    }).addTo(map)
+    L.tileLayer(IGN.url, IGN.config).addTo(map)
 
     const markersfg = L.featureGroup().addTo(map)
     const linesfg = L.featureGroup().addTo(map)

--- a/apps/transport/client/javascripts/map.js
+++ b/apps/transport/client/javascripts/map.js
@@ -1,6 +1,6 @@
 import Leaflet from 'leaflet'
 import 'leaflet.pattern'
-import { Mapbox } from './mapbox-credentials'
+import { Mapbox } from './map-config'
 
 const regionsUrl = '/api/stats/regions'
 const aomsUrl = '/api/stats/'

--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -1,6 +1,6 @@
 import L from 'leaflet'
 import Papa from 'papaparse'
-import { Mapbox } from './mapbox-credentials'
+import { IGN } from './map-config'
 
 // possible field names in csv files
 const latLabels = ['Lat', 'Ylat', 'Ylatitude', 'consolidated_latitude']
@@ -17,13 +17,7 @@ function getLabel (obj, labelsList) {
 
 function initilizeMap (id) {
     const map = L.map(id, { preferCanvas: true }).setView([46.505, 2], 5)
-    L.tileLayer(Mapbox.url, {
-        accessToken: Mapbox.accessToken,
-        attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
-        tileSize: Mapbox.tileSize,
-        zoomOffset: Mapbox.zoomOffset
-    }).addTo(map)
+    L.tileLayer(IGN.url, IGN.config).addTo(map)
 
     const fg = L.featureGroup().addTo(map)
     return { map, fg }

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -1,15 +1,9 @@
 import L from 'leaflet'
-import { Mapbox } from './mapbox-credentials'
+import { IGN } from './map-config'
 
 function initilizeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
-    L.tileLayer(Mapbox.url, {
-        accessToken: Mapbox.accessToken,
-        attribution: Mapbox.attribution,
-        maxZoom: Mapbox.maxZoom,
-        tileSize: Mapbox.tileSize,
-        zoomOffset: Mapbox.zoomOffset
-    }).addTo(map)
+    L.tileLayer(IGN.url, IGN.config).addTo(map)
 
     const fg = L.featureGroup().addTo(map)
     return { map, fg }

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -529,6 +529,10 @@
   padding-right: 6px;
 }
 
+.ign-tile {
+  filter: grayscale(100%) opacity(70%);
+}
+
 .leaflet-map {
   width: 100%;
   height: 400px;


### PR DESCRIPTION
Fixes #4300

Utilise des tuiles IGN en noir et blanc pour plusieurs de nos cartes, sauf carte d'exploration et cartes affichées sur la page statistiques.

![image](https://github.com/user-attachments/assets/3c815579-7e2d-42a4-9f7b-92345148c41d)
![image](https://github.com/user-attachments/assets/365335b3-b87a-44a4-bec9-6a0839e811ee)
