### PR TITLE
Mise à jour 2024 des AOM

### DIFF
--- a/apps/transport/lib/mix/tasks/transport/import_aoms.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aoms.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
   @moduledoc """
   Import the AOM files and updates the database.
 
-  The AOM files  come from the Cerema dataset:
+  The AOM files come from the Cerema dataset:
   https://www.data.gouv.fr/fr/datasets/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/
   https://www.cerema.fr/fr/actualites/liste-composition-autorites-organisatrices-mobilite-au-1er-4
 

--- a/apps/transport/lib/mix/tasks/transport/import_aoms.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aoms.ex
@@ -335,7 +335,8 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
     -- update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
     --
     -- 2024
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 16) where aom_id IN (1283, 1285, 1288, 1292, 1294);
+    -- Migrates a dataset to Pôle Métropolitain Mobilités Le Mans – Sarthe
+    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 1293) where aom_id IN (1283, 1285, 1288, 1292, 1294);
     """
 
     queries |> String.split(";") |> Enum.each(&Repo.query!/1)

--- a/apps/transport/lib/mix/tasks/transport/import_aoms.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aoms.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
   @moduledoc """
   Import the AOM files and updates the database.
 
-  The AOM files are custom made from an Excel file from the Cerema
+  The AOM files  come from the Cerema dataset:
   https://www.data.gouv.fr/fr/datasets/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/
   https://www.cerema.fr/fr/actualites/liste-composition-autorites-organisatrices-mobilite-au-1er-4
 
@@ -22,11 +22,14 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
   alias DB.{AOM, Commune, Region, Repo}
   require Logger
 
-  # The 2 community resources stable urls
-  # To create the following file: just rename columns and export as CSV, no content modification needed
-  @aom_file "https://gist.githubusercontent.com/vdegove/42d134c59b286525ff412876be3b6547/raw/d631b46c9096c148d854fbd5e9710987efb22999/base-rt-2023-diffusion-v2-aoms.csv"
-  # To create the following file: just delete useless columns and export as CSV, no content modification needed
-  @aom_insee_file "https://gist.githubusercontent.com/vdegove/42d134c59b286525ff412876be3b6547/raw/d631b46c9096c148d854fbd5e9710987efb22999/base-rt-2023-diffusion-v2-communes.csv"
+  # The resources urls
+  # To create the following file:
+  # download the Cerema file (.ods)
+  # rename columns that are on two lines
+  # export as CSV and publish as community resource
+  @aom_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20241108-105224/liste-aoms-2024.csv"
+  # Same for composition of each AOM, but no need even to rename columns
+  @aom_insee_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20241122-150150/composition-communale-aom-2024.csv"
 
   # We don’t add collectivité d’outremer de Saint-Martin
   @ignored_aom_ids ["312"]
@@ -319,17 +322,20 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
     -- CC du Pays d'Issoudun (id : 230, res_id: 275) to Région Centre-Val de Loire (CC du Pays d'Issoudun) (res_id: 13608)
     -- Migrates this dataset as both territory and legal owner https://transport.data.gouv.fr/datasets/issoudun-offre-theorique-mobilite-reseau-urbain
     -- This one as legal owner https://transport.data.gouv.fr/datasets/arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin
-    update dataset set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
+    -- update dataset set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
+    -- update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
     -- CC Arve et Salève (id : 440, res_id: 1475) to SM4CC (res_id: 417)
     -- CC Faucigny-Glières (id: 558, res_id :1509 to SM4CC (res_id: 417)
     -- CC du Pays Rochois (id: 677, res_id: 1478 to SM4CC (res_id: 417)
     -- There is a fourth CC in SM4CC, CC des Quatre Rivières (haute savoie)
     -- Removes aggregate legal owner here https://transport.data.gouv.fr/datasets/agregat-oura but keeps SM4CC
-    delete from dataset_aom_legal_owner where aom_id in (440, 558, 677);
+    -- delete from dataset_aom_legal_owner where aom_id in (440, 558, 677);
     -- L'Île-d'Yeu (id: 449, res_id: 1509) to L’Île-d’Yeu (res_id: 310);
-    update dataset set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
+    -- update dataset set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
+    -- update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
+    --
+    -- 2024
+    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 16) where aom_id IN (1283, 1285, 1288, 1292, 1294);
     """
 
     queries |> String.split(";") |> Enum.each(&Repo.query!/1)
@@ -354,7 +360,9 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
       |> DB.Repo.all()
       |> Enum.group_by(&hd(&1))
 
