### PR TITLE
ResourceHistory job pour ReuserImprovedData

### DIFF
--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -15,6 +15,7 @@ defmodule DB.ResourceHistory do
 
     timestamps(type: :utc_datetime_usec)
     belongs_to(:resource, DB.Resource)
+    belongs_to(:reuser_improved_data, DB.ReuserImprovedData)
     has_many(:geo_data_import, DB.GeoDataImport)
     has_many(:validations, DB.MultiValidation)
     has_many(:metadata, DB.ResourceMetadata)

--- a/apps/transport/lib/db/resource_history.ex
+++ b/apps/transport/lib/db/resource_history.ex
@@ -8,6 +8,7 @@ defmodule DB.ResourceHistory do
 
   @derive {Jason.Encoder, only: [:resource_id, :payload, :last_up_to_date_at, :inserted_at, :updated_at]}
   typed_schema "resource_history" do
+    # `datagouv_id` is `null` for reuser improved data and filled for resources
     field(:datagouv_id, :string)
     field(:payload, :map)
     # the last moment we checked and the resource history was corresponding to the real online resource

--- a/apps/transport/lib/db/reuser_improved_data.ex
+++ b/apps/transport/lib/db/reuser_improved_data.ex
@@ -5,6 +5,7 @@ defmodule DB.ReuserImprovedData do
   use Ecto.Schema
   use TypedEctoSchema
   import Ecto.Changeset
+  import Ecto.Query
 
   typed_schema "reuser_improved_data" do
     belongs_to(:dataset, DB.Dataset)
@@ -14,6 +15,8 @@ defmodule DB.ReuserImprovedData do
     field(:download_url, :string)
     timestamps(type: :utc_datetime_usec)
   end
+
+  def base_query, do: from(rm in __MODULE__, as: :reuser_improved_data)
 
   def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
     fields = [:dataset_id, :resource_id, :contact_id, :organization_id, :download_url]

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -180,6 +180,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
       false ->
         Appsignal.increment_counter("resource_history_job.failed", 1)
+        Logger.error("Historization failed for #{inspect(resource_or_improved_data)}")
         {:error, "historization failed"}
     end
   end

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -287,7 +287,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
   defp store_resource_history!(%DB.ReuserImprovedData{id: reuser_improved_data_id}, payload) do
     %DB.ResourceHistory{
-      datagouv_id: "reuser_improved_data::#{reuser_improved_data_id}",
       reuser_improved_data_id: reuser_improved_data_id,
       payload: Map.merge(payload, %{format: "GTFS"}),
       last_up_to_date_at: DateTime.utc_now()

--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -7,6 +7,20 @@ defmodule Transport.Jobs.ResourceHistoryAndValidationDispatcherJob do
   import Ecto.Query
 
   @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "reuser_improved_data"}}) do
+    DB.ReuserImprovedData.base_query()
+    |> select([reuser_improved_data: rid], rid.id)
+    |> DB.Repo.all()
+    |> Enum.map(fn reuser_improved_data_id ->
+      %{reuser_improved_data_id: reuser_improved_data_id}
+      |> Transport.Jobs.ResourceHistoryJob.historize_and_validate_job()
+    end)
+    |> Oban.insert_all()
+
+    :ok
+  end
+
+  @impl Oban.Worker
   def perform(_job) do
     resource_ids = Enum.map(resources_to_historise(), & &1.id)
 
@@ -44,7 +58,7 @@ end
 
 defmodule Transport.Jobs.ResourceHistoryJob do
   @moduledoc """
-  Job historicising a single resource
+  Job historicising a single `DB.Resource` or a `DB.ReuserImprovedData`.
   """
   use Oban.Worker, unique: [period: {5, :hours}, fields: [:args, :queue, :worker]], tags: ["history"], max_attempts: 5
   require Logger
@@ -72,6 +86,11 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     |> handle_history(job)
   end
 
+  def perform(%Oban.Job{args: %{"reuser_improved_data_id" => reuser_improved_data_id}} = job) do
+    DB.Repo.get!(DB.ReuserImprovedData, reuser_improved_data_id)
+    |> handle_history(job)
+  end
+
   defp handle_history([], %Oban.Job{} = job) do
     reason = "Resource should not be historicised"
     notify_workflow(job, %{"success" => false, "job_id" => job.id, "reason" => reason})
