### PR TITLE
Cache préemptif des statistiques

### DIFF
--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -45,6 +45,7 @@ defmodule Transport.Application do
       |> add_scheduler()
       |> add_if(fn -> run_web_processes end, Transport.RealtimePoller)
       |> add_if(fn -> run_web_processes end, Transport.PreemptiveAPICache)
+      |> add_if(fn -> run_web_processes end, Transport.PreemptiveStatsCache)
       ## manually add a children supervisor that is not scheduled
       |> Kernel.++([{Task.Supervisor, name: ImportTaskSupervisor}])
 

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -7,7 +7,6 @@ defmodule Transport.PreemptiveAPICache do
     first_run: 0,
     job_delay: :timer.seconds(300),
     # more than twice job_delay to reduce the risk of parallel computation
-
     cache_ttl: :timer.seconds(700)
 
   require Logger

--- a/apps/transport/lib/transport/preemptive_api_cache.ex
+++ b/apps/transport/lib/transport/preemptive_api_cache.ex
@@ -6,6 +6,7 @@ defmodule Transport.PreemptiveAPICache do
   use GenServer
   require Logger
 
+  @first_run 0
   @job_delay :timer.seconds(300)
   # slightly more than twice `@job_delay` to reduce the risk of parallel computation
   @cache_ttl :timer.seconds(700)
@@ -19,7 +20,7 @@ defmodule Transport.PreemptiveAPICache do
   def init(state) do
     # initial schedule is immediate, but via the same code path,
     # to ensure we jump on the data
-    schedule_next_occurrence(0)
+    schedule_next_occurrence(@first_run)
 
     {:ok, state}
   end

--- a/apps/transport/lib/transport/preemptive_base_cache.ex
+++ b/apps/transport/lib/transport/preemptive_base_cache.ex
@@ -1,6 +1,20 @@
 defmodule Transport.PreemptiveBaseCache do
   @moduledoc """
-  Common code for preemptive caches
+  Common code for preemptive caches. This module is a macro that generates a GenServer,
+  which will populate a cache at regular intervals (similar to a cron job).
+
+  Usage:
+  ```
+  use Transport.PreemptiveBaseCache,
+    first_run: 0,
+    job_delay: :timer.seconds(300),
+    cache_ttl: :timer.seconds(700)
+  ```
+  The module in which it is used must implement the `populate_cache/0` function, that will be regularly called.
+
+  - First run indicates the time to wait before the first run of the job between the start of the application and the first run.
+  - Job delay indicates the time to wait between each run of the job.
+  - Cache TTL indicates the time to keep the cache alive.
   """
   defmacro __using__(opts) do
     quote do

--- a/apps/transport/lib/transport/preemptive_base_cache.ex
+++ b/apps/transport/lib/transport/preemptive_base_cache.ex
@@ -17,8 +17,6 @@ defmodule Transport.PreemptiveBaseCache do
       end
 
       def init(state) do
-        # initial schedule is immediate, but via the same code path,
-        # to ensure we jump on the data
         schedule_next_occurrence(@first_run)
 
         {:ok, state}

--- a/apps/transport/lib/transport/preemptive_base_cache.ex
+++ b/apps/transport/lib/transport/preemptive_base_cache.ex
@@ -36,12 +36,12 @@ defmodule Transport.PreemptiveBaseCache do
         {:ok, state}
       end
 
-      def schedule_next_occurrence(delay \\ @job_delay) do
+      def schedule_next_occurrence(delay) do
         Process.send_after(self(), :tick, delay)
       end
 
       def handle_info(:tick, state) do
-        schedule_next_occurrence()
+        schedule_next_occurrence(@job_delay)
         populate_cache()
         {:noreply, state}
       end

