### PR TITLE
Supprimer traduction horaires théoriques

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -154,7 +154,7 @@ defmodule DB.Dataset do
   @spec type_to_str_map() :: %{binary() => binary()}
   def type_to_str_map,
     do: %{
-      "public-transit" => dgettext("db-dataset", "Public transit - static schedules"),
+      "public-transit" => dgettext("db-dataset", "Public transit"),
       "carpooling-areas" => dgettext("db-dataset", "Carpooling areas"),
       "carpooling-lines" => dgettext("db-dataset", "Carpooling lines"),
       "carpooling-offers" => dgettext("db-dataset", "Carpooling offers"),

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -273,14 +273,6 @@
           text: Dataset.type_to_str(@dataset.type),
           icon: icon_type_path(@dataset)
         ) %>
-        <%= if real_time_public_transit?(@dataset) do %>
-          <%= render("_dataset_type.html",
-            conn: @conn,
-            link: dataset_path(@conn, :index, type: "public-transit", filter: "has_realtime"),
-            text: dgettext("page-index", "Public transport - realtime traffic"),
-            icon: icon_type_path("real-time-public-transit")
-          ) %>
-        <% end %>
       </div>
       <div class="pt-12">
         <%= render("_licence.html", conn: @conn, dataset: @dataset) %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -367,12 +367,6 @@ defmodule TransportWeb.DatasetView do
     |> Enum.filter(&Resource.documentation?/1)
   end
 
-  def real_time_public_transit?(%Dataset{type: "public-transit"} = dataset) do
-    not Enum.empty?(real_time_official_resources(dataset))
-  end
-
-  def real_time_public_transit?(%Dataset{}), do: false
-
   def community_resources(dataset), do: Dataset.community_resources(dataset)
 
   def licence_url(licence) when licence in ["fr-lo", "lov2"],

--- a/apps/transport/priv/gettext/db-dataset.pot
+++ b/apps/transport/priv/gettext/db-dataset.pot
@@ -75,7 +75,7 @@ msgid "Charging & refuelling stations"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Public transit - static schedules"
+msgid "Public transit"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/db-dataset.po
@@ -76,7 +76,7 @@ msgid "Charging & refuelling stations"
 msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "Public transit - static schedules"
+msgid "Public transit"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/db-dataset.po
@@ -76,8 +76,8 @@ msgid "Charging & refuelling stations"
 msgstr "Stations de réapprovisionnement de véhicules"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "Public transit - static schedules"
-msgstr "Transport public collectif - horaires théoriques"
+msgid "Public transit"
+msgstr "Transport public collectif"
 
 #, elixir-autogen, elixir-format
 msgid "Road data"

--- a/apps/transport/test/transport/data_checker_test.exs
+++ b/apps/transport/test/transport/data_checker_test.exs
@@ -340,7 +340,7 @@ defmodule Transport.DataCheckerTest do
         subject: "Nouveaux jeux de données référencés",
         text_body: nil,
         html_body:
-          ~r|<li><a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a> - \(Transport public collectif - horaires théoriques\)</li>|
+          ~r|<li><a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a> - \(Transport public collectif\)</li>|
       )
 
       assert [

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -850,7 +850,7 @@ defmodule TransportWeb.DatasetControllerTest do
 
   test "dataset-page-title", %{conn: conn} do
     [
-      {%{"type" => "public-transit"}, "Transport public collectif - horaires théoriques"},
+      {%{"type" => "public-transit"}, "Transport public collectif"},
       {%{"type" => "public-transit", "filter" => "has_realtime"}, "Transport public collectif - horaires temps réel"},
       {%{"modes" => ["rail"]}, "Transport ferroviaire"}
     ]

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -62,7 +62,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
   test "GET /datasets filter", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index))
     # info dans les filtres à gauche des datasets
-    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (2)"
+    assert html_response(conn, 200) =~ "Transport public collectif (2)"
   end
 
   describe "list datasets" do
@@ -156,7 +156,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
   test "GET /datasets?type=public-transit&licence=odc-odbl", %{conn: conn} do
     conn = conn |> get(dataset_path(conn, :index), %{type: "public-transit", licence: "odc-odbl"})
-    assert html_response(conn, 200) =~ "Transport public collectif - horaires théoriques (1)"
+    assert html_response(conn, 200) =~ "Transport public collectif (1)"
     assert html_response(conn, 200) =~ "Horaires Angers"
     refute html_response(conn, 200) =~ "Horaires Laval"
 

--- a/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/followed_datasets_live_test.exs
@@ -27,7 +27,7 @@ defmodule TransportWeb.Live.FollowedDatasetsLiveTest do
              {"select", [{"id", "type"}, {"name", "type"}],
               [
                 {"option", [{"selected", "selected"}, {"value", ""}], ["Tout"]},
-                {"option", [{"value", "public-transit"}], ["Transport public collectif - horaires théoriques"]},
+                {"option", [{"value", "public-transit"}], ["Transport public collectif"]},
                 {"option", [{"value", "bike-scooter-sharing"}], ["Vélos et trottinettes en libre-service"]}
               ]}
            ] == view |> element("form select") |> render() |> Floki.parse_document!()


### PR DESCRIPTION
Fixes #4388

- Change le label pour la catégorie `public-transit` : de "Transport public collectif - horaires théoriques" à "Transport public collectif"
- N'affiche pas 2 labels pour les JDDs avec du temps-réel : uniquement "Transport public collectif"
- On garde le titre de la tuile "Transport public collectif - horaires temps réel" sur la page d'accueil et le titre des résultats de la recherche si on clique sur cette tuile

La page d'accueil est laissée telle quelle, seul le titre de la première tuile est modifié pour correspondre au reste, uniquement "Transport public collectif". La question des tuiles pour les autres modes pourra être abordée ultérieurement.

cc @cyrilmorin