### PR TITLE
CSP : active la content security policy en local

### DIFF
--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -20,60 +20,55 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
   end
 
   @doc """
-  Returns content-security-policy headers, depending on the APP_ENV value
+  Returns content-security-policy headers for an app environment.
 
-  iex> csp_headers("")
-  %{}
-  iex> csp_headers("test")
-  %{}
-  iex> match?(%{"content-security-policy" => _csp_content}, csp_headers(:prod))
+  iex> nonce = "foo"
+  iex> match?(%{"content-security-policy" => _csp_content}, csp_headers(:production, nonce))
   true
-  iex> match?(%{"content-security-policy" => _csp_content}, csp_headers(:staging))
+  iex> match?(%{"content-security-policy" => _csp_content}, csp_headers(:staging, nonce))
   true
+  iex> csp_headers(:staging, nonce) != csp_headers(:production, nonce)
+  true
+  iex> String.contains?("report-uri", csp_headers(:dev, nonce) |> Map.fetch!("content-security-policy"))
+  false
   """
   def csp_headers(app_env, nonce) do
     # https://github.com/vega/vega-embed/issues/1214#issuecomment-1670812445
     vega_hash_values =
       "'sha256-9uoGUaZm3j6W7+Fh2wfvjI8P7zXcclRw5tVUu3qKZa0=' 'sha256-MmUum7+PiN7Rz79EUMm0OmUFWjCx6NZ97rdjoIbTnAg='"
 
-    logos_bucket_url = Transport.S3.permanent_url(:logos)
+    value =
+      %{
+        "default-src" => "'none'",
+        "connect-src" => "*",
+        "font-src" => "*",
+        "frame-ancestors" => "'none'",
+        "img-src" =>
+          "'self' data: https://api.mapbox.com https://data.geopf.fr https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{Transport.S3.permanent_url(:logos)}",
+        "script-src" => "'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js",
+        "frame-src" => "https://*.dailymotion.com",
+        "style-src" => "'self' 'nonce-#{nonce}' #{vega_hash_values}",
+        "report-uri" => ""
+      }
+      |> Enum.map(fn {directive, value} ->
+        extra = " #{additional_content(directive, app_env)}" |> String.trim()
+        {directive, value <> extra}
+      end)
+      |> Enum.reject(fn {_, v} -> v == "" end)
+      |> Enum.map_join(";", fn {k, v} -> "#{k} #{v}" end)
 
-    csp_content =
-      case app_env do
-        :production ->
-          """
-          default-src 'none';
-          connect-src *;
-          font-src *;
-          frame-ancestors 'none';
-          img-src 'self' data: https://api.mapbox.com https://data.geopf.fr https://static.data.gouv.fr https://www.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
-          script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
-          frame-src https://*.dailymotion.com;
-          style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
-          report-uri #{Application.fetch_env!(:sentry, :csp_url)}
-          """
+    %{"content-security-policy" => value}
+  end
 
-        :staging ->
-          # prochainement is currently making calls to both data.gouv.fr and demo.data.gouv.fr, which is probably not expected
-          """
-            default-src 'none';
-            connect-src *;
-            font-src *;
-            frame-ancestors 'none';
-            img-src 'self' data: https://api.mapbox.com https://data.geopf.fr https://static.data.gouv.fr https://demo-static.data.gouv.fr https://www.data.gouv.fr https://demo.data.gouv.fr https://*.dmcdn.net #{logos_bucket_url};
-            script-src 'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js;
-            frame-src https://*.dailymotion.com;
-            style-src 'self' 'nonce-#{nonce}' #{vega_hash_values};
-            report-uri #{Application.fetch_env!(:sentry, :csp_url)}
-          """
+  defp additional_content("img-src", :staging) do
+    "https://demo-static.data.gouv.fr https://demo.data.gouv.fr"
+  end
 
-        _ ->
-          nil
-      end
+  defp additional_content("report-uri", app_env) when app_env in [:production, :staging] do
+    Application.fetch_env!(:sentry, :csp_url)
+  end
 
-    case csp_content do
-      nil -> %{}
-      csp_content -> %{"content-security-policy" => csp_content |> String.replace("\n", "")}
-    end
+  defp additional_content(_directive, _app_env) do
+    ""
   end
 end

--- a/apps/transport/test/transport_web/plugs/custom_secure_browser_headers_test.exs
+++ b/apps/transport/test/transport_web/plugs/custom_secure_browser_headers_test.exs
@@ -1,0 +1,4 @@
+defmodule TransportWeb.Plugs.CustomSecureBrowserHeadersTest do
+  use ExUnit.Case, async: true
+  doctest TransportWeb.Plugs.CustomSecureBrowserHeaders, import: true
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -151,4 +151,6 @@ config :os_mon,
   start_memsup: false
 
 # See https://hexdocs.pm/sentry/Sentry.Test.html
-config :sentry, test_mode: true
+config :sentry,
+  test_mode: true,
+  csp_url: ""


### PR DESCRIPTION
Fixes #4305

- Refactor du fichier
- Fait en sorte que ce fichier soit _réellement_ testé
- Ajoute le contenu spécifique en staging/production à part