--- a/apps/transport/lib/transport/preemptive_base_cache.ex
+++ b/apps/transport/lib/transport/preemptive_base_cache.ex
@@ -1,0 +1,38 @@
+defmodule Transport.PreemptiveBaseCache do
+  @moduledoc """
+  Common code for preemptive caches
+  """
+  defmacro __using__(opts) do
+    quote do
+      use GenServer
+
+      @first_run unquote(opts[:first_run])
+      @job_delay unquote(opts[:job_delay])
+      @cache_ttl unquote(opts[:cache_ttl])
+
+      def cache_ttl, do: @cache_ttl
+
+      def start_link(_opts) do
+        GenServer.start_link(__MODULE__, %{})
+      end
+
+      def init(state) do
+        # initial schedule is immediate, but via the same code path,
+        # to ensure we jump on the data
+        schedule_next_occurrence(@first_run)
+
+        {:ok, state}
+      end
+
+      def schedule_next_occurrence(delay \\ @job_delay) do
+        Process.send_after(self(), :tick, delay)
+      end
+
+      def handle_info(:tick, state) do
+        schedule_next_occurrence()
+        populate_cache()
+        {:noreply, state}
+      end
+    end
+  end
+end

--- a/apps/transport/lib/transport/preemptive_stats_cache.ex
+++ b/apps/transport/lib/transport/preemptive_stats_cache.ex
@@ -1,0 +1,48 @@
+defmodule Transport.PreemptiveStatsCache do
+  @moduledoc """
+  A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
+  """
+
+  use GenServer
+  require Logger
+
+  # Let’s give some time for the system to boot up before we start
+  @first_run :timer.minutes(1)
+  # We want to refresh the cache every 3 hours
+  @job_delay :timer.hours(3)
+  # slightly more than twice `@job_delay` to reduce the risk of parallel computation
+  @cache_ttl :timer.hours(7)
+
+  def cache_ttl, do: @cache_ttl
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  def init(state) do
+    # initial schedule is immediate, but via the same code path,
+    # to ensure we jump on the data
+    schedule_next_occurrence(@first_run)
+
+    {:ok, state}
+  end
+
+  def schedule_next_occurrence(delay \\ @job_delay) do
+    Process.send_after(self(), :tick, delay)
+  end
+
+  def handle_info(:tick, state) do
+    schedule_next_occurrence()
+    populate_cache()
+    {:noreply, state}
+  end
+
+  def populate_cache do
+    Logger.info("[preemptive-stats-cache] Populating cache for stats…")
+    Transport.Cache.put("stats-page-index", Transport.StatsHandler.compute_stats(), @cache_ttl)
+    Transport.Cache.put("api-stats-aoms", TransportWeb.API.StatsController.rendered_geojson(:aoms), @cache_ttl)
+    Transport.Cache.put("api-stats-regions", TransportWeb.API.StatsController.rendered_geojson(:regions), @cache_ttl)
+    Transport.Cache.put("api-stats-quality", TransportWeb.API.StatsController.rendered_geojson(:quality), @cache_ttl)
+    Logger.info("[preemptive-stats-cache] Finished populating cache for stats.")
+  end
+end

--- a/apps/transport/lib/transport/preemptive_stats_cache.ex
+++ b/apps/transport/lib/transport/preemptive_stats_cache.ex
@@ -15,9 +15,25 @@ defmodule Transport.PreemptiveStatsCache do
   def populate_cache do
     Logger.info("[preemptive-stats-cache] Populating cache for stats…")
     Transport.Cache.put("stats-page-index", Transport.StatsHandler.compute_stats(), @cache_ttl)
