### PR TITLE
GTFS diff par URLs : télécharger les sources

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -152,8 +152,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
         %{
           "complete" => job_id,
           "diff_file_url" => diff_file_url,
-          "gtfs_original_file_name_1" => gtfs_original_file_name_1,
-          "gtfs_original_file_name_2" => gtfs_original_file_name_2
+          "context" => context
         },
         job_id,
         socket
@@ -162,7 +161,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     unlisten_job_notifications()
 
     socket
-    |> present_results(diff_file_url, gtfs_original_file_name_1, gtfs_original_file_name_2)
+    |> present_results(diff_file_url, context)
     |> scroll_to_steps()
   end
 
@@ -266,11 +265,10 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     end
   end
 
-  defp present_results(socket, diff_file_url, gtfs_original_file_name_1, gtfs_original_file_name_2) do
+  defp present_results(socket, diff_file_url, context) do
     updates = [
       set(:diff_file_url, diff_file_url),
-      set(:gtfs_original_file_name_1, gtfs_original_file_name_1),
-      set(:gtfs_original_file_name_2, gtfs_original_file_name_2)
+      set(:context, context)
     ]
 
     socket

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -473,6 +473,14 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "Modified GTFS"
 msgstr ""
 

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -473,6 +473,14 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr "Les fichier GTFS <code>%{gtfs_original_file_name_2}</code> et <code>%{gtfs_original_file_name_1}</code> sont similaires."
 
 #, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
+msgstr "Le fichier GTFS modifié (<a href=\"%{gtfs_url_2}\">source</a>) comporte les différences ci-dessous par rapport au fichier GTFS de référence (<a href=\"%{gtfs_url_2}\">source</a>) :"
+
+#, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
+msgstr "Le fichier GTFS modifié (<a href=\"%{gtfs_url_2}\">source</a>) et le fichier GTFS de référence (<a href=\"%{gtfs_url_1}\">source</a>) sont similaires."
+
+#, elixir-autogen, elixir-format
 msgid "Modified GTFS"
 msgstr "GTFS modifié"
 

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -471,6 +471,14 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "Modified GTFS"
 msgstr ""
 


### PR DESCRIPTION
En cas de GTFS diff depuis des URLs, il est désormais possible de télécharger les fichiers d'origine.

Aperçu :

![image](https://github.com/user-attachments/assets/e24a7b10-8ec5-4323-b860-25dd5fa84a2d)