### PR TITLE
Cache préemptif pour l’endpoint /api/datasets

### DIFF
--- a/apps/transport/lib/transport/api_cache.ex
+++ b/apps/transport/lib/transport/api_cache.ex
@@ -9,6 +9,8 @@ defmodule Transport.APICache do
   @job_delay :timer.seconds(300)
   @cache_ttl :timer.seconds(600)
 
+  def cache_ttl, do: @cache_ttl
+
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, %{})
   end

--- a/apps/transport/lib/transport/api_cache.ex
+++ b/apps/transport/lib/transport/api_cache.ex
@@ -1,0 +1,46 @@
+defmodule Transport.APICache do
+  @moduledoc """
+  A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
+  """
+
+  use GenServer
+  require Logger
+
+  @job_delay :timer.seconds(300)
+  @cache_ttl :timer.seconds(600)
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  def init(state) do
+    # initial schedule is immediate, but via the same code path,
+    # to ensure we jump on the data
+    schedule_next_occurrence(0)
+
+    {:ok, state}
+  end
+
+  def schedule_next_occurrence(delay \\ @job_delay) do
+    Process.send_after(self(), :tick, delay)
+  end
+
+  def handle_info(:tick, state) do
+    schedule_next_occurrence()
+    populate_cache()
+    {:noreply, state}
+  end
+
+  def populate_cache do
+    Logger.info("[api-cache-genserver] Populating cache for /api/datasets…")
+
+    Cachex.put(
+      Transport.Application.cache_name(),
+      "api-datasets-index",
+      TransportWeb.API.DatasetController.prepare_datasets_index_data(),
+      ttl: @cache_ttl
+    )
+
+    Logger.info("[api-cache-genserver] Finished populating cache for /api/datasets")
+  end
+end

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -44,7 +44,7 @@ defmodule Transport.Application do
       ]
       |> add_scheduler()
       |> add_if(fn -> run_web_processes end, Transport.RealtimePoller)
-      |> add_if(fn -> run_web_processes end, Transport.APICache)
+      |> add_if(fn -> run_web_processes end, Transport.PreemptiveAPICache)
       ## manually add a children supervisor that is not scheduled
       |> Kernel.++([{Task.Supervisor, name: ImportTaskSupervisor}])
 

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -24,7 +24,7 @@ defmodule Transport.Application do
       end
     end
 
-    run_realtime_poller = webserver_enabled?() && Mix.env() != :test
+    run_web_processes = webserver_enabled?() && Mix.env() != :test
 
     children =
       [
@@ -43,7 +43,8 @@ defmodule Transport.Application do
         Transport.Vault
       ]
       |> add_scheduler()
-      |> add_if(fn -> run_realtime_poller end, Transport.RealtimePoller)
+      |> add_if(fn -> run_web_processes end, Transport.RealtimePoller)
+      |> add_if(fn -> run_web_processes end, Transport.APICache)
       ## manually add a children supervisor that is not scheduled
       |> Kernel.++([{Task.Supervisor, name: ImportTaskSupervisor}])
 

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -39,6 +39,9 @@ defmodule Transport.PreemptiveAPICache do
 
     Transport.Cache.put(
       "api-datasets-index",
+      # NOTE: the structure saved in Cachex is currently an Elixir structure,
+      # not the final JSON. We may have to persist JSON directly instead to
+      # reduce memory use in the future.
       TransportWeb.API.DatasetController.prepare_datasets_index_data(),
       @cache_ttl
     )

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -7,7 +7,8 @@ defmodule Transport.PreemptiveAPICache do
   require Logger
 
   @job_delay :timer.seconds(300)
-  @cache_ttl :timer.seconds(600)
+  # slightly more than twice `@job_delay` to reduce the risk of parallel computation
+  @cache_ttl :timer.seconds(700)
 
   def cache_ttl, do: @cache_ttl
 

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -36,11 +36,10 @@ defmodule Transport.PreemptiveAPICache do
   def populate_cache do
     Logger.info("[preemptive-api-cache] Populating cache for /api/datasets…")
 
