### PR TITLE
GTFS diff: bouton pour échanger les fichiers

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -41,6 +41,10 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     {:noreply, cancel_upload(socket, :gtfs, ref)}
   end
 
+  def handle_event("switch-uploads", _, socket) do
+    {:noreply, update(socket, :uploads, &switch_uploads/1)}
+  end
+
   def handle_event("gtfs_diff", _, socket) do
     send(self(), :enqueue_job)
     {:noreply, socket |> assign(:job_running, true)}
@@ -189,5 +193,11 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
       "column" -> dngettext("validations", "%{count} column", "%{count} columns", n)
       _ -> "#{n} #{target}#{if n > 1, do: "s"}"
     end
+  end
+
+  defp switch_uploads(uploads) do
+    Map.update!(uploads, :gtfs, fn gtfs ->
+      Map.update!(gtfs, :entries, &Enum.reverse/1)
+    end)
   end
 end

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.html.heex
@@ -46,6 +46,11 @@
             </div>
           </article>
         <% end %>
+        <%= if uploads_are_valid(@uploads) do %>
+          <button class="button-outline primary small" type="button" phx-click="switch-uploads">
+            <i class="fa fa-shuffle"></i>&nbsp;<%= dgettext("validations", "Switch files") %>
+          </button>
+        <% end %>
         <%= for err <- upload_errors(@uploads.gtfs) do %>
           <p class="alert alert-danger">❌ <%= error_to_string(err) %></p>
         <% end %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -455,3 +455,7 @@ msgid "%{count} row"
 msgid_plural "%{count} rows"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Switch files"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -455,3 +455,7 @@ msgid "%{count} row"
 msgid_plural "%{count} rows"
 msgstr[0] "%{count} ligne"
 msgstr[1] "%{count} lignes"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Switch files"
+msgstr "Échanger les fichiers"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -453,3 +453,7 @@ msgid "%{count} row"
 msgid_plural "%{count} rows"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Switch files"
+msgstr ""


### PR DESCRIPTION
Si on upload 2 fichiers à la fois, l'ordre résultant peut ne pas convenir (ordre alphabétique peu pertinent par exemple).

![image](https://github.com/user-attachments/assets/6b5daa1c-bd73-4eba-847c-f43951ad1b90)