-    Transport.Cache.put("api-stats-aoms", TransportWeb.API.StatsController.rendered_geojson(:aoms), @cache_ttl)
-    Transport.Cache.put("api-stats-regions", TransportWeb.API.StatsController.rendered_geojson(:regions), @cache_ttl)
-    Transport.Cache.put("api-stats-quality", TransportWeb.API.StatsController.rendered_geojson(:quality), @cache_ttl)
+
+    Transport.Cache.put(
+      "api-stats-aoms",
+      TransportWeb.API.StatsController.rendered_geojson(:aoms, timeout: :timer.seconds(60)),
+      @cache_ttl
+    )
+
+    Transport.Cache.put(
+      "api-stats-regions",
+      TransportWeb.API.StatsController.rendered_geojson(:regions, timeout: :timer.seconds(60)),
+      @cache_ttl
+    )
+
+    Transport.Cache.put(
+      "api-stats-quality",
+      TransportWeb.API.StatsController.rendered_geojson(:quality, timeout: :timer.seconds(60)),
+      @cache_ttl
+    )
+
     Logger.info("[preemptive-stats-cache] Finished populating cache for stats.")
   end
 end

--- a/apps/transport/lib/transport/preemptive_stats_cache.ex
+++ b/apps/transport/lib/transport/preemptive_stats_cache.ex
@@ -3,39 +3,14 @@ defmodule Transport.PreemptiveStatsCache do
   A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
   """
 
-  use GenServer
+  use Transport.PreemptiveBaseCache,
+    # Let’s give some time for the system to boot up before we start and the API cache to be populated
+    first_run: :timer.minutes(1),
+    job_delay: :timer.hours(3),
+    # more than twice job_delay to reduce the risk of parallel computation
+    cache_ttl: :timer.hours(7)
+
   require Logger
-
-  # Let’s give some time for the system to boot up before we start
-  @first_run :timer.minutes(1)
-  # We want to refresh the cache every 3 hours
-  @job_delay :timer.hours(3)
-  # slightly more than twice `@job_delay` to reduce the risk of parallel computation
-  @cache_ttl :timer.hours(7)
-
-  def cache_ttl, do: @cache_ttl
-
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, %{})
-  end
-
-  def init(state) do
-    # initial schedule is immediate, but via the same code path,
-    # to ensure we jump on the data
-    schedule_next_occurrence(@first_run)
-
-    {:ok, state}
-  end
-
-  def schedule_next_occurrence(delay \\ @job_delay) do
-    Process.send_after(self(), :tick, delay)
-  end
-
-  def handle_info(:tick, state) do
-    schedule_next_occurrence()
-    populate_cache()
-    {:noreply, state}
-  end
 
   def populate_cache do
     Logger.info("[preemptive-stats-cache] Populating cache for stats…")

--- a/apps/transport/lib/transport/preemptive_stats_cache.ex
+++ b/apps/transport/lib/transport/preemptive_stats_cache.ex
@@ -1,6 +1,6 @@
 defmodule Transport.PreemptiveStatsCache do
   @moduledoc """
