### PR TITLE
Opérateurs GBFS : ajout URLs Okina pour Ecovélo

### DIFF
--- a/apps/transport/priv/gbfs_operators.csv
+++ b/apps/transport/priv/gbfs_operators.csv
@@ -16,6 +16,8 @@ fifteen.site;Fifteen
 getapony.com;Pony
 lime.bike;Lime
 media.ilevia.fr/opendata;Cykleo
+mobi-iti-nam.okina.fr/api-proxy/api/gbfs/1.0/gbfs/velibeo_ecovelo/gbfs;Ecovélo
+mobi-iti-nam.okina.fr/api-proxy/api/gbfs/1.0/gbfs/perivelo_ecovelo/gbfs;Ecovélo
 nextbike.net;nextbike
 smovengo.cloud;Fifteen
 urbansharing.com/lovelolibreservice.fr;Citybike


### PR DESCRIPTION
Contexte : on a une liste de mapping URLs/opérateur GBFS pour enrichir des métadonnées et un job qui identifie les manques. Voir précédemment https://github.com/etalab/transport-site/pull/4361#pullrequestreview-2489509605

[Voir sur Front](https://app.frontapp.com/open/cnv_19rqbkpi?key=jqe910-na5u2tlBkTswE7NLSx6xRe3pv)