### PR TITLE
GTFS diff : profil uniquement pour les lignes

### DIFF
--- a/apps/transport/lib/transport/gtfs_diff.ex
+++ b/apps/transport/lib/transport/gtfs_diff.ex
@@ -214,7 +214,7 @@ defmodule Transport.GTFSDiff do
     delete_messages ++ add_messages ++ update_messages
   end
 
-  def compare_files(unzip_1, unzip_2, profile) do
+  def compare_files(unzip_1, unzip_2, profile \\ "full") do
     file_names_1 = unzip_1 |> list_entries(profile)
     file_names_2 = unzip_2 |> list_entries(profile)
     added_files = file_names_2 -- file_names_1
@@ -227,8 +227,8 @@ defmodule Transport.GTFSDiff do
     }
   end
 
-  def file_diff(unzip_1, unzip_2, profile) do
-    %{added_files: added_files, deleted_files: deleted_files} = compare_files(unzip_1, unzip_2, profile)
+  def file_diff(unzip_1, unzip_2) do
+    %{added_files: added_files, deleted_files: deleted_files} = compare_files(unzip_1, unzip_2)
 
     added_files_diff =
       added_files
@@ -245,8 +245,8 @@ defmodule Transport.GTFSDiff do
     added_files_diff ++ deleted_files_diff
   end
 
-  def column_diff(unzip_1, unzip_2, profile) do
-    %{same_files: same_files, added_files: added_files} = compare_files(unzip_1, unzip_2, profile)
+  def column_diff(unzip_1, unzip_2) do
+    %{same_files: same_files, added_files: added_files} = compare_files(unzip_1, unzip_2)
 
     (same_files ++ added_files)
     |> Enum.flat_map(fn file_name ->
@@ -306,8 +306,8 @@ defmodule Transport.GTFSDiff do
   end
 
   def diff(unzip_1, unzip_2, profile, notify_func \\ nil, locale \\ "fr") do
-    file_diff = file_diff(unzip_1, unzip_2, profile)
-    column_diff = column_diff(unzip_1, unzip_2, profile)
+    file_diff = file_diff(unzip_1, unzip_2)
+    column_diff = column_diff(unzip_1, unzip_2)
     row_diff = row_diff(unzip_1, unzip_2, notify_func, locale, profile)
 
     diff = file_diff ++ column_diff ++ row_diff

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -549,17 +549,9 @@ msgid "not enough memory"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Only a subset of the GTFS specification is currently supported for differences analysis. Supported files:"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Other files…"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Looking for other files?"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Summary"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Row changes have not been analyzed for this file. We suggest you dive into both GTFS files for more details."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -549,17 +549,9 @@ msgid "not enough memory"
 msgstr "mémoire insuffisante"
 
 #, elixir-autogen, elixir-format
-msgid "Only a subset of the GTFS specification is currently supported for differences analysis. Supported files:"
-msgstr "Seul un sous-ensemble de la spécification GTFS est actuellement supporté pour la recherche de différences. Fichiers supportés :"
-
-#, elixir-autogen, elixir-format
-msgid "Other files…"
-msgstr "Autres fichiers…"
-
-#, elixir-autogen, elixir-format
-msgid "Looking for other files?"
-msgstr "À la recherche d’autres fichiers ?"
-
-#, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr "Résumé"
+
+#, elixir-autogen, elixir-format
+msgid "Row changes have not been analyzed for this file. We suggest you dive into both GTFS files for more details."
+msgstr "Les différences de lignes n’ont pas été analysées pour ce fichier. Nous vous invitons à explorer directement dans les 2 GTFS si vous souhaitez plus de précisions."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -547,17 +547,9 @@ msgid "not enough memory"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Only a subset of the GTFS specification is currently supported for differences analysis. Supported files:"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Other files…"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Looking for other files?"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Summary"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Row changes have not been analyzed for this file. We suggest you dive into both GTFS files for more details."
 msgstr ""


### PR DESCRIPTION
## Changements

La notion de profil du GTFS diff concernait toutes les différences,visant à limiter la taille du CSV pour l'affichage dans l'outil. Ceci masquait les ajouts/suppressions de fichiers ou toutes les différences de colonnes des fichiers hors profil. Hors ces différences sont pas nature peu nombreuses.

Cette PR modifie donc le filtre pour ne s'appliquait qu'aux différences liées aux lignes des fichiers hors profil. Cela a pour conséquence de lister tous les fichiers présents dans l'écran de résultats. Un avertissement est ajouté pour les fichiers hors profil pour rappeler que certaines différences peuvent donc ne pas apparaître. Le panneau "Autres fichiers" est supprimé car désormais superflu.

Voir #4460.

## Aperçu

![image](https://github.com/user-attachments/assets/224597ca-02be-4c45-943e-645bb7335ee7)