### PR TITLE
GTFS diff : affichage tabulaire des changements

### DIFF
--- a/apps/transport/client/stylesheets/components/_gtfs_diff.scss
+++ b/apps/transport/client/stylesheets/components/_gtfs_diff.scss
@@ -167,6 +167,22 @@
   .symbol {
     margin-inline: 6px;
   }
+
+  div.scrollable-table {
+    display: inline-block;
+    max-height: 20em;
+    overflow-y: auto;
+    width: 100%;
+
+    thead th {
+      position: sticky;
+      top: -1px;
+    }
+    tfoot td {
+      position: sticky;
+      bottom: -1px;
+    }
+  }
 }
 
 @media (max-width: 749px) {

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -150,7 +150,7 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt",
+      {"stops.txt", "stop_name",
        dgettext(
          "validations",
          ~s(The name of the stop_id %{stop_id} has been modified. Initial name: "%{initial_stop_name}", New name: "%{new_stop_name}"),
@@ -179,7 +179,7 @@ defmodule TransportWeb.GTFSDiffExplain do
       )
       when new_wheelchair_boarding in ["1", "2"] do
     [
-      {"stops.txt",
+      {"stops.txt", "wheelchair_boarding",
        dgettext(
          "validations",
          ~s(Wheelchair_boarding information added for stop_id %{stop_id}, previously: "%{initial_wheelchair_boarding}", now: "%{new_wheelchair_boarding}"),
@@ -205,7 +205,7 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt",
+      {"stops.txt", "stop_lon",
        dgettext(
          "validations",
          ~s(The longitude of the stop_id %{stop_id} has been modified. "%{initial_stop_lon}" -> "%{new_stop_lon}"),
@@ -233,7 +233,7 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt",
+      {"stops.txt", "stop_lat",
        dgettext(
          "validations",
          ~s(The latitude of the stop_id %{stop_id} has been modified. "%{initial_stop_lat}" -> "%{new_stop_lat}"),

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain.ex
@@ -150,14 +150,14 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt", "stop_name",
-       dgettext(
-         "validations",
-         ~s(The name of the stop_id %{stop_id} has been modified. Initial name: "%{initial_stop_name}", New name: "%{new_stop_name}"),
-         stop_id: stop_id,
-         initial_stop_name: initial_stop_name,
-         new_stop_name: new_stop_name
-       )}
+      %{
+        file: "stops.txt",
+        type: "stop_name",
+        message: dgettext("validations", "Stop %{stop_id} has been renamed", stop_id: stop_id),
+        before: initial_stop_name,
+        after: new_stop_name,
+        sort_key: initial_stop_name
+      }
       | explanations
     ]
   end
@@ -179,14 +179,14 @@ defmodule TransportWeb.GTFSDiffExplain do
       )
       when new_wheelchair_boarding in ["1", "2"] do
     [
-      {"stops.txt", "wheelchair_boarding",
-       dgettext(
-         "validations",
-         ~s(Wheelchair_boarding information added for stop_id %{stop_id}, previously: "%{initial_wheelchair_boarding}", now: "%{new_wheelchair_boarding}"),
-         stop_id: stop_id,
-         initial_wheelchair_boarding: initial_wheelchair_boarding,
-         new_wheelchair_boarding: new_wheelchair_boarding
-       )}
+      %{
+        file: "stops.txt",
+        type: "wheelchair_boarding",
+        message: dgettext("validations", "Wheelchair_boarding updated for stop %{stop_id}", stop_id: stop_id),
+        before: initial_wheelchair_boarding,
+        after: new_wheelchair_boarding,
+        sort_key: stop_id
+      }
       | explanations
     ]
   end
@@ -205,14 +205,21 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt", "stop_lon",
-       dgettext(
-         "validations",
-         ~s(The longitude of the stop_id %{stop_id} has been modified. "%{initial_stop_lon}" -> "%{new_stop_lon}"),
-         stop_id: stop_id,
-         initial_stop_lon: initial_stop_lon,
-         new_stop_lon: new_stop_lon
-       )}
+      %{
+        file: "stops.txt",
+        type: "stop_position",
+        message:
+          dgettext(
+            "validations",
+            "The longitude of the stop_id %{stop_id} has been modified",
+            stop_id: stop_id,
+            initial_stop_lon: initial_stop_lon,
+            new_stop_lon: new_stop_lon
+          ),
+        before: initial_stop_lon,
+        after: new_stop_lon,
+        sort_key: "#{stop_id}-lon"
+      }
       | explanations
     ]
   end
@@ -233,14 +240,21 @@ defmodule TransportWeb.GTFSDiffExplain do
         }
       ) do
     [
-      {"stops.txt", "stop_lat",
-       dgettext(
-         "validations",
-         ~s(The latitude of the stop_id %{stop_id} has been modified. "%{initial_stop_lat}" -> "%{new_stop_lat}"),
-         stop_id: stop_id,
-         initial_stop_lat: initial_stop_lat,
-         new_stop_lat: new_stop_lat
-       )}
+      %{
+        file: "stops.txt",
+        type: "stop_position",
+        message:
+          dgettext(
+            "validations",
+            "The latitude of the stop_id %{stop_id} has been modified",
+            stop_id: stop_id,
+            initial_stop_lat: initial_stop_lat,
+            new_stop_lat: new_stop_lat
+          ),
+        before: initial_stop_lat,
+        after: new_stop_lat,
+        sort_key: "#{stop_id}-lat"
+      }
       | explanations
     ]
   end

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -21,8 +21,9 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
       <%= if assigns[:diff_explanations] do %>
         <% active_explanations =
           @diff_explanations
-          |> Enum.filter(fn {file, _} -> file == @selected_file end)
-          |> Enum.map(fn {_, explanation} -> explanation end) %>
+          |> Enum.filter(fn {file, _, _} -> file == @selected_file end)
+          |> Enum.sort_by(fn {_, nature, _} -> nature end)
+          |> Enum.map(fn {_, _, explanation} -> explanation end) %>
         <.detailed_explanations :if={not Enum.empty?(active_explanations)} active_explanations={active_explanations} />
       <% end %>
     </div>

--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/differences.ex
@@ -209,25 +209,27 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Differences do
   defp detailed_explanations(%{file: _, explanations: _, explanation_type: _} = assigns) do
     ~H"""
     <h6><%= translate_explanation_type(@file, @explanation_type) %> (<%= length(@explanations) %>)</h6>
-    <table class="table">
-      <thead>
-        <tr>
-          <th><%= dgettext("validations", "Comment") %></th>
-          <th><%= dgettext("validations", "Original") %></th>
-          <th><%= dgettext("validations", "Modified") %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr :for={
-          %{message: message, before: before, after: after_} <-
-            Enum.sort_by(@explanations, fn %{sort_key: sort_key} -> sort_key end)
-        }>
-          <td><%= message %></td>
-          <td><%= before %></td>
-          <td><%= after_ %></td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="scrollable-table">
+      <table class="table">
+        <thead>
+          <tr>
+            <th><%= dgettext("validations", "Comment") %></th>
+            <th><%= dgettext("validations", "Original") %></th>
+            <th><%= dgettext("validations", "Modified") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={
+            %{message: message, before: before, after: after_} <-
+              Enum.sort_by(@explanations, fn %{sort_key: sort_key} -> sort_key end)
+          }>
+            <td><%= message %></td>
+            <td><%= before %></td>
+            <td><%= after_ %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     """
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -441,22 +441,6 @@ msgid "An error occurred while interpreting the results. Note that the report is
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The latitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lat}\" -> \"%{new_stop_lat}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "The longitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lon}\" -> \"%{new_stop_lon}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "The name of the stop_id %{stop_id} has been modified. Initial name: \"%{initial_stop_name}\", New name: \"%{new_stop_name}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Wheelchair_boarding information added for stop_id %{stop_id}, previously: \"%{initial_wheelchair_boarding}\", now: \"%{new_wheelchair_boarding}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Start over"
 msgstr ""
 
@@ -586,4 +570,48 @@ msgstr[1] ""
 
 #, elixir-autogen, elixir-format
 msgid "non standard column"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Other change: %{unknown}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Weelchair boarding"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops' names"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops' positions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Wheelchair_boarding updated for stop %{stop_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stop %{stop_id} has been renamed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Comment"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Modified"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Original"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The latitude of the stop_id %{stop_id} has been modified"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The longitude of the stop_id %{stop_id} has been modified"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -441,22 +441,6 @@ msgid "An error occurred while interpreting the results. Note that the report is
 msgstr "Une erreur est survenue en interprétant les résultats. Notez que le rapport est toujours disponible au téléchargement. Erreur :"
 
 #, elixir-autogen, elixir-format
-msgid "The latitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lat}\" -> \"%{new_stop_lat}\""
-msgstr "La latitude du stop_id %{stop_id} a été modifiée : \"%{initial_stop_lat}\" -> \"%{new_stop_lat}\""
-
-#, elixir-autogen, elixir-format
-msgid "The longitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lon}\" -> \"%{new_stop_lon}\""
-msgstr "La longitude du stop_id %{stop_id} a été modifiée : \"%{initial_stop_lon}\" -> \"%{new_stop_lon}\""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "The name of the stop_id %{stop_id} has been modified. Initial name: \"%{initial_stop_name}\", New name: \"%{new_stop_name}\""
-msgstr "Le nom du stop_id %{stop_id} a été modifié. Nom initial : \"%{initial_stop_name}\", Nouveau nom : \"%{new_stop_name}\""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Wheelchair_boarding information added for stop_id %{stop_id}, previously: \"%{initial_wheelchair_boarding}\", now: \"%{new_wheelchair_boarding}\""
-msgstr "Une information d'accessibilité wheelchair_boarding a été ajouté pour le stop_id %{stop_id}, valeur initiale : \"%{initial_wheelchair_boarding}\", nouvelle valeur : \"%{new_wheelchair_boarding}\""
-
-#, elixir-autogen, elixir-format
 msgid "Start over"
 msgstr "Recommencer"
 
@@ -587,3 +571,47 @@ msgstr[1] "fichier supprimé avec %{count} colonnes :"
 #, elixir-autogen, elixir-format
 msgid "non standard column"
 msgstr "colonne non standard"
+
+#, elixir-autogen, elixir-format
+msgid "Other change: %{unknown}"
+msgstr "Autre changement : %{unknown}"
+
+#, elixir-autogen, elixir-format
+msgid "Weelchair boarding"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops' names"
+msgstr "Noms des arrêts"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops' positions"
+msgstr "Positions des arrêts"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The latitude of the stop_id %{stop_id} has been modified"
+msgstr "La latitude de l’arrêt %{stop_id} a été modifiée"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The longitude of the stop_id %{stop_id} has been modified"
+msgstr "La longitude de l’arrêt %{stop_id} a été modifiée"
+
+#, elixir-autogen, elixir-format
+msgid "Wheelchair_boarding updated for stop %{stop_id}"
+msgstr "L’information d’accessibilité wheelchair_boarding a été modifiée pour l’arrêt %{stop_id}"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stop %{stop_id} has been renamed"
+msgstr "L’arrêt %{stop_id} a été renommé"
+
+#, elixir-autogen, elixir-format
+msgid "Comment"
+msgstr "Commentaire"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Modified"
+msgstr "Modifié"
+
+#, elixir-autogen, elixir-format
+msgid "Original"
+msgstr "Original"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -439,22 +439,6 @@ msgid "An error occurred while interpreting the results. Note that the report is
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The latitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lat}\" -> \"%{new_stop_lat}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "The longitude of the stop_id %{stop_id} has been modified. \"%{initial_stop_lon}\" -> \"%{new_stop_lon}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "The name of the stop_id %{stop_id} has been modified. Initial name: \"%{initial_stop_name}\", New name: \"%{new_stop_name}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Wheelchair_boarding information added for stop_id %{stop_id}, previously: \"%{initial_wheelchair_boarding}\", now: \"%{new_wheelchair_boarding}\""
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Start over"
 msgstr ""
 
