### PR TITLE
Feature flag pour la validation NeTEx

### DIFF
--- a/apps/transport/lib/validators/validator_selection.ex
+++ b/apps/transport/lib/validators/validator_selection.ex
@@ -33,7 +33,14 @@ defmodule Transport.ValidatorsSelection.Impl do
   def validators(%{format: "GTFS"}), do: [Validators.GTFSTransport]
   def validators(%{format: "gtfs-rt"}), do: [Validators.GTFSRT]
   def validators(%{format: "gbfs"}), do: [Validators.GBFSValidator]
-  def validators(%{format: "NeTEx"}), do: [Validators.NeTEx]
+
+  def validators(%{format: "NeTEx"}) do
+    if netex_validator_enabled?() do
+      [Validators.NeTEx]
+    else
+      []
+    end
+  end
 
   def validators(%{schema_name: schema_name}) when not is_nil(schema_name) do
     cond do
@@ -49,4 +56,6 @@ defmodule Transport.ValidatorsSelection.Impl do
   end
 
   def validators(_), do: []
+
+  defp netex_validator_enabled?, do: !Application.fetch_env!(:transport, :disable_netex_validator)
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,7 +39,8 @@ config :transport,
   webserver: webserver,
   # kill switches: set specific variable environments to disable features
   disable_reuser_space: System.get_env("DISABLE_REUSER_SPACE") in ["1", "true"],
-  disable_national_gtfs_map: System.get_env("DISABLE_NATIONAL_GTFS_MAP") in ["1", "true"]
+  disable_national_gtfs_map: System.get_env("DISABLE_NATIONAL_GTFS_MAP") in ["1", "true"],
+  disable_netex_validator: System.get_env("DISABLE_NETEX_VALIDATOR") in ["1", "true"]
 
 config :unlock,
   enforce_ttl: webserver


### PR DESCRIPTION
Dans la perspective funeste où il nous faille la débrancher (notamment pendant les congés de fin d'année), voici une PR qui introduit la variable d'environnement `DISABLE_NETEX_VALIDATOR`, acceptant une valeur représentant un booléen, donc par convention `true` ou `false`. Par défaut la valeur est fausse. Il s'agit donc davantage d'un kill switch que d'un feature flag.