### PR TITLE
StatsHandler : stocke des statistiques pour les réutilisations

### DIFF
--- a/apps/transport/lib/db/reuse.ex
+++ b/apps/transport/lib/db/reuse.ex
@@ -34,6 +34,8 @@ defmodule DB.Reuse do
     many_to_many(:datasets, DB.Dataset, join_through: "reuse_dataset", on_replace: :delete)
   end
 
+  def base_query, do: from(r in __MODULE__, as: :reuse)
+
   def changeset(model, attrs) do
     model
     |> cast(attrs, [

--- a/apps/transport/lib/transport/stats_handler.ex
+++ b/apps/transport/lib/transport/stats_handler.ex
@@ -19,7 +19,7 @@ defmodule Transport.StatsHandler do
   end
 
   defp store_stat_history(key, values, %DateTime{} = timestamp)
-       when key in [:gtfs_rt_types, :climate_resilience_bill_count, :count_geo_data_lines] do
+       when key in [:gtfs_rt_types, :climate_resilience_bill_count, :count_geo_data_lines, :reuses] do
     Enum.map(values, fn {type, count} ->
       store_stat_history("#{key}::#{type}", count, timestamp)
     end)
@@ -88,7 +88,8 @@ defmodule Transport.StatsHandler do
       climate_resilience_bill_count: count_datasets_climate_resilience_bill(),
       nb_siri: count_dataset_with_format("SIRI"),
       nb_siri_lite: count_dataset_with_format("SIRI Lite"),
-      count_geo_data_lines: count_geo_data_lines()
+      count_geo_data_lines: count_geo_data_lines(),
+      reuses: reuses_stats()
     }
     |> Map.merge(gbfs_stats())
   end
@@ -189,6 +190,30 @@ defmodule Transport.StatsHandler do
     |> select([f], {f.feature, count(f.feature)})
     |> DB.Repo.all()
     |> Enum.into(%{})
+  end
+
+  def reuses_stats do
+    reuses_by_type =
+      DB.Reuse.base_query()
+      |> group_by([reuse: r], r.type)
+      |> select([reuse: r], {r.type, count(r.id)})
+      |> DB.Repo.all()
+      |> Enum.into(%{})
+
+    reuses_metrics_sum =
+      DB.Reuse.base_query()
+      |> select([reuse: r], %{
+        sum_metric_discussions: sum(r.metric_discussions),
+        sum_metric_followers: sum(r.metric_followers),
+        sum_metric_views: sum(r.metric_views)
+      })
+      |> DB.Repo.one()
+
+    %{
+      nb_reuses: DB.Repo.aggregate(DB.Reuse.base_query(), :count, :id)
+    }
+    |> Map.merge(reuses_by_type)
+    |> Map.merge(reuses_metrics_sum)
   end
 
   defp count_datasets_climate_resilience_bill do

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -41,6 +41,7 @@ defmodule DB.Factory do
       nom: "Grenoble",
       siren: "253800825",
       region: build(:region),
+      population: 1_000,
       # The value must be unique, ExFactory helps us with a named sequence
       composition_res_id: 1000 + sequence("composition_res_id", & &1)
     }
@@ -334,6 +335,33 @@ defmodule DB.Factory do
       logo_thumbnail: "https://example.com/#{Ecto.UUID.generate()}.small.png",
       name: sequence(:name, fn i -> "organization_name_#{i}" end),
       slug: sequence(:slug, fn i -> "organization_slug_#{i}" end)
+    }
+  end
+
+  def reuse_factory do
+    %DB.Reuse{
+      datagouv_id: sequence(:datagouv_id, &"datagouv_id-#{&1}"),
+      title: sequence(:title, &"Reuse Title #{&1}"),
+      slug: sequence(:slug, &"reuse-slug-#{&1}"),
+      url: sequence(:url, &"http://example.com/reuse/#{&1}"),
+      type: "api",
+      description: "A description of the reuse.",
+      remote_url: sequence(:remote_url, &"http://remote.example.com/reuse/#{&1}"),
+      organization: "Example Organization",
+      organization_id: sequence(:organization_id, &"org-#{&1}"),
+      owner: "Example Owner",
+      owner_id: sequence(:owner_id, &"owner-#{&1}"),
+      image: sequence(:image, &"http://example.com/image/#{&1}.jpg"),
+      featured: false,
+      archived: false,
+      topic: "transport_and_mobility",
+      tags: ["tag1", "tag2"],
+      metric_discussions: 0,
+      metric_datasets: 0,
+      metric_followers: 0,
+      metric_views: 0,
+      created_at: DateTime.utc_now(),
+      last_modified: DateTime.utc_now()
     }
   end
 


### PR DESCRIPTION
En lien avec #4477, suite de #4478

Stocke des statistiques quotidiennement dans `stats_history` liées aux réutilisations.

```
%{
  "reuses::nb_reuses" => 235,
  "reuses::sum_metric_discussions" => 60,
  "reuses::sum_metric_followers" => 586,
  "reuses::sum_metric_views" => 3405602,
  "reuses::api" => 14,
  "reuses::application" => 160,
  "reuses::hardware" => 1,
  "reuses::news_article" => 7,
  "reuses::paper" => 2,
  "reuses::post" => 5,
  "reuses::visualization" => 46
}
```