@@ -584,4 +568,48 @@ msgstr[1] ""
 
 #, elixir-autogen, elixir-format
 msgid "non standard column"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Other change: %{unknown}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Weelchair boarding"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Stops' names"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Stops' positions"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The latitude of the stop_id %{stop_id} has been modified"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The longitude of the stop_id %{stop_id} has been modified"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Wheelchair_boarding updated for stop %{stop_id}"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Stop %{stop_id} has been renamed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Comment"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Modified"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Original"
 msgstr ""

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -34,9 +34,9 @@ defmodule TransportWeb.GtfsDiffExplainTest do
     ]
 
     assert [
-             {"stops.txt",
+             {"stops.txt", "stop_name",
               "Le nom du stop_id 3000055 a été modifié. Nom initial : \"Hôpital\", Nouveau nom : \"Hôpital Arnauzand\""},
-             {"stops.txt",
+             {"stops.txt", "wheelchair_boarding",
               "Une information d'accessibilité wheelchair_boarding a été ajouté pour le stop_id 100, valeur initiale : \"0\", nouvelle valeur : \"1\""}
            ] == GTFSDiffExplain.diff_explanations(diff)
   end

--- a/apps/transport/test/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/gtfs_diff_explain_test.exs
@@ -19,8 +19,8 @@ defmodule TransportWeb.GtfsDiffExplainTest do
         "action" => "update",
         "file" => "stops.txt",
         "identifier" => "{\"stop_id\":\"3000055\"}",
-        "initial_value" => "{\"stop_name\":\"Hôpital\"}",
-        "new_value" => "{\"stop_name\":\"Hôpital Arnauzand\"}",
+        "initial_value" => "{\"stop_name\":\"Hôpital\", \"stop_lat\":\"46.605513\", \"stop_lon\":\"0.275126\"}",
+        "new_value" => "{\"stop_name\":\"Hôpital Arnauzand\", \"stop_lat\":\"46.605348\", \"stop_lon\":\"0.275881\"}",
         "target" => "row"
       },
       %{
@@ -34,10 +34,38 @@ defmodule TransportWeb.GtfsDiffExplainTest do
     ]
 
     assert [
-             {"stops.txt", "stop_name",
-              "Le nom du stop_id 3000055 a été modifié. Nom initial : \"Hôpital\", Nouveau nom : \"Hôpital Arnauzand\""},
-             {"stops.txt", "wheelchair_boarding",
-              "Une information d'accessibilité wheelchair_boarding a été ajouté pour le stop_id 100, valeur initiale : \"0\", nouvelle valeur : \"1\""}
+             %{
+               file: "stops.txt",
+               type: "stop_position",
+               message: "La latitude de l’arrêt 3000055 a été modifiée",
+               before: "46.605513",
+               after: "46.605348",
+               sort_key: "3000055-lat"
+             },
+             %{
+               file: "stops.txt",
+               type: "stop_position",
+               message: "La longitude de l’arrêt 3000055 a été modifiée",
+               before: "0.275126",
+               after: "0.275881",
+               sort_key: "3000055-lon"
+             },
+             %{
+               file: "stops.txt",
+               type: "stop_name",
+               message: "L’arrêt 3000055 a été renommé",
+               before: "Hôpital",
+               after: "Hôpital Arnauzand",
+               sort_key: "Hôpital"
+             },
+             %{
+               file: "stops.txt",
+               type: "wheelchair_boarding",
+               message: "L’information d’accessibilité wheelchair_boarding a été modifiée pour l’arrêt 100",
+               before: "0",
+               after: "1",
+               sort_key: "100"
+             }
            ] == GTFSDiffExplain.diff_explanations(diff)
   end
 

--- a/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
@@ -286,25 +286,23 @@ defmodule Transport.Test.Transport.Jobs.DatasetQualityScoreTest do
         metadata: %{"feed_timestamp_delay" => 1000}
       )
 
