### PR TITLE
GTFS diff : davantage de détails des changements

### DIFF
--- a/apps/transport/client/stylesheets/components/_gtfs_diff.scss
+++ b/apps/transport/client/stylesheets/components/_gtfs_diff.scss
@@ -183,6 +183,13 @@
       bottom: -1px;
     }
   }
+
+  .color-picker {
+    display: grid;
+    grid-template-columns: min-content min-content;
+    gap: 6px;
+    align-items: center;
+  }
 }
 
 @media (max-width: 749px) {

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -22,6 +22,7 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_route_short_name(diff)
       |> explanation_route_long_name(diff)
       |> explanation_route_type(diff)
+      |> explanation_stop_location_type(diff)
     end)
   end
 
@@ -377,6 +378,34 @@ defmodule TransportWeb.GTFSDiffExplain do
   end
 
   def explanation_route_type(explanations, _), do: explanations
+
+  def explanation_stop_location_type(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "stops.txt",
+          "target" => "row",
+          "identifier" => %{"stop_id" => stop_id},
+          "new_value" => %{"location_type" => new_location_type},
+          "initial_value" => %{"location_type" => initial_location_type}
+        }
+      ) do
+    [
+      %{
+        file: "stops.txt",
+        type: "location_type",
+        message: dgettext("validations", "Location type for stop %{stop_id} has been changed", stop_id: stop_id),
+        before: initial_location_type,
+        after: new_location_type,
+        sort_key: stop_id
+      }
+      | explanations
+    ]
+  end
+
+  def explanation_stop_location_type(explanations, _) do
+    explanations
+  end
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -19,6 +19,8 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_update_stop_position(diff)
       |> explanation_route_color(diff)
       |> explanation_route_text_color(diff)
+      |> explanation_route_short_name(diff)
+      |> explanation_route_long_name(diff)
     end)
   end
 
@@ -296,6 +298,58 @@ defmodule TransportWeb.GTFSDiffExplain do
   def explanation_route_text_color(explanations, _), do: explanations
 
   defp different_colors?(initial_color, new_color), do: String.downcase(initial_color) != String.downcase(new_color)
+
+  def explanation_route_short_name(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "routes.txt",
+          "target" => "row",
+          "identifier" => %{"route_id" => route_id},
+          "new_value" => %{"route_short_name" => new_route_short_name},
+          "initial_value" => %{"route_short_name" => initial_route_short_name}
+        }
+      ) do
+    [
+      %{
+        file: "routes.txt",
+        type: "route_short_name",
+        message: dgettext("validations", "Route short name has been updated for route %{route_id}", route_id: route_id),
+        before: initial_route_short_name,
+        after: new_route_short_name,
+        sort_key: route_id
+      }
+      | explanations
+    ]
+  end
+
+  def explanation_route_short_name(explanations, _), do: explanations
+
+  def explanation_route_long_name(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "routes.txt",
+          "target" => "row",
+          "identifier" => %{"route_id" => route_id},
+          "new_value" => %{"route_long_name" => new_route_long_name},
+          "initial_value" => %{"route_long_name" => initial_route_long_name}
+        }
+      ) do
+    [
+      %{
+        file: "routes.txt",
+        type: "route_long_name",
+        message: dgettext("validations", "Route long name has been updated for route %{route_id}", route_id: route_id),
+        before: initial_route_long_name,
+        after: new_route_long_name,
+        sort_key: route_id
+      }
+      | explanations
+    ]
+  end
+
+  def explanation_route_long_name(explanations, _), do: explanations
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -24,6 +24,7 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_route_type(diff)
       |> explanation_stop_location_type(diff)
       |> explanation_agency_url(diff)
+      |> explanation_trip_headsign(diff)
     end)
   end
 
@@ -431,6 +432,32 @@ defmodule TransportWeb.GTFSDiffExplain do
   end
 
   def explanation_agency_url(explanations, _), do: explanations
+
+  def explanation_trip_headsign(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "trips.txt",
+          "target" => "row",
+          "identifier" => %{"trip_id" => trip_id},
+          "new_value" => %{"trip_headsign" => new_trip_headsign},
+          "initial_value" => %{"trip_headsign" => initial_trip_headsign}
+        }
+      ) do
+    [
+      %{
+        file: "trips.txt",
+        type: "trip_headsign",
+        message: dgettext("validations", "Headsign for trip %{trip_id} has been changed", trip_id: trip_id),
+        before: initial_trip_headsign,
+        after: new_trip_headsign,
+        sort_key: trip_id
+      }
+      | explanations
+    ]
+  end
+
+  def explanation_trip_headsign(explanations, _), do: explanations
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -17,6 +17,8 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_update_stop_name(diff)
       |> explanation_stop_wheelchair_access(diff)
       |> explanation_update_stop_position(diff)
