### PR TITLE
Réutilisations : fond des images transparent

### DIFF
--- a/apps/transport/client/stylesheets/reuses.scss
+++ b/apps/transport/client/stylesheets/reuses.scss
@@ -15,3 +15,7 @@
   display: inline-block;
   margin-left: 16px !important;
 }
+
+.reuses .card__cover {
+  background: transparent;
+}

--- a/apps/transport/lib/transport_web/templates/reuse/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuse/index.html.heex
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="cards">
+  <div class="cards reuses">
     <h1><%= dgettext("reuses", "Reuses") %></h1>
     <%= form_for @conn, reuse_path(@conn, :index), [id: "reuses_search_container", method: "get"], fn f -> %>
       <%= search_input(f, :q,


### PR DESCRIPTION
Fixes #4534

Rend le fond des images des réutilisations transparent, bleu auparavant dans le CSS par défaut.

![image](https://github.com/user-attachments/assets/51b7254d-cd5d-4f90-987a-058f0a6832ad)
