### PR TITLE
GTFS-diff : Tests de l'écran résultats

### DIFF
--- a/apps/transport/client/stylesheets/components/_gtfs_diff.scss
+++ b/apps/transport/client/stylesheets/components/_gtfs_diff.scss
@@ -138,7 +138,7 @@
   }
 }
 
-.gtfs-diff-results {
+#gtfs-diff-results {
   min-height: 90vh;
   .green {
     color: green;

--- a/apps/transport/client/stylesheets/components/_gtfs_diff.scss
+++ b/apps/transport/client/stylesheets/components/_gtfs_diff.scss
@@ -5,10 +5,6 @@
   }
 }
 
-.gtfs-diff-results h4 {
-  margin: 24px 0 12px;
-}
-
 .actions {
   margin-top: var(--space-m);
   display: flex;

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live.ex
@@ -280,25 +280,9 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive do
     diff_summary = diff |> GTFSDiffExplain.diff_summary()
     diff_explanations = diff |> GTFSDiffExplain.diff_explanations() |> drop_empty()
 
-    files_with_changes =
-      diff_summary
-      |> Map.values()
-      |> Enum.concat()
-      |> Enum.map(fn {{file, _, _}, _} -> file end)
-      |> Enum.sort()
-      |> Enum.dedup()
-
-    selected_file =
-      case files_with_changes do
-        [] -> nil
-        _ -> Kernel.hd(files_with_changes)
-      end
-
     update_many(socket, :results, [
       set(:diff_summary, diff_summary),
-      set(:diff_explanations, diff_explanations),
-      set(:files_with_changes, files_with_changes),
-      set(:selected_file, selected_file)
+      set(:diff_explanations, diff_explanations)
     ])
   end
 

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/results.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/results.ex
@@ -43,32 +43,30 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
             target: "_blank"
           ) %>
         </h4>
-        <%= raw(
-          dgettext(
-            "validations",
-            "<a href=\"%{spec}\">Read</a> the GTFS Diff specification to understand how differences between GTFS are expressed",
-            spec: "https://github.com/MobilityData/gtfs_diff/blob/main/specification.md"
-          )
-        ) %>.
+        <p>
+          <%= raw(
+            dgettext(
+              "validations",
+              "<a href=\"%{spec}\">Read</a> the GTFS Diff specification to understand how differences between GTFS are expressed",
+              spec: "https://github.com/MobilityData/gtfs_diff/blob/main/specification.md"
+            )
+          ) %>.
+        </p>
         <%= if @diff_summary do %>
-          <div class="pt-24">
-            <%= display_context(@diff_summary, @context) |> raw() %>
-            <.diff_summaries
-              :if={@diff_summary != %{}}
-              diff_explanations={@diff_explanations}
-              diff_summary={@diff_summary}
-              files_with_changes={@files_with_changes}
-              selected_file={@selected_file}
-              profile={@profile}
-            />
-          </div>
+          <p><%= display_context(@diff_summary, @context) |> raw() %></p>
+          <.diff_summaries
+            :if={@diff_summary != %{}}
+            diff_explanations={@diff_explanations}
+            diff_summary={@diff_summary}
+            files_with_changes={@files_with_changes}
+            selected_file={@selected_file}
+            profile={@profile}
+          />
         <% else %>
           <%= if @error_msg do %>
             <.validation_error error_msg={@error_msg} />
           <% else %>
-            <div class="pt-24">
-              <%= dgettext("validations", "Analyzing found differences…") %>
-            </div>
+            <p><%= dgettext("validations", "Analyzing found differences…") %></p>
           <% end %>
         <% end %>
       </div>
@@ -147,13 +145,11 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
 
   defp diff_summary_for_file(%{summary: _, selected_file: _, translation: _, class: _} = assigns) do
     ~H"""
-    <div :if={@summary}>
-      <%= for {{file, _nature, target}, n} <- @summary do %>
-        <li :if={file == @selected_file}>
-          <span class={@class}><%= @translation %> &nbsp;</span><%= translate_target(target, n) %>
-        </li>
-      <% end %>
-    </div>
+    <%= for {{file, _nature, target}, n} <- @summary || [] do %>
+      <li :if={file == @selected_file}>
+        <span class={@class}><%= @translation %></span>&nbsp;<%= translate_target(target, n) %>
+      </li>
+    <% end %>
     """
   end
 
@@ -161,16 +157,14 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
          %{files_with_changes: _, selected_file: _, diff_summary: _, diff_explanations: _, profile: _} = assigns
        ) do
     ~H"""
-    <div class="pt-24">
-      <div class="dashboard">
-        <.navigation files_with_changes={@files_with_changes} selected_file={@selected_file} />
-        <.differences
-          diff_summary={@diff_summary}
-          selected_file={@selected_file}
-          diff_explanations={@diff_explanations}
-          profile={@profile}
-        />
-      </div>
+    <div class="dashboard">
+      <.navigation files_with_changes={@files_with_changes} selected_file={@selected_file} />
+      <.differences
+        diff_summary={@diff_summary}
+        selected_file={@selected_file}
+        diff_explanations={@diff_explanations}
+        profile={@profile}
+      />
     </div>
     """
   end
