### PR TITLE
NewDatagouvDatasetsJob : gérer JDD non identifiés

### DIFF
--- a/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
+++ b/apps/transport/lib/jobs/new_datagouv_datasets_job.ex
@@ -223,12 +223,8 @@ defmodule Transport.Jobs.NewDatagouvDatasetsJob do
   defp string_matches?(nil, _rule), do: false
 
   defp string_matches?(str, %{formats: formats, tags: tags} = _rule) when is_binary(str) do
-    str
-    |> String.downcase()
-    |> String.split(" ")
-    |> MapSet.new()
-    |> MapSet.intersection(MapSet.union(formats, tags))
-    |> MapSet.size() > 0
+    searches = MapSet.union(formats, tags) |> MapSet.to_list()
+    str |> String.downcase() |> String.contains?(searches)
   end
 
   defp tags_is_relevant?(%{"tags" => tags} = _dataset, rule) do

--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -23,10 +23,15 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
       |> Enum.filter(&NewDatagouvDatasetsJob.dataset_is_relevant?(dataset, &1))
       |> case do
         [rule] -> rule
+        [_ | _] = rules -> Enum.sort_by(rules, & &1.category)
         _ -> :no_match
       end
     end
 
+    assert [%{category: "Freefloating"}, %{category: "Vélo et stationnements"}] =
+             relevant_fn.(%{base | "title" => "Vélos en libre service"})
+
+    assert %{category: "IRVE"} = relevant_fn.(%{base | "title" => "Borne de recharge Lidl"})
     assert %{category: "Transport en commun"} = relevant_fn.(%{base | "title" => "GTFS de Dijon"})
     assert %{category: "Transport en commun"} = relevant_fn.(%{base | "description" => "GTFS de Dijon"})
     assert %{category: "Transport en commun"} = relevant_fn.(%{base | "tags" => [Ecto.UUID.generate(), "gtfs"]})


### PR DESCRIPTION
Fixes #4333

Détecte de manière plus intelligente les JDDs pertinents.

- Gère les pluriels
- Permet de matcher sur les tags avec plusieurs mots

On avait plusieurs tags qui ne pouvaient pas être reconnus avant : `libre service`, `borne de recharge` etc. Ceux contenant des espaces.