### PR TITLE
Création d'un token : gestion des erreurs

### DIFF
--- a/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
@@ -10,6 +10,14 @@
         <%= dgettext("reuser-space", "You need to be a member of an organisation to create new tokens.") %>
       </p>
 
+      <div :if={Enum.count(@errors) > 0} class="notification error">
+        <ul>
+          <%= for {key, {message, _}} <- @errors do %>
+            <li><%= to_string(key) <> ": " <> message %></li>
+          <% end %>
+        </ul>
+      </div>
+
       <%= if Enum.count(@organizations) > 0 do %>
         <%= form_for @conn, reuser_space_path(@conn, :new_token), [class: "no-margin"], fn f -> %>
           <%= label do %>

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -347,7 +347,7 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       assert [] = DB.Repo.all(DB.Token)
     end
 
-    @moduletag :capture_log
+    @tag :capture_log
     test "cannot pass a random organization_id", %{conn: conn} do
       organization = insert(:organization)
 

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -300,26 +300,71 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
     end
   end
 
-  test "create_new_token", %{conn: conn} do
-    %DB.Organization{id: organization_id} = organization = insert(:organization)
+  describe "create_new_token" do
+    test "create a new token", %{conn: conn} do
+      %DB.Organization{id: organization_id} = organization = insert(:organization)
 
-    %DB.Contact{id: contact_id} =
+      %DB.Contact{id: contact_id} =
+        contact =
+        insert_contact(%{
+          datagouv_user_id: Ecto.UUID.generate(),
+          organizations: [organization |> Map.from_struct()]
+        })
+
+      assert DB.Token |> DB.Repo.all() |> Enum.empty?()
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+        |> post(reuser_space_path(conn, :create_new_token), %{organization_id: organization.id, name: name = "Name"})
+
+      assert redirected_to(conn, 302) == reuser_space_path(conn, :settings)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Votre token a bien été créé"
+
+      assert [%DB.Token{contact_id: ^contact_id, organization_id: ^organization_id, name: ^name}] =
+               DB.Repo.all(DB.Token)
+    end
+
+    test "creating a new token, with an error", %{conn: conn} do
+      organization = insert(:organization)
+
       contact =
-      insert_contact(%{
-        datagouv_user_id: Ecto.UUID.generate(),
-        organizations: [organization |> Map.from_struct()]
-      })
+        insert_contact(%{
+          datagouv_user_id: Ecto.UUID.generate(),
+          organizations: [organization |> Map.from_struct()]
+        })
 
-    assert DB.Token |> DB.Repo.all() |> Enum.empty?()
+      assert DB.Token |> DB.Repo.all() |> Enum.empty?()
 
-    conn =
-      conn
-      |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
-      |> post(reuser_space_path(conn, :create_new_token), %{organization_id: organization.id, name: name = "Name"})
+      assert conn
+             |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+             |> post(reuser_space_path(conn, :create_new_token), %{organization_id: organization.id})
+             |> html_response(200)
+             |> Floki.parse_document!()
+             |> Floki.find(".notification.error")
+             |> Floki.text() == "name: can't be blank"
 
-    assert redirected_to(conn, 302) == reuser_space_path(conn, :settings)
-    assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Votre token a bien été créé"
+      assert [] = DB.Repo.all(DB.Token)
+    end
 
-    assert [%DB.Token{contact_id: ^contact_id, organization_id: ^organization_id, name: ^name}] = DB.Repo.all(DB.Token)
+    @moduletag :capture_log
+    test "cannot pass a random organization_id", %{conn: conn} do
+      organization = insert(:organization)
+
+      contact =
+        insert_contact(%{
+          datagouv_user_id: Ecto.UUID.generate(),
+          organizations: [organization |> Map.from_struct()]
+        })
+
+      assert DB.Token |> DB.Repo.all() |> Enum.empty?()
+
+      assert_raise MatchError, fn ->
+        conn
+        |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+        |> post(reuser_space_path(conn, :create_new_token), %{organization_id: Ecto.UUID.generate(), name: "Default"})
+        |> html_response(200)
+      end
+    end
   end
 end


### PR DESCRIPTION
Suite de #4526

Gère les éventuelles erreurs lors de la création d'un token via le formulaire. Ceci peut survenir si quelqu'un manipule le DOM pour retirer des attributs HTML, ce n'est donc pas une situation classique. Les tests prouvent qu'on gère tout de même correctement ce scénario.