### PR TITLE
Transport.Jobs.Workflow : gérer Oban.TimeoutError

### DIFF
--- a/apps/transport/lib/jobs/workflow.ex
+++ b/apps/transport/lib/jobs/workflow.ex
@@ -82,7 +82,7 @@ defmodule Transport.Jobs.Workflow do
 
           {:notification, :gossip, %{"success" => false, "job_id" => ^job_id} = notif} ->
             reason = notif |> Map.get("reason", "unknown reason")
-            {:error, "Job #{job_id} has failed: #{inspect(reason)}. Workflow is stopping here"}
+            {:error, "Job #{job_id} has failed: #{reason}. Workflow is stopping here"}
         end
     end
   end
@@ -173,10 +173,17 @@ defmodule Transport.Jobs.Workflow do
         },
         nil
       ) do
+    # `error` can be an error message or an `Oban.TimeoutError` exception.
+    # ````
+    # %Oban.TimeoutError{
+    #   message: "Transport.Jobs.ResourceHistoryJob timed out after 1000ms",
+    #   reason: :timeout
+    # }
+    # ```
     Notifier.notify_workflow(%{meta: %{"workflow" => true}}, %{
       "success" => false,
       "job_id" => job_id,
-      "reason" => error
+      "reason" => inspect(error)
     })
   end
 


### PR DESCRIPTION
Fixes #4408

Voir le ticket pour la source du problème et les conséquences.

Je n'ai pas réussi à écrire de bons tests en moins de 30 minutes, le challenge est important : dummy Job Oban qui timeout et échanges de messages par le Notifier Oban.

En local j'ai bien reproduit l'erreur, vu la stracktrace qui la causait et vu que c'était correctement géré en exécutant les jobs en local avec le fix présenté ici : encoder la payload, pour gérer le fait qu'on peut avoir une structure ou une chaine de caractères.