### PR TITLE
Traduction pour MissingAgencyId

### DIFF
--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -264,7 +264,8 @@ defmodule Transport.Validators.GTFSTransport do
       "SubFolder" => dgettext("gtfs-transport-validator", "Files in a subfolder"),
       "NegativeStopDuration" => dgettext("gtfs-transport-validator", "Negative stop duration"),
       "UnusableTrip" => dgettext("gtfs-transport-validator", "Unusable trip"),
-      "NoCalendar" => dgettext("gtfs-transport-validator", "Calendar files are empty. The service is never running.")
+      "NoCalendar" => dgettext("gtfs-transport-validator", "Calendar files are empty. The service is never running."),
+      "MissingAgencyId" => dgettext("gtfs-transport-validator", "Field agency_id should not be empty.")
     }
 
   @spec gtfs_outdated?(any()) :: boolean | nil

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -190,3 +190,7 @@ msgstr[1] "%{count} warnings"
 #, elixir-autogen, elixir-format
 msgid "Calendar files are empty. The service is never running."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Field agency_id should not be empty."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -190,3 +190,7 @@ msgstr[1] "%{count} avertissements"
 #, elixir-autogen, elixir-format
 msgid "Calendar files are empty. The service is never running."
 msgstr "Les fichiers de calendrier sont vides. Le service n'est jamais en exploitation."
+
+#, elixir-autogen, elixir-format
+msgid "Field agency_id should not be empty."
+msgstr "Le champ agency_id ne doit pas être vide."

--- a/apps/transport/priv/gettext/gtfs-transport-validator.pot
+++ b/apps/transport/priv/gettext/gtfs-transport-validator.pot
@@ -189,3 +189,7 @@ msgstr[1] ""
 #, elixir-autogen, elixir-format
 msgid "Calendar files are empty. The service is never running."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Field agency_id should not be empty."
+msgstr ""


### PR DESCRIPTION
En lien avec https://github.com/etalab/transport-validator/pull/219

Ajoute une traduction pour une nouvelle erreur du validateur GTFS