+      |> explanation_route_color(diff)
+      |> explanation_route_text_color(diff)
     end)
   end
 
@@ -232,6 +234,68 @@ defmodule TransportWeb.GTFSDiffExplain do
   end
 
   def explanation_update_stop_position(explanations, _), do: explanations
+
+  def explanation_route_color(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "routes.txt",
+          "target" => "row",
+          "identifier" => %{"route_id" => route_id},
+          "new_value" => %{"route_color" => new_route_color},
+          "initial_value" => %{"route_color" => initial_route_color}
+        }
+      ) do
+    if different_colors?(initial_route_color, new_route_color) do
+      [
+        %{
+          file: "routes.txt",
+          type: "route_color",
+          message: dgettext("validations", "Color has been updated for route %{route_id}", route_id: route_id),
+          before: "##{initial_route_color}",
+          after: "##{new_route_color}",
+          sort_key: route_id
+        }
+        | explanations
+      ]
+    else
+      explanations
+    end
+  end
+
+  def explanation_route_color(explanations, _), do: explanations
+
+  def explanation_route_text_color(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "routes.txt",
+          "target" => "row",
+          "identifier" => %{"route_id" => route_id},
+          "new_value" => %{"route_text_color" => new_route_text_color},
+          "initial_value" => %{"route_text_color" => initial_route_text_color}
+        }
+      ) do
+    if different_colors?(initial_route_text_color, new_route_text_color) do
+      [
+        %{
+          file: "routes.txt",
+          type: "route_text_color",
+          message: dgettext("validations", "Text color has been updated for route %{route_id}", route_id: route_id),
+          before: "##{initial_route_text_color}",
+          after: "##{new_route_text_color}",
+          sort_key: route_id
+        }
+        | explanations
+      ]
+    else
+      explanations
+    end
+  end
+
+  def explanation_route_text_color(explanations, _), do: explanations
+
+  defp different_colors?(initial_color, new_color), do: String.downcase(initial_color) != String.downcase(new_color)
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -23,6 +23,7 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_route_long_name(diff)
       |> explanation_route_type(diff)
       |> explanation_stop_location_type(diff)
+      |> explanation_agency_url(diff)
     end)
   end
 
@@ -403,9 +404,33 @@ defmodule TransportWeb.GTFSDiffExplain do
     ]
   end
 
-  def explanation_stop_location_type(explanations, _) do
-    explanations
+  def explanation_stop_location_type(explanations, _), do: explanations
+
+  def explanation_agency_url(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "agency.txt",
+          "target" => "row",
+          "identifier" => %{"agency_id" => agency_id},
+          "new_value" => %{"agency_url" => new_agency_url},
+          "initial_value" => %{"agency_url" => initial_agency_url}
+        }
+      ) do
+    [
+      %{
+        file: "agency.txt",
+        type: "agency_url",
+        message: dgettext("validations", "Agency URL for agency %{agency_id} has been changed", agency_id: agency_id),
+        before: initial_agency_url,
+        after: new_agency_url,
+        sort_key: agency_id
+      }
+      | explanations
+    ]
   end
+
+  def explanation_agency_url(explanations, _), do: explanations
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -21,6 +21,7 @@ defmodule TransportWeb.GTFSDiffExplain do
       |> explanation_route_text_color(diff)
       |> explanation_route_short_name(diff)
       |> explanation_route_long_name(diff)
+      |> explanation_route_type(diff)
     end)
   end
 
@@ -350,6 +351,32 @@ defmodule TransportWeb.GTFSDiffExplain do
   end
 
   def explanation_route_long_name(explanations, _), do: explanations