-  A module that populates the Cachex cache for the /api/datasets endpoint ("api-datasets-index")
+  A module that populates the Cachex cache for the /stats and /api/stats/* endpoints
   """
 
   use Transport.PreemptiveBaseCache,

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -5,6 +5,8 @@ defmodule TransportWeb.API.StatsController do
   alias Geo.JSON
   alias OpenApiSpex.Operation
 
+  @longer_ecto_timeout 60_000
+
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])
 
@@ -283,7 +285,7 @@ defmodule TransportWeb.API.StatsController do
       :regions -> region_features_query()
       :quality -> quality_features_query()
     end
-    |> Repo.all()
+    |> Repo.all(timeout: @longer_ecto_timeout)
     |> features()
     |> geojson()
     |> Jason.encode!()
@@ -291,7 +293,7 @@ defmodule TransportWeb.API.StatsController do
 
   def rendered_geojson(:bike_scooter_sharing) do
     bike_scooter_sharing_features_query()
-    |> Repo.all()
+    |> Repo.all(timeout: @longer_ecto_timeout)
     |> bike_scooter_sharing_features()
     |> geojson()
     |> Jason.encode!()

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -5,7 +5,7 @@ defmodule TransportWeb.API.StatsController do
   alias Geo.JSON
   alias OpenApiSpex.Operation
 
-  @longer_ecto_timeout 60_000
+  @longer_ecto_timeout :timer.seconds(60)
 
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -265,7 +265,8 @@ defmodule TransportWeb.API.StatsController do
   #
   @spec render_features(Plug.Conn.t(), atom(), binary()) :: Plug.Conn.t()
   defp render_features(conn, item, cache_key) do
-    data = Transport.Cache.fetch(cache_key, fn -> rendered_geojson(item) end)
+    data =
+      Transport.Cache.fetch(cache_key, fn -> rendered_geojson(item) end, Transport.PreemptiveStatsCache.cache_ttl())
 
     render(conn, data: {:skip_json_encoding, data})
   end

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -5,8 +5,6 @@ defmodule TransportWeb.API.StatsController do
   alias Geo.JSON
   alias OpenApiSpex.Operation
 
-  @longer_ecto_timeout :timer.seconds(60)
-
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])
 
@@ -279,21 +277,23 @@ defmodule TransportWeb.API.StatsController do
     render(conn, data: {:skip_json_encoding, data})
   end
 
-  def rendered_geojson(item) when item in [:aoms, :regions, :quality] do
+  def rendered_geojson(item, ecto_opts \\ [])
+
+  def rendered_geojson(item, ecto_opts) when item in [:aoms, :regions, :quality] do
     case item do
       :aoms -> aom_features_query()
       :regions -> region_features_query()
       :quality -> quality_features_query()
     end
-    |> Repo.all(timeout: @longer_ecto_timeout)
+    |> Repo.all(ecto_opts)
     |> features()
     |> geojson()
     |> Jason.encode!()
   end
 
-  def rendered_geojson(:bike_scooter_sharing) do
+  def rendered_geojson(:bike_scooter_sharing, ecto_opts) do
     bike_scooter_sharing_features_query()
-    |> Repo.all(timeout: @longer_ecto_timeout)
+    |> Repo.all(ecto_opts)
     |> bike_scooter_sharing_features()
     |> geojson()
     |> Jason.encode!()

--- a/apps/transport/lib/transport_web/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/stats_controller.ex
@@ -3,7 +3,12 @@ defmodule TransportWeb.StatsController do
 
   @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
-    stats = Transport.Cache.fetch("stats-page-index", fn -> Transport.StatsHandler.compute_stats() end)
+    stats =
+      Transport.Cache.fetch(
+        "stats-page-index",
+        fn -> Transport.StatsHandler.compute_stats() end,
+        Transport.PreemptiveStatsCache.cache_ttl()
+      )
 
     conn =
       stats

--- a/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
@@ -14,17 +14,17 @@ defmodule TransportWeb.API.StatsControllerTest do
   for {route, cache_key} <- @cached_features_routes do
     test "GET #{route} (invokes the cache system)", %{conn: conn} do
       # return original computed payload
-      mock = fn unquote(cache_key), x -> x.() end
+      mock = fn unquote(cache_key), x, _ -> x.() end
 
       with_mock Transport.Cache, fetch: mock do
         conn = conn |> get(unquote(route))
         %{"features" => _features} = json_response(conn, 200)
-        assert_called_exactly(Transport.Cache.fetch(:_, :_), 1)
+        assert_called_exactly(Transport.Cache.fetch(:_, :_, :_), 1)
       end
     end
 
     test "GET #{route} (returns the cached value as is)", %{conn: conn} do
-      mock = fn unquote(cache_key), _ -> %{hello: 123} |> Jason.encode!() end
+      mock = fn unquote(cache_key), _, _ -> %{hello: 123} |> Jason.encode!() end
 
       with_mock Transport.Cache, fetch: mock do
         conn = conn |> get(unquote(route))


### PR DESCRIPTION
Rajoute un cache préemptif sur le modèle du point principal d’API et créé un module générique pour tous les mécanismes similaires à l’avenir.

À comparer à la branche de la PR #4432 sur laquelle elle est basée.