@@ -79,16 +98,25 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   end
 
   defp handle_history([%DB.Resource{} = resource], %Oban.Job{} = job) do
-    path = download_path(resource)
+    do_handle_history(resource, job)
+  end
+
+  defp handle_history(%DB.ReuserImprovedData{} = reuser_improved_data, %Oban.Job{} = job) do
+    do_handle_history(reuser_improved_data, job)
+  end
+
+  defp do_handle_history(data, %Oban.Job{} = job) do
+    path = download_path(data)
 
     notification =
       try do
         %{resource_history_id: resource_history_id} =
-          :req |> download_resource(resource, path) |> process_download(resource)
+          download_resource(data, path) |> process_download(data)
 
         %{"success" => true, "job_id" => job.id, "output" => %{resource_history_id: resource_history_id}}
       rescue
-        e -> %{"success" => false, "job_id" => job.id, "reason" => inspect(e)}
+        e ->
+          %{"success" => false, "job_id" => job.id, "reason" => inspect(e)}
       after
         remove_file(path)
       end
@@ -107,29 +135,21 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     Logger.debug("Got an error while downloading resource##{resource_id}: #{message}")
   end
 
-  defp process_download({:ok, resource_path, headers}, %DB.Resource{} = resource) do
+  defp process_download({:ok, resource_path, headers}, resource_or_improved_data) do
     download_datetime = DateTime.utc_now()
 
-    hash = resource_hash(resource, resource_path)
+    hash = resource_hash(resource_or_improved_data, resource_path)
 
-    case should_store_resource?(resource, hash) do
+    case should_store_resource?(resource_or_improved_data, hash) do
       true ->
-        filename = upload_filename(resource, resource_path, download_datetime)
+        filename = upload_filename(resource_or_improved_data, resource_path, download_datetime)
 
         base = %{
           download_datetime: download_datetime,
           uuid: Ecto.UUID.generate(),
           http_headers: headers,
           filename: filename,
-          permanent_url: Transport.S3.permanent_url(:history, filename),
-          resource_url: resource.url,
-          resource_latest_url: resource.latest_url,
-          title: resource.title,
-          format: resource.format,
-          dataset_id: resource.dataset_id,
-          schema_name: resource.schema_name,
-          schema_version: resource.schema_version,
-          latest_schema_version_to_date: latest_schema_version_to_date(resource)
+          permanent_url: Transport.S3.permanent_url(:history, filename)
         }
 
         data =
@@ -149,20 +169,17 @@ defmodule Transport.Jobs.ResourceHistoryJob do
           end
 
         Transport.S3.stream_to_s3!(:history, resource_path, filename, acl: :public_read)
-        %{id: resource_history_id} = store_resource_history!(resource, data)
-        Appsignal.increment_counter("resource_history_job.success", 1, %{resource_id: resource.id})
-
+        %{id: resource_history_id} = store_resource_history!(resource_or_improved_data, data)
+        Appsignal.increment_counter("resource_history_job.success", 1)
         %{resource_history_id: resource_history_id}
 
       {false, history} ->
-        Appsignal.increment_counter("resource_history_job.skipped", 1, %{resource_id: resource.id})
-        Logger.debug("skipping historization for resource##{resource.id} because resource did not change")
+        Appsignal.increment_counter("resource_history_job.skipped", 1)
         touch_resource_history!(history)
         %{resource_history_id: history.id}
 
       false ->
-        Appsignal.increment_counter("resource_history_job.failed", 1, %{resource_id: resource.id})
-        Logger.error("Failed historization for resource##{resource.id}")
+        Appsignal.increment_counter("resource_history_job.failed", 1)
         {:error, "historization failed"}
     end
   end
@@ -178,13 +195,24 @@ defmodule Transport.Jobs.ResourceHistoryJob do
   def should_store_resource?(_, nil), do: false
 
   def should_store_resource?(%DB.Resource{id: resource_id}, resource_hash) do
-    history =
-      DB.ResourceHistory
-      |> where([r], r.resource_id == ^resource_id)
-      |> order_by(desc: :inserted_at)
-      |> limit(1)
-      |> DB.Repo.one()
+    DB.ResourceHistory
+    |> where([r], r.resource_id == ^resource_id)
+    |> order_by(desc: :inserted_at)
+    |> limit(1)
+    |> DB.Repo.one()
+    |> compare_history(resource_hash)
+  end
 
