### PR TITLE
GTFS validator: Fix unusable_trip display

### DIFF
--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -262,7 +262,8 @@ defmodule Transport.Validators.GTFSTransport do
       "InvalidShapeId" => dgettext("gtfs-transport-validator", "Invalid shape ID"),
       "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID"),
       "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder"),
-      "NegativeStopDuration" => dgettext("gtfs-transport-validator", "Negative stop duration")
+      "NegativeStopDuration" => dgettext("gtfs-transport-validator", "Negative stop duration"),
+      "UnusableTrip" => dgettext("gtfs-transport-validator", "Unusable trip")
     }
 
   @spec gtfs_outdated?(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -159,6 +159,10 @@ msgstr ""
 msgid "Negative stop duration"
 msgstr ""
 
+#, elixir-autogen, elixir-format
+msgid "Unusable trip"
+msgstr ""
+
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error"
 msgid_plural "Errors"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -161,7 +161,7 @@ msgstr "Temps d'arrêt négatif"
 
 #, elixir-autogen, elixir-format
 msgid "Unusable trip"
-msgstr "Trajet trop court"
+msgstr "Trajet non utilisable"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -159,6 +159,10 @@ msgstr "Fichiers dans un sous-dossier"
 msgid "Negative stop duration"
 msgstr "Temps d'arrêt négatif"
 
+#, elixir-autogen, elixir-format
+msgid "Unusable trip"
+msgstr "Trajet trop court"
+
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error"
 msgid_plural "Errors"

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -159,6 +159,10 @@ msgid "Negative stop duration"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "Unusable trip"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "Error"
 msgid_plural "Errors"
 msgstr[0] ""


### PR DESCRIPTION
See #4431.

![image](https://github.com/user-attachments/assets/7ef6892d-4dd5-4302-8715-a9733ee26ff5)
