### PR TITLE
Page de réutilisations : ajout d'une recherche

### DIFF
--- a/apps/transport/client/stylesheets/app.scss
+++ b/apps/transport/client/stylesheets/app.scss
@@ -47,6 +47,7 @@
 @import 'espace_producteur';
 @import 'climate_resilience_bill';
 @import 'reuser_space';
+@import 'reuses';
 
 // Prism for syntax coloring ; TODO: cherry-pick from the npm package instead
 // (and remove the manual download)

--- a/apps/transport/client/stylesheets/reuses.scss
+++ b/apps/transport/client/stylesheets/reuses.scss
@@ -1,0 +1,17 @@
+#reuses_search {
+  padding-left: 30px;
+  width: 400px;
+  display: inline-block;
+}
+
+#reuses_search_container {
+  margin: 0;
+  .form__group {
+    display: inline-block;
+  }
+}
+
+.reuses_search_button {
+  display: inline-block;
+  margin-left: 16px !important;
+}

--- a/apps/transport/lib/transport_web/controllers/reuse_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuse_controller.ex
@@ -6,8 +6,11 @@ defmodule TransportWeb.ReuseController do
 
   def index(%Plug.Conn{} = conn, params) do
     config = make_pagination_config(params)
-    reuses = DB.Reuse.base_query() |> DB.Repo.paginate(page: config.page_number)
+    reuses = DB.Reuse.search(params) |> DB.Repo.paginate(page: config.page_number)
 
-    render(conn, "index.html", reuses: reuses)
+    conn
+    |> assign(:q, params["q"])
+    |> assign(:reuses, reuses)
+    |> render("index.html")
   end
 end

--- a/apps/transport/lib/transport_web/templates/reuse/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuse/index.html.heex
@@ -1,6 +1,14 @@
 <div class="container">
   <div class="cards">
     <h1><%= dgettext("reuses", "Reuses") %></h1>
+    <%= form_for @conn, reuse_path(@conn, :index), [id: "reuses_search_container", method: "get"], fn f -> %>
+      <%= search_input(f, :q,
+        id: "reuses_search",
+        value: @q,
+        placeholder: dgettext("reuses", "Find reuses")
+      ) %>
+      <button type="submit" class="button reuses_search_button"><i class="fa fa-search"></i></button>
+    <% end %>
 
     <p>
       <%= raw(dgettext("reuses", "index-intro")) %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
@@ -60,3 +60,7 @@ msgstr "Below is the list of reusers who have declared reusing a dataset referen
 #, elixir-autogen, elixir-format
 msgid "Publish a reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Find reuses"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
@@ -60,3 +60,7 @@ msgstr "Vous trouverez ci-dessous la liste des réutilisateurs qui ont déclaré
 #, elixir-autogen, elixir-format
 msgid "Publish a reuse"
 msgstr "Publier une réutilisation"
+
+#, elixir-autogen, elixir-format
+msgid "Find reuses"
+msgstr "Rechercher des réutilisations"

--- a/apps/transport/priv/gettext/reuses.pot
+++ b/apps/transport/priv/gettext/reuses.pot
@@ -60,3 +60,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Publish a reuse"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Find reuses"
+msgstr ""

--- a/apps/transport/test/db/reuse_test.exs
+++ b/apps/transport/test/db/reuse_test.exs
@@ -2,6 +2,8 @@ defmodule DB.ReuseTest do
   use ExUnit.Case, async: true
   import DB.Factory
 
+  doctest DB.Reuse, import: true
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
@@ -29,5 +31,17 @@ defmodule DB.ReuseTest do
 
     [reuse] = DB.Repo.all(DB.Reuse)
     assert [%DB.Dataset{id: ^dataset_id}] = reuse |> DB.Repo.preload(:datasets) |> Map.fetch!(:datasets)
+  end
+
+  test "search" do
+    foo = insert(:reuse, title: "Foo")
+    bar = insert(:reuse, owner: "Bar")
+    hello = insert(:reuse, organization: "hello")
+
+    search = fn value -> DB.Reuse.search(%{"q" => value}) |> DB.Repo.all() end
+
+    assert [foo] == search.("foo")
+    assert [bar] == search.("bar")
+    assert [hello] == search.("héllo")
   end
 end

--- a/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
@@ -6,8 +6,28 @@ defmodule TransportWeb.ReuseControllerTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "index", %{conn: conn} do
-    insert(:reuse, title: title = "Ma réutilisation")
-    assert conn |> get(reuse_path(conn, :index)) |> html_response(200) =~ title
+  describe "index" do
+    test "page is displayed", %{conn: conn} do
+      insert(:reuse, title: title = "Ma réutilisation")
+      assert conn |> get(reuse_path(conn, :index)) |> html_response(200) =~ title
+    end
+
+    test "searching reuses", %{conn: conn} do
+      insert(:reuse, title: "Foo")
+      bar = insert(:reuse, owner: "Bar")
+
+      reuse_titles = fn search ->
+        conn
+        |> get(reuse_path(conn, :index), q: search)
+        |> html_response(200)
+        |> Floki.parse_document!()
+        |> Floki.find(".card__content h3")
+        |> Enum.map(&Floki.text/1)
+      end
+
+      assert ["Foo", bar.title] == reuse_titles.("")
+      assert ["Foo"] == reuse_titles.("foo")
+      assert [bar.title] == reuse_titles.("ba")
+    end
   end
 end


### PR DESCRIPTION
Fixes #4507

Ajoute une barre de recherche à la page de réutilisations afin de chercher par :
- titre de réutilisation
- auteur
- organisation

La recherche est effectuée sans tenir compte de la casse ni des accents.

![image](https://github.com/user-attachments/assets/138687f7-8a39-4026-bfe6-f22a9d00df3b)