-    Cachex.put(
-      Transport.Application.cache_name(),
+    Transport.Cache.put(
       "api-datasets-index",
       TransportWeb.API.DatasetController.prepare_datasets_index_data(),
-      ttl: @cache_ttl
+      @cache_ttl
     )
 
     Logger.info("[preemptive-api-cache] Finished populating cache for /api/datasets.")

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -1,4 +1,4 @@
-defmodule Transport.APICache do
+defmodule Transport.PreemptiveAPICache do
   @moduledoc """
   A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
   """
@@ -34,7 +34,7 @@ defmodule Transport.APICache do
   end
 
   def populate_cache do
-    Logger.info("[api-cache-genserver] Populating cache for /api/datasets…")
+    Logger.info("[preemptive-api-cache] Populating cache for /api/datasets…")
 
     Cachex.put(
       Transport.Application.cache_name(),
@@ -43,6 +43,6 @@ defmodule Transport.APICache do
       ttl: @cache_ttl
     )
 
-    Logger.info("[api-cache-genserver] Finished populating cache for /api/datasets")
+    Logger.info("[preemptive-api-cache] Finished populating cache for /api/datasets.")
   end
 end

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.API.DatasetController do
   # The default (one minute) felt a bit too high for someone doing scripted operations
   # (have to wait during experimentations), so I lowered it a bit. It is high enough
   # that it will still protect a lot against excessive querying.
-  @cache_ttl :timer.seconds(30)
+  @cache_ttl :timer.seconds(600)
 
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -32,7 +32,7 @@ defmodule TransportWeb.API.DatasetController do
 
   @spec datasets(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def datasets(%Plug.Conn{} = conn, _params) do
-    comp_fn = fn -> prepare_datasets_index_data(conn) end
+    comp_fn = fn -> prepare_datasets_index_data() end
     data = Transport.Cache.fetch("api-datasets-index", comp_fn, @cache_ttl)
 
     render(conn, %{data: data})
@@ -86,7 +86,7 @@ defmodule TransportWeb.API.DatasetController do
     if is_nil(dataset) do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
-      comp_fn = fn -> prepare_dataset_detail_data(conn, dataset) end
+      comp_fn = fn -> prepare_dataset_detail_data(dataset) end
       data = Transport.Cache.fetch("api-datasets-#{datagouv_id}", comp_fn, @cache_ttl)
 
       conn |> assign(:data, data) |> render()
@@ -155,8 +155,8 @@ defmodule TransportWeb.API.DatasetController do
       "features" => features
     }
 
-  @spec transform_dataset(Plug.Conn.t(), Dataset.t() | map()) :: map()
-  defp transform_dataset(%Plug.Conn{} = conn, %Dataset{} = dataset),
+  @spec transform_dataset(Dataset.t() | map()) :: map()
+  defp transform_dataset(%Dataset{} = dataset),
     do: %{
       "datagouv_id" => dataset.datagouv_id,
       # to help discoverability, we explicitly add the datagouv_id as the id
@@ -164,7 +164,7 @@ defmodule TransportWeb.API.DatasetController do
       "id" => dataset.datagouv_id,
       "title" => dataset.custom_title,
       "created_at" => dataset.created_at |> DateTime.to_date() |> Date.to_string(),
-      "page_url" => TransportWeb.Router.Helpers.dataset_url(conn, :details, dataset.slug),
+      "page_url" => TransportWeb.Router.Helpers.dataset_url(TransportWeb.Endpoint, :details, dataset.slug),
       "slug" => dataset.slug,
       "updated" => Helpers.last_updated(Dataset.official_resources(dataset)),
       "resources" => Enum.map(dataset.resources, &transform_resource/1),
@@ -185,10 +185,10 @@ defmodule TransportWeb.API.DatasetController do
       "type" => "organization"
     }
 
-  @spec transform_dataset_with_detail(Plug.Conn.t(), Dataset.t() | map()) :: map()
-  defp transform_dataset_with_detail(%Plug.Conn{} = conn, %Dataset{} = dataset) do
-    conn
-    |> transform_dataset(dataset)
+  @spec transform_dataset_with_detail(Dataset.t() | map()) :: map()
+  defp transform_dataset_with_detail(%Dataset{} = dataset) do
+    dataset
+    |> transform_dataset()
     |> add_conversions(dataset)
     |> Map.put(
       "history",
@@ -334,7 +334,7 @@ defmodule TransportWeb.API.DatasetController do
     |> Enum.map(fn region -> %{"name" => region.nom, "insee" => region.insee} end)
   end
 
-  defp prepare_datasets_index_data(%Plug.Conn{} = conn) do
+  def prepare_datasets_index_data do
     datasets_with_gtfs_metadata =
       DB.Dataset.base_query()
       |> DB.Dataset.join_from_dataset_to_metadata(Transport.Validators.GTFSTransport.validator_name())
@@ -383,10 +383,10 @@ defmodule TransportWeb.API.DatasetController do
       enriched_dataset = Map.get(existing_ids, dataset.id)
       add_enriched_resources_to_dataset(dataset, enriched_dataset)
     end)
-    |> Enum.map(&transform_dataset(conn, &1))
+    |> Enum.map(&transform_dataset(&1))
   end
 
-  defp prepare_dataset_detail_data(%Plug.Conn{} = conn, %DB.Dataset{} = dataset) do
+  defp prepare_dataset_detail_data(%DB.Dataset{} = dataset) do
     gtfs_resources_with_metadata =
       DB.Resource.base_query()
       |> DB.ResourceHistory.join_resource_with_latest_resource_history()
@@ -421,6 +421,6 @@ defmodule TransportWeb.API.DatasetController do
 
     dataset = dataset |> Map.put(:resources, enriched_resources)
 
-    transform_dataset_with_detail(conn, dataset)
+    transform_dataset_with_detail(dataset)
   end
 end

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -9,7 +9,7 @@ defmodule TransportWeb.API.DatasetController do
   # The default (one minute) felt a bit too high for someone doing scripted operations
   # (have to wait during experimentations), so I lowered it a bit. It is high enough
   # that it will still protect a lot against excessive querying.
-  @index_cache_ttl Transport.APICache.cache_ttl()
+  @index_cache_ttl Transport.PreemptiveAPICache.cache_ttl()
   @by_id_cache_ttl :timer.seconds(30)
 
   @spec open_api_operation(any) :: Operation.t()


### PR DESCRIPTION
Cette PR rajoute un mécanisme pour calculer et remplir automatiquement le contenu du cache pour la réponse de l’endpoint principal `/api/datasets`. 

Ce calcul du cache se fait au lancement de l’application puis toutes les 5 minutes, le cache étant configuré pour expirer au bout de 10 minutes. En théorie donc, aucun utilisateur ne devrait obtenir de résultat non caché sur cet endpoint. J’ai toutefois gardé le fonctionnement précédent par sécurité : si jamais le cache venait à ne pas être rempli, l’appel GET sur `/api/datasets` devrait fonctionner (et re-remplir le cache avec un délai de 10 minutes).

Chez moi ça marche, (mais ce n’est pas testé par des tests en dur), extrait de logs :

```
[info] [api-cache-genserver] Finished populating cache for /api/datasets
[info] GET /api/datasets/
[debug] Processing with TransportWeb.API.DatasetController.datasets/2
  Parameters: %{}
  Pipelines: [:accept_json, :api, :public_cache]
[info] Value for key api-datasets-index served from cache
[info] Sent 304 in 64ms
```

**Je n’ai pas augmenté le timeout Ecto volontairement :** celui-ci est par défaut à 15 secondes et l’ensemble de la fonction générant la payload JSON est calculée à environ 3,5s sur ma machine en local. Je préfère donc pour l’instant observer. J’ai mis des logs en début et fin de fonction principale pour avoir une idée du temps réel en production.