### PR TITLE
Proxy GTFS-RT : réduit volume de logs

### DIFF
--- a/apps/transport/lib/transport/telemetry.ex
+++ b/apps/transport/lib/transport/telemetry.ex
@@ -35,7 +35,7 @@ defmodule Transport.Telemetry do
     # make it non-blocking, to ensure the traffic will be served quickly. this also means, though, we
     # won't notice if a tracing of event fails
     Task.start(fn ->
-      Logger.info("Telemetry event: processing #{type} proxy request for #{target}")
+      Logger.debug("Telemetry event: processing #{type} proxy request for #{target}")
       count_event(target, event)
     end)
   end
@@ -49,7 +49,7 @@ defmodule Transport.Telemetry do
     # make it non-blocking, to ensure the traffic will be served quickly. this also means, though, we
     # won't notice if a tracing of event fails
     Task.start(fn ->
-      Logger.info("Telemetry event: processing #{convert_to} conversions request for #{target}")
+      Logger.debug("Telemetry event: processing #{convert_to} conversions request for #{target}")
       count_event(target, event, DateTime.utc_now(), :day)
     end)
   end

--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -150,7 +150,7 @@ defmodule Unlock.Controller do
 
   defp fetch_remote(%Unlock.Config.Item.Generic.HTTP{} = item) do
     comp_fn = fn _key ->
-      Logger.info("Processing proxy request for identifier #{item.identifier}")
+      Logger.debug("Processing proxy request for identifier #{item.identifier}")
 
       try do
         Unlock.Telemetry.trace_request(item.identifier, :internal)
@@ -172,14 +172,14 @@ defmodule Unlock.Controller do
 
     case outcome do
       {:ok, result} ->
-        Logger.info("Proxy response for #{item.identifier} served from cache")
+        Logger.debug("Proxy response for #{item.identifier} served from cache")
         result
 
       {:commit, result, _options} ->
         result
 
       {:ignore, result} ->
-        Logger.info("Cache has been skipped for proxy response")
+        Logger.debug("Cache has been skipped for proxy response")
         result
 
       {:error, _error} ->


### PR DESCRIPTION
En lien avec #4180

Réduit le nombre de lignes de log envoyées vers AppSignal. Actuellement chaque requête sur le proxy.

Exemples de lignes qui ne seront plus envoyées

```
Telemetry event: processing external proxy request for proxy:palmbus-cannes-gtfs-rt-vehicle-position
Proxy response for palmbus-cannes-gtfs-rt-vehicle-position served from cache
```