### PR TITLE
Validation GTFS : ajout warning pour NoCalendar

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_gtfs_no_calendar.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_gtfs_no_calendar.html.heex
@@ -1,0 +1,3 @@
+<p>
+  <%= raw(dgettext("validations-explanations", "NoCalendar")) %>
+</p>

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -41,7 +41,8 @@ defmodule TransportWeb.ResourceView do
           "MissingName" => "_missing_name_issue.html",
           "SubFolder" => "_subfolder_issue.html",
           "NegativeStopDuration" => "_negative_stop_duration_issue.html",
-          "UnusableTrip" => "_unusable_trip.html"
+          "UnusableTrip" => "_unusable_trip.html",
+          "NoCalendar" => "_no_calendar.html"
         },
         Transport.Validators.GTFSTransport.issue_type(issues.entries),
         "_generic_issue.html"

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -263,7 +263,8 @@ defmodule Transport.Validators.GTFSTransport do
       "UnusedShapeId" => dgettext("gtfs-transport-validator", "Unused shape ID"),
       "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder"),
       "NegativeStopDuration" => dgettext("gtfs-transport-validator", "Negative stop duration"),
-      "UnusableTrip" => dgettext("gtfs-transport-validator", "Unusable trip")
+      "UnusableTrip" => dgettext("gtfs-transport-validator", "Unusable trip"),
+      "NoCalendar" => dgettext("gtfs-transport-validator", "Calendar files are empty. The service is never running.")
     }
 
   @spec gtfs_outdated?(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -186,3 +186,7 @@ msgid "Warning"
 msgid_plural "Warnings"
 msgstr[0] "%{count} warning"
 msgstr[1] "%{count} warnings"
+
+#, elixir-autogen, elixir-format
+msgid "Calendar files are empty. The service is never running."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -150,3 +150,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "UnusableTrip"
 msgstr "A trip must visit more than one stop in stop_times.txt to be usable by passengers for boarding and alighting."
+
+#, elixir-autogen, elixir-format
+msgid "NoCalendar"
+msgstr "<code>calendar.txt</code> and <code>calendar_dates.txt</code> are empty. The service is never running."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -186,3 +186,7 @@ msgid "Warning"
 msgid_plural "Warnings"
 msgstr[0] "%{count} avertissement"
 msgstr[1] "%{count} avertissements"
+
+#, elixir-autogen, elixir-format
+msgid "Calendar files are empty. The service is never running."
+msgstr "Les fichiers de calendrier sont vides. Le service n'est jamais en exploitation."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -150,3 +150,7 @@ msgstr "Détails à fin de débogage"
 #, elixir-autogen, elixir-format
 msgid "UnusableTrip"
 msgstr "Un trajet doit passer par plus d’un arrêt dans stop_times.txt pour être utilisable par les voyageurs à la montée ou la descente."
+
+#, elixir-autogen, elixir-format
+msgid "NoCalendar"
+msgstr "<code>calendar.txt</code> et <code>calendar_dates.txt</code> sont vides. Le service n'est jamais en exploitation."

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -185,3 +185,7 @@ msgid "Warning"
 msgid_plural "Warnings"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Calendar files are empty. The service is never running."
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -149,3 +149,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "UnusableTrip"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "NoCalendar"
+msgstr ""


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-validator/pull/218 et https://github.com/etalab/transport-validator/issues/168.

Ajoute une description du nouvel avertissement `NoCalendar` pour la validation GTFS.