### PR TITLE
CI : cache du build Webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ defaults: &defaults
       default: plt-v4
       type: string
     js_cache_key:
-      default: js-v2
+      default: js-v3
       type: string
   working_directory: ~/transport
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
           key: js-<< parameters.js_cache_key >>-{{ checksum "apps/transport/client/yarn.lock" }}
           paths:
             - ~/transport/apps/transport/client/node_modules
+            - ~/transport/apps/transport/priv/static
 
       - run:
           name: Run gettext check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ defaults: &defaults
       default: plt-v4
       type: string
     js_cache_key:
-      default: js-v3
+      default: js-v4
       type: string
   working_directory: ~/transport
   docker:

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
     mode: 'production',
     cache: {
         type: 'filesystem',
-        compression: 'gzip',
+        compression: 'gzip'
     },
     optimization: {
         minimizer: [

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -23,7 +23,7 @@ if (process.env.CI === 'true') {
         type: 'filesystem',
         compression: 'gzip'
     }
-    config.infrastructureLogging: { debug: true }
+    config.infrastructureLogging = { debug: true }
 }
 
 module.exports = merge(common, config)

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -17,6 +17,8 @@ const config = {
 
 // Enable caching only in the continuous integration env to speed-up builds
 if (process.env.CI === 'true') {
+    console.log('cache is enabled ♻️⚡️')
+
     config.cache = {
         type: 'filesystem',
         compression: 'gzip'

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -6,6 +6,10 @@ console.log('webpack production configuration is used 🚀')
 
 module.exports = merge(common, {
     mode: 'production',
+    cache: {
+        type: 'filesystem',
+        compression: 'gzip',
+    },
     optimization: {
         minimizer: [
             // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), uncomment the next line

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -23,6 +23,7 @@ if (process.env.CI === 'true') {
         type: 'filesystem',
         compression: 'gzip'
     }
+    config.infrastructureLogging: { debug: true }
 }
 
 module.exports = merge(common, config)

--- a/apps/transport/client/webpack.prod.js
+++ b/apps/transport/client/webpack.prod.js
@@ -4,12 +4,8 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 
 console.log('webpack production configuration is used 🚀')
 
-module.exports = merge(common, {
+const config = {
     mode: 'production',
-    cache: {
-        type: 'filesystem',
-        compression: 'gzip'
-    },
     optimization: {
         minimizer: [
             // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), uncomment the next line
@@ -17,4 +13,14 @@ module.exports = merge(common, {
             new CssMinimizerPlugin()
         ]
     }
-})
+}
+
+// Enable caching only in the continuous integration env to speed-up builds
+if (process.env.CI === 'true') {
+    config.cache = {
+        type: 'filesystem',
+        compression: 'gzip'
+    }
+}
+
+module.exports = merge(common, config)


### PR DESCRIPTION
Cette PR met en place du [cache Webpack](https://webpack.js.org/configuration/cache/) pour accéder le job `Compile assets` et la commande `cd ~/transport/apps/transport/client && npm run build`.

On passe d'environ 60 secondes à 4s en CI, soit un gain d'environ 1 minute par build 🥳 

À noter qu'il n'y a pas de risque d'impact en production, on ne package pas (encore ?) les assets JS/CSS/images lors du CI pour une release en production.

[Voir le dernier workflow](https://app.circleci.com/pipelines/github/etalab/transport-site/11596/workflows/c6e8c006-3af8-4abb-a92d-14b48ad95b14/jobs/44906)