### PR TITLE
GBFSMetadata : gère le cas des stations virtuelles

### DIFF
--- a/apps/transport/lib/transport/gbfs_metadata.ex
+++ b/apps/transport/lib/transport/gbfs_metadata.ex
@@ -233,7 +233,7 @@ defmodule Transport.GBFSMetadata do
   def stats(%{"data" => _data} = payload) do
     stations_statistics(payload)
     |> Map.merge(vehicle_statistics(payload))
-    |> Map.merge(%{version: 1})
+    |> Map.merge(%{version: 2})
   end
 
   def stations_statistics(%{"data" => _data} = payload) do

--- a/apps/transport/test/fixture/gbfs/station_status.3.0.json
+++ b/apps/transport/test/fixture/gbfs/station_status.3.0.json
@@ -48,6 +48,7 @@
         "last_reported":"2023-07-17T13:34:13+02:00",
         "num_docks_available":8,
         "num_docks_disabled":1,
+        "is_virtual_station":true,
         "vehicle_docks_available":[
           {
             "vehicle_type_ids":[

--- a/apps/transport/test/transport/gbfs_metadata_test.exs
+++ b/apps/transport/test/transport/gbfs_metadata_test.exs
@@ -60,7 +60,7 @@ defmodule Transport.GBFSMetadataTest do
                  nb_stations: 2,
                  nb_vehicles_available_stations: 7,
                  nb_vehicles_disabled_stations: 3,
-                 version: 1
+                 version: 2
                },
                operator: "Example"
              } = compute_feed_metadata(@gbfs_url)
@@ -123,7 +123,7 @@ defmodule Transport.GBFSMetadataTest do
                  nb_stations: 2,
                  nb_vehicles_available_stations: 7,
                  nb_vehicles_disabled_stations: 3,
-                 version: 1
+                 version: 2
                },
                operator: "Example"
              } = compute_feed_metadata(@gbfs_url)
@@ -631,7 +631,7 @@ defmodule Transport.GBFSMetadataTest do
                nb_returning_stations: 2,
                nb_stations: 2,
                nb_vehicles: 2,
-               version: 1,
+               version: 2,
                nb_vehicles_available_stations: 7,
                nb_vehicles_disabled_stations: 3,
                nb_virtual_stations: 1
@@ -660,7 +660,7 @@ defmodule Transport.GBFSMetadataTest do
                nb_vehicles_available_stations: 7,
                nb_vehicles_disabled_stations: 0,
                nb_virtual_stations: 0,
-               version: 1
+               version: 2
              } == stats(fixture_content("gbfs.2.2") |> Jason.decode!())
     end
   end

--- a/apps/transport/test/transport/gbfs_metadata_test.exs
+++ b/apps/transport/test/transport/gbfs_metadata_test.exs
@@ -616,6 +616,10 @@ defmodule Transport.GBFSMetadataTest do
       setup_response("https://example.com/gbfs/station_status", fixture_content("station_status.3.0"))
       setup_response("https://example.com/gbfs/vehicle_status", fixture_content("vehicle_status.3.0"))
 
+      # `version` is bumped when keys change
+      %{version: 2} = stats = stats(fixture_content("gbfs.3.0") |> Jason.decode!())
+      assert "7f96f20d6737450db8338d4ce83ae888" == stats |> Map.keys() |> Enum.sort() |> Enum.join("|") |> md5()
+
       # Values may not make sense: responses have been taken from the GBFS spec
       # and edited to make sure we test various possibilities without having massive
       # fixture files.
@@ -635,7 +639,7 @@ defmodule Transport.GBFSMetadataTest do
                nb_vehicles_available_stations: 7,
                nb_vehicles_disabled_stations: 3,
                nb_virtual_stations: 1
-             } == stats(fixture_content("gbfs.3.0") |> Jason.decode!())
+             } == stats
     end
 
     test "2.2 feed" do
@@ -989,4 +993,6 @@ defmodule Transport.GBFSMetadataTest do
 
     setup_response("https://example.com/station_status.json", body)
   end
+
+  defp md5(value), do: :crypto.hash(:md5, value) |> Base.encode16(case: :lower)
 end


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/4331

Gère le cas des stations virtuelles en GBFS (pas d'infrastructure physique/de docks).

Cette PR :
- ajoute une métrique `nb_virtual_stations`
- adapte le code pour déterminer le type d'un système/de ne pas compter comme `stations` quand des véhicules sont présents dans des stations virtuelles