+
+  def explanation_route_type(
+        explanations,
+        %{
+          "action" => "update",
+          "file" => "routes.txt",
+          "target" => "row",
+          "identifier" => %{"route_id" => route_id},
+          "new_value" => %{"route_type" => new_route_type},
+          "initial_value" => %{"route_type" => initial_route_type}
+        }
+      ) do
+    [
+      %{
+        file: "routes.txt",
+        type: "route_type",
+        message: dgettext("validations", "Route type has been updated for route %{route_id}", route_id: route_id),
+        before: initial_route_type,
+        after: new_route_type,
+        sort_key: route_id
+      }
+      | explanations
+    ]
+  end
+
+  def explanation_route_type(explanations, _), do: explanations
 
   @doc """
     From https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf:

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -266,23 +266,30 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
 
   defp attribute_type("routes.txt", "route_color"), do: :color
   defp attribute_type("routes.txt", "route_text_color"), do: :color
+  defp attribute_type("routes.txt", "route_type"), do: :route_type
   defp attribute_type(_, _), do: :text
 
-  defp attribute_value(%{type: _, value: _} = assigns) do
-    if assigns[:type] == :color do
-      ~H"""
-      <div class="color-picker">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-          <rect x="0" y="0" width="16" height="16" stroke="black" stroke-width="2" fill={@value} />
-        </svg>
-        <%= @value %>
-      </div>
-      """
-    else
-      ~H"""
+  defp attribute_value(%{type: :color, value: _} = assigns) do
+    ~H"""
+    <div class="color-picker">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+        <rect x="0" y="0" width="16" height="16" stroke="black" stroke-width="2" fill={@value} />
+      </svg>
       <%= @value %>
-      """
-    end
+    </div>
+    """
+  end
+
+  defp attribute_value(%{type: :route_type, value: _} = assigns) do
+    ~H"""
+    <%= @value %> (<%= route_type_short_description(@value) %>)
+    """
+  end
+
+  defp attribute_value(%{type: _, value: _} = assigns) do
+    ~H"""
+    <%= @value %>
+    """
   end
 
   defp translate_explanation_type("stops.txt", "stop_name"), do: dgettext("validations", "Stops' names")
@@ -292,6 +299,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp translate_explanation_type("routes.txt", "route_text_color"), do: dgettext("validations", "Route text color")
   defp translate_explanation_type("routes.txt", "route_short_name"), do: dgettext("validations", "Route short name")
   defp translate_explanation_type("routes.txt", "route_long_name"), do: dgettext("validations", "Route long name")
+  defp translate_explanation_type("routes.txt", "route_type"), do: dgettext("validations", "Route type")
   defp translate_explanation_type(_, unknown), do: dgettext("validations", "Other change: %{unknown}", unknown: unknown)
 
   @doc """

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -309,6 +309,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp translate_explanation_type("routes.txt", "route_long_name"), do: dgettext("validations", "Route long name")
   defp translate_explanation_type("routes.txt", "route_type"), do: dgettext("validations", "Route type")
   defp translate_explanation_type("agency.txt", "agency_url"), do: dgettext("validations", "Agency URL")
+  defp translate_explanation_type("trips.txt", "trip_headsign"), do: dgettext("validations", "Trip headsign")
   defp translate_explanation_type(_, unknown), do: dgettext("validations", "Other change: %{unknown}", unknown: unknown)
 
   @doc """

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -267,6 +267,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp attribute_type("routes.txt", "route_color"), do: :color
   defp attribute_type("routes.txt", "route_text_color"), do: :color
   defp attribute_type("routes.txt", "route_type"), do: :route_type
+  defp attribute_type("stops.txt", "location_type"), do: :stop_location_type
   defp attribute_type(_, _), do: :text
 
   defp attribute_value(%{type: :color, value: _} = assigns) do
@@ -286,6 +287,12 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
     """
   end
 
+  defp attribute_value(%{type: :stop_location_type, value: _} = assigns) do
+    ~H"""
+    <%= @value %> (<%= stop_location_type_short_description(@value) %>)
+    """
+  end
+
   defp attribute_value(%{type: _, value: _} = assigns) do
     ~H"""
     <%= @value %>
@@ -295,6 +302,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp translate_explanation_type("stops.txt", "stop_name"), do: dgettext("validations", "Stops' names")
   defp translate_explanation_type("stops.txt", "stop_position"), do: dgettext("validations", "Stops' positions")
   defp translate_explanation_type("stops.txt", "wheelchair_boarding"), do: dgettext("validations", "Weelchair boarding")
+  defp translate_explanation_type("stops.txt", "location_type"), do: dgettext("validations", "Location type")
   defp translate_explanation_type("routes.txt", "route_color"), do: dgettext("validations", "Route color")
   defp translate_explanation_type("routes.txt", "route_text_color"), do: dgettext("validations", "Route text color")
   defp translate_explanation_type("routes.txt", "route_short_name"), do: dgettext("validations", "Route short name")

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -251,12 +251,12 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
         </thead>
         <tbody>
           <tr :for={
-            %{message: message, before: before, after: after_} <-
+            %{message: message, type: type_, before: before, after: after_} <-
               Enum.sort_by(@explanations, fn %{sort_key: sort_key} -> sort_key end)
           }>
             <td><%= message %></td>
-            <td><%= before %></td>
-            <td><%= after_ %></td>
+            <td><.attribute_value type={attribute_type(@file, type_)} value={before} /></td>
+            <td><.attribute_value type={attribute_type(@file, type_)} value={after_} /></td>
           </tr>
         </tbody>
       </table>
@@ -264,9 +264,32 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
     """
   end
 