+  def should_store_resource?(%DB.ReuserImprovedData{id: reuser_improved_data_id}, resource_hash) do
+    DB.ResourceHistory
+    |> where([r], r.reuser_improved_data_id == ^reuser_improved_data_id)
+    |> order_by(desc: :inserted_at)
+    |> limit(1)
+    |> DB.Repo.one()
+    |> compare_history(resource_hash)
+  end
+
+  defp compare_history(history, resource_hash) do
     case {history, same_resource?(history, resource_hash)} do
       {nil, _} -> true
       {_history, false} -> true
@@ -211,13 +239,20 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     items |> Enum.map(&{map_get(&1, :file_name), map_get(&1, :sha256)}) |> MapSet.new()
   end
 
-  defp resource_hash(%DB.Resource{} = resource, resource_path) do
+  defp resource_hash(data, resource_path) do
     if Transport.ZipMetaDataExtractor.zip?(resource_path) do
       try do
         Transport.ZipMetaDataExtractor.extract!(resource_path)
       rescue
         _ ->
-          Logger.error("Cannot compute ZIP metadata for resource##{resource.id}")
+          case data do
+            %DB.Resource{} = resource ->
+              Logger.error("Cannot compute ZIP metadata for resource##{resource.id}")
+
+            _ ->
+              :ok
+          end
+
           nil
       end
     else
@@ -229,13 +264,31 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     Map.get(map, key) || Map.get(map, to_string(key))
   end
 
-  defp store_resource_history!(%DB.Resource{datagouv_id: datagouv_id, id: resource_id}, payload) do
-    Logger.debug("Saving ResourceHistory for resource##{resource_id}")
-
+  defp store_resource_history!(%DB.Resource{} = resource, payload) do
     %DB.ResourceHistory{
-      datagouv_id: datagouv_id,
-      resource_id: resource_id,
-      payload: payload,
+      datagouv_id: resource.datagouv_id,
+      resource_id: resource.id,
+      payload:
+        Map.merge(payload, %{
+          resource_url: resource.url,
+          resource_latest_url: resource.latest_url,
+          title: resource.title,
+          format: resource.format,
+          dataset_id: resource.dataset_id,
+          schema_name: resource.schema_name,
+          schema_version: resource.schema_version,
+          latest_schema_version_to_date: latest_schema_version_to_date(resource)
+        }),
+      last_up_to_date_at: DateTime.utc_now()
+    }
+    |> DB.Repo.insert!()
+  end
+
+  defp store_resource_history!(%DB.ReuserImprovedData{id: reuser_improved_data_id}, payload) do
+    %DB.ResourceHistory{
+      datagouv_id: "reuser_improved_data::#{reuser_improved_data_id}",
+      reuser_improved_data_id: reuser_improved_data_id,
+      payload: Map.merge(payload, %{format: "GTFS"}),
       last_up_to_date_at: DateTime.utc_now()
     }
     |> DB.Repo.insert!()
@@ -251,13 +304,24 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     System.tmp_dir!() |> Path.join("resource_#{resource_id}_download")
   end
 
-  def download_resource(:req, %DB.Resource{id: resource_id, url: url}, file_path) do
+  defp download_path(%DB.ReuserImprovedData{id: reuser_improved_data_id}) do
+    System.tmp_dir!() |> Path.join("reuser_improved_data_#{reuser_improved_data_id}_download")
+  end
+
+  def download_resource(%DB.Resource{url: url}, file_path) do
+    download_resource(url, file_path)
+  end
+
+  def download_resource(%DB.ReuserImprovedData{download_url: download_url}, file_path) do
+    download_resource(download_url, file_path)
+  end
+
+  def download_resource(url, file_path) when is_binary(url) do
     file_stream = File.stream!(file_path)
     req_options = [compressed: false, decode_body: false, receive_timeout: 180_000, into: file_stream]
 
     case Transport.Req.impl().get(url, req_options) do
       {:ok, %{status: 200} = r} ->
-        Logger.debug("Saved resource##{resource_id} to #{file_path}")
         {:ok, file_path, relevant_http_headers(r)}
 
       {:ok, %{status: status_code}} ->
@@ -266,22 +330,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
 
       {:error, error} ->
         {:error, "Got an error: #{error |> inspect}"}
