### PR TITLE
Correctif & amélioration outil de scan IRVE back-office

### DIFF
--- a/apps/transport/lib/irve/extractor.ex
+++ b/apps/transport/lib/irve/extractor.ex
@@ -157,7 +157,7 @@ defmodule Transport.IRVE.Extractor do
     |> Map.put(:line_count, line_count)
   end
 
-  def process_body(row), do: row
+  def process_resource_body(row, _body), do: row
 
   @doc """
   Save the outcome in the database for reporting.

--- a/apps/transport/lib/irve/extractor.ex
+++ b/apps/transport/lib/irve/extractor.ex
@@ -111,6 +111,7 @@ defmodule Transport.IRVE.Extractor do
     |> Enum.map(fn x ->
       Map.take(x, [
         :dataset_id,
+        :http_status,
         :dataset_title,
         :dataset_organisation_name,
         :dataset_organisation_url,
@@ -133,7 +134,7 @@ defmodule Transport.IRVE.Extractor do
       Transport.IRVE.Fetcher.get!(row[:url], compressed: false, decode_body: false)
 
     row
-    |> Map.put(:status, status)
+    |> Map.put(:http_status, status)
     |> Map.put(:index, index)
     |> then(fn x -> process_resource_body(x, body) end)
   end
@@ -142,7 +143,7 @@ defmodule Transport.IRVE.Extractor do
   For a given resource and corresponding body, enrich data with
   extra stuff like estimated number of charge points.
   """
-  def process_resource_body(%{status: 200} = row, body) do
+  def process_resource_body(%{http_status: 200} = row, body) do
     body = body |> String.split("\n")
     first_line = body |> hd()
     line_count = (body |> length) - 1

--- a/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
@@ -3,7 +3,7 @@ defmodule TransportWeb.Backoffice.IRVEDashboardLive do
   use Phoenix.HTML
   import TransportWeb.Backoffice.JobsLive, only: [ensure_admin_auth_or_redirect: 3]
   import TransportWeb.Router.Helpers
-  import Helpers, only: [format_number: 1]
+  import Helpers, only: [format_number_maybe_nil: 2]
   import Ecto.Query, only: [last: 2]
 
   @impl true

--- a/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
@@ -25,7 +25,12 @@ defmodule TransportWeb.Backoffice.IRVEDashboardLive do
 
     filtering_expression == "" ||
       String.contains?(resource["dataset_organisation_name"] |> String.downcase(), filtering_expression) ||
-      String.contains?(format_validity(resource["valid"], resource["http_status"]) |> inspect |> String.downcase(), filtering_expression)
+      String.contains?(
+        format_validity(resource["valid"], resource["http_status"])
+        |> inspect
+        |> String.downcase(),
+        filtering_expression
+      )
   end
 
   def assign_data(socket) do

--- a/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.ex
@@ -25,7 +25,7 @@ defmodule TransportWeb.Backoffice.IRVEDashboardLive do
 
     filtering_expression == "" ||
       String.contains?(resource["dataset_organisation_name"] |> String.downcase(), filtering_expression) ||
-      String.contains?(format_validity(resource["valid"]) |> inspect |> String.downcase(), filtering_expression)
+      String.contains?(format_validity(resource["valid"], resource["http_status"]) |> inspect |> String.downcase(), filtering_expression)
   end
 
   def assign_data(socket) do
@@ -119,7 +119,9 @@ defmodule TransportWeb.Backoffice.IRVEDashboardLive do
     |> Enum.sort_by(fn x -> x["line_count"] end, :desc)
   end
 
-  def format_validity(false), do: {:safe, "<strong class='red'>KO</strong>"}
-  def format_validity(true), do: "OK"
-  def format_validity(nil), do: "Non testé"
+  def format_validity(false, 200), do: {:safe, "<strong class='red'>KO</strong>"}
+  def format_validity(true, 200), do: "OK"
+  def format_validity(nil, 200), do: "Non testé"
+  # mostly there to handle 404/500. Ignore validity and assume the resource is not reachable at all
+  def format_validity(_validity, http_status), do: {:safe, "<strong class='red'>KO (#{http_status})</strong>"}
 end

