### PR TITLE
Ajout page pour afficher les réutilisations

### DIFF
--- a/apps/transport/lib/db/reuse.ex
+++ b/apps/transport/lib/db/reuse.ex
@@ -6,6 +6,7 @@ defmodule DB.Reuse do
   use Ecto.Schema
   import Ecto.Changeset
   import Ecto.Query
+  import TransportWeb.Gettext
 
   typed_schema "reuse" do
     field(:datagouv_id, :string)
@@ -33,6 +34,8 @@ defmodule DB.Reuse do
 
     many_to_many(:datasets, DB.Dataset, join_through: "reuse_dataset", on_replace: :delete)
   end
+
+  def base_query, do: from(r in __MODULE__, as: :reuse)
 
   def changeset(model, attrs) do
     model
@@ -79,6 +82,20 @@ defmodule DB.Reuse do
     |> cast_datasets(attrs)
   end
 
+  def type_to_str(type) do
+    %{
+      "api" => dgettext("reuses", "api"),
+      "application" => dgettext("reuses", "application"),
+      "hardware" => dgettext("reuses", "hardware"),
+      "idea" => dgettext("reuses", "idea"),
+      "news_article" => dgettext("reuses", "news_article"),
+      "paper" => dgettext("reuses", "paper"),
+      "post" => dgettext("reuses", "post"),
+      "visualization" => dgettext("reuses", "visualization")
+    }
+    |> Map.fetch!(type)
+  end
+
   defp cast_datasets(%Ecto.Changeset{} = changeset, %{"datasets" => datasets}) do
     datagouv_ids = (datasets || "") |> String.split(",")
 
@@ -107,7 +124,7 @@ defmodule DB.Reuse do
   end
 
   defp transform_tags(%Ecto.Changeset{} = changeset, %{"tags" => tags}) do
-    put_change(changeset, :tags, String.split(tags || "", ","))
+    put_change(changeset, :tags, String.split(tags || "", ",") |> Enum.reject(&(&1 == "")))
   end
 
   defp transform_datagouv_id(%Ecto.Changeset{} = changeset, %{"id" => id}) do

--- a/apps/transport/lib/transport_web/controllers/reuse_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuse_controller.ex
@@ -1,0 +1,13 @@
+defmodule TransportWeb.ReuseController do
+  @moduledoc """
+  Controller for data.gouv.fr reuses.
+  """
+  use TransportWeb, :controller
+
+  def index(%Plug.Conn{} = conn, params) do
+    config = make_pagination_config(params)
+    reuses = DB.Reuse.base_query() |> DB.Repo.paginate(page: config.page_number)
+
+    render(conn, "index.html", reuses: reuses)
+  end
+end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -88,6 +88,7 @@ defmodule TransportWeb.Router do
     get("/robots.txt", PageController, :robots_txt)
     get("/.well-known/security.txt", PageController, :security_txt)
     get("/humans.txt", PageController, :humans_txt)
+    get("/reuses", ReuseController, :index)
 
     scope "/espace_producteur" do
       pipe_through([:producer_space])

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -24,6 +24,7 @@
                 <%= link(gettext("Datasets"), to: dataset_path(@conn, :index)) %>
                 <%= link(gettext("Exploration map"), to: explore_path(@conn, :index)) %>
                 <%= link(gettext("National GTFS stops map"), to: explore_path(@conn, :gtfs_stops)) %>
+                <%= link(gettext("Reuses"), to: reuse_path(@conn, :index)) %>
               </div>
             </div>
           </li>

--- a/apps/transport/lib/transport_web/templates/reuse/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuse/index.html.heex
@@ -2,6 +2,14 @@
   <div class="cards">
     <h1><%= dgettext("reuses", "Reuses") %></h1>
 
