### PR TITLE
GBFSMetadata : retire les stations avec données irréalistes

### DIFF
--- a/apps/shared/lib/gbfs_metadata.ex
+++ b/apps/shared/lib/gbfs_metadata.ex
@@ -182,7 +182,7 @@ defmodule Transport.Shared.GBFSMetadata do
     with {:feed_exists, true} <- {:feed_exists, not is_nil(feed_url)},
          {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http_client().get(feed_url),
          {:ok, json} <- Jason.decode(body) do
-      stations = json["data"]["stations"]
+      stations = Enum.reject(json["data"]["stations"], &unrealistic_station_data?/1)
 
       %{
         nb_stations: Enum.count(stations),
@@ -229,6 +229,24 @@ defmodule Transport.Shared.GBFSMetadata do
         Logger.error("Cannot get GBFS vehicle_status details: #{inspect(e)}")
         %{}
     end
+  end
+
+  @doc """
+  Is the number of docks or vehicles unrealistic for this station? (more than 500 docks or vehicles).
+  If yes, used to ignore this station to maintain relevant statistics.
+
+  iex> unrealistic_station_data?(%{"num_vehicles_available" => 1_000})
+  true
+  iex> unrealistic_station_data?(%{"num_docks_available" => 1_000})
+  true
+  iex> unrealistic_station_data?(%{"num_docks_available" => 20, "num_vehicles_available" => 10})
+  false
+  """
+  def unrealistic_station_data?(%{} = data) do
+    data
+    |> Map.take(["num_vehicles_available", "num_bikes_available", "num_docks_available"])
+    |> Map.values()
+    |> Enum.any?(&(&1 >= 500))
   end
 
   # As of 3.0

--- a/apps/shared/test/fixtures/gbfs/station_status.2.2.json
+++ b/apps/shared/test/fixtures/gbfs/station_status.2.2.json
@@ -1,54 +1,84 @@
 {
-  "last_updated": 1609866247,
-  "ttl": 0,
-  "version": "2.2",
-  "data": {
-    "stations": [
+  "last_updated":1609866247,
+  "ttl":0,
+  "version":"2.2",
+  "data":{
+    "stations":[
       {
-        "station_id": "station 1",
-        "is_installed": true,
-        "is_renting": true,
-        "is_returning": true,
-        "last_reported": 1609866125,
-        "num_docks_available": 3,
-        "vehicle_docks_available": [{
-          "vehicle_type_ids": ["abc123"],
-          "count": 2
-        }, {
-          "vehicle_type_ids": ["def456"],
-          "count": 1
-        }],
-        "num_bikes_available": 1,
-        "vehicle_types_available": [{
-          "vehicle_type_id": "abc123",
-          "count": 1
-        }, {
-          "vehicle_type_id": "def456",
-          "count": 0
-        }]
-      }, {
-        "station_id": "station 2",
-        "is_installed": true,
-        "is_renting": true,
-        "is_returning": true,
-        "last_reported": 1609866106,
-        "num_docks_available": 8,
-        "num_docks_disabled": 1,
-        "vehicle_docks_available": [{
-          "vehicle_type_ids": ["abc123"],
-          "count": 6
-        }, {
-          "vehicle_type_ids": ["def456"],
-          "count": 2
-        }],
-        "num_bikes_available": 6,
-        "vehicle_types_available": [{
-          "vehicle_type_id": "abc123",
-          "count": 2
-        }, {
-          "vehicle_type_id": "def456",
-          "count": 4
-        }]
+        "station_id":"station 1",
+        "is_installed":true,
+        "is_renting":true,
+        "is_returning":true,
+        "last_reported":1609866125,
+        "num_docks_available":3,
+        "vehicle_docks_available":[
+          {
+            "vehicle_type_ids":[
+              "abc123"
+            ],
+            "count":2
+          },
+          {
+            "vehicle_type_ids":[
+              "def456"
+            ],
+            "count":1
+          }
+        ],
+        "num_bikes_available":1,
+        "vehicle_types_available":[
+          {
+            "vehicle_type_id":"abc123",
+            "count":1
+          },
+          {
+            "vehicle_type_id":"def456",
+            "count":0
+          }
+        ]
+      },
+      {
+        "station_id":"station 2",
+        "is_installed":true,
+        "is_renting":true,
+        "is_returning":true,
+        "last_reported":1609866106,
+        "num_docks_available":8,
+        "num_docks_disabled":1,
+        "vehicle_docks_available":[
+          {
+            "vehicle_type_ids":[
+              "abc123"
+            ],
+            "count":6
+          },
+          {
+            "vehicle_type_ids":[
+              "def456"
+            ],
+            "count":2
+          }
+        ],
+        "num_bikes_available":6,
+        "vehicle_types_available":[
+          {
+            "vehicle_type_id":"abc123",
+            "count":2
+          },
+          {
+            "vehicle_type_id":"def456",
+            "count":4
+          }
+        ]
+      },
+      {
+        "station_id":"station 3",
+        "is_installed":true,
+        "is_renting":true,
+        "is_returning":true,
+        "last_reported":1609866106,
+        "num_docks_available":999999,
+        "num_bikes_available":555555
       }
     ]
   }


### PR DESCRIPTION
Ignore les données des stations où le nombre de docks ou de véhicules disponibles dans une seule station semble irréaliste (plus de 500).

Ceci permet d'éviter d'avoir des statistiques incohérentes.

Ceci survient par exemple [pour Lime Paris](https://transport.data.gouv.fr/datasets/gbfs-paris), [voir Mattermost](https://mattermost.incubateur.net/betagouv/pl/6agr96dzqtb4dfrhg3ge3bfp3e).

```json
{
  "last_updated": 1731763709,
  "ttl": 0,
  "version": "2.2",
  "data": {
    "stations": [{
      "station_id": "paris",
      "num_bikes_available": 9669,
      "num_docks_available": 999999,
      "is_installed": true,
      "is_renting": true,
      "is_returning": true,
      "last_reported": 1731763709
    }]
  }
}
```