### PR TITLE
Carte exploration : corrige z-index

### DIFF
--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -200,6 +200,7 @@ nav.navigation input {
   width: 100vw;
   height: 80vh;
   border-top: 1px solid #ccc;
+  z-index: 0;
 }
 
 iframe#dailymotion-video {


### PR DESCRIPTION
Fixes #4387

Passe de `auto` à un 0 explicite, le `z-index` pour le formulaire de contact est déjà renseigné.