### PR TITLE
Recherche : tri sur JDD ajoutés récemment

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -30,6 +30,8 @@ defmodule DB.Dataset do
   typed_schema "dataset" do
     field(:datagouv_id, :string)
     field(:custom_title, :string)
+    # `created_at` comes from data.gouv.fr.
+    # To know when the dataset has been added on the NAP, use `inserted_at`
     field(:created_at, :utc_datetime_usec)
     field(:description, :string)
     field(:frequency, :string)
@@ -411,7 +413,7 @@ defmodule DB.Dataset do
 
   @spec order_datasets(Ecto.Query.t(), map()) :: Ecto.Query.t()
   def order_datasets(datasets, %{"order_by" => "alpha"}), do: order_by(datasets, asc: :custom_title)
-  def order_datasets(datasets, %{"order_by" => "most_recent"}), do: order_by(datasets, desc: :created_at)
+  def order_datasets(datasets, %{"order_by" => "most_recent"}), do: order_by(datasets, desc: :inserted_at)
 
   def order_datasets(datasets, %{"q" => q}),
     do:

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -322,4 +322,29 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
     refute hidden_dataset.id in (%{} |> DB.Dataset.list_datasets() |> DB.Repo.all() |> Enum.map(& &1.id))
   end
+
+  test "sort by most_recent" do
+    today = DateTime.utc_now()
+    last_week = DateTime.add(today, -7, :day)
+    type = "private-parking"
+
+    older_dataset = insert(:dataset, type: type, inserted_at: last_week)
+    recent_dataset = insert(:dataset, type: type, inserted_at: today)
+
+    assert [recent_dataset.id, older_dataset.id] ==
+             %{"type" => type, "order_by" => "most_recent"}
+             |> Dataset.list_datasets()
+             |> DB.Repo.all()
+             |> Enum.map(& &1.id)
+  end
+
+  test "sort by alpha" do
+    type = "private-parking"
+
+    b_dataset = insert(:dataset, type: type, custom_title: "B")
+    a_dataset = insert(:dataset, type: type, custom_title: "A")
+
+    assert [a_dataset.id, b_dataset.id] ==
+             %{"type" => type, "order_by" => "alpha"} |> Dataset.list_datasets() |> DB.Repo.all() |> Enum.map(& &1.id)
+  end
 end


### PR DESCRIPTION
Fixes #4337

Utilise la date d'ajout sur le PAN pour le tri par "ajouté récemment", ce qui est le fonctionnement plus naturel pour les utilisateurs. `created_at` est une colonne hasardeuse, venant de data.gouv.fr, qui peut avoir des valeurs très étonnantes à cause du moissonnage.

Ajoute des tests pour les tris sur la recherche, ce n'était pas présent pour le moment.