### PR TITLE
Hot-fix: shutdown du worker si les jobs ne sont plus traités

### DIFF
--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -42,7 +42,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
       # if the app is completely down.
       if !healthy_state?() do
         Logger.info "Hot-fix: shutting down!!!"
-        # "Carefully stops the Erlang runtime system."
+        # "Asynchronously and carefully stops the Erlang runtime system."
         System.stop()
       end
     else

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -26,17 +26,18 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
       store_last_attempted_at_delay_metric()
       status_code = if healthy_state?(), do: 200, else: 503
 
-      conn = conn
-      |> put_resp_content_type("text/plain")
-      |> send_resp(status_code, """
-      UP (WORKER-ONLY)
-      App start time: #{app_start_datetime()}
-      App started recently?: #{app_started_recently?()}
-      Oban last attempt: #{oban_last_attempted_at()}
-      Oban attempted jobs recently?: #{oban_attempted_jobs_recently?()}
-      Healthy state?: #{healthy_state?()}
-      """)
-      |> halt()
+      conn =
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(status_code, """
+        UP (WORKER-ONLY)
+        App start time: #{app_start_datetime()}
+        App started recently?: #{app_started_recently?()}
+        Oban last attempt: #{oban_last_attempted_at()}
+        Oban attempted jobs recently?: #{oban_attempted_jobs_recently?()}
+        Healthy state?: #{healthy_state?()}
+        """)
+        |> halt()
 
       # NOTE: Clever Cloud monitoring will better pick stuff back up
       # if the app is completely down.

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -12,6 +12,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   if Oban attempted jobs recently.
   """
   import Plug.Conn
+  require Logger
 
   @app_start_waiting_delay {20, :minute}
   @oban_max_delay_since_last_attempt {60, :minute}
@@ -36,6 +37,14 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
       Healthy state?: #{healthy_state?()}
       """)
       |> halt()
+
+      # NOTE: Clever Cloud monitoring will better pick stuff back up
+      # if the app is completely down.
+      if !healthy_state?() do
+        Logger.info "Hot-fix: shutting down!!!"
+        # "Carefully stops the Erlang runtime system."
+        System.stop()
+      end
     else
       conn
     end

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -41,7 +41,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
       # NOTE: Clever Cloud monitoring will better pick stuff back up
       # if the app is completely down.
       if !healthy_state?() do
-        Logger.info "Hot-fix: shutting down!!!"
+        Logger.info("Hot-fix: shutting down!!!")
         # "Asynchronously and carefully stops the Erlang runtime system."
         System.stop()
       end

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -26,7 +26,7 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
       store_last_attempted_at_delay_metric()
       status_code = if healthy_state?(), do: 200, else: 503
 
-      conn
+      conn = conn
       |> put_resp_content_type("text/plain")
       |> send_resp(status_code, """
       UP (WORKER-ONLY)
@@ -45,6 +45,8 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
         # "Asynchronously and carefully stops the Erlang runtime system."
         System.stop()
       end
+
+      conn
     else
       conn
     end


### PR DESCRIPTION
Après le merge, voilà le comportement consolidé:
- chaque appel d'Updown sur le worker lance un calcul de health et affiche le résultat en sortie HTTP
- au même moment, un métrique est envoyé dans AppSignal (avec un seuil qui nous alerte par mail, et moi par PagerDuty à titre de test)
- un état de "health" est calculé : si aucun job n'a tourné dans les 60 dernières minutes, _et_ que l'application tourne au moins depuis 20 minutes (période de grâce pour éviter des redémarrages intempestifs), on considère que l'application n'est pas healthy
- jusque là on ne faisait que retourner un 503 à partir de ça, mais ça ne suffit pas en pratique
- ⚠️ à présent si non healthy (donc après 20 minutes minimum depuis le démarrage, + 60 minutes sans job Oban attempted), je fais un `System.stop()`, qui est un graceful stop de toute la VM.

En effet, les tentatives précédentes ont montré que:
- 503 ne suffit pas
- si le socket répond (même sans réponse HTTP), ça peut être considéré up (testé par @thbar sur metabase, et note support "Le monitoring va venir surveiller si l'application accepte bien les nouvelles connections entrantes.")

Donc là je pense qu'on a davantage de chances que ça soit bien considéré comme down.