@@ -286,13 +280,13 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
 
   defp validation_error(%{error_msg: _} = assigns) do
     ~H"""
-    <div class="pt-24">
+    <p>
       <%= dgettext(
         "validations",
         "An error occurred while interpreting the results. Note that the report is still available as download. Error:"
       ) %>
       <span class="red"><%= translate_error(@error_msg) %></span>.
-    </div>
+    </p>
     """
   end
 

--- a/apps/transport/test/transport_web/live_views/gtfs_diff_select_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/gtfs_diff_select_live_test.exs
@@ -1,6 +1,89 @@
 defmodule TransportWeb.Live.GTFSDiffSelectLiveTest do
   use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
   doctest TransportWeb.Live.GTFSDiffSelectLive, import: true
   doctest TransportWeb.Live.GTFSDiffSelectLive.Results, import: true
   doctest TransportWeb.Live.GTFSDiffSelectLive.Setup, import: true
+
+  alias TransportWeb.Live.GTFSDiffSelectLive.Results
+
+  describe "results" do
+    test "display results for similar GTFS files" do
+      gtfs_original_file_name_1 = "base.zip"
+      gtfs_original_file_name_2 = "modified.zip"
+
+      results = %{
+        context: %{
+          "gtfs_original_file_name_1" => gtfs_original_file_name_1,
+          "gtfs_original_file_name_2" => gtfs_original_file_name_2
+        },
+        diff_file_url: "http://localhost:5000/gtfs-diff.csv",
+        diff_summary: %{}
+      }
+
+      html = render_results(error_msg: nil, profile: "core", results: results)
+
+      assert html |> Floki.find("p:nth-child(3)") |> Floki.text() ==
+               "Les fichier GTFS #{gtfs_original_file_name_2} et #{gtfs_original_file_name_1} sont similaires."
+
+      assert html |> Floki.find("div.dashboard") == []
+    end
+
+    test "display results for different GTFS files" do
+      gtfs_original_file_name_1 = "base.zip"
+      gtfs_original_file_name_2 = "modified.zip"
+
+      results = %{
+        context: %{
+          "gtfs_original_file_name_1" => gtfs_original_file_name_1,
+          "gtfs_original_file_name_2" => gtfs_original_file_name_2
+        },
+        diff_file_url: "http://localhost:5000/gtfs-diff.csv",
+        diff_summary: %{
+          "add" => [{{"stop_times.txt", "add", "row"}, 1}],
+          "delete" => [
+            {{"agency.txt", "delete", "file"}, 1},
+            {{"calendar.txt", "delete", "column"}, 1}
+          ]
+        }
+      }
+
+      html = render_results(error_msg: nil, profile: "core", results: results)
+
+      assert html |> Floki.find("p:nth-child(3)") |> Floki.text() ==
+               "Le fichier GTFS #{gtfs_original_file_name_2} comporte les différences ci-dessous par rapport au fichier GTFS #{gtfs_original_file_name_1} :"
+
+      navigation = html |> Floki.find("div.dashboard aside")
+
+      assert navigation |> Floki.find("a") |> texts == [
+               "agency.txt",
+               "calendar.txt",
+               "stop_times.txt"
+             ]
+
+      assert navigation |> Floki.find("a.active") |> Floki.text() == "agency.txt"
+
+      selected_file_details = html |> Floki.find("div.dashboard div.main")
+      assert selected_file_details |> Floki.find("h4") |> texts == ["Résumé"]
+      assert selected_file_details |> Floki.find("ul li") |> texts == ["supprimé 1 fichier"]
+    end
+  end
+
+  defp texts(html_tuples) do
+    Enum.map(html_tuples, fn tuple ->
+      tuple |> Floki.text() |> clean_whitespaces()
+    end)
+  end
+
+  defp clean_whitespaces(text) do
+    text
+    |> String.trim()
+    |> String.replace(~r/\s+/, " ")
+  end
+
+  defp render_results(args) do
+    render_component(&Results.results_step/1, args)
+    |> Floki.parse_document!()
+    |> Floki.find("div#gtfs-diff-results")
+  end
 end


### PR DESCRIPTION
Ça ne teste pas directement la liveview (problèmes avec l'upload) mais ça teste au moins le composant d'affichage des résultats, en anticipation de changements prochains listés dans #4460.

Pour les biens des requêtes Floki des tests, la structure HTML est simplifiée au passage, et un id est introduit pour requêter plus fiablement le contenu du DOM. Ces deux modifications justifient le changement de CSS.