### PR TITLE
Ajout section learning track pour documenter comment mettre à jour les assets javascript

### DIFF
--- a/learning_track.md
+++ b/learning_track.md
@@ -92,6 +92,13 @@ This guide tracks useful steps to learn how to maintain and modify this system.
 * Verify the linking status with `clever applications`
 * Log with the app alias: `clever ssh --alias transport-prochainement`
 
+### Learn how to upgrade the javascript assets
+
+* `cd apps/transport/client`
+* `yarn outdated` shows the outdated packages (see [here](https://github.com/etalab/transport-site/pull/4287) for a sample)
+* Use `yarn upgrade abc [def]` ([doc](https://classic.yarnpkg.com/lang/en/docs/cli/upgrade/)) to upgrade one or more packages
+* Look into [package.json](https://github.com/etalab/transport-site/blob/master/apps/transport/client/package.json) to see how to specify versions
+
 ### Learn about the GTFS and GTFS-RT specifications
 
 * @thbar bought https://gumroad.com/l/gtfsbundle (available to the team on demand)

--- a/learning_track.md
+++ b/learning_track.md
@@ -98,6 +98,7 @@ This guide tracks useful steps to learn how to maintain and modify this system.
 * `yarn outdated` shows the outdated packages (see [here](https://github.com/etalab/transport-site/pull/4287) for a sample)
 * Use `yarn upgrade abc [def]` ([doc](https://classic.yarnpkg.com/lang/en/docs/cli/upgrade/)) to upgrade one or more packages
 * Look into [package.json](https://github.com/etalab/transport-site/blob/master/apps/transport/client/package.json) to see how to specify versions
+* Most javascript-enabled features are not tested specifically - use `prochainement` or a local rendering to verify if nothing is broken
 
 ### Learn about the GTFS and GTFS-RT specifications
 


### PR DESCRIPTION
Suite à:
- #4287 
- et la bonne remarque de @vdegove (https://github.com/etalab/transport-site/pull/4287#pullrequestreview-2429805896)

je mets quelques billes sur le travail de mise à jour des assets javascript.