+  defp attribute_type("routes.txt", "route_color"), do: :color
+  defp attribute_type("routes.txt", "route_text_color"), do: :color
+  defp attribute_type(_, _), do: :text
+
+  defp attribute_value(%{type: _, value: _} = assigns) do
+    if assigns[:type] == :color do
+      ~H"""
+      <div class="color-picker">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+          <rect x="0" y="0" width="16" height="16" stroke="black" stroke-width="2" fill={@value} />
+        </svg>
+        <%= @value %>
+      </div>
+      """
+    else
+      ~H"""
+      <%= @value %>
+      """
+    end
+  end
+
   defp translate_explanation_type("stops.txt", "stop_name"), do: dgettext("validations", "Stops' names")
   defp translate_explanation_type("stops.txt", "stop_position"), do: dgettext("validations", "Stops' positions")
   defp translate_explanation_type("stops.txt", "wheelchair_boarding"), do: dgettext("validations", "Weelchair boarding")
+  defp translate_explanation_type("routes.txt", "route_color"), do: dgettext("validations", "Route color")
+  defp translate_explanation_type("routes.txt", "route_text_color"), do: dgettext("validations", "Route text color")
   defp translate_explanation_type(_, unknown), do: dgettext("validations", "Other change: %{unknown}", unknown: unknown)
 
   @doc """

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -308,6 +308,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp translate_explanation_type("routes.txt", "route_short_name"), do: dgettext("validations", "Route short name")
   defp translate_explanation_type("routes.txt", "route_long_name"), do: dgettext("validations", "Route long name")
   defp translate_explanation_type("routes.txt", "route_type"), do: dgettext("validations", "Route type")
+  defp translate_explanation_type("agency.txt", "agency_url"), do: dgettext("validations", "Agency URL")
   defp translate_explanation_type(_, unknown), do: dgettext("validations", "Other change: %{unknown}", unknown: unknown)
 
   @doc """

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -290,6 +290,8 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp translate_explanation_type("stops.txt", "wheelchair_boarding"), do: dgettext("validations", "Weelchair boarding")
   defp translate_explanation_type("routes.txt", "route_color"), do: dgettext("validations", "Route color")
   defp translate_explanation_type("routes.txt", "route_text_color"), do: dgettext("validations", "Route text color")
