### PR TITLE
WorkerHealthcheck : pas de réponse au lieu de 503

### DIFF
--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -15,7 +15,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   """
   import Plug.Conn
 
-  @app_start_waiting_delay {5, :minute}
+  @app_start_waiting_delay {20, :minute}
   @oban_max_delay_since_last_attempt {60, :minute}
 
   def init(options), do: options
@@ -69,7 +69,6 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   def oban_attempted_jobs_recently? do
     {delay, unit} = @oban_max_delay_since_last_attempt
     DateTime.after?(oban_last_attempted_at(), DateTime.add(DateTime.utc_now(), -delay, unit))
-    false
   end
 
   def oban_last_attempted_at do

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -15,7 +15,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   """
   import Plug.Conn
 
-  @app_start_waiting_delay {20, :minute}
+  @app_start_waiting_delay {5, :minute}
   @oban_max_delay_since_last_attempt {60, :minute}
 
   def init(options), do: options
@@ -69,6 +69,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   def oban_attempted_jobs_recently? do
     {delay, unit} = @oban_max_delay_since_last_attempt
     DateTime.after?(oban_last_attempted_at(), DateTime.add(DateTime.utc_now(), -delay, unit))
+    false
   end
 
   def oban_last_attempted_at do

--- a/apps/transport/test/transport_web/plugs/worker_healthcheck_test.exs
+++ b/apps/transport/test/transport_web/plugs/worker_healthcheck_test.exs
@@ -121,7 +121,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheckTest do
       refute WorkerHealthcheck.oban_attempted_jobs_recently?()
       refute WorkerHealthcheck.healthy_state?()
 
-      assert conn |> WorkerHealthcheck.call(if: {__MODULE__, :plug_enabled?}) |> text_response(503)
+      assert %Plug.Conn{halted: true} = conn |> WorkerHealthcheck.call(if: {__MODULE__, :plug_enabled?})
     end
   end
 


### PR DESCRIPTION
Suite de #4399

Notre hébergeur ne reboot pas notre app quand on répond une 503 mais attend plutôt une absence de réponse complète, [voir sa réponse](https://app.frontapp.com/open/msg_2aou7exi?key=NcvKoUk4r2AwuwVTNwgcbZzOVH_jmPUl).

J'utilise donc `Plug.Conn.halt/0` pour ne renvoyer aucune réponse HTTP plutôt que de répondre vite qu'il y a une erreur.