### PR TITLE
Suppression feature flag espace réutilisateur

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -56,7 +56,6 @@ defmodule TransportWeb.Router do
   pipeline :reuser_space do
     plug(:browser)
     plug(:authentication_required, destination_path: "/infos_reutilisateurs")
-    plug(:check_reuser_space_enabled)
   end
 
   scope "/", OpenApiSpex.Plug do
@@ -384,17 +383,6 @@ defmodule TransportWeb.Router do
 
       _ ->
         conn
-    end
-  end
-
-  def check_reuser_space_enabled(%Plug.Conn{} = conn, _) do
-    if TransportWeb.Session.display_reuser_space?(conn) do
-      conn
-    else
-      conn
-      |> put_flash(:info, dgettext("alert", "This feature is currently not available."))
-      |> redirect(to: "/")
-      |> halt()
     end
   end
 

--- a/apps/transport/lib/transport_web/session.ex
+++ b/apps/transport/lib/transport_web/session.ex
@@ -58,23 +58,6 @@ defmodule TransportWeb.Session do
     DB.Dataset.base_query() |> where([dataset: d], d.organization_id in ^org_ids) |> DB.Repo.exists?()
   end
 
-  @doc """
-  A temporary helper method to determine if we should display "reuser space features".
-  Convenient method to find various entrypoints in the codebase:
-  - links and buttons to the reuser space
-  - follow dataset hearts (search results, dataset pages)
-  - reuser space
-
-  Enable it for everybody but keep a "kill switch" to disable it quickly
-  by setting an environment variable and rebooting the app.
-
-  transport.data.gouv.fr admins get access no matter what.
-  """
-  def display_reuser_space?(%Plug.Conn{} = conn) do
-    feature_disabled = Application.fetch_env!(:transport, :disable_reuser_space)
-    admin?(conn) or not feature_disabled
-  end
-
   @spec set_session_attribute_attribute(Plug.Conn.t(), binary(), boolean()) :: Plug.Conn.t()
   defp set_session_attribute_attribute(%Plug.Conn{} = conn, key, value) do
     current_user = current_user(conn)

--- a/apps/transport/lib/transport_web/templates/dataset/_header_links.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_header_links.html.heex
@@ -3,32 +3,30 @@
     <i class="fa fa-external-link-alt"></i>
     <%= link("Backoffice", to: backoffice_page_path(@conn, :edit, @dataset.id)) %> &middot;
   <% end %>
-  <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
-    <i class="fa fa-external-link-alt"></i>
-    <%= if @current_user do %>
-      <%= if @is_producer do %>
-        <%= link(dgettext("default", "Producer space"),
-          to: espace_producteur_path(@conn, :edit_dataset, @dataset.id, utm_campaign: "dataset_details"),
+  <i class="fa fa-external-link-alt"></i>
+  <%= if @current_user do %>
+    <%= if @is_producer do %>
+      <%= link(dgettext("default", "Producer space"),
+        to: espace_producteur_path(@conn, :edit_dataset, @dataset.id, utm_campaign: "dataset_details"),
+        target: "_blank"
+      ) %>
+    <% else %>
+      <%= if @follows_dataset do %>
+        <%= link(dgettext("default", "Reuser space"),
+          to: reuser_space_path(@conn, :datasets_edit, @dataset.id, utm_campaign: "dataset_details"),
           target: "_blank"
         ) %>
       <% else %>
-        <%= if @follows_dataset do %>
-          <%= link(dgettext("default", "Reuser space"),
-            to: reuser_space_path(@conn, :datasets_edit, @dataset.id, utm_campaign: "dataset_details"),
-            target: "_blank"
-          ) %>
-        <% else %>
-          <%= link(dgettext("default", "Reuser space"),
-            to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "dataset_details"),
-            target: "_blank"
-          ) %>
-        <% end %>
+        <%= link(dgettext("default", "Reuser space"),
+          to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "dataset_details"),
+          target: "_blank"
+        ) %>
       <% end %>
-    <% else %>
-      <%= link(dgettext("default", "Reuser space"),
-        to: page_path(@conn, :infos_reutilisateurs, utm_campaign: "dataset_details"),
-        target: "_blank"
-      ) %>
     <% end %>
+  <% else %>
+    <%= link(dgettext("default", "Reuser space"),
+      to: page_path(@conn, :infos_reutilisateurs, utm_campaign: "dataset_details"),
+      target: "_blank"
+    ) %>
   <% end %>
 </div>

--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -239,11 +239,9 @@
   </div>
   <div class="dataset-metas">
     <div class="panel">
-      <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
-        <%= live_render(@conn, TransportWeb.Live.FollowDatasetLive,
-          session: %{"current_user" => @current_user, "dataset_id" => @dataset.id}
-        ) %>
-      <% end %>
+      <%= live_render(@conn, TransportWeb.Live.FollowDatasetLive,
+        session: %{"current_user" => @current_user, "dataset_id" => @dataset.id}
+      ) %>
       <div class="dataset__logo">
         <%= img_tag(DB.Dataset.full_logo(@dataset), alt: @dataset.custom_title) %>
       </div>

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -196,9 +196,7 @@
                     </div>
                   </div>
                   <div class="dataset__type">