--- a/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.html.heex
@@ -45,7 +45,7 @@
             <td>
               <%= format_validity(resource["valid"]) %>
             </td>
-            <td><%= format_number(resource["line_count"]) %></td>
+            <td><%= format_number_maybe_nil(resource["line_count"], nil_result: "???") %></td>
           </tr>
         <% end %>
       </tbody>

--- a/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/irve_dashboard_live.html.heex
@@ -43,7 +43,7 @@
               &mdash; <%= resource["last_modified"] |> String.slice(0..15) %>
             </td>
             <td>
-              <%= format_validity(resource["valid"]) %>
+              <%= format_validity(resource["valid"], resource["http_status"]) %>
             </td>
             <td><%= format_number_maybe_nil(resource["line_count"], nil_result: "???") %></td>
           </tr>

--- a/apps/transport/test/transport/irve/irve_extractor_test.exs
+++ b/apps/transport/test/transport/irve/irve_extractor_test.exs
@@ -117,6 +117,7 @@ defmodule Transport.IRVE.ExtractorTest do
              orig_resource
              |> Map.put(:index, 0)
              |> Map.put(:line_count, 3)
+             |> Map.put(:http_status, 200)
              |> Map.delete(:url)
            ]
   end
@@ -147,6 +148,7 @@ defmodule Transport.IRVE.ExtractorTest do
     assert Transport.IRVE.Extractor.download_and_parse_all(resources) == [
       orig_resource
       |> Map.put(:index, 0)
+      |> Map.put(:http_status, 404)
       |> Map.delete(:url)
     ]
   end

--- a/apps/transport/test/transport/irve/irve_extractor_test.exs
+++ b/apps/transport/test/transport/irve/irve_extractor_test.exs
@@ -146,10 +146,10 @@ defmodule Transport.IRVE.ExtractorTest do
 
     # parsed resources must be enriched with line count & index, and url removed
     assert Transport.IRVE.Extractor.download_and_parse_all(resources) == [
-      orig_resource
-      |> Map.put(:index, 0)
-      |> Map.put(:http_status, 404)
-      |> Map.delete(:url)
-    ]
+             orig_resource
+             |> Map.put(:index, 0)
+             |> Map.put(:http_status, 404)
+             |> Map.delete(:url)
+           ]
   end
 end

--- a/apps/transport/test/transport/irve/irve_extractor_test.exs
+++ b/apps/transport/test/transport/irve/irve_extractor_test.exs
@@ -120,4 +120,34 @@ defmodule Transport.IRVE.ExtractorTest do
              |> Map.delete(:url)
            ]
   end
+
+  test "handles non-200 response" do
+    resources = [
+      orig_resource = %{
+        url: expected_url = "https://static.data.gouv.fr/resources/something/something.csv",
+        dataset_id: "the-dataset-id",
+        dataset_title: "the-dataset-title",
+        resource_id: "the-resource-id",
+        resource_title: "the-resource-title",
+        valid: true
+      }
+    ]
+
+    Transport.Req.Mock
+    |> expect(:get!, fn _request, options ->
+      assert options[:url] == expected_url
+
+      %Req.Response{
+        status: 404,
+        body: "there is nothing here"
+      }
+    end)
+
+    # parsed resources must be enriched with line count & index, and url removed
+    assert Transport.IRVE.Extractor.download_and_parse_all(resources) == [
+      orig_resource
+      |> Map.put(:index, 0)
+      |> Map.delete(:url)
+    ]
+  end
 end


### PR DESCRIPTION
Cette PR corrige ce bug:
- #4383 

### Cause racine

Quand une ressource ne retournait pas HTTP 200, une erreur se produisait qui stoppait la progression. Le code est testé pour ce cas à présent.

### Amélioration ergonomique

Si une ressource est rapportée comme "valide" par data gouv, _mais_ retourne un HTTP différent de 200 (typiquement 404/500), comme ça s'est produit ici, j'affiche à présent `KO` suivi du status HTTP, ce qui permet de filtrer sur ce cas. Vidéo:

https://github.com/user-attachments/assets/4c5e841b-9ae1-47c8-ac59-5de7a6ea88e7


