### PR TITLE
Ne plus stopper la BEAM pendant les tests

### DIFF
--- a/apps/transport/test/transport_web/plugs/worker_healthcheck_test.exs
+++ b/apps/transport/test/transport_web/plugs/worker_healthcheck_test.exs
@@ -121,7 +121,11 @@ defmodule TransportWeb.Plugs.WorkerHealthcheckTest do
       refute WorkerHealthcheck.oban_attempted_jobs_recently?()
       refute WorkerHealthcheck.healthy_state?()
 
-      assert conn |> WorkerHealthcheck.call(if: {__MODULE__, :plug_enabled?}) |> text_response(503)
+      # Current fix for job ops troubles: the system must stop completely when unhealthy,
+      # so that Clever Cloud will restart it.
+      assert_raise RuntimeError, ~r/would halt the BEAM/, fn ->
+        conn |> WorkerHealthcheck.call(if: {__MODULE__, :plug_enabled?})
+      end
     end
   end
 


### PR DESCRIPTION
Le correctif introduit dans https://github.com/etalab/transport-site/issues/4377 (https://github.com/etalab/transport-site/pull/4405) arrête complètement le programme dans certaines conditions. Or je n'avais pas vu que le plug correspondant est sous tests (https://github.com/etalab/transport-site/pull/4399).

La conséquence est que la suite de test est interrompue au "moment où ce test tourne", et le tout avec un code d'erreur zéro, qui fait que ça ne se remarque que difficilement.

Par conséquent, dans cette PR :
- Je remplace l'appel à `System.stop()` par un raise avec un message clair, uniquement pendant les tests
- Je modifie le test associé, et j'ajoute de la documentation, car ce comportement est important pour le bon fonctionnement de la prod
- Je modifie (y compris en production mais je ne pense pas que ça portera à conséquence et j'aurais gagné à faire ça en premier lieu dans #4405) l'exit code associé, pour retourner un non-zero plutôt que zero, de façon à ce que ça soit détecté si jamais ça devenait revenir, dès la CI

À merger dès que possible, car concrètement ça veut dire qu'une partie des tests sont bypassés dans nos PR actuelles !