### PR TITLE
ConsolidateLEZJob : utilisation unique du fichier CSV

### DIFF
--- a/apps/transport/priv/zfe_ids.csv
+++ b/apps/transport/priv/zfe_ids.csv
@@ -1,44 +1,44 @@
-siren;code;epci_principal;autres_siren
-248000531;AMIENS;Amiens Métropole;
-244900015;ANGERS;Angers Loire Métropole;
-200066793;ANNECY;Grand Annecy;
-200011773;ANNEMASSE;Annemasse agglo;
-248400251;AVIGNON;Grand Avignon;
-200067106;BAYONNE;Communauté d'agglomération du Pays Basque;
-200072460;BETHUNE;Communauté d'agglomération de Béthune-Bruay;
-243300316;BORDEAUX;Bordeaux Métropole;
-242900314;BREST;Brest métropole;
-200051183;CAEN;Caen Normandie Métropole;
-200069110;CHAMBERY;Grand Chambéry;
-246300701;CLERMONT-FERRAND;Clermont Auvergne métropole;
-242100410;DIJON;Dijon Métropole;
-246200364;DOUAI-LENS;Communauté d'agglomération de Lens-Lievin;
-245900428;DUNKERQUE;Communauté Urbaine de Dunkerque;
-253800825;GRENOBLE;Grenoble Alpes métropole;
-200084952;LE HAVRE;Le Havre Seine Métropole;
-247200132;LE MANS;Le Mans Métropole;
-200093201;LILLE;Métropole Européenne de Lille;
-248719312;LIMOGES;Limoges Métropole;
-200046977;LYON;Métropole de Lyon;256900994
-200054807;MARSEILLE-AIX EN PROVENCE;Métropole Aix-Marseille-Provence;
-200039865;METZ;Metz Métropole;
-243400017;MONTPELLIER;Montpellier Méditerranée Métropole;
-200066009;MULHOUSE;Mulhouse Alsace Agglomération;
-245400676;NANCY;Métropole du Grand Nancy;
-244400404;NANTES;Métropole Nantes Métropole;
-200030195;NICE;Métropole Nice Côte d'Azur;
-243000643;NIMES;Nîmes métropole;
-244500468;ORLEANS;Orléans métropole;
-217500016;PARIS;Métropole du Grand Paris;
-200067254;PAU;Agglomération de Pau Béarn Pyrénées;
-200027183;PERPIGNAN;Perpignan méditerranée métropole;
-200067213;REIMS;Grand Reims;
-243500139;RENNES;Rennes métropole;
-200023414;ROUEN;Métropole Rouen Normandie;
-214401846;SAINT-NAZAIRE;Commune de Saint-Nazaire;
-244200770;SAINT-ETIENNE;Saint-Étienne Métropole;
-246700488;STRASBOURG;Eurométropole de Strasbourg;
-248300543;TOULON;Métropole Toulon Provence Méditerranée;
-253100986;TOULOUSE;Toulouse métropole;243100518
-243700754;TOURS;Tours Métropole Val de Loire;200085108
-245901160;VALENCIENNES;Valenciennes métropole;
+siren;code;epci_principal;autres_siren;forme_juridique
+248000531;AMIENS;Amiens Métropole;;Métropole
+244900015;ANGERS;Angers Loire Métropole;;Métropole
+200066793;ANNECY;Grand Annecy;;Communauté d'agglomération
+200011773;ANNEMASSE;Annemasse agglo;;Communauté d'agglomération
+248400251;AVIGNON;Grand Avignon;;Métropole
+200067106;BAYONNE;Communauté d'agglomération du Pays Basque;;Communauté d'agglomération
+200072460;BETHUNE;Communauté d'agglomération de Béthune-Bruay;;Communauté d'agglomération
+243300316;BORDEAUX;Bordeaux Métropole;;Métropole
+242900314;BREST;Brest métropole;;Métropole
+200051183;CAEN;Caen Normandie Métropole;;Métropole
+200069110;CHAMBERY;Grand Chambéry;;Métropole
+246300701;CLERMONT-FERRAND;Clermont Auvergne métropole;;Métropole
+242100410;DIJON;Dijon Métropole;;Métropole
+246200364;DOUAI-LENS;Communauté d'agglomération de Lens-Lievin;;Communauté d'agglomération
+245900428;DUNKERQUE;Communauté Urbaine de Dunkerque;;Communauté urbaine
+253800825;GRENOBLE;Grenoble Alpes métropole;;Métropole
+200084952;LE HAVRE;Le Havre Seine Métropole;;Métropole
+247200132;LE MANS;Le Mans Métropole;;Métropole
+200093201;LILLE;Métropole Européenne de Lille;;Métropole
+248719312;LIMOGES;Limoges Métropole;;Métropole
+200046977;LYON;Métropole de Lyon;256900994;Métropole
+200054807;MARSEILLE-AIX EN PROVENCE;Métropole Aix-Marseille-Provence;;Métropole
+200039865;METZ;Metz Métropole;;Métropole
+243400017;MONTPELLIER;Montpellier Méditerranée Métropole;;Métropole
+200066009;MULHOUSE;Mulhouse Alsace Agglomération;;Communauté d'agglomération
+245400676;NANCY;Métropole du Grand Nancy;;Métropole
+244400404;NANTES;Métropole Nantes Métropole;;Métropole
+200030195;NICE;Métropole Nice Côte d'Azur;;Métropole
+243000643;NIMES;Nîmes métropole;;Métropole
+244500468;ORLEANS;Orléans métropole;;Métropole
+217500016;PARIS;Ville de Paris;;Autre collectivité territoriale
+200067254;PAU;Agglomération de Pau Béarn Pyrénées;;Métropole
+200027183;PERPIGNAN;Perpignan méditerranée métropole;;Métropole
+200067213;REIMS;Grand Reims;;Métropole
+243500139;RENNES;Rennes métropole;;Métropole
+200023414;ROUEN;Métropole Rouen Normandie;;Métropole
+214401846;SAINT-NAZAIRE;Commune de Saint-Nazaire;;Commune
+244200770;SAINT-ETIENNE;Saint-Étienne Métropole;;Métropole
+246700488;STRASBOURG;Eurométropole de Strasbourg;;Métropole
+248300543;TOULON;Métropole Toulon Provence Méditerranée;;Métropole
+243100518;TOULOUSE;Toulouse Métropole;253100986;Métropole
+243700754;TOURS;Tours Métropole Val de Loire;200085108;Métropole
+245901160;VALENCIENNES;Valenciennes métropole;;Métropole

--- a/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_lez_job_test.exs
@@ -5,6 +5,8 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateLEZsJobTest do
   import Mox
   alias Transport.Jobs.ConsolidateLEZsJob
 
+  doctest Transport.Jobs.ConsolidateLEZsJob, import: true
+
   setup :verify_on_exit!
 
   setup do


### PR DESCRIPTION
Fixes #4464

Permet de retrouver une organization qui publie la ZFE quand un JDD est rattaché à une AOM ou non. Auparavant dans le second cas on avait une variable qui faisait le mapping alors qu'un semblant de mapping coexistait dans le [fichier CSV zfe_ids.csv](https://github.com/etalab/transport-site/blob/master/apps/transport/priv/zfe_ids.csv).

Cette PR uniformise la méthode pour trouver le nom/code/SIREN d'une ZFE pour se reposer uniquement sur le fichier CSV.