### PR TITLE
[WIP] Cache préemptif des statistiques

### DIFF
--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -45,6 +45,7 @@ defmodule Transport.Application do
       |> add_scheduler()
       |> add_if(fn -> run_web_processes end, Transport.RealtimePoller)
       |> add_if(fn -> run_web_processes end, Transport.PreemptiveAPICache)
+      |> add_if(fn -> run_web_processes end, Transport.PreemptiveStatsCache)
       ## manually add a children supervisor that is not scheduled
       |> Kernel.++([{Task.Supervisor, name: ImportTaskSupervisor}])
 

--- a/apps/transport/lib/transport/preemptive_stats_cache.ex
+++ b/apps/transport/lib/transport/preemptive_stats_cache.ex
@@ -1,0 +1,48 @@
+defmodule Transport.PreemptiveStatsCache do
+  @moduledoc """
+  A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
+  """
+
+  use GenServer
+  require Logger
+
+  # Let’s give some time for the system to boot up before we start
+  @first_run :timer.minutes(1)
+  # We want to refresh the cache every 3 hours
+  @job_delay :timer.hours(3)
+  # slightly more than twice `@job_delay` to reduce the risk of parallel computation
+  @cache_ttl :timer.hours(7)
+
+  def cache_ttl, do: @cache_ttl
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  def init(state) do
+    # initial schedule is immediate, but via the same code path,
+    # to ensure we jump on the data
+    schedule_next_occurrence(@first_run)
+
+    {:ok, state}
+  end
+
+  def schedule_next_occurrence(delay \\ @job_delay) do
+    Process.send_after(self(), :tick, delay)
+  end
+
+  def handle_info(:tick, state) do
+    schedule_next_occurrence()
+    populate_cache()
+    {:noreply, state}
+  end
+
+  def populate_cache do
+    Logger.info("[preemptive-stats-cache] Populating cache for stats…")
+    Transport.Cache.put("stats-page-index", Transport.StatsHandler.compute_stats(), @cache_ttl)
+    Transport.Cache.put("api-stats-aoms", Transport.StatsHandler.rendered_geojson(:aom), @cache_ttl)
+    Transport.Cache.put("api-stats-regions", Transport.StatsHandler.rendered_geojson(:region), @cache_ttl)
+    Transport.Cache.put("api-stats-quality", Transport.StatsHandler.rendered_geojson(:quality), @cache_ttl)
+    Logger.info("[preemptive-stats-cache] Finished populating cache for stats.")
+  end
+end

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -11,6 +11,8 @@ defmodule Transport.StatsHandler do
   import Ecto.Query
   require Logger
 
+  @longer_ecto_timeout 60_000
+
   @doc """
   Compute and store all stats as a snapshot of the database
   """
@@ -343,7 +345,7 @@ defmodule Transport.StatsHandler do
       end
 
     query
-    |> Repo.all()
+    |> Repo.all(timeout: @longer_ecto_timeout)
     |> features()
     |> geojson()
     |> Jason.encode!()
@@ -351,7 +353,7 @@ defmodule Transport.StatsHandler do
 
   def rendered_geojson(:bike_scooter_sharing) do
     bike_scooter_features_query()
-    |> Repo.all()
+    |> Repo.all(timeout: @longer_ecto_timeout)
     |> bike_scooter_sharing_features()
     |> geojson()
     |> Jason.encode!()

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -90,7 +90,7 @@ defmodule TransportWeb.API.StatsController do
       Transport.StatsHandler.rendered_geojson(item)
     end
 
-    rendered_geojson = Transport.Cache.fetch(cache_key, comp_fn)
+    rendered_geojson = Transport.Cache.fetch(cache_key, comp_fn, Transport.PreemptiveStatsCache.cache_ttl())
 
     render(conn, data: {:skip_json_encoding, rendered_geojson})
   end

--- a/apps/transport/lib/transport_web/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/stats_controller.ex
@@ -3,7 +3,12 @@ defmodule TransportWeb.StatsController do
 
   @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
-    stats = Transport.Cache.fetch("stats-page-index", fn -> Transport.StatsHandler.compute_stats() end)
+    stats =
+      Transport.Cache.fetch(
+        "stats-page-index",
+        fn -> Transport.StatsHandler.compute_stats() end,
+        Transport.PreemptiveStatsCache.cache_ttl()
+      )
 
     conn =
       stats

--- a/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
@@ -14,17 +14,17 @@ defmodule TransportWeb.API.StatsControllerTest do
   for {route, cache_key} <- @cached_features_routes do
     test "GET #{route} (invokes the cache system)", %{conn: conn} do
       # return original computed payload
-      mock = fn unquote(cache_key), x -> x.() end
+      mock = fn unquote(cache_key), x, _ -> x.() end
 
       with_mock Transport.Cache, fetch: mock do
         conn = conn |> get(unquote(route))
         %{"features" => _features} = json_response(conn, 200)
-        assert_called_exactly(Transport.Cache.fetch(:_, :_), 1)
+        assert_called_exactly(Transport.Cache.fetch(:_, :_, :_), 1)
       end
     end
 
     test "GET #{route} (returns the cached value as is)", %{conn: conn} do
-      mock = fn unquote(cache_key), _ -> %{hello: 123} |> Jason.encode!() end
+      mock = fn unquote(cache_key), _, _ -> %{hello: 123} |> Jason.encode!() end
 
       with_mock Transport.Cache, fetch: mock do
         conn = conn |> get(unquote(route))


### PR DESCRIPTION
Rajoute un cache préemptif sur le modèle du point principal d’API.

À faire : mutualiser le code entre les deux modules de cache préemptif.

À merger après #4429 sur laquelle cette branche se base.