### PR TITLE
Tests exécutés les lundis en CI

### DIFF
--- a/apps/transport/test/documentation_links_test.exs
+++ b/apps/transport/test/documentation_links_test.exs
@@ -1,6 +1,6 @@
 defmodule Transport.DocumentationLinksTest do
   use ExUnit.Case, async: true
-  @moduletag :documentation_links
+  @moduletag :ci_only_on_mondays
   @documentation_domain "doc.transport.data.gouv.fr"
 
   test "documentation links are valid" do

--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -3,13 +3,15 @@ exclude = [:pending]
 # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 extra_exclude =
   if System.get_env("CI") == "true" do
-    # Run :documentation_links only on Mondays
+    # Run tests tagged with `:ci_only_on_mondays` only:
+    # - within the continuous integration env
+    # - on Mondays
     case Date.utc_today() |> Date.day_of_week() do
       1 -> []
-      _ -> [:documentation_links]
+      _ -> [:ci_only_on_mondays]
     end
   else
-    [:transport_tools, :documentation_links, :external]
+    [:transport_tools, :ci_only_on_mondays, :external]
   end
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -183,7 +183,7 @@ defmodule Transport.GTFSRTTest do
            } == feed |> GTFSRT.service_alerts_for_display() |> List.first()
   end
 
-  @tag :external
+  @tag :ci_only_on_mondays
   test ".proto file is up-to-date" do
     normalize_whitespace = fn value ->
       String.trim(Regex.replace(~r/\s*/u, value, ""))


### PR DESCRIPTION
Exécute certains tests uniquement sur CircleCI, uniquement les lundis. Ceci est utile pour des tests que l'on doit exécuter de manière régulière sans que ce soit nécessaire et bloquant.

Les tests concernés sont :
- vérifier que les liens vers la documentation sont bien valides
- que le fichier Protobuf GTFS-RT est bien à jour