### PR TITLE
ImportData : devine le bon type de ressource

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -304,7 +304,7 @@ defmodule Transport.ImportData do
          # GOTCHA: `filetype` is set to `file` for exports coming from ODS
          # https://github.com/opendatateam/udata-ods/issues/250
          "filetype" => resource["filetype"],
-         "type" => resource["type"],
+         "type" => formated_type(resource),
          "id" => existing_resource[:id],
          "datagouv_id" => resource["id"],
          "is_available" => availability_checker().available?(format, resource["url"]),
@@ -827,6 +827,21 @@ defmodule Transport.ImportData do
       type == "public-transit" and not is_documentation and not is_community_resource -> "GTFS"
       type in ["bike-scooter-sharing", "car-motorbike-sharing"] and gbfs?(resource) -> "gbfs"
       true -> format
+    end
+  end
+
+  @doc """
+  iex> formated_type(%{"type" => "main", "format" => "pdf", "title" => "Fichier"})
+  "documentation"
+  iex> formated_type(%{"type" => "main", "format" => "GTFS", "title" => "Fichier"})
+  "main"
+  """
+  @spec formated_type(map()) :: binary()
+  def formated_type(%{"type" => type} = resource) do
+    if documentation?(resource) do
+      "documentation"
+    else
+      type
     end
   end
 

--- a/apps/transport/test/transport/import_data_service_test.exs
+++ b/apps/transport/test/transport/import_data_service_test.exs
@@ -29,6 +29,7 @@ defmodule Transport.ImportDataServiceTest do
           "resources": [
               {
                 "filetype": "remote",
+                "type": "main",
                 "format": "gtfs",
                 "latest": "https://demo.data.gouv.fr/fr/datasets/r/9bff120f-d1ba-4753-83cb-6d598ebe2e60",
                 "url": "#{resource_url}",
@@ -61,6 +62,7 @@ defmodule Transport.ImportDataServiceTest do
           "resources": [
               {
                 "filetype": "remote",
+                "type": "main",
                 "format": "csv",
                 "mime": "text/csv",
                 "latest": "https://url-csv-file",

--- a/apps/transport/test/transport/import_data_test.exs
+++ b/apps/transport/test/transport/import_data_test.exs
@@ -3,24 +3,24 @@ defmodule Transport.ImportDataTest do
   use ExUnit.Case, async: false
   alias Transport.ImportData
   import Mock
+  import Mox
   import DB.Factory
   import ExUnit.CaptureLog
   import Ecto.Query
+
   doctest ImportData, import: true
+
+  setup :verify_on_exit!
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
 
     # The national dataset is pre-inserted in the DB via a migration
     assert DB.Region |> where([r], r.nom == "National") |> DB.Repo.aggregate(:count) == 1
-
-    :ok
-  end
-
-  setup do
     Mox.stub_with(Transport.HTTPoison.Mock, HTTPoison)
     Mox.stub_with(Transport.AvailabilityChecker.Mock, Transport.AvailabilityChecker)
     Mox.stub_with(Hasher.Mock, Hasher.Dummy)
+
     :ok
   end
 
@@ -471,17 +471,42 @@ defmodule Transport.ImportDataTest do
            }
   end
 
-  test "get_valid_resources for public-transit detects documentation resources" do
-    resources = %{
-      "resources" => [
-        %{"type" => "main", "title" => "Fichier", "format" => "gtfs"},
-        %{"type" => "main", "title" => "Fichier", "format" => "geojson"},
-        %{"type" => "main", "title" => "Fichier", "format" => "svg"}
-      ]
-    }
+  describe "get_resources" do
+    test "public-transit: filters resources and detects documentation" do
+      dataset = %{
+        "id" => Ecto.UUID.generate(),
+        "resources" => [
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/gtfs", format: "gtfs"),
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/geojson", format: "geojson"),
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/svg", format: "svg")
+        ]
+      }
 
-    assert [%{"format" => "gtfs", "type" => "main"}, %{"format" => "svg", "type" => "documentation"}] =
-             ImportData.get_valid_resources(resources, "public-transit")
+      Datagouvfr.Client.CommunityResources.Mock |> expect(:get, fn _ -> {:ok, []} end)
+
+      assert [%{"format" => "GTFS", "type" => "main"}, %{"format" => "svg", "type" => "documentation"}] =
+               ImportData.get_resources(dataset, "public-transit")
+    end
+
+    test "another type: detects documentation" do
+      dataset = %{
+        "id" => Ecto.UUID.generate(),
+        "resources" => [
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/gtfs", format: "gtfs"),
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/geojson", format: "geojson"),
+          generate_resource_payload(id: Ecto.UUID.generate(), url: "https://example.com/svg", format: "svg")
+        ]
+      }
+
+      Datagouvfr.Client.CommunityResources.Mock |> expect(:get, fn _ -> {:ok, []} end)
+
+      assert [
+               %{"format" => "GTFS", "type" => "main"},
+               %{"format" => "geojson", "type" => "main"},
+               %{"format" => "svg", "type" => "documentation"}
+             ] =
+               ImportData.get_resources(dataset, "low-emission-zones")
+    end
   end
 
   describe "read_datagouv_zone" do

--- a/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/backoffice_controller_test.exs
@@ -134,7 +134,8 @@ defmodule TransportWeb.BackofficeControllerTest do
               "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601(),
               "url" => "url1",
               "id" => "resource_datagouv_id",
-              "format" => "siri"
+              "format" => "siri",
+              "type" => "main"
             }
           ]
         }
@@ -153,13 +154,15 @@ defmodule TransportWeb.BackofficeControllerTest do
            "url" => "url2",
            "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601(),
            "format" => "json",
-           "id" => "resource_datagouv_id_2"
+           "id" => "resource_datagouv_id_2",
+           "type" => "main"
          },
          %{
            "url" => "url3",
            "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601(),
            "format" => "csv",
-           "id" => "resource_datagouv_id_3"
+           "id" => "resource_datagouv_id_3",
+           "type" => "main"
          }
        ]}
     end)
@@ -189,11 +192,13 @@ defmodule TransportWeb.BackofficeControllerTest do
          %{
            "url" => "https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs-rt.json",
            "id" => "r1",
+           "type" => "main",
            "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601()
          },
          %{
            "url" => "https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs-rt",
            "id" => "r2",
+           "type" => "main",
            "last_modified" => DateTime.utc_now() |> DateTime.to_iso8601()
          }
        ]}


### PR DESCRIPTION
En lien avec #4308 / #4309

L'adaptation du code précédente n'était pas suffisante, il faut véritablement écraser la valeur de `resource.type` quand on a détecté que c'est de la documentation.

Je réalise ce changement et je fais des tests bien plus complets.