### PR TITLE
Supprime le check sur les annotations TODO dans Credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -69,11 +69,7 @@
         #
         # {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
 
-        # You can also customize the exit_status of each check.
-        # If you don't want TODO comments to cause `mix credo` to fail, just
-        # set this value to 0 (zero).
-        #
-        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagTODO, false},
         {Credo.Check.Design.TagFIXME},
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},


### PR DESCRIPTION
Comme discuté, on retire le check sur les annotations TODO, et on garde sur FIXME, pour que la CI puisse passer au moins sur les premiers.

J’ai aussi retiré un commentaire qui était faux sur la configuration, la syntaxe du fichier de configuration a changé depuis que le fichier a été initialement généré.