+    <p>
+      <%= raw(dgettext("reuses", "index-intro")) %>
+      <%= link(dgettext("reuses", "Publish a reuse"),
+        to: "https://guides.data.gouv.fr/guide-data.gouv.fr/reutilisations/publier-une-reutilisation",
+        target: "_blank"
+      ) %>
+    </p>
+
     <%= for reuses <- Enum.chunk_every(@reuses, 4) do %>
       <div class="row pt-24">
         <%= for reuse <- reuses do %>

--- a/apps/transport/lib/transport_web/templates/reuse/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuse/index.html.heex
@@ -1,0 +1,44 @@
+<div class="container">
+  <div class="cards">
+    <h1><%= dgettext("reuses", "Reuses") %></h1>
+
+    <%= for reuses <- Enum.chunk_every(@reuses, 4) do %>
+      <div class="row pt-24">
+        <%= for reuse <- reuses do %>
+          <div class="card">
+            <div class="card__cover">
+              <img src={reuse.image} alt="{reuse.title}" />
+            </div>
+            <div class="card__content">
+              <h3><%= link(reuse.title, to: reuse.url) %></h3>
+              <div class="card__meta">
+                <time><%= Shared.DateTimeDisplay.format_date(reuse.created_at, get_session(@conn, :locale)) %></time>
+                <span :if={reuse.organization != nil}>
+                  <%= link(reuse.organization, to: "https://www.data.gouv.fr/organizations/#{reuse.organization_id}") %>
+                </span>
+                <span :if={reuse.owner != nil}><%= reuse.owner %></span>
+              </div>
+              <p>
+                <%= DB.Reuse.type_to_str(reuse.type) %> &middot; <%= reuse.metric_datasets %> <%= dngettext(
+                  "reuses",
+                  "dataset",
+                  "datasets",
+                  reuse.metric_datasets
+                ) %>
+              </p>
+            </div>
+            <div :if={Enum.count(reuse.tags) > 0} class="card__extra">
+              <%= for tag <- Enum.take(reuse.tags, 5) do %>
+                <span class="label"><%= tag %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="pt-24">
+    <%= pagination_links(@conn, @reuses) %>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/views/reuse_view.ex
+++ b/apps/transport/lib/transport_web/views/reuse_view.ex
@@ -1,0 +1,4 @@
+defmodule TransportWeb.ReuseView do
+  use TransportWeb, :view
+  import TransportWeb.PaginationHelpers
+end

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -166,3 +166,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Statistics"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuses"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -166,3 +166,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Statistics"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reuses"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
@@ -52,3 +52,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "idea"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "index-intro"
+msgstr "Below is the list of reusers who have declared reusing a dataset referenced on transport.data.gouv.fr.<br/><br/>Not on the list? Showcase your reuses from your data.gouv.fr account administration and your work will automatically appear on this page!<br/><br/>More information in our online documentation:"
+
+#, elixir-autogen, elixir-format
+msgid "Publish a reuse"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
@@ -1,0 +1,54 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "Reuses"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "dataset"
+msgid_plural "datasets"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "api"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "application"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "hardware"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "news_article"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "paper"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "post"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "visualization"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "idea"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -166,3 +166,7 @@ msgstr "Toutes les données"
 #, elixir-autogen, elixir-format
 msgid "Statistics"
 msgstr "Statistiques"
+
+#, elixir-autogen, elixir-format
+msgid "Reuses"
+msgstr "Réutilisations"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
@@ -52,3 +52,11 @@ msgstr "visualisation"
 #, elixir-autogen, elixir-format
 msgid "idea"
 msgstr "idée"