-    Logger.info("Datasets still associated with deleted AOM as territory : #{inspect(deleted_aom_datasets)}")
+    Logger.info(
+      "Datasets still associated with deleted AOM as territory (aom.id => [aom.id, aom.composition_res_id, dataset.id]) : #{inspect(deleted_aom_datasets)}"
+    )
 
     deleted_legal_owners_query =
       from(d in DB.Dataset,
@@ -366,6 +374,8 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
 
     deleted_legal_owners = deleted_legal_owners_query |> DB.Repo.all() |> Enum.group_by(&hd(&1))
 
-    Logger.info("Datasets still associated with deleted AOM as legal owner: #{inspect(deleted_legal_owners)}")
+    Logger.info(
+      "Datasets still associated with deleted AOM as legal owner (aom.id => [aom.id, aom.composition_res_id, dataset.id]): #{inspect(deleted_legal_owners)}"
+    )
   end
 end

--- a/apps/transport/lib/mix/tasks/transport/import_aoms.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aoms.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
   # export as CSV and publish as community resource
   @aom_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20241108-105224/liste-aoms-2024.csv"
   # Same for composition of each AOM, but no need even to rename columns
-  @aom_insee_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20241122-150150/composition-communale-aom-2024.csv"
+  @aom_insee_file "https://static.data.gouv.fr/resources/liste-et-composition-des-autorites-organisatrices-de-la-mobilite-aom/20241122-154942/composition-communale-aom-2024.csv"
 
   # We don’t add collectivité d’outremer de Saint-Martin
   @ignored_aom_ids ["312"]

--- a/apps/transport/lib/mix/tasks/transport/import_aoms.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_aoms.ex
@@ -125,7 +125,7 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
           # we load all aoms
           import_aoms(aoms_to_add)
           # Some datasets should change AOM
-          migrate_datasets_to_new_aoms(2024)
+          migrate_datasets_to_new_aoms()
           delete_old_aoms(aoms_to_add, old_aoms)
           # we load the join on cities
           import_insee_aom()
@@ -306,9 +306,10 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
     Repo.query!("REFRESH MATERIALIZED VIEW places;")
   end
 
-  # This could be mostly automatized, you just have to look for a commune of the old AOM and see where it was migrated.
-  defp migrate_datasets_to_new_aoms(2023) do
+  defp migrate_datasets_to_new_aoms do
     queries = """
+    -- This could be mostly automatized, you just have to look for a commune of the old AOM and see where it was migrated.
+    --
     -- 2023
     -- [info] Datasets still associated with deleted AOM as territory :
     -- %{230 => [[230, 275, 401]], 449 => [[449, 1509, 653]]}
@@ -321,28 +322,19 @@ defmodule Mix.Tasks.Transport.ImportAOMs do
     -- CC du Pays d'Issoudun (id : 230, res_id: 275) to Région Centre-Val de Loire (CC du Pays d'Issoudun) (res_id: 13608)
     -- Migrates this dataset as both territory and legal owner https://transport.data.gouv.fr/datasets/issoudun-offre-theorique-mobilite-reseau-urbain
     -- This one as legal owner https://transport.data.gouv.fr/datasets/arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin
-    update dataset set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
+    -- update dataset set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
+    -- update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 13608) where aom_id = 230;
     -- CC Arve et Salève (id : 440, res_id: 1475) to SM4CC (res_id: 417)
     -- CC Faucigny-Glières (id: 558, res_id :1509 to SM4CC (res_id: 417)
     -- CC du Pays Rochois (id: 677, res_id: 1478 to SM4CC (res_id: 417)
     -- There is a fourth CC in SM4CC, CC des Quatre Rivières (haute savoie)
     -- Removes aggregate legal owner here https://transport.data.gouv.fr/datasets/agregat-oura but keeps SM4CC
-    delete from dataset_aom_legal_owner where aom_id in (440, 558, 677);
+    -- delete from dataset_aom_legal_owner where aom_id in (440, 558, 677);
     -- L'Île-d'Yeu (id: 449, res_id: 1509) to L’Île-d’Yeu (res_id: 310);
-    update dataset set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
+    -- update dataset set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
+    -- update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 310) where aom_id = 449;
     --
     -- 2024
-    -- Migrates a dataset to Pôle Métropolitain Mobilités Le Mans – Sarthe
-    update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 1293) where aom_id IN (1283, 1285, 1288, 1292, 1294);
-    """
-
-    queries |> String.split(";") |> Enum.each(&Repo.query!/1)
-  end
-
-  defp migrate_datasets_to_new_aoms(2024) do
-    queries = """
     -- Migrates a dataset to Pôle Métropolitain Mobilités Le Mans – Sarthe
     update dataset_aom_legal_owner set aom_id = (select id from aom where composition_res_id = 1293) where aom_id IN (1283, 1285, 1288, 1292, 1294);
     """


### PR DESCRIPTION
## Description des changements

Cette année pas grand chose qui change, juste un petit changement autour du Mans. Un ensemble d’AOMs, qui étaient des communautés de communes en périphérie du Mans, fusionnent en une seule AOM. Elle reprend un reseau_id existant d’une des communautés de communes, le 1293, mais se renomme «Pôle Métropolitain Mobilités Le Mans – Sarthe».

AOM concernées (supprimées) :
- 1283 : CC Maine Coeur de Sarthe, insee_commune_principale: "72024"
- 1285 : CC Le Gesnois Bilurien,   insee_commune_principale: "72329"
- 1288 : CC de la Champagne Conlinoise et du Pays de Sillé, insee_commune_principale: "72334"
- 1292 : CC du Sud Est Manceau, insee_commune_principale: "72058"
- 1294 : CC du Val de Sarthe, insee_commune_principale: "72346"

Cette nouvelle AOM  «Pôle Métropolitain Mobilités Le Mans – Sarthe» est séparée de l’AOM du Mans, « CU Le Mans Métropole » (réseau 58), comme on peut le voir dans la base de données après mise à jour, et comme indiqué sur leur site ici https://lemanssarthe-mobilites.fr/qui-sommes-nous/ Il y a une offre propre de transport, https://transport.data.gouv.fr/datasets/reseau-urbain-illygo séparée de l’offre métropolitaine du Mans https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole

![Capture d’écran du 2024-11-22 17-12-36](https://github.com/user-attachments/assets/9d3531e3-8588-4557-8027-3481abc63a4d)
![Capture d’écran du 2024-11-22 17-11-04](https://github.com/user-attachments/assets/57156750-1018-4acd-ae74-3fd37a58d498)


Un dataset, ID 720, était associé à l’AOM réseau id 1288 (CC de la Champagne Conlinoise et du Pays de Sillé), il est migré sur l’AOM.

@cyrilmorin après déploiement tu pourras corriger le JDD https://transport.data.gouv.fr/datasets/reseau-urbain-illygo en mettant la nouvelle AOM en legal owner, et le territoire reste comme il est (en incluant Le Mans).

## Notes techniques

RAS de spécial, les modifications de l’année dernière marchent toujours, il n’y a quasi rien à faire, ça marche avec les fichiers du CEREMA quasi inchangés. J’ai juste dû bidouiller le reseau_id des communes faisant partie de la nouvelle AOM, il était resté sur les identifiants des AOM précédentes.

## Logs


```
[info] Importing Cerema file…
[info] 0 new AOMs. reseau_id codes: 
[info] 5 removed AOMs. reseau_id codes: 1283, 1285, 1288, 1292, 1294
[info] Datasets still associated with deleted AOM as territory (aom.id => [aom.id, aom.composition_res_id, dataset.id]) : %{}
[info] Datasets still associated with deleted AOM as legal owner (aom.id => [aom.id, aom.composition_res_id, dataset.id]): %{720 => [[720, 1288, 979]]}
[info] importing AOMs…
[info] deleting removed aom
[info] trying to delete old aom: 523 - CC Le Gesnois Bilurien
[info] trying to delete old aom: 720 - CC de la Champagne Conlinoise et du Pays de Sillé
[info] trying to delete old aom: 834 - CC Maine Coeur de Sarthe
[info] trying to delete old aom: 809 - CC du Sud Est Manceau
[info] trying to delete old aom: 674 - CC du Val de Sarthe
[info] Linking aoms to cities
[info] computing AOM geometries
[info] set main commune
```

## Analyse des différences avec PostsgreSQL

Avant l’import, copie de la table AOM pour analyse :

```
CREATE TABLE aom_copy AS SELECT * FROM aom;
```

Puis `mix Transport.ImportAOMs`

Puis :

```
SELECT
  COALESCE(a.id, c.id) AS id,
  c.composition_res_id AS c_composition_res_id, a.composition_res_id AS a_composition_res_id,
  c.insee_commune_principale AS c_insee_commune_principale, a.insee_commune_principale AS a_insee_commune_principale, 
  c.departement AS c_departement, a.departement AS a_departement, 
  c.siren AS c_siren, a.siren AS a_siren, 
  c.nom AS c_nom, a.nom AS a_nom, 
  c.forme_juridique AS c_forme_juridique, a.forme_juridique AS a_forme_juridique, 
  c.nombre_communes AS c_nombre_communes,  a.nombre_communes AS a_nombre_communes, 
  c.region_id AS c_region_id, a.region_id AS a_region_id
FROM aom a
FULL OUTER JOIN aom_copy c ON a.id = c.id
WHERE
  a.composition_res_id IS DISTINCT FROM c.composition_res_id OR
  a.insee_commune_principale IS DISTINCT FROM c.insee_commune_principale OR
  a.departement IS DISTINCT FROM c.departement OR
  a.siren IS DISTINCT FROM c.siren OR
  a.nom IS DISTINCT FROM c.nom OR
  a.forme_juridique IS DISTINCT FROM c.forme_juridique OR
  a.nombre_communes IS DISTINCT FROM c.nombre_communes OR
  a.region_id IS DISTINCT FROM c.region_id
  ORDER BY a.composition_res_id, c.composition_res_id;
  ```

Ce qui donne :

```
id  |c_composition_res_id|a_composition_res_id|c_insee_commune_principale|a_insee_commune_principale|c_departement|a_departement|c_siren  |a_siren  |c_nom                                                      |a_nom                                                      |c_forme_juridique     |a_forme_juridique         |c_nombre_communes|a_nombre_communes|c_region_id|a_region_id|
----+--------------------+--------------------+--------------------------+--------------------------+-------------+-------------+---------+---------+-----------------------------------------------------------+-----------------------------------------------------------+----------------------+--------------------------+-----------------+-----------------+-----------+-----------+
 224|                 286|                 286|44055                     |44055                     |44           |44           |244400610|244400610|CA de la Presqu'île de Guérande Atlantique (CAP ATLANTIQUE)|CA de la Presqu'île de Guérande Atlantique (CAP ATLANTIQUE)|Syndicat              |Communauté d'agglomération|               15|               15|         10|         10|
 456|                1293|                1293|72124                     |72058                     |72           |72           |247200447|200051944|CC Orée de Bercé - Belinois                                |Pôle Métropolitain Mobilités Le Mans – Sarthe              |Communauté de communes|Syndicat                  |                8|               88|         10|         10|
 728|                1320|                1320|02058                     |02215                     |02           |02           |240200592|240200592|CC du Chemin des Dames                                     |CC du Chemin des Dames                                     |Communauté de communes|Communauté de communes    |               30|               30|          5|          5|
 409|                1451|                1451|38022                     |38507                     |38           |38           |200068542|200068542|CC Les Balcons du Dauphiné                                 |CC Les Balcons du Dauphiné                                 |Communauté de communes|Communauté de communes    |               47|               47|          2|          2|
1340|               11102|               11102|11367                     |11115                     |11           |11           |200053791|200053791|Région Occitanie (CC de la Montagne Noire)                 |Région Occitanie (CC de la Montagne Noire)                 |Région                |Région                    |               22|               22|         12|         12|
1282|               11507|               11507|15138                     |15119                     |15           |15           |200053767|200053767|Région Auvergne-Rhône-Alpes (CC Hautes Terres)             |Région Auvergne-Rhône-Alpes (CC Hautes Terres)             |Région                |Région                    |               35|               35|          2|          2|
1229|               13702|               13702|37245                     |37167                     |37           |37           |234500023|234500023|Région Centre-Val de Loire (CC de Gâtine-Racan)            |Région Centre-Val de Loire (CC de Gâtine-Racan)            |Région                |Région                    |               19|               19|          3|          3|
1227|               17301|               17301|73257                     |73181                     |73           |73           |200053767|200053767|Région Auvergne-Rhône-Alpes (CC Coeur de Tarentaise)       |Région Auvergne-Rhône-Alpes (CC Coeur de Tarentaise)       |Région                |Région                    |                6|                6|          2|          2|
 834|                1283|                    |72024                     |                          |72           |             |200068963|         |CC Maine Coeur de Sarthe                                   |                                                           |Communauté de communes|                          |               13|                 |         10|           |
 523|                1285|                    |72329                     |                          |72           |             |200072684|         |CC Le Gesnois Bilurien                                     |                                                           |Communauté de communes|                          |               23|                 |         10|           |
 720|                1288|                    |72334                     |                          |72           |             |200072718|         |CC de la Champagne Conlinoise et du Pays de Sillé          |                                                           |Communauté de communes|                          |               24|                 |         10|           |
 809|                1292|                    |72058                     |                          |72           |             |247200421|         |CC du Sud Est Manceau                                      |                                                           |Communauté de communes|                          |                5|                 |         10|           |
 674|                1294|                    |72346                     |                          |72           |             |247200629|         |CC du Val de Sarthe                                        |                                                           |Communauté de communes|                          |               16|                 |         10|           |
 ```

Donc que les changements annoncés plus haut, plus des changements de «commune principale» non significatifs.