### PR TITLE
GBFS : mise à jour opérateur pour Lyon

### DIFF
--- a/apps/transport/priv/gbfs_operators.csv
+++ b/apps/transport/priv/gbfs_operators.csv
@@ -6,6 +6,7 @@ backend.citiz.fr;Citiz
 bdx.mecatran.com;Cykleo
 bird.co;Bird
 clermontferrand.publicbikesystem.net;Citybike
+data.grandlyon.com/files/rdata/lpa_mobilite.donnees;Citiz
 data.metropolegrenoble.fr/sites/default/files/dataset/2023/08/10/75c1054c-e602-445c-9852-0fc7abddf592/velos_gbfs.json;Dott
 data.mobilites-m.fr/api/gbfs/dott_grenoble;Dott
 data.optymo.fr;SMTC 90


### PR DESCRIPTION
[Voir alerte sur Front](https://app.frontapp.com/open/msg_2c7yni3a?key=XytrR-1DaY9VAmIBHmsCVIqzohoNG6f1)