### PR TITLE
Tri des JDDs : null en dernier

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -413,7 +413,7 @@ defmodule DB.Dataset do
 
   @spec order_datasets(Ecto.Query.t(), map()) :: Ecto.Query.t()
   def order_datasets(datasets, %{"order_by" => "alpha"}), do: order_by(datasets, asc: :custom_title)
-  def order_datasets(datasets, %{"order_by" => "most_recent"}), do: order_by(datasets, desc: :inserted_at)
+  def order_datasets(datasets, %{"order_by" => "most_recent"}), do: order_by(datasets, desc_nulls_last: :inserted_at)
 
   def order_datasets(datasets, %{"q" => q}),
     do:

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -330,8 +330,9 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
     older_dataset = insert(:dataset, type: type, inserted_at: last_week)
     recent_dataset = insert(:dataset, type: type, inserted_at: today)
+    null_dataset = insert(:dataset, type: type) |> Ecto.Changeset.change(%{inserted_at: nil}) |> DB.Repo.update!()
 
-    assert [recent_dataset.id, older_dataset.id] ==
+    assert [recent_dataset.id, older_dataset.id, null_dataset.id] ==
              %{"type" => type, "order_by" => "most_recent"}
              |> Dataset.list_datasets()
              |> DB.Repo.all()


### PR DESCRIPTION
En lien avec #4337

Malheureusement la précédente PR se heurte à la question des quelques valeurs `null` présentes dans la colonne, avant que la colonne n'existe dans la table. https://github.com/etalab/transport-site/pull/4338#issuecomment-2501537923

Cette PR fait en sorte que l'on mette ces JDDs à la fin, et non au début.