### PR TITLE
CircleCI : checksum pour fichiers Webpack et yarn.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,13 @@ jobs:
             - ~/transport/deps
             - ~/.mix
 
+      - run:
+          name: Create checksum for JS files
+          command: cd ~/transport/apps/transport/client && shasum webpack.*.js yarn.lock > /tmp/js-checksum
+
       - restore_cache:
           keys:
-            - js-<< parameters.js_cache_key >>-{{ checksum "apps/transport/client/yarn.lock" }}
+            - js-<< parameters.js_cache_key >>-{{ checksum "/tmp/js-checksum" }}
             - js-<< parameters.js_cache_key >>
 
       - run:
@@ -113,7 +117,7 @@ jobs:
           command: cd ~/transport/apps/transport/client && npm run build
 
       - save_cache:
-          key: js-<< parameters.js_cache_key >>-{{ checksum "apps/transport/client/yarn.lock" }}
+          key: js-<< parameters.js_cache_key >>-{{ checksum "/tmp/js-checksum" }}
           paths:
             - ~/transport/apps/transport/client/node_modules
             - ~/transport/apps/transport/priv/static


### PR DESCRIPTION
Suite de #4375

L'amélioration introduite en cours de PR (cache uniquement en CI et non quand le build est en production) nous amène à la situation suivante :
- le fichier `webpack.prod.js` a été modifié depuis que le cache CircleCI a été créé (la clé du cache étant `js-<< parameters.js_cache_key >>-{{ checksum "apps/transport/client/yarn.lock" }}`)
- webpack ignore le cache préalablement sauvegardé car la configuration webpack a changé

[Un build sur master](https://app.circleci.com/jobs/github/etalab/transport-site/44921) fait apparaitre les logs suivants pour la tâche "Compile assets"

```
<t> [webpack.cache.PackFileCacheStrategy] restore cache container: 58.304911 ms
    [webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] /root/transport/apps/transport/client/webpack.prod.js invalidated because hashes differ (b5fd4b5d52abcefc450986a4c7dcb374 != 12c2e7f65daf765a0e93f9acf8bb1e1b)
    [webpack.cache.PackFileCacheStrategy] Restored pack from /root/transport/apps/transport/client/node_modules/.cache/webpack/default-production.pack.gz, but build dependencies have changed.
    [webpack.cache.PackFileCacheStrategy] resolving of build dependencies is invalid, will re-resolve build dependencies
<t> [webpack.cache.PackFileCacheStrategy] check build dependencies: 914.619459 ms
    [IdleFileCachePlugin] Initial cache was generated and cache will be persisted in 5s.
    [webpack-cli] Compiler finished
    [webpack.cache.PackFileCacheStrategy] Pack got invalid because of write to: ResolverCachePlugin|normal|default|dependencyType=|esm|path=|/root/transport/apps/transport/client|request=|./javascripts/app.js
```

Cette PR propose donc de lier le cache JS à `yarn.lock` et aux fichiers de configuration webpack, pour forcer le fait d'écrire un nouveau cache JS quand on met à jour les dépendances ou la configuration Webpack.