+  defp translate_explanation_type("routes.txt", "route_short_name"), do: dgettext("validations", "Route short name")
+  defp translate_explanation_type("routes.txt", "route_long_name"), do: dgettext("validations", "Route long name")
   defp translate_explanation_type(_, unknown), do: dgettext("validations", "Other change: %{unknown}", unknown: unknown)
 
   @doc """

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/gtfs_specification.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/gtfs_specification.ex
@@ -277,4 +277,16 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.GTFSSpecification do
   defp specification_url(file) do
     "https://gtfs.org/documentation/schedule/reference/##{String.replace(file, ".", "")}"
   end
+
+  def route_type_short_description("0"), do: dgettext("gtfs-file-descriptions", "tram, streetcar, light rail")
+  def route_type_short_description("1"), do: dgettext("gtfs-file-descriptions", "subway, metro")
+  def route_type_short_description("2"), do: dgettext("gtfs-file-descriptions", "rail")
+  def route_type_short_description("3"), do: dgettext("gtfs-file-descriptions", "bus")
+  def route_type_short_description("4"), do: dgettext("gtfs-file-descriptions", "ferry")
+  def route_type_short_description("5"), do: dgettext("gtfs-file-descriptions", "cable tram")
+  def route_type_short_description("6"), do: dgettext("gtfs-file-descriptions", "aerial lift, suspended cable car")
+  def route_type_short_description("7"), do: dgettext("gtfs-file-descriptions", "funicular")
+  def route_type_short_description("11"), do: dgettext("gtfs-file-descriptions", "trolleybus")
+  def route_type_short_description("12"), do: dgettext("gtfs-file-descriptions", "monorail")
+  def route_type_short_description(_unexpected), do: dgettext("gtfs-file-descriptions", "unknown")
 end

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/gtfs_specification.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/gtfs_specification.ex
@@ -289,4 +289,11 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.GTFSSpecification do
   def route_type_short_description("11"), do: dgettext("gtfs-file-descriptions", "trolleybus")
   def route_type_short_description("12"), do: dgettext("gtfs-file-descriptions", "monorail")
   def route_type_short_description(_unexpected), do: dgettext("gtfs-file-descriptions", "unknown")
+
+  def stop_location_type_short_description("0"), do: dgettext("gtfs-file-descriptions", "stop or platform")
+  def stop_location_type_short_description("1"), do: dgettext("gtfs-file-descriptions", "station")
+  def stop_location_type_short_description("2"), do: dgettext("gtfs-file-descriptions", "entrance/exit")
+  def stop_location_type_short_description("3"), do: dgettext("gtfs-file-descriptions", "generic node")
+  def stop_location_type_short_description("4"), do: dgettext("gtfs-file-descriptions", "boarding area")
+  def stop_location_type_short_description(_unexpected), do: dgettext("gtfs-file-descriptions", "unknown")
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-file-descriptions.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-file-descriptions.po
@@ -182,3 +182,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "trolleybus"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "boarding area"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "entrance/exit"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "generic node"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "station"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "stop or platform"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-file-descriptions.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-file-descriptions.po
@@ -138,3 +138,47 @@ msgstr "Trips for each route. A trip is a sequence of two or more stops that occ
 #, elixir-autogen, elixir-format
 msgid "unknown-file"
 msgstr "Unknown file %{unknonw_file}."
+
+#, elixir-autogen, elixir-format
+msgid "unknown"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "aerial lift, suspended cable car"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "bus"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "cable tram"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "ferry"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "funicular"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "monorail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "rail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "subway, metro"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "tram, streetcar, light rail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "trolleybus"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -639,3 +639,19 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Route text color"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route long name has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route short name has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route long name"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route short name"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -663,3 +663,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Route type"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Location type for stop %{stop_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Location type"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -671,3 +671,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Location type"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL for agency %{agency_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -655,3 +655,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Route short name"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route type has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route type"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -679,3 +679,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Agency URL"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Headsign for trip %{trip_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip headsign"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -623,3 +623,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "file deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Color has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route color"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Text color has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route text color"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-file-descriptions.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-file-descriptions.po
@@ -182,3 +182,23 @@ msgstr "tramway"
 #, elixir-autogen, elixir-format
 msgid "trolleybus"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "boarding area"
+msgstr "zone d’embarquement"
+
+#, elixir-autogen, elixir-format
+msgid "entrance/exit"
+msgstr "entrée / sortie"
+
+#, elixir-autogen, elixir-format
+msgid "generic node"
+msgstr "noeud générique"
+
+#, elixir-autogen, elixir-format
+msgid "station"
+msgstr "gare"
+
+#, elixir-autogen, elixir-format
+msgid "stop or platform"
+msgstr "arrêt ou quai"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-file-descriptions.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-file-descriptions.po
@@ -138,3 +138,47 @@ msgstr "Courses pour chaque ligne. Une course est une séquence de deux arrêts 
 #, elixir-autogen, elixir-format
 msgid "unknown-file"
 msgstr "Fichier inconnu %{unknonw_file}."
+
+#, elixir-autogen, elixir-format
+msgid "unknown"
+msgstr "inconnu"
+
+#, elixir-autogen, elixir-format
+msgid "aerial lift, suspended cable car"
+msgstr "téléphérique, télécabine"
+
+#, elixir-autogen, elixir-format
+msgid "bus"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "cable tram"
+msgstr "tramway à traction par câble"
+
+#, elixir-autogen, elixir-format
+msgid "ferry"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "funicular"
+msgstr "funiculaire"
+
+#, elixir-autogen, elixir-format
+msgid "monorail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "rail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "subway, metro"
+msgstr "métro"
+
+#, elixir-autogen, elixir-format
+msgid "tram, streetcar, light rail"
+msgstr "tramway"
+
+#, elixir-autogen, elixir-format
+msgid "trolleybus"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -663,3 +663,11 @@ msgstr "Le type de la route %{route_id} a été modifié"
 #, elixir-autogen, elixir-format
 msgid "Route type"
 msgstr "Type de route"
+
+#, elixir-autogen, elixir-format
+msgid "Location type for stop %{stop_id} has been changed"
+msgstr "Le type de lieu pour l’arrêt %{stop_id} a été modifié"
+
+#, elixir-autogen, elixir-format
+msgid "Location type"
+msgstr "Type de lieu"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -623,3 +623,19 @@ msgstr "fichier ajouté"
 #, elixir-autogen, elixir-format
 msgid "file deleted"
 msgstr "fichier supprimé"
+
+#, elixir-autogen, elixir-format
+msgid "Color has been updated for route %{route_id}"
+msgstr "La couleur de la route %{route_id} a été modifiée"
+
+#, elixir-autogen, elixir-format
+msgid "Route color"
+msgstr "Couleur des routes"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Text color has been updated for route %{route_id}"
+msgstr "La couleur de texte de la route %{route_id} a été modifiée"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route text color"
+msgstr "Couleur de texte des routes"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -671,3 +671,11 @@ msgstr "Le type de lieu pour l’arrêt %{stop_id} a été modifié"
 #, elixir-autogen, elixir-format
 msgid "Location type"
 msgstr "Type de lieu"
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL for agency %{agency_id} has been changed"
+msgstr "L’URL de l’exploitant %{agency_id} a été modifiée"
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL"
+msgstr "URL de l’exploitant"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -679,3 +679,11 @@ msgstr "L’URL de l’exploitant %{agency_id} a été modifiée"
 #, elixir-autogen, elixir-format
 msgid "Agency URL"
 msgstr "URL de l’exploitant"
+
+#, elixir-autogen, elixir-format
+msgid "Headsign for trip %{trip_id} has been changed"
+msgstr "Le panneau de destination du trajet %{trip_id} a été modifié"
+
+#, elixir-autogen, elixir-format
+msgid "Trip headsign"
+msgstr "Panneau de destination d’un trajet"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -639,3 +639,19 @@ msgstr "La couleur de texte de la route %{route_id} a été modifiée"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Route text color"
 msgstr "Couleur de texte des routes"
+
+#, elixir-autogen, elixir-format
+msgid "Route long name has been updated for route %{route_id}"
+msgstr "Le nom long de la route %{route_id} a été modifié"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route short name has been updated for route %{route_id}"
+msgstr "Le nom court de la route %{route_id} a été modifié"
+
+#, elixir-autogen, elixir-format
+msgid "Route long name"
+msgstr "Nom de route long"
+
+#, elixir-autogen, elixir-format
+msgid "Route short name"
+msgstr "Nom de route court"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -655,3 +655,11 @@ msgstr "Nom de route long"
 #, elixir-autogen, elixir-format
 msgid "Route short name"
 msgstr "Nom de route court"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Route type has been updated for route %{route_id}"
+msgstr "Le type de la route %{route_id} a été modifié"
+
+#, elixir-autogen, elixir-format
+msgid "Route type"
+msgstr "Type de route"

--- a/apps/transport/priv/gettext/gtfs-file-descriptions.pot
+++ b/apps/transport/priv/gettext/gtfs-file-descriptions.pot
@@ -182,3 +182,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "trolleybus"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "boarding area"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "entrance/exit"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "generic node"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "station"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "stop or platform"
+msgstr ""

--- a/apps/transport/priv/gettext/gtfs-file-descriptions.pot
+++ b/apps/transport/priv/gettext/gtfs-file-descriptions.pot
@@ -138,3 +138,47 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "unknown-file"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "unknown"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "aerial lift, suspended cable car"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "bus"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "cable tram"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "ferry"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "funicular"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "monorail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "rail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "subway, metro"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "tram, streetcar, light rail"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "trolleybus"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -661,3 +661,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Route type"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Location type for stop %{stop_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Location type"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -653,3 +653,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Route short name"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route type has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route type"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -621,3 +621,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "file deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Color has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route color"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Text color has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route text color"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -669,3 +669,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Location type"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL for agency %{agency_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency URL"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -677,3 +677,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Agency URL"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Headsign for trip %{trip_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Trip headsign"
+msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -637,3 +637,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Route text color"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route long name has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route short name has been updated for route %{route_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route long name"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Route short name"
+msgstr ""

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -27,8 +27,8 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "action" => "update",
         "file" => "stops.txt",
         "identifier" => "{\"stop_id\":\"100\"}",
-        "initial_value" => "{\"wheelchair_boarding\":\"0\"}",
-        "new_value" => "{\"wheelchair_boarding\":\"1\"}",
+        "initial_value" => "{\"wheelchair_boarding\":\"0\", \"location_type\": \"0\"}",
+        "new_value" => "{\"wheelchair_boarding\":\"1\", \"location_type\": \"1\"}",
         "target" => "row"
       },
       %{
@@ -115,6 +115,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                before: "0",
                after: "1",
                sort_key: "146"
+             },
+             %{
+               file: "stops.txt",
+               type: "location_type",
+               message: "Le type de lieu pour l’arrêt 100 a été modifié",
+               before: "0",
+               after: "1",
+               sort_key: "100"
              }
            ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()
   end

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -35,8 +35,10 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "action" => "update",
         "file" => "routes.txt",
         "identifier" => "{\"route_id\":\"146\"}",
-        "initial_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\", \"route_short_name\":\"30\", \"route_long_name\":\"Migné Rochereaux-Laborit/Mignaloux\"}",
-        "new_value" => "{\"route_color\":\"0000B0\", \"route_text_color\":\"000000\", \"route_short_name\":\"TER\", \"route_long_name\":\"Migné Rochereaux-Laborit / Mignaloux\"}",
+        "initial_value" =>
+          "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\", \"route_short_name\":\"30\", \"route_long_name\":\"Migné Rochereaux-Laborit/Mignaloux\", \"route_type\":\"0\"}",
+        "new_value" =>
+          "{\"route_color\":\"0000B0\", \"route_text_color\":\"000000\", \"route_short_name\":\"TER\", \"route_long_name\":\"Migné Rochereaux-Laborit / Mignaloux\", \"route_type\":\"1\"}",
         "target" => "row"
       },
       %{
@@ -91,22 +93,30 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                sort_key: "146"
              },
              %{
-                file: "routes.txt",
-                type: "route_long_name",
-                message: "Le nom long de la route 146 a été modifié",
-                before: "Migné Rochereaux-Laborit/Mignaloux",
-                after: "Migné Rochereaux-Laborit / Mignaloux",
-                sort_key: "146"
-              },
-              %{
-                file: "routes.txt",
-                type: "route_short_name",
-                message: "Le nom court de la route 146 a été modifié",
-                before: "30",
-                after: "TER",
-                sort_key: "146"
-              },
-            ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()
+               file: "routes.txt",
+               type: "route_long_name",
+               message: "Le nom long de la route 146 a été modifié",
+               before: "Migné Rochereaux-Laborit/Mignaloux",
+               after: "Migné Rochereaux-Laborit / Mignaloux",
+               sort_key: "146"
+             },
+             %{
+               file: "routes.txt",
+               type: "route_short_name",
+               message: "Le nom court de la route 146 a été modifié",
+               before: "30",
+               after: "TER",
+               sort_key: "146"
+             },
+             %{
+               file: "routes.txt",
+               type: "route_type",
+               message: "Le type de la route 146 a été modifié",
+               before: "0",
+               after: "1",
+               sort_key: "146"
+             }
+           ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()
   end
 
   test "structural changes" do

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -35,8 +35,8 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "action" => "update",
         "file" => "routes.txt",
         "identifier" => "{\"route_id\":\"146\"}",
-        "initial_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\"}",
-        "new_value" => "{\"route_color\":\"0000B0\", \"route_text_color\":\"000000\"}",
+        "initial_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\", \"route_short_name\":\"30\", \"route_long_name\":\"Migné Rochereaux-Laborit/Mignaloux\"}",
+        "new_value" => "{\"route_color\":\"0000B0\", \"route_text_color\":\"000000\", \"route_short_name\":\"TER\", \"route_long_name\":\"Migné Rochereaux-Laborit / Mignaloux\"}",
         "target" => "row"
       },
       %{
@@ -49,7 +49,7 @@ defmodule TransportWeb.GtfsDiffExplainTest do
       }
     ]
 
-    assert [
+    assert MapSet.new([
              %{
                file: "stops.txt",
                type: "stop_position",
@@ -89,8 +89,24 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                before: "#5C2483",
                after: "#0000B0",
                sort_key: "146"
-             }
-           ] == GTFSDiffExplain.diff_explanations(diff)
+             },
+             %{
+                file: "routes.txt",
+                type: "route_long_name",
+                message: "Le nom long de la route 146 a été modifié",
+                before: "Migné Rochereaux-Laborit/Mignaloux",
+                after: "Migné Rochereaux-Laborit / Mignaloux",
+                sort_key: "146"
+              },
+              %{
+                file: "routes.txt",
+                type: "route_short_name",
+                message: "Le nom court de la route 146 a été modifié",
+                before: "30",
+                after: "TER",
+                sort_key: "146"
+              },
+            ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()
   end
 
   test "structural changes" do

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -30,6 +30,22 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "initial_value" => "{\"wheelchair_boarding\":\"0\"}",
         "new_value" => "{\"wheelchair_boarding\":\"1\"}",
         "target" => "row"
+      },
+      %{
+        "action" => "update",
+        "file" => "routes.txt",
+        "identifier" => "{\"route_id\":\"146\"}",
+        "initial_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\"}",
+        "new_value" => "{\"route_color\":\"0000B0\", \"route_text_color\":\"000000\"}",
+        "target" => "row"
+      },
+      %{
+        "action" => "update",
+        "file" => "routes.txt",
+        "identifier" => "{\"route_id\":\"147\"}",
+        "initial_value" => "{\"route_color\":\"5c2483\", \"route_text_color\":\"ffffff\"}",
+        "new_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\"}",
+        "target" => "row"
       }
     ]
 
@@ -57,6 +73,22 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                before: "0",
                after: "1",
                sort_key: "100"
+             },
+             %{
+               file: "routes.txt",
+               type: "route_text_color",
+               message: "La couleur de texte de la route 146 a été modifiée",
+               before: "#FFFFFF",
+               after: "#000000",
+               sort_key: "146"
+             },
+             %{
+               file: "routes.txt",
+               type: "route_color",
+               message: "La couleur de la route 146 a été modifiée",
+               before: "#5C2483",
+               after: "#0000B0",
+               sort_key: "146"
              }
            ] == GTFSDiffExplain.diff_explanations(diff)
   end

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -56,6 +56,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "initial_value" => "{\"agency_url\":\"http://localhost/foo\"}",
         "new_value" => "{\"agency_url\":\"http://localhost/bar\"}",
         "target" => "row"
+      },
+      %{
+        "action" => "update",
+        "file" => "trips.txt",
+        "identifier" => "{\"trip_id\":\"1\"}",
+        "initial_value" => "{\"trip_headsign\":\"Foo\"}",
+        "new_value" => "{\"trip_headsign\":\"Bar\"}",
+        "target" => "row"
       }
     ]
 
@@ -138,6 +146,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                message: "L’URL de l’exploitant 1 a été modifiée",
                before: "http://localhost/foo",
                after: "http://localhost/bar",
+               sort_key: "1"
+             },
+             %{
+               file: "trips.txt",
+               type: "trip_headsign",
+               message: "Le panneau de destination du trajet 1 a été modifié",
+               before: "Foo",
+               after: "Bar",
                sort_key: "1"
              }
            ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -48,6 +48,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "initial_value" => "{\"route_color\":\"5c2483\", \"route_text_color\":\"ffffff\"}",
         "new_value" => "{\"route_color\":\"5C2483\", \"route_text_color\":\"FFFFFF\"}",
         "target" => "row"
+      },
+      %{
+        "action" => "update",
+        "file" => "agency.txt",
+        "identifier" => "{\"agency_id\":\"1\"}",
+        "initial_value" => "{\"agency_url\":\"http://localhost/foo\"}",
+        "new_value" => "{\"agency_url\":\"http://localhost/bar\"}",
+        "target" => "row"
       }
     ]
 
@@ -123,6 +131,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                before: "0",
                after: "1",
                sort_key: "100"
+             },
+             %{
+               file: "agency.txt",
+               type: "agency_url",
+               message: "L’URL de l’exploitant 1 a été modifiée",
+               before: "http://localhost/foo",
+               after: "http://localhost/bar",
+               sort_key: "1"
              }
            ]) == GTFSDiffExplain.diff_explanations(diff) |> MapSet.new()
   end


### PR DESCRIPTION
Nouveaux détails de modifications :
- agency_url
  <img width="50%" src="https://github.com/user-attachments/assets/ba735d6f-b7af-4693-8fb2-365fdadae63d" />
- stop's location_type
  <img width="50%" src="https://github.com/user-attachments/assets/44c9e7ce-7824-466e-838b-26b857ca9b30" />
- type de route
  <img width="50%" src="https://github.com/user-attachments/assets/0a19e256-afad-49b5-bde5-dcbc789c657b" />
- couleur de ligne;
  <img width="50%" src="https://github.com/user-attachments/assets/6309a3a8-e942-4bcb-9ba1-3bc2dd93211d" />
- trip_headsign
  <img width="50%" src="https://github.com/user-attachments/assets/78a1eae7-ff75-4a07-84bd-0b6d64352960" />
- noms de ligne
  <img width="50%" src="https://github.com/user-attachments/assets/1af2457c-4eb7-44ef-9053-5f385f33ea7c" />

Voir #4460.