### PR TITLE
DB.Resource.get_related_conversion_info : utilise l'index SQL

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -224,6 +224,9 @@ defmodule DB.Resource do
 
   def get_related_conversion_info(resource_id, format) do
     converter = DB.DataConversion.converter_to_use(format)
+    # Only value supported for now but needed to make the query fast
+    # https://github.com/etalab/transport-site/issues/4448
+    convert_from = :GTFS
 
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
@@ -237,8 +240,9 @@ defmodule DB.Resource do
     })
     |> where(
       [rh, dc],
-      rh.resource_id == ^resource_id and dc.convert_to == ^format and dc.status == :success and
-        dc.converter == ^converter
+      rh.resource_id == ^resource_id and
+        dc.convert_from == ^convert_from and dc.convert_to == ^format and
+        dc.status == :success and dc.converter == ^converter
     )
     |> order_by([rh, _], desc: rh.inserted_at)
     |> limit(1)


### PR DESCRIPTION
Fixes #4448

Voir https://github.com/etalab/transport-site/issues/4448#issuecomment-2664994230

Sans l'utilisation de la colonne `convert_from` on ne peut pas utiliser l'index en place et la requête prend alors 18s au lieu de 80ms.