-      assert %{
-               score: 0.5,
-               details: %{
-                 resources: [
-                   %{
-                     format: "GTFS",
-                     freshness: 1.0,
-                     raw_measure: %{end_date: end_date, start_date: start_date},
-                     resource_id: ^resource_id
-                   },
-                   %{
-                     format: "gtfs-rt",
-                     freshness: +0.0,
-                     raw_measure: 1000,
-                     resource_id: ^resource_id_2
-                   }
-                 ]
+      assert %{score: 0.5, details: %{resources: resources}} = current_dataset_freshness(dataset.id)
+
+      assert [
+               %{
+                 format: "GTFS",
+                 freshness: 1.0,
+                 raw_measure: %{end_date: end_date, start_date: start_date},
+                 resource_id: ^resource_id
+               },
+               %{
+                 format: "gtfs-rt",
+                 freshness: +0.0,
+                 raw_measure: 1000,
+                 resource_id: ^resource_id_2
                }
-             } = current_dataset_freshness(dataset.id)
+             ] =
+               resources |> Enum.sort_by(fn %{format: format} -> format end)
 
       today = Date.utc_today()
       assert Date.diff(today, start_date) > 0 and Date.diff(end_date, today) > 0

--- a/apps/transport/test/transport_web/live_views/gtfs_diff_select_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/gtfs_diff_select_live_test.exs
@@ -81,6 +81,22 @@ defmodule TransportWeb.Live.GTFSDiffSelectLiveTest do
           "action" => "add",
           "file" => "stop_times.txt",
           "target" => "row"
+        },
+        %{
+          "action" => "update",
+          "file" => "stops.txt",
+          "identifier" => "{\"stop_id\":\"3000055\"}",
+          "initial_value" => "{\"stop_name\":\"Hôpital\"}",
+          "new_value" => "{\"stop_name\":\"Hôpital Arnauzand\"}",
+          "target" => "row"
+        },
+        %{
+          "action" => "update",
+          "file" => "stops.txt",
+          "identifier" => "{\"stop_id\":\"100\"}",
+          "initial_value" => "{\"wheelchair_boarding\":\"0\"}",
+          "new_value" => "{\"wheelchair_boarding\":\"1\"}",
+          "target" => "row"
         }
       ]
 
@@ -109,7 +125,8 @@ defmodule TransportWeb.Live.GTFSDiffSelectLiveTest do
       assert navigation |> Floki.find("a") |> texts == [
                "agency.txt",
                "calendar.txt",
-               "stop_times.txt"
+               "stop_times.txt",
+               "stops.txt"
              ]
 
       assert navigation |> Floki.find("a.active") |> Floki.text() == "agency.txt"


### PR DESCRIPTION
Spinoff de #4493 se concentrant sur la mise en page des différences détaillées. Pas de nouveauté métier.

<img src=https://github.com/user-attachments/assets/196335e6-e3d1-4747-8f08-e20a034e2e4e width='70%' />

Voir #4460.
