### PR TITLE
ImportGBFSFeedContactEmailJob : remplit organization pour le contact

### DIFF
--- a/apps/transport/lib/jobs/import_gbfs_feed_contact_email_job.ex
+++ b/apps/transport/lib/jobs/import_gbfs_feed_contact_email_job.ex
@@ -1,11 +1,12 @@
 defmodule Transport.Jobs.ImportGBFSFeedContactEmailJob do
   @moduledoc """
-  Reuse `feed_contact_email` from GBFS feed.
+  Reuse `feed_contact_email` from GBFS feeds.
 
   Use these email addresses to find or create a contact and subscribe this contact
   to producer subscriptions for this dataset.
 
-  When a `feed_contact_point` was previously set and has been removed, we delete old subscriptions.
+  When a `feed_contact_point` was previously set and changed,
+  we delete old subscriptions and create new ones.
   """
   use Oban.Worker, max_attempts: 3
   import Ecto.Query
@@ -45,7 +46,12 @@ defmodule Transport.Jobs.ImportGBFSFeedContactEmailJob do
         contact
 
       nil ->
-        %{mailing_list_title: contact_title(resource_url), email: feed_contact_email, creation_source: @contact_source}
+        %{
+          mailing_list_title: contact_title(resource_url),
+          email: feed_contact_email,
+          creation_source: @contact_source,
+          organization: Transport.GBFSMetadata.operator(resource_url)
+        }
         |> DB.Contact.insert!()
     end
   end

--- a/apps/transport/test/transport/jobs/import_gbfs_feed_contact_point_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_gbfs_feed_contact_point_job_test.exs
@@ -143,7 +143,7 @@ defmodule Transport.Test.Transport.Jobs.ImportGBFSFeedContactEmailJobTest do
         feed_contact_email: email
       })
 
-      %DB.Contact{email: ^email, creation_source: :"automation:import_gbfs_feed_contact_email"} =
+      %DB.Contact{email: ^email, creation_source: :"automation:import_gbfs_feed_contact_email", organization: "Example"} =
         contact = DB.Repo.get_by(DB.Contact, mailing_list_title: "Équipe technique GBFS Example")
 
       assert nil == DB.Repo.reload(previous_gbfs_contact_ns)
@@ -167,7 +167,7 @@ defmodule Transport.Test.Transport.Jobs.ImportGBFSFeedContactEmailJobTest do
           )
         end)
 
-      # Another producer production does not interfere
+      # Another producer's subscription does not interfere
       other_ns =
         insert(:notification_subscription,
           dataset_id: dataset.id,


### PR DESCRIPTION
Suite de #4344

- Remplit le champ `contact.organization` lorsque l'on crée un contact
- Correction de quelques commentaires