### PR TITLE
Backoffice - jobs : support des états "retryable" et "scheduled"

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.ex
@@ -107,6 +107,8 @@ defmodule TransportWeb.Backoffice.JobsLive do
       count_scheduled_jobs: count_jobs("scheduled", worker_filter),
       last_discarded_jobs: last_jobs("discarded", 5, worker_filter),
       count_discarded_jobs: count_jobs("discarded", worker_filter),
+      retryable_jobs: last_jobs("retryable", 5, worker_filter),
+      count_retryable_jobs: count_jobs("retryable", worker_filter),
       jobs_count: jobs_count(worker_filter)
     )
   end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.ex
@@ -47,7 +47,7 @@ defmodule TransportWeb.Backoffice.JobsLive do
 
   def last_jobs_query(state, n) do
     from(j in "oban_jobs",
-      select: map(j, [:id, :state, :queue, :worker, :args, :inserted_at, :errors]),
+      select: map(j, [:id, :state, :queue, :worker, :args, :inserted_at, :scheduled_at, :errors]),
       order_by: [desc: j.id],
       where: j.state == ^state,
       limit: ^n
@@ -103,6 +103,8 @@ defmodule TransportWeb.Backoffice.JobsLive do
       count_completed_jobs: count_jobs("completed", worker_filter),
       available_jobs: last_jobs("available", 5, worker_filter),
       count_available_jobs: count_jobs("available", worker_filter),
+      scheduled_jobs: last_jobs("scheduled", 5, worker_filter),
+      count_scheduled_jobs: count_jobs("scheduled", worker_filter),
       last_discarded_jobs: last_jobs("discarded", 5, worker_filter),
       count_discarded_jobs: count_jobs("discarded", worker_filter),
       jobs_count: jobs_count(worker_filter)

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -47,6 +47,10 @@
   <.live_component module={JobsTableComponent} jobs={@scheduled_jobs} state="scheduled" id="scheduled_jobs" />
   <p class="small">Total: <%= Helpers.format_number(@count_scheduled_jobs, locale: "en") %></p>
 
+  <h2>Retryable jobs</h2>
+  <.live_component module={JobsTableComponent} jobs={@retryable_jobs} state="retryable" id="retryable_jobs" />
+  <p class="small">Total: <%= Helpers.format_number(@count_retryable_jobs, locale: "en") %></p>
+
   <h2>Available jobs</h2>
   <.live_component module={JobsTableComponent} jobs={@available_jobs} state="available" id="available_jobs" />
   <p class="small">Total: <%= Helpers.format_number(@count_available_jobs, locale: "en") %></p>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -43,6 +43,10 @@
   <.live_component module={JobsTableComponent} jobs={@last_completed_jobs} state="completed" id="completed_jobs" />
   <p class="small">Total: <%= Helpers.format_number(@count_completed_jobs, locale: "en") %></p>
 
+  <h2>Scheduled jobs</h2>
+  <.live_component module={JobsTableComponent} jobs={@scheduled_jobs} state="scheduled" id="scheduled_jobs" />
+  <p class="small">Total: <%= Helpers.format_number(@count_scheduled_jobs, locale: "en") %></p>
+
   <h2>Available jobs</h2>
   <.live_component module={JobsTableComponent} jobs={@available_jobs} state="available" id="available_jobs" />
   <p class="small">Total: <%= Helpers.format_number(@count_available_jobs, locale: "en") %></p>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -18,6 +18,9 @@ defmodule JobsTableComponent do
           <%= if @state == "discarded" do %>
             <th>errors</th>
           <% end %>
+          <%= if @state == "scheduled" do %>
+            <th>scheduled_at (Paris time)</th>
+          <% end %>
         </tr>
       </thead>
       <tbody>
@@ -32,6 +35,9 @@ defmodule JobsTableComponent do
             <%= if @state == "discarded" do %>
               <td><%= inspect(job.errors) %></td>
             <% end %>
+            <%= if @state == "scheduled" do %>
+              <td><%= format_datetime(job.scheduled_at) %></td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>
@@ -40,6 +46,6 @@ defmodule JobsTableComponent do
   end
 
   defp format_datetime(dt) do
-    Shared.DateTimeDisplay.format_datetime_to_paris(dt, "en", no_timezone: true)
+    Shared.DateTimeDisplay.format_datetime_to_paris(dt, "en", no_timezone: true, with_seconds: true)
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -15,10 +15,10 @@ defmodule JobsTableComponent do
           <th>worker</th>
           <th>args</th>
           <th>inserted_at (Paris time)</th>
-          <%= if @state == "discarded" do %>
+          <%= if @state in ["discarded", "retryable"] do %>
             <th>errors</th>
           <% end %>
-          <%= if @state == "scheduled" do %>
+          <%= if @state in ["scheduled", "retryable"] do %>
             <th>scheduled_at (Paris time)</th>
           <% end %>
         </tr>
@@ -32,10 +32,10 @@ defmodule JobsTableComponent do
             <td><%= job.worker %></td>
             <td><%= inspect(job.args) %></td>
             <td><%= format_datetime(job.inserted_at) %></td>
-            <%= if @state == "discarded" do %>
+            <%= if @state in ["discarded", "retryable"] do %>
               <td><%= inspect(job.errors) %></td>
             <% end %>
-            <%= if @state == "scheduled" do %>
+            <%= if @state in ["scheduled", "retryable"] do %>
               <td><%= format_datetime(job.scheduled_at) %></td>
             <% end %>
           </tr>


### PR DESCRIPTION
Dans le cadre de #4326 j'ai utilisé la fonctionnalité de "snooze" d'Oban, ce qui place certains jobs dans l'état "scheduled_in". En testant davantage cette PR j'ai également constaté que certains jobs en erreurs (état "retryable") n'étaient pas non plus listés.

Pour les jobs "scheduled", la date de prochaine exécution est affichée.

Pour les jobs "retryable", l'erreur et la date de prochaine exécution sont affichées.