### PR TITLE
NewDatagouvDatasetsJob : recherche pour ZFE et gestion accents

### DIFF
--- a/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_datagouv_datasets_job_test.exs
@@ -36,6 +36,9 @@ defmodule Transport.Test.Transport.Jobs.NewDatagouvDatasetsJobTest do
     assert %{category: "Transport en commun"} = relevant_fn.(%{base | "description" => "GTFS de Dijon"})
     assert %{category: "Transport en commun"} = relevant_fn.(%{base | "tags" => [Ecto.UUID.generate(), "gtfs"]})
 
+    assert %{category: "Covoiturage et ZFE"} =
+             relevant_fn.(%{base | "description" => "Périmètre de la Zone à Faible Émission (ZFE) de Dijon Métropole."})
+
     assert %{category: "Freefloating"} =
              relevant_fn.(%{
                base


### PR DESCRIPTION
Adapte `NewDatagouvDatasetsJob`, le job en charge d'identifier les JDDs récemment publiés sur data.gouv.fr susceptibles d'être pertinents chez nous pour :
- avoir de meilleurs mots clés pour la catégorie des ZFE
- mieux gérer les accents dans les règles, pour éviter de voir indiquer `velo` et `vélo` par exemple