-                    <%= if not is_nil(@current_user) and TransportWeb.Session.display_reuser_space?(@conn) do %>
-                      <i class={heart_class(@dataset_heart_values, dataset)}></i>
-                    <% end %>
+                    <i :if={not is_nil(@current_user)} class={heart_class(@dataset_heart_values, dataset)}></i>
                     <%= unless is_nil(icon_type_path(dataset)) do %>
                       <%= img_tag(icon_type_path(dataset), alt: dataset.type) %>
                     <% end %>

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -97,11 +97,9 @@
                       to: page_path(@conn, :espace_producteur, utm_campaign: "menu_dropdown")
                     ) %>
                   <% end %>
-                  <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
-                    <%= link(gettext("Reuser space"),
-                      to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "menu_dropdown")
-                    ) %>
-                  <% end %>
+                  <%= link(gettext("Reuser space"),
+                    to: reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "menu_dropdown")
+                  ) %>
                   <a
                     class="navigation__link nagivation__link--logout"
                     href={session_path(@conn, :delete, redirect_path: current_path(@conn))}

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -7,14 +7,12 @@
         <a href={page_path(@conn, :espace_producteur, utm_campaign: "home_button")} class="button">
           <%= dgettext("page-index", "Producer space") %>
         </a>
-        <%= if TransportWeb.Session.display_reuser_space?(@conn) do %>
-          <a
-            href={reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "home_button")}
-            class="button reuser-space"
-          >
-            <%= dgettext("page-index", "Reuser space") %>
-          </a>
-        <% end %>
+        <a
+          href={reuser_space_path(@conn, :espace_reutilisateur, utm_campaign: "home_button")}
+          class="button reuser-space"
+        >
+          <%= dgettext("page-index", "Reuser space") %>
+        </a>
       </div>
       <div class="home-search">
         <div class="searchBar">

--- a/apps/transport/priv/gettext/alert.pot
+++ b/apps/transport/priv/gettext/alert.pot
@@ -29,7 +29,3 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This feature is currently not available."
-msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/alert.po
@@ -29,7 +29,3 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "This feature is currently not available."
-msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/alert.po
@@ -29,7 +29,3 @@ msgstr "Une erreur a eu lieu lors de la récupération de vos ressources"
 #, elixir-autogen, elixir-format
 msgid "Unable to get this dataset for the moment"
 msgstr "Impossible de récupérer ce jeu de données pour le moment"
-
-#, elixir-autogen, elixir-format
-msgid "This feature is currently not available."
-msgstr "La fonctionnalité n'est pas disponible pour le moment."

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -28,17 +28,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       # Feedback form is displayed
       refute content |> Floki.parse_document!() |> Floki.find("form.feedback-form") |> Enum.empty?()
     end
-
-    test "reuser space disabled by killswitch", %{conn: conn} do
-      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
-      Application.put_env(:transport, :disable_reuser_space, true)
-      conn = Plug.Test.init_test_session(conn, %{current_user: %{}})
-      refute TransportWeb.Session.display_reuser_space?(conn)
-      conn = conn |> get(@home_url)
-      assert redirected_to(conn, 302) == "/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "La fonctionnalité n'est pas disponible pour le moment"
-      Application.put_env(:transport, :disable_reuser_space, old_value)
-    end
   end
 
   describe "datasets_edit" do

--- a/apps/transport/test/transport_web/session_test.exs
+++ b/apps/transport/test/transport_web/session_test.exs
@@ -55,24 +55,6 @@ defmodule TransportWeb.SessionTest do
     end
   end
 
-  describe "display_reuser_space?" do
-    test "killswitch can disable the reuser space" do
-      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
-      Application.put_env(:transport, :disable_reuser_space, true)
-      conn = Plug.Test.init_test_session(%Plug.Conn{}, %{})
-      refute TransportWeb.Session.display_reuser_space?(conn)
-      Application.put_env(:transport, :disable_reuser_space, old_value)
-    end
-
-    test "admins get access when killswitch is enabled" do
-      old_value = Application.fetch_env!(:transport, :disable_reuser_space)
-      Application.put_env(:transport, :disable_reuser_space, true)
-      conn = Plug.Test.init_test_session(%Plug.Conn{}, %{current_user: %{"is_admin" => true}})
-      assert TransportWeb.Session.display_reuser_space?(conn)
-      Application.put_env(:transport, :disable_reuser_space, old_value)
-    end
-  end
-
   def pan_org do
     %{"slug" => "equipe-transport-data-gouv-fr", "name" => "PAN", "id" => @pan_org_id}
   end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -38,7 +38,6 @@ config :transport,
   worker: worker,
   webserver: webserver,
   # kill switches: set specific variable environments to disable features
-  disable_reuser_space: System.get_env("DISABLE_REUSER_SPACE") in ["1", "true"],
   disable_national_gtfs_map: System.get_env("DISABLE_NATIONAL_GTFS_MAP") in ["1", "true"]
 
 config :unlock,


### PR DESCRIPTION
L'espace réutilisateur est déployé depuis plusieurs mois. On avait du code permettant de désactiver rapidement cette fonctionnalité au lancement, pour corriger d'éventuels bugs ou problèmes de performance.

Ceci ne semble pas nécessaire maintenant, je :broom: donc.