### PR TITLE
Amélioration de la stabilité d'un test

### DIFF
--- a/apps/transport/test/transport/jobs/import_gbfs_feed_contact_point_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_gbfs_feed_contact_point_job_test.exs
@@ -209,7 +209,7 @@ defmodule Transport.Test.Transport.Jobs.ImportGBFSFeedContactEmailJobTest do
 
     assert :ok == perform_job(ImportGBFSFeedContactEmailJob, %{})
 
-    assert [first_contact, new_contact] = DB.Contact |> DB.Repo.all() |> Enum.sort_by(& &1.inserted_at)
+    assert [first_contact, new_contact] = DB.Contact |> DB.Repo.all() |> Enum.sort_by(& &1.id)
 
     assert %DB.Contact{id: ^existing_gbfs_contact_id, email: ^gbfs_2_email} = first_contact
     assert "Example" == Transport.GBFSMetadata.operator(gbfs_1.url)


### PR DESCRIPTION
Fixes #4398

Il me semblait que le code précédent était suffisant pour avoir un tri déterministe mais on a eu au moins une occurence qui prouve le contrainte. Une création des 2 contacts lors de la même milliseconde ?!?

En triant par ID on devrait avoir quelque chose de plus stable, respectant l'ordre d'exécution :
- création du contact dans la phase de setup du test
- exécution du job, qui crée un second contact