### PR TITLE
GBFSMetadata : lit station_information.is_virtual_station

### DIFF
--- a/apps/transport/test/fixture/gbfs/gbfs.2.2.json
+++ b/apps/transport/test/fixture/gbfs/gbfs.2.2.json
@@ -10,6 +10,10 @@
           "url": "https://example.com/gbfs/station_status"
         },
         {
+          "name": "station_information",
+          "url": "https://example.com/gbfs/station_information"
+        },
+        {
           "name": "free_bike_status",
           "url": "https://example.com/gbfs/free_bike_status"
         }

--- a/apps/transport/test/fixture/gbfs/gbfs.3.0.json
+++ b/apps/transport/test/fixture/gbfs/gbfs.3.0.json
@@ -9,6 +9,10 @@
         "url": "https://example.com/gbfs/station_status"
       },
       {
+        "name": "station_information",
+        "url": "https://example.com/gbfs/station_information"
+      },
+      {
         "name": "vehicle_status",
         "url": "https://example.com/gbfs/vehicle_status"
       }

--- a/apps/transport/test/fixture/gbfs/station_information.2.2.json
+++ b/apps/transport/test/fixture/gbfs/station_information.2.2.json
@@ -1,0 +1,19 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "pga",
+        "name": "Parking garage A",
+        "lat": 12.345678,
+        "lon": 45.678901,
+        "vehicle_type_capacity": {
+          "abc123": 7,
+          "def456": 9
+        }
+      }
+    ]
+  }
+}

--- a/apps/transport/test/fixture/gbfs/station_information.3.0.json
+++ b/apps/transport/test/fixture/gbfs/station_information.3.0.json
@@ -1,0 +1,86 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.0",
+  "data": {
+    "stations": [
+      {
+        "station_id": "pga",
+        "name": [
+          {
+            "text": "Parking garage A",
+            "language": "en"
+          }
+        ],
+        "lat": 12.345678,
+        "lon": 45.678901,
+        "station_opening_hours": "Su-Th 05:00-22:00; Fr-Sa 05:00-01:00",
+        "parking_type": "underground_parking",
+        "parking_hoop": false,
+        "contact_phone": "+33109874321",
+        "is_charging_station": true,
+        "vehicle_docks_capacity": [
+          {
+            "vehicle_type_ids": ["abc123"],
+            "count": 7
+          }
+        ]
+      },
+      {
+        "station_id": "station12",
+        "name": [
+          {
+            "text": "SE Belmont & SE 10th",
+            "language": "en"
+          }
+        ],
+        "lat": 45.516445,
+        "lon": -122.655775,
+        "is_valet_station": false,
+        "is_virtual_station": true,
+        "is_charging_station": false,
+        "station_area": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -122.655775,
+                  45.516445
+                ],
+                [
+                  -122.655705,
+                  45.516445
+                ],
+                [
+                  -122.655705,
+                  45.516495
+                ],
+                [
+                  -122.655775,
+                  45.516495
+                ],
+                [
+                  -122.655775,
+                  45.516445
+                ]
+              ]
+            ]
+          ]
+        },
+        "capacity": 16,
+        "vehicle_types_capacity": [
+          {
+            "vehicle_type_ids": ["abc123", "def456"],
+            "count": 15
+          },
+          {
+            "vehicle_type_ids": ["def456"],
+            "count": 1
+          }
+
+        ]
+      }
+    ]
+  }
+}

--- a/apps/transport/test/fixture/gbfs/station_status.3.0.json
+++ b/apps/transport/test/fixture/gbfs/station_status.3.0.json
@@ -48,7 +48,6 @@
         "last_reported":"2023-07-17T13:34:13+02:00",
         "num_docks_available":8,
         "num_docks_disabled":1,
-        "is_virtual_station":true,
         "vehicle_docks_available":[
           {
             "vehicle_type_ids":[

--- a/apps/transport/test/transport/gbfs_metadata_test.exs
+++ b/apps/transport/test/transport/gbfs_metadata_test.exs
@@ -614,6 +614,7 @@ defmodule Transport.GBFSMetadataTest do
   describe "stats" do
     test "3.0 feed" do
       setup_response("https://example.com/gbfs/station_status", fixture_content("station_status.3.0"))
+      setup_response("https://example.com/gbfs/station_information", fixture_content("station_information.3.0"))
       setup_response("https://example.com/gbfs/vehicle_status", fixture_content("vehicle_status.3.0"))
 
       # `version` is bumped when keys change
@@ -644,6 +645,7 @@ defmodule Transport.GBFSMetadataTest do
 
     test "2.2 feed" do
       setup_response("https://example.com/gbfs/station_status", fixture_content("station_status.2.2"))
+      setup_response("https://example.com/gbfs/station_information", fixture_content("station_information.2.2"))
       setup_response("https://example.com/gbfs/free_bike_status", fixture_content("free_bike_status.2.2"))
 
       # Values may not make sense: responses have been taken from the GBFS spec


### PR DESCRIPTION
#4331, le retour.

J'ai été trop vite https://github.com/etalab/transport-site/pull/4332#issuecomment-2501242118 et placé ce champ dans `station_status` alors qu'il est présent dans `station_information`. Repéré en inspectant les statistiques en production et en constatant un 0 partout…

Cette PR répare ceci.