### PR TITLE
Amélioration du wording du mail de rappel de notification des producteurs

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -1,9 +1,9 @@
 Bonjour,
 
 <%= if Enum.count(@datasets_subscribed) == 1 do %>
-Vous êtes inscrit à des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset() %>.
+En tant que producteur de données de transport, vous êtes inscrit à des notifications pour le jeu de données <%= @datasets_subscribed |> hd() |> link_for_dataset() %>.
 <% else %>
-Vous êtes inscrit à des notifications concernant les jeux de données suivants :
+En tant que producteur de données de transport, vous êtes inscrit à des notifications concernant les jeux de données suivants :
 <ul>
   <%= for dataset <- @datasets_subscribed do %>
   <li><%= link_for_dataset(dataset) %></li>
@@ -11,10 +11,10 @@ Vous êtes inscrit à des notifications concernant les jeux de données suivants
 </ul>
 <% end %>
 
-Les notifications vous permettent d’être alerté en cas d’expiration, d’indisponibilité et d’erreurs de vos données. Rendez-vous sur votre <%= link_for_espace_producteur(:periodic_reminder_producer_with_subscriptions) %> pour les gérer de manière autonome.
+Les notifications vous permettent d’être alerté en cas d’expiration, d’indisponibilité et d’erreurs de vos données. Si vous souhaitez gérer vos notifications, rendez-vous sur votre <%= link_for_espace_producteur(:periodic_reminder_producer_with_subscriptions) %>.
 
 <%= if @has_other_producers_subscribers do %>
-Les autres personnes inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
+Les autres personnes impliquées dans la production de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
 <% end %>
 
 Nous restons disponibles pour vous accompagner si besoin.

--- a/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_with_subscriptions.html.md
@@ -14,7 +14,7 @@ En tant que producteur de données de transport, vous êtes inscrit à des notif
 Les notifications vous permettent d’être alerté en cas d’expiration, d’indisponibilité et d’erreurs de vos données. Si vous souhaitez gérer vos notifications, rendez-vous sur votre <%= link_for_espace_producteur(:periodic_reminder_producer_with_subscriptions) %>.
 
 <%= if @has_other_producers_subscribers do %>
-Les autres personnes impliquées dans la production de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
+Les autres personnes impliquées dans la production ou publication de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : <%= @other_producers_subscribers %>.
 <% end %>
 
 Nous restons disponibles pour vous accompagner si besoin.

--- a/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
+++ b/apps/transport/lib/transport_web/templates/email/producer_without_subscriptions.html.md
@@ -1,9 +1,9 @@
 Bonjour,
 
 <%= if Enum.count(@datasets) == 1 do %>
-Le saviez-vous ? Il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <%= @datasets |> hd() |> link_for_dataset() %>.
+Le saviez-vous ? En tant que producteur de données de transport, il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <%= @datasets |> hd() |> link_for_dataset() %>.
 <% else %>
-Le saviez-vous ? Il est possible de vous inscrire à des notifications concernant les jeux de données que vous gérez sur transport.data.gouv.fr :
+Le saviez-vous ? En tant que producteur de données de transport, il est possible de vous inscrire à des notifications concernant les jeux de données que vous gérez sur transport.data.gouv.fr :
 <ul>
   <%= for dataset <- @datasets do %>
   <li><%= link_for_dataset(dataset) %></li>

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -226,7 +226,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
                ~s(vous êtes inscrit à des notifications pour le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
 
       assert html =~
-               "impliquées dans la production de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : Marina Loiseau."
+               "Les autres personnes impliquées dans la production ou publication de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : Marina Loiseau."
     end)
 
     assert [

--- a/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/periodic_reminder_producers_notification_job_test.exs
@@ -223,9 +223,10 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       assert subject == "Rappel : vos notifications pour vos données sur transport.data.gouv.fr"
 
       assert html =~
-               ~s(Vous êtes inscrit à des notifications pour le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
+               ~s(vous êtes inscrit à des notifications pour le jeu de données <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
 
-      assert html =~ "Les autres personnes inscrites à ces notifications sont : Marina Loiseau."
+      assert html =~
+               "impliquées dans la production de vos données (qu’ils soient exploitants, intervenants techniques ou responsables légaux) et inscrites à ces notifications sont : Marina Loiseau."
     end)
 
     assert [
@@ -271,7 +272,7 @@ defmodule Transport.Test.Transport.Jobs.PeriodicReminderProducersNotificationJob
       assert subject == "Notifications pour vos données sur transport.data.gouv.fr"
 
       assert html =~
-               ~s(Il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
+               ~s(il est possible de vous inscrire à des notifications concernant le jeu de données que vous gérez sur transport.data.gouv.fr, <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}">#{dataset.custom_title}</a>)
 
       assert html =~
                ~s(Pour vous inscrire, rien de plus simple : rendez-vous sur votre <a href="http://127.0.0.1:5100/espace_producteur?utm_source=transactional_email&amp;utm_medium=email&amp;utm_campaign=periodic_reminder_producer_without_subscriptions">Espace Producteur</a>)


### PR DESCRIPTION
- Indique le pourquoi (rôle producteur)
- Clarifie les autres abonnements (dans le cas où ce n’est pas dans la même organisation, exemple prestataire technique VS AOM).