### PR TITLE
GTFS-diff, calcul de distance: erreurs d'arrondi

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
@@ -356,6 +356,18 @@ defmodule TransportWeb.GTFSDiffExplain.Explanations do
 
     iex> curvilinear_abscissa({46.605513, 0.275126}, {46.605348, 0.275881}) |> round()
     61
+    iex> curvilinear_abscissa({47.6355, 6.1649}, {47.6355, 6.1649})
+    0.0
+    iex> curvilinear_abscissa({47.6355, 6.1687}, {47.6355, 6.1687})
+    0.0
+    iex> curvilinear_abscissa({47.6355, 6.143}, {47.6355, 6.143})
+    0.0
+    iex> curvilinear_abscissa({47.6333, 6.1015}, {47.6333, 6.1015})
+    0.0
+    iex> curvilinear_abscissa({47.6547, 6.1255}, {47.6547, 6.1255})
+    0.0
+    iex> curvilinear_abscissa({47.632, 6.1142}, {47.632, 6.1142})
+    0.0
   """
   def curvilinear_abscissa({lat1, lon1}, {lat2, lon2}) do
     # Semi-major axis of WGS 84

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
@@ -368,7 +368,17 @@ defmodule TransportWeb.GTFSDiffExplain.Explanations do
 
     dlon = lon2r - lon1r
 
-    r * :math.acos(:math.sin(lat1r) * :math.sin(lat2r) + :math.cos(lat1r) * :math.cos(lat2r) * :math.cos(dlon))
+    # clamping is necessary unfortunately as they can be rounding errors
+    r *
+      :math.acos(
+        clamp(:math.sin(lat1r) * :math.sin(lat2r) + :math.cos(lat1r) * :math.cos(lat2r) * :math.cos(dlon), -1, 1)
+      )
+  end
+
+  defp clamp(number, minimum, maximum) do
+    number
+    |> max(minimum)
+    |> min(maximum)
   end
 
   defp deg2rad(deg), do: deg * :math.pi() / 180.0


### PR DESCRIPTION
La fonction acos() est définie sur l‘intervalle [-1, 1]. L’argument de acos() est le résultat d’un calcul qui est correct mathématiquement mais souffre d’erreurs d’arrondi avec les flottants, ce qui est notre cas ici.

Quand la distance est très très courte, elle peut produire une valeur très proche de 1 et à cause des arrondis dépasser cette valeur et sortir de l’intervalle.

Cette PR s’assure que la valeur est bien comprise dans l’intervalle attendu, au risque d'une inapproximation. Cette inapproximation est négligeable comparées aux erreurs d’arrondi en jeu. A noter également que dans ce cas la distance est tellement faible que ce résultat sera ignoré quoi qu’il en soit.

Fixes #4522.