### PR TITLE
Oban : logs des composants importants

### DIFF
--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -1,8 +1,14 @@
 defmodule Transport.Jobs.ObanLogger do
   @moduledoc """
-  Logs the Oban job exceptions as warnings
+  Setup telemetry/logging for Oban.
+
+  We:
+  - log job exceptions as warnings
+  - log Oban events related to the orchestration (notifier, queues, plugins etc.)
+  - we send an email when a job failed after its maximum attempt for jobs with a specific tag
   """
   require Logger
+
   @tag_email_on_failure "email_on_failure"
 
   @doc """
@@ -35,5 +41,22 @@ defmodule Transport.Jobs.ObanLogger do
     )
   end
 
-  def setup, do: :telemetry.attach("oban-logger", [:oban, :job, :exception], &handle_event/4, nil)
+  def setup do
+    :telemetry.attach("oban-logger", [:oban, :job, :exception], &handle_event/4, nil)
+
+    # Log recommended events for production.
+    # We leave out `job` events because job start/end can be quite noisy.
+    # https://hexdocs.pm/oban/preparing_for_production.html#logging
+    # https://hexdocs.pm/oban/Oban.Telemetry.html
+    # We may simplify this when
+    # https://github.com/oban-bg/oban/commit/13eabe3f8019e350ef979369a26f186bdf7be63e
+    # will be released.
+    events = [
+      [:oban, :notifier, :switch],
+      [:oban, :queue, :shutdown],
+      [:oban, :stager, :switch]
+    ]
+
+    :telemetry.attach_many("oban-default-logger", events, &Oban.Telemetry.handle_event/4, encode: true, level: :info)
+  end
 end

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -44,4 +44,17 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
         "Un job Oban Transport.Test.Transport.Jobs.ObanLoggerJobTag vient d'échouer, il serait bien d'investiguer."
     )
   end
+
+  test "oban default logger is set up for important components" do
+    events = Enum.filter(:telemetry.list_handlers([]), &(&1.id == "oban-default-logger"))
+
+    assert Enum.count(events) > 0
+
+    components =
+      events
+      |> Enum.map(fn %{event_name: [:oban, component, _]} -> component end)
+      |> MapSet.new()
+
+    assert MapSet.new([:notifier, :queue, :stager]) == MapSet.new(components)
+  end
 end

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -46,12 +46,12 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
   end
 
   test "oban default logger is set up for important components" do
-    events = Enum.filter(:telemetry.list_handlers([]), &(&1.id == "oban-default-logger"))
+    registered_handlers = Enum.filter(:telemetry.list_handlers([]), &(&1.id == "oban-default-logger"))
 
-    assert Enum.count(events) > 0
+    assert Enum.count(registered_handlers) > 0
 
     components =
-      events
+      registered_handlers
       |> Enum.map(fn %{event_name: [:oban, component, _]} -> component end)
       |> MapSet.new()
 


### PR DESCRIPTION
En lien avec #4377, #4384, #4408

Ajoute des logs pour Oban, pour aider à diagnostiquer des problèmes en production.

Je suis les [bonnes pratiques](https://hexdocs.pm/oban/preparing_for_production.html#logging) pour la production mais je ne log pas `:job, :start` et `:job, :end` sinon on aurait au moins 120k lignes de logs par jour vu notre volume de jobs exécuté.