### PR TITLE
GBFS operators : renseigne Ilévia

### DIFF
--- a/apps/transport/priv/gbfs_operators.csv
+++ b/apps/transport/priv/gbfs_operators.csv
@@ -15,6 +15,7 @@ fifteen.eu;Fifteen
 fifteen.site;Fifteen
 getapony.com;Pony
 lime.bike;Lime
+media.ilevia.fr/opendata;Cykleo
 nextbike.net;nextbike
 smovengo.cloud;Fifteen
 urbansharing.com/lovelolibreservice.fr;Citybike


### PR DESCRIPTION
Lille diffuse les données VLS de Cykleo sur leur domaine depuis peu. [Le job de suivi](https://app.frontapp.com/open/msg_2ahlrwra?key=XMuQtFcBrrejewA3hxMC2N8LcacyNHug) a identifié qu'on ne connaissait pas l'opérateur.

Cette URL est donc ajoutée à la configuration.