-    end
-  end
-
-  # NOTE: dead code, kept to allow comparison in the coming weeks if needed
-  def download_resource(:legacy, %DB.Resource{id: resource_id, url: url}, file_path) do
-    case http_client().get(url, [], follow_redirect: true, recv_timeout: 180_000) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body} = r} ->
-        Logger.debug("Saving resource##{resource_id} to #{file_path}")
-        File.write!(file_path, body)
-        {:ok, file_path, relevant_http_headers(r)}
-
-      {:ok, %HTTPoison.Response{status_code: status}} ->
-        {:error, "Got a non 200 status: #{status}"}
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, "Got an error: #{inspect(reason)}"}
     end
   end
 
@@ -295,6 +343,16 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     "#{resource_id}/#{resource_id}.#{time}#{file_extension(resource, resource_path)}"
   end
 
+  def upload_filename(
+        %DB.ReuserImprovedData{id: reuser_improved_data_id} = reuser_improved_data,
+        resource_path,
+        %DateTime{} = dt
+      ) do
+    time = Calendar.strftime(dt, "%Y%m%d.%H%M%S.%f")
+
+    "reuser_improved_data_#{reuser_improved_data_id}/#{reuser_improved_data_id}.#{time}#{file_extension(reuser_improved_data, resource_path)}"
+  end
+
   @doc """
   Guess an appropriate file extension according to a format.
   """
@@ -303,6 +361,14 @@ defmodule Transport.Jobs.ResourceHistoryJob do
       ".zip"
     else
       "." <> (format |> String.downcase() |> String.replace_prefix(".", ""))
+    end
+  end
+
+  def file_extension(%DB.ReuserImprovedData{}, resource_path) do
+    if Transport.ZipMetaDataExtractor.zip?(resource_path) do
+      ".zip"
+    else
+      raise "not implemented"
     end
   end
 
@@ -357,7 +423,9 @@ defmodule Transport.Jobs.ResourceHistoryJob do
     Schemas.latest_version(schema_name)
   end
 
-  def historize_and_validate_job(%{resource_id: resource_id}, options \\ []) do
+  @spec historize_and_validate_job(%{resource_id: integer()} | %{reuser_improved_data_id: integer()}, keyword()) ::
+          Transport.Jobs.Workflow.t()
+  def historize_and_validate_job(first_jobs_args, options \\ []) do
     history_options = options |> Keyword.get(:history_options, []) |> Transport.Jobs.Workflow.kw_to_map()
     validation_custom_args = options |> Keyword.get(:validation_custom_args, %{})
 
@@ -368,6 +436,6 @@ defmodule Transport.Jobs.ResourceHistoryJob do
       [Transport.Jobs.ResourceHistoryValidationJob, validation_custom_args, %{}]
     ]
 
-    Transport.Jobs.Workflow.new(%{jobs: jobs, first_job_args: %{resource_id: resource_id}})
+    Transport.Jobs.Workflow.new(%{jobs: jobs, first_job_args: first_jobs_args})
   end
 end

--- a/apps/transport/priv/repo/migrations/20250225130151_resource_history_add_reuser_improved_data.exs
+++ b/apps/transport/priv/repo/migrations/20250225130151_resource_history_add_reuser_improved_data.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ResourceHistoryAddReuserImprovedData do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_history) do
+      add(:reuser_improved_data_id, references(:reuser_improved_data, on_delete: :delete_all))
+    end
+  end
+end

--- a/apps/transport/priv/repo/migrations/20250305130125_resource_history_nullable_datagouv_id.exs
+++ b/apps/transport/priv/repo/migrations/20250305130125_resource_history_nullable_datagouv_id.exs
@@ -3,7 +3,7 @@ defmodule DB.Repo.Migrations.ResourceHistoryNullableDatagouvId do
 
   def change do
     alter table(:resource_history) do
-      modify :datagouv_id, :string, null: true, from: :string
+      modify(:datagouv_id, :string, null: true, from: :string)
     end
   end
 end

--- a/apps/transport/priv/repo/migrations/20250305130125_resource_history_nullable_datagouv_id.exs
+++ b/apps/transport/priv/repo/migrations/20250305130125_resource_history_nullable_datagouv_id.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ResourceHistoryNullableDatagouvId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_history) do
+      modify :datagouv_id, :string, null: true, from: :string
+    end
+  end
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -314,6 +314,18 @@ defmodule DB.Factory do
     %DB.ResourceRelated{}
   end
 
