### PR TITLE
GTFS-diff: Correction lien téléchargement

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_select_live/results.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_select_live/results.ex
@@ -198,7 +198,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
   defp similar_urls(url_1, url_2) do
     dgettext(
       "validations",
-      "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar.",
+      "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> and the <a href=\"%{gtfs_url_1}\">reference GTFS file</a> are similar.",
       gtfs_url_1: url_1,
       gtfs_url_2: url_2
     )
@@ -207,7 +207,7 @@ defmodule TransportWeb.Live.GTFSDiffSelectLive.Results do
   defp different_urls(url_1, url_2) do
     dgettext(
       "validations",
-      "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:",
+      "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> has differences with the <a href=\"%{gtfs_url_1}\">reference GTFS file</a>, as summarized below:",
       gtfs_url_1: url_1,
       gtfs_url_2: url_2
     )

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -445,11 +445,11 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> has differences with the <a href=\"%{gtfs_url_1}\">reference GTFS file</a>, as summarized below:"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> and the <a href=\"%{gtfs_url_1}\">reference GTFS file</a> are similar."
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -445,12 +445,12 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr "Les fichier GTFS <code>%{gtfs_original_file_name_2}</code> et <code>%{gtfs_original_file_name_1}</code> sont similaires."
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
-msgstr "Le fichier GTFS modifié (<a href=\"%{gtfs_url_2}\">source</a>) comporte les différences ci-dessous par rapport au fichier GTFS de référence (<a href=\"%{gtfs_url_2}\">source</a>) :"
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> has differences with the <a href=\"%{gtfs_url_1}\">reference GTFS file</a>, as summarized below:"
+msgstr "Le <a href=\"%{gtfs_url_2}\">fichier GTFS modifié</a> comporte les différences ci-dessous par rapport au <a href=\"%{gtfs_url_1}\">fichier GTFS de référence</a> :"
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
-msgstr "Le fichier GTFS modifié (<a href=\"%{gtfs_url_2}\">source</a>) et le fichier GTFS de référence (<a href=\"%{gtfs_url_1}\">source</a>) sont similaires."
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> and the <a href=\"%{gtfs_url_1}\">reference GTFS file</a> are similar."
+msgstr "Le <a href=\"%{gtfs_url_2}\">fichier GTFS modifié</a> et le <a href=\"%{gtfs_url_1}\">fichier GTFS de référence</a> sont similaires."
 
 #, elixir-autogen, elixir-format
 msgid "Modified GTFS"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -443,11 +443,11 @@ msgid "The GTFS files <code>%{gtfs_original_file_name_2}</code> and <code>%{gtfs
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) has differences with the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>), as summarized below:"
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> has differences with the <a href=\"%{gtfs_url_1}\">reference GTFS file</a>, as summarized below:"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "The modified GTFS file (<a href=\"%{gtfs_url_2}\">source</a>) and the reference GTFS file (<a href=\"%{gtfs_url_1}\">source</a>) are similar."
+msgid "The <a href=\"%{gtfs_url_2}\">modified GTFS file</a> and the <a href=\"%{gtfs_url_1}\">reference GTFS file</a> are similar."
 msgstr ""
 
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
Seule la version française était concernée.

Le lien est déplacé sur l'expression "GTFS modifié" pour alléger le texte.

See #4517.