### PR TITLE
DB.Resource : ajuste real_time?

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -153,9 +153,24 @@ defmodule DB.Resource do
   def community_resource?(%__MODULE__{is_community_resource: true}), do: true
   def community_resource?(_), do: false
 
+  @doc """
+  iex> real_time?(%DB.Resource{format: "gbfs"})
+  true
+  iex> real_time?(%DB.Resource{format: "GTFS"})
+  false
+  iex> real_time?(%DB.Resource{format: "csv", description: "Données mises à jour en temps réel"})
+  true
+  """
   @spec real_time?(__MODULE__.t()) :: boolean
   def real_time?(%__MODULE__{} = resource) do
-    gtfs_rt?(resource) or gbfs?(resource) or siri_lite?(resource) or siri?(resource)
+    [
+      &gtfs_rt?/1,
+      &gbfs?/1,
+      &siri_lite?/1,
+      &siri?/1,
+      &String.contains?(&1.description || "", ["mis à jour en temps réel", "mises à jour en temps réel"])
+    ]
+    |> Enum.any?(fn function -> function.(resource) end)
   end
 
   @doc """


### PR DESCRIPTION
Adapte `DB.Resource.real_time?/1` pour qu'une ressource soit reconnue comme en temps réel quand sa description contient "mis à jour en temps réel" (ou au féminin).

Utile pour [ce JDD routier](https://transport.data.gouv.fr/datasets/evenements-routiers-sur-le-reseau-routier-national-non-concede) en particulier.