+  def reuser_improved_data_factory do
+    dataset = build(:dataset)
+
+    %DB.ReuserImprovedData{
+      dataset: dataset,
+      resource: build(:resource, dataset_id: dataset.id),
+      contact: insert_contact(),
+      organization: build(:organization),
+      download_url: sequence(:download_url, fn i -> "https://example.com/file_#{i}" end)
+    }
+  end
+
   def organization_factory do
     %DB.Organization{
       id: Ecto.UUID.generate(),

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -500,11 +500,10 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       ensure_no_tmp_files!("reuser_improved_data_")
 
       expected_zip_metadata = zip_metadata()
-      datagouv_id = "reuser_improved_data::#{reuser_improved_data_id}"
 
       assert %DB.ResourceHistory{
                resource_id: nil,
-               datagouv_id: ^datagouv_id,
+               datagouv_id: nil,
                payload: %{
                  "filenames" => [
                    "ExportService.checksum.md5",

--- a/apps/transport/test/transport/jobs/resource_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_history_job_test.exs
@@ -56,7 +56,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                opts: [acl: :public_read]
              } = request
 
-      assert String.starts_with?(path, "#{resource_id}/#{resource_id}.")
+      assert String.starts_with?(path, to_string(resource_id))
     end)
   end
 
@@ -69,7 +69,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                ResourceHistoryAndValidationDispatcherJob.resources_to_historise() |> Enum.map(& &1.id) |> MapSet.new()
     end
 
-    test "a simple successful case" do
+    test "a successful case for resources" do
       ids = create_resources_for_history()
 
       assert count_resources() > 1
@@ -85,17 +85,44 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       refute_enqueued(worker: ResourceHistoryAndValidationDispatcherJob)
     end
+
+    test "a successful case for reuser improved data jobs" do
+      insert(:reuser_improved_data)
+      insert(:reuser_improved_data)
+      insert(:reuser_improved_data)
+
+      ids =
+        DB.ReuserImprovedData.base_query()
+        |> select([reuser_improved_data: rid], rid.id)
+        |> DB.Repo.all()
+
+      assert :ok == perform_job(ResourceHistoryAndValidationDispatcherJob, %{mode: "reuser_improved_data"})
+
+      assert [
+               %{args: %{"first_job_args" => %{"reuser_improved_data_id" => first_id}}},
+               %{args: %{"first_job_args" => %{"reuser_improved_data_id" => second_id}}},
+               %{args: %{"first_job_args" => %{"reuser_improved_data_id" => third_id}}}
+             ] = all_enqueued(worker: Transport.Jobs.Workflow)
+
+      assert Enum.sort([first_id, second_id, third_id]) == Enum.sort(ids)
+
+      refute_enqueued(worker: ResourceHistoryAndValidationDispatcherJob)
+    end
   end
 
   describe "should_store_resource?" do
     test "with an empty or a nil ZIP metadata" do
       refute ResourceHistoryJob.should_store_resource?(%DB.Resource{}, nil)
+      refute ResourceHistoryJob.should_store_resource?(%DB.ReuserImprovedData{}, nil)
+
       refute ResourceHistoryJob.should_store_resource?(%DB.Resource{}, [])
+      refute ResourceHistoryJob.should_store_resource?(%DB.ReuserImprovedData{}, [])
     end
 
     test "with no ResourceHistory records" do
       assert 0 == count_resource_history()
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{id: 1}, zip_metadata())
+      assert ResourceHistoryJob.should_store_resource?(%DB.ReuserImprovedData{id: 1}, zip_metadata())
     end
 
     test "with the latest ResourceHistory matching for a ZIP" do
@@ -111,6 +138,26 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       assert {false, %{id: ^resource_history_id}} =
                ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id}, zip_metadata())
+    end
+
+    test "with the latest ResourceHistory matching for a ZIP, reuser improved data" do
+      reuser_improved_data = insert(:reuser_improved_data)
+
+      %{id: resource_history_id} =
+        resource_history =
+        insert(:resource_history,
+          payload: %{"zip_metadata" => zip_metadata()},
+          reuser_improved_data_id: reuser_improved_data.id
+        )
+
+      assert 1 == count_resource_history()
+      assert ResourceHistoryJob.same_resource?(resource_history, zip_metadata())
+
+      assert {false, %{id: ^resource_history_id}} =
+               ResourceHistoryJob.should_store_resource?(
+                 %DB.ReuserImprovedData{id: reuser_improved_data.id},
+                 zip_metadata()
+               )
     end
 
     test "with the latest ResourceHistory matching for a content hash" do