+
+#, elixir-autogen, elixir-format
+msgid "index-intro"
+msgstr "Vous trouverez ci-dessous la liste des réutilisateurs qui ont déclaré réutiliser un jeu de données référencé sur transport.data.gouv.fr.<br/><br/>Vous n’y êtes pas ? Mettez en avant vos réutilisations depuis l’administration de votre compte data.gouv.fr et vos réalisations apparaitront automatiquement sur cette page !<br/><br/>Plus d’informations sur notre documentation en ligne :"
+
+#, elixir-autogen, elixir-format
+msgid "Publish a reuse"
+msgstr "Publier une réutilisation"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
@@ -1,0 +1,54 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n>1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "Reuses"
+msgstr "Réutilisations"
+
+#, elixir-autogen, elixir-format
+msgid "dataset"
+msgid_plural "datasets"
+msgstr[0] "jeu de données"
+msgstr[1] "jeux de données"
+
+#, elixir-autogen, elixir-format
+msgid "api"
+msgstr "API"
+
+#, elixir-autogen, elixir-format
+msgid "application"
+msgstr "application"
+
+#, elixir-autogen, elixir-format
+msgid "hardware"
+msgstr "objet connecté"
+
+#, elixir-autogen, elixir-format
+msgid "news_article"
+msgstr "article de presse"
+
+#, elixir-autogen, elixir-format
+msgid "paper"
+msgstr "papier"
+
+#, elixir-autogen, elixir-format
+msgid "post"
+msgstr "article de blog"
+
+#, elixir-autogen, elixir-format
+msgid "visualization"
+msgstr "visualisation"
+
+#, elixir-autogen, elixir-format
+msgid "idea"
+msgstr "idée"

--- a/apps/transport/priv/gettext/reuses.pot
+++ b/apps/transport/priv/gettext/reuses.pot
@@ -1,0 +1,54 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Reuses"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "dataset"
+msgid_plural "datasets"
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "api"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "application"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "hardware"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "news_article"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "paper"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "post"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "visualization"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "idea"
+msgstr ""

--- a/apps/transport/priv/gettext/reuses.pot
+++ b/apps/transport/priv/gettext/reuses.pot
@@ -52,3 +52,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "idea"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "index-intro"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Publish a reuse"
+msgstr ""

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -337,6 +337,33 @@ defmodule DB.Factory do
     }
   end
 
+  def reuse_factory do
+    %DB.Reuse{
+      datagouv_id: sequence(:datagouv_id, &"datagouv_id-#{&1}"),
+      title: sequence(:title, &"Reuse Title #{&1}"),
+      slug: sequence(:slug, &"reuse-slug-#{&1}"),
+      url: sequence(:url, &"http://example.com/reuse/#{&1}"),
+      type: "api",
+      description: "A description of the reuse.",
+      remote_url: sequence(:remote_url, &"http://remote.example.com/reuse/#{&1}"),
+      organization: "Example Organization",
+      organization_id: sequence(:organization_id, &"org-#{&1}"),
+      owner: "Example Owner",
+      owner_id: sequence(:owner_id, &"owner-#{&1}"),
+      image: sequence(:image, &"http://example.com/image/#{&1}.jpg"),
+      featured: false,
+      archived: false,
+      topic: "transport_and_mobility",
+      tags: ["tag1", "tag2"],
+      metric_discussions: 0,
+      metric_datasets: 0,
+      metric_followers: 0,
+      metric_views: 0,
+      created_at: DateTime.utc_now(),
+      last_modified: DateTime.utc_now()
+    }
+  end
+
   def insert_contact(%{} = args \\ %{}) do
     %{
       first_name: "John",

--- a/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule TransportWeb.ReuseControllerTest do
+  use TransportWeb.ConnCase, async: true
+  import DB.Factory
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "index", %{conn: conn} do
+    insert(:reuse, title: title = "Ma réutilisation")
+    assert conn |> get(reuse_path(conn, :index)) |> html_response(200) =~ title
+  end
+end


### PR DESCRIPTION
Dernière étape de #4477, ajoute une page pour afficher les réutilisations data.gouv.fr des JDDs référencés sur notre plateforme.

La nouvelle page affiche ceci sous forme de cartes et est paginée.

![image](https://github.com/user-attachments/assets/8dc2e586-d87c-4f6e-84d4-f070bc0018ab)
