### PR TITLE
Espace réutilisateur : créer un nouveau token

### DIFF
--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -2,7 +2,7 @@ defmodule TransportWeb.ReuserSpaceController do
   use TransportWeb, :controller
   import Ecto.Query
 
-  plug(:find_contact when action in [:espace_reutilisateur, :settings])
+  plug(:find_contact when action in [:espace_reutilisateur, :settings, :new_token, :create_new_token])
   plug(:find_dataset_or_redirect when action in [:datasets_edit, :unfavorite, :add_improved_data])
 
   def espace_reutilisateur(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn, _) do
@@ -27,6 +27,30 @@ defmodule TransportWeb.ReuserSpaceController do
     conn
     |> assign(:tokens, tokens)
     |> render("settings.html")
+  end
+
+  def new_token(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn, _) do
+    contact = DB.Repo.preload(contact, :organizations)
+
+    conn
+    |> assign(:organizations, contact.organizations)
+    |> render("new_token.html")
+  end
+
+  def create_new_token(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn, params) do
+    contact = DB.Repo.preload(contact, :organizations)
+    [organization] = Enum.filter(contact.organizations, &(&1.id == params["organization_id"]))
+
+    DB.Token.changeset(%DB.Token{}, %{
+      "contact_id" => contact.id,
+      "organization_id" => organization.id,
+      "name" => params["name"]
+    })
+    |> DB.Repo.insert!()
+
+    conn
+    |> put_flash(:info, dgettext("reuser-space", "Your token has been created"))
+    |> redirect(to: reuser_space_path(conn, :settings))
   end
 
   def datasets_edit(

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -126,6 +126,8 @@ defmodule TransportWeb.Router do
       post("/datasets/:dataset_id/add_improved_data", ReuserSpaceController, :add_improved_data)
       post("/datasets/:dataset_id/unfavorite", ReuserSpaceController, :unfavorite)
       get("/settings", ReuserSpaceController, :settings)
+      get("/settings/new_token", ReuserSpaceController, :new_token)
+      post("/settings/new_token", ReuserSpaceController, :create_new_token)
 
       live_session :reuser_space, session: %{"role" => :reuser}, root_layout: {TransportWeb.LayoutView, :app} do
         live("/notifications", Live.NotificationsLive, :notifications, as: :reuser_space)

--- a/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
@@ -1,0 +1,32 @@
+<section class="container pt-48 pb-24">
+  <%= breadcrumbs([@conn, :new_token]) %>
+</section>
+<section class="reuser-space-section pb-48">
+  <div class="container pt-24">
+    <div class="panel">
+      <h2><%= dgettext("reuser-space", "Create a new token") %></h2>
+
+      <p :if={Enum.empty?(@organizations)} class="notification error">
+        <%= dgettext("reuser-space", "You need to be a member of an organisation to create new tokens.") %>
+      </p>
+
+      <%= if Enum.count(@organizations) > 0 do %>
+        <%= form_for @conn, reuser_space_path(@conn, :new_token), [class: "no-margin"], fn f -> %>
+          <%= label do %>
+            <%= dgettext("reuser-space", "Token name") %> <%= text_input(f, :name, required: true) %>
+            <p class="small"><%= dgettext("reuser-space", "A name identifying the application using this token.") %></p>
+          <% end %>
+
+          <%= label class: "pt-12 pb-12" do %>
+            <%= dgettext("reuser-space", "Organisation") %> <%= select(
+              f,
+              :organization_id,
+              Enum.map(@organizations, &{&1.name, &1.id})
+            ) %>
+          <% end %>
+          <%= submit(dgettext("reuser-space", "Create")) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
@@ -27,6 +27,10 @@
           <% end %>
         </tbody>
       </table>
+      <a href={reuser_space_path(@conn, :new_token)} class="button">
+        <i class="fa fa-plus icon"></i>
+        <%= dgettext("reuser-space", "Create a new token") %>
+      </a>
     </div>
   </div>
 </section>

--- a/apps/transport/lib/transport_web/views/bread_crumbs.ex
+++ b/apps/transport/lib/transport_web/views/bread_crumbs.ex
@@ -19,7 +19,11 @@ defmodule TransportWeb.BreadCrumbs do
   end
 
   def crumbs(conn, :settings) do
-    crumbs(conn, :reuser_space) ++ [{dgettext("reuser-space", "Settings"), nil}]
+    crumbs(conn, :reuser_space) ++ [{dgettext("reuser-space", "Settings"), reuser_space_path(conn, :settings)}]
+  end
+
+  def crumbs(conn, :new_token) do
+    crumbs(conn, :settings) ++ [{dgettext("reuser-space", "Create a new token"), nil}]
   end
 
   def crumbs(conn, :contacts) do

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -198,3 +198,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Update your preferences, manage tokens to access data."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "A name identifying the application using this token."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Create"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Create a new token"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Token name"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You need to be a member of an organisation to create new tokens."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your token has been created"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -198,3 +198,27 @@ msgstr "Tokens"
 #, elixir-autogen, elixir-format
 msgid "Update your preferences, manage tokens to access data."
 msgstr "Gérer vos préférences, gérer vos tokens pour accéder aux données."
+
+#, elixir-autogen, elixir-format
+msgid "A name identifying the application using this token."
+msgstr "Un nom identifiant l'application utilisant ce token."
+
+#, elixir-autogen, elixir-format
+msgid "Create"
+msgstr "Créer"
+
+#, elixir-autogen, elixir-format
+msgid "Create a new token"
+msgstr "Créer un nouveau token"
+
+#, elixir-autogen, elixir-format
+msgid "Token name"
+msgstr "Nom du token"
+
+#, elixir-autogen, elixir-format
+msgid "You need to be a member of an organisation to create new tokens."
+msgstr "Vous devez être membre d'une organisation pour créer un nouveau token."
+
+#, elixir-autogen, elixir-format
+msgid "Your token has been created"
+msgstr "Votre token a bien été créé"

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -198,3 +198,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Update your preferences, manage tokens to access data."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "A name identifying the application using this token."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Create"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Create a new token"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Token name"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You need to be a member of an organisation to create new tokens."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your token has been created"
+msgstr ""


### PR DESCRIPTION
Ajoute le code nécessaire pour créer un nouveau token (nom et organisation à voir) et les tests associés.

ℹ️ la page des paramètres est toujours accessible uniquement par les membres du PAN.

![image](https://github.com/user-attachments/assets/22546ed9-e0ec-46de-8948-6650cca86990)
![image](https://github.com/user-attachments/assets/54ba4910-3a10-4dd9-b118-45dae6ecc368)