@@ -130,6 +177,27 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id}, content_hash)
     end
 
+    test "with the latest ResourceHistory matching for a content hash, reuser improved data" do
+      content_hash = "hash"
+      reuser_improved_data = insert(:reuser_improved_data)
+
+      %{id: resource_history_id} =
+        resource_history =
+        insert(:resource_history,
+          payload: %{"content_hash" => content_hash},
+          reuser_improved_data_id: reuser_improved_data.id
+        )
+
+      assert 1 == count_resource_history()
+      assert ResourceHistoryJob.same_resource?(resource_history, content_hash)
+
+      assert {false, %{id: ^resource_history_id}} =
+               ResourceHistoryJob.should_store_resource?(
+                 %DB.ReuserImprovedData{id: reuser_improved_data.id},
+                 content_hash
+               )
+    end
+
     test "with the latest ResourceHistory matching but for a different resource ID" do
       %{resource_id: resource_id} =
         insert(:resource_history,
@@ -139,6 +207,22 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
 
       assert 1 == count_resource_history()
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id + 1}, zip_metadata())
+    end
+
+    test "with the latest ResourceHistory matching but for a different reuser improved data ID" do
+      %{id: reuser_improved_data_id} = insert(:reuser_improved_data)
+
+      insert(:resource_history,
+        reuser_improved_data_id: reuser_improved_data_id,
+        payload: %{"zip_metadata" => zip_metadata()}
+      )
+
+      assert 1 == count_resource_history()
+
+      assert ResourceHistoryJob.should_store_resource?(
+               %DB.ReuserImprovedData{id: reuser_improved_data_id + 1},
+               zip_metadata()
+             )
     end
 
     test "with the second to last ResourceHistory matching" do
@@ -162,6 +246,37 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert {false, _} = ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id}, zip_metadata())
     end
 
+    test "with the second to last ResourceHistory matching, reuser improved data" do
+      %{id: reuser_improved_data_id} = insert(:reuser_improved_data)
+
+      %{payload: %{"zip_metadata" => zip_metadata}} =
+        insert(:resource_history,
+          reuser_improved_data_id: reuser_improved_data_id,
+          payload: %{"zip_metadata" => zip_metadata()}
+        )
+
+      %{id: latest_rh_id} =
+        insert(:resource_history,
+          reuser_improved_data_id: reuser_improved_data_id,
+          payload: %{"zip_metadata" => zip_metadata |> Enum.take(2)}
+        )
+
+      assert 2 == count_resource_history()
+
+      assert ResourceHistoryJob.should_store_resource?(
+               %DB.ReuserImprovedData{id: reuser_improved_data_id},
+               zip_metadata()
+             )
+
+      %DB.ResourceHistory{id: latest_rh_id} |> DB.Repo.delete()
+
+      assert {false, _} =
+               ResourceHistoryJob.should_store_resource?(
+                 %DB.ReuserImprovedData{id: reuser_improved_data_id},
+                 zip_metadata()
+               )
+    end
+
     test "with the latest ResourceHistory not matching for a ZIP" do
       %{resource_id: resource_id} =
         insert(:resource_history,
@@ -174,6 +289,22 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id}, zip_metadata())
     end
 
+    test "with the latest ResourceHistory not matching for a ZIP, reuser improved data" do
+      %{id: reuser_improved_data_id} = insert(:reuser_improved_data)
+
+      insert(:resource_history,
+        reuser_improved_data_id: reuser_improved_data_id,
+        payload: %{"zip_metadata" => zip_metadata() |> Enum.take(2)}
+      )
+
+      assert 1 == count_resource_history()
+
+      assert ResourceHistoryJob.should_store_resource?(
+               %DB.ReuserImprovedData{id: reuser_improved_data_id},
+               zip_metadata()
+             )
+    end
+
     test "with the latest ResourceHistory not matching" do
       %{resource_id: resource_id} =
         insert(:resource_history, resource: insert(:resource), payload: %{"content_hash" => "foo"})
@@ -181,6 +312,22 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
       assert 1 == count_resource_history()
 
       assert ResourceHistoryJob.should_store_resource?(%DB.Resource{id: resource_id}, "bar")
