### PR TITLE
humans.txt : suppression de doublons

### DIFF
--- a/apps/transport/lib/transport_web/controllers/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/page_controller.ex
@@ -170,6 +170,7 @@ defmodule TransportWeb.PageController do
       |> List.flatten()
       |> Enum.map(&author_fullname.(&1))
       |> Enum.sort()
+      |> Enum.dedup()
 
     ["# Membres actuels", active_members, "", "# Anciens membres", previous_members]
     |> List.flatten()

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -296,7 +296,7 @@ defmodule TransportWeb.PageControllerTest do
       body = %{
         "transport" => %{
           "active_members" => ["foo"],
-          "previous_members" => ["bar"],
+          "previous_members" => ["bar", "baz"],
           "expired_members" => ["baz", "nope"]
         }
       }


### PR DESCRIPTION
On peut avoir des doublons dans https://transport.data.gouv.fr/humans.txt quand il y a des membres de l'équipe qui sont anciens et que leur compte est expiré.

Gère ce cas et ajoute un test.