### PR TITLE
API GTFS transport : adaptation des plugs

### DIFF
--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -69,7 +69,7 @@ defmodule TransportWeb.API.Router do
   end
 
   scope "/api" do
-    pipe_through(:simple_token_auth)
+    pipe_through([:accept_json, :api, :simple_token_auth])
 
     scope "/validators" do
       get("/gtfs-transport", TransportWeb.API.ValidatorsController, :gtfs_transport)


### PR DESCRIPTION
Suite de #4516

Rétablit les plugs comme initialement pour le validateur GTFS transport dans l'API. La suppression de ces plugs ne devait pas présenter un problème important mais il n'y a pas de raison de les supprimer.

Merci @thbar de ta vigilance.