### PR TITLE
CSP : autorise images venant du Géoportail IGN

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -46,7 +46,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
           connect-src *;
           font-src *;
           frame-ancestors 'none';
-          img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
+          img-src 'self' data: https://api.mapbox.com https://data.geopf.fr https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
           script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
           frame-src https://*.dailymotion.com;
           style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
@@ -60,7 +60,7 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
             connect-src *;
             font-src *;
             frame-ancestors 'none';
-            img-src 'self' data: https://api.mapbox.com https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
+            img-src 'self' data: https://api.mapbox.com https://data.geopf.fr https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
             script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
             frame-src https://*.dailymotion.com;
             style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};


### PR DESCRIPTION
En lien avec #4300 et #4301

J'ai oublié d'autoriser les images provenant du Géoportail IGN dans la CSP…

Il faudrait vraiment que l'on revoit la CSP en local, facile de se faire avoir.