+    end
+
+    test "with the latest ResourceHistory not matching, reuser improved data" do
+      %{id: reuser_improved_data_id} = insert(:reuser_improved_data)
+
+      insert(:resource_history,
+        resource: insert(:resource),
+        reuser_improved_data_id: reuser_improved_data_id,
+        payload: %{
+          "content_hash" => "foo"
+        }
+      )
+
+      assert 1 == count_resource_history()
+
+      assert ResourceHistoryJob.should_store_resource?(%DB.ReuserImprovedData{id: reuser_improved_data_id}, "bar")
     end
   end
 
@@ -325,6 +472,55 @@ defmodule Transport.Test.Transport.Jobs.ResourceHistoryJobTest do
                  "total_compressed_size" => 2_370,
                  "total_uncompressed_size" => 10_685,
                  "title" => ^title,
+                 "filename" => filename,
+                 "permanent_url" => permanent_url,
+                 "zip_metadata" => ^expected_zip_metadata,
+                 "uuid" => _uuid,
+                 "download_datetime" => _download_datetime
+               },
+               last_up_to_date_at: last_up_to_date_at
+             } = DB.ResourceHistory |> DB.Repo.one!()
+
+      assert permanent_url == Transport.S3.permanent_url(:history, filename)
+      refute is_nil(last_up_to_date_at)
+    end
+
+    test "a simple successful case for a reuser improved GTFS" do
+      download_url = "https://example.com/gtfs.zip"
+
+      %DB.ReuserImprovedData{id: reuser_improved_data_id} = insert(:reuser_improved_data, download_url: download_url)
+
+      setup_req_mock(download_url, @gtfs_content)
+      setup_aws_mock("reuser_improved_data_#{reuser_improved_data_id}")
+
+      assert 0 == count_resource_history()
+      assert :ok == perform_job(ResourceHistoryJob, %{reuser_improved_data_id: reuser_improved_data_id})
+      assert 1 == count_resource_history()
+
+      ensure_no_tmp_files!("reuser_improved_data_")
+
+      expected_zip_metadata = zip_metadata()
+      datagouv_id = "reuser_improved_data::#{reuser_improved_data_id}"
+
+      assert %DB.ResourceHistory{
+               resource_id: nil,
+               datagouv_id: ^datagouv_id,
+               payload: %{
+                 "filenames" => [
+                   "ExportService.checksum.md5",
+                   "agency.txt",
+                   "calendar.txt",
+                   "calendar_dates.txt",
+                   "routes.txt",
+                   "stop_times.txt",
+                   "stops.txt",
+                   "transfers.txt",
+                   "trips.txt"
+                 ],
+                 "format" => "GTFS",
+                 "http_headers" => %{"content-type" => "application/octet-stream"},
+                 "total_compressed_size" => 2_370,
+                 "total_uncompressed_size" => 10_685,
                  "filename" => filename,
                  "permanent_url" => permanent_url,
                  "zip_metadata" => ^expected_zip_metadata,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,6 +110,7 @@ base_oban_conf = [repo: DB.Repo, insert_trigger: false]
 # See https://hexdocs.pm/oban/Oban.html#module-cron-expressions
 oban_prod_crontab = [
   {"0 */6 * * *", Transport.Jobs.ResourceHistoryAndValidationDispatcherJob},
+  {"0 4,16 * * *", Transport.Jobs.ResourceHistoryAndValidationDispatcherJob, args: %{mode: :reuser_improved_data}},
   {"30 */6 * * *", Transport.Jobs.GTFSToGeoJSONConverterJob},
   {"0 4 * * *", Transport.Jobs.GTFSImportStopsJob},
   # every 6 hours but not at the same time as other jobs


### PR DESCRIPTION
En lien avec #4011

Cette PR permet d'historiser des ressources améliorées partagées par les réutilisateurs. Les réutilisateurs partagent une URL vers un GTFS amélioré actuellement, on souhaite historiser cette URL et procéder à la validation de ces resource history.

Le code actuel est adapté pour gérer des `DB.Resource` et `DB.ReuserImprovedData` dans `ResourceHistoryJob` qui est en charge de l'historisation.

L'historisation de ces ressources améliorées est effectuée 2 fois par jour (toutes les 6h pour les ressources statiques classiques).

La validation se fait automatiquement dès qu'on a une ressource history avec un champ `payload.format = 'GTFS'` par le biais du job de workflow.