### PR TITLE
Carte d'exploration : intitulés et tout cocher

### DIFF
--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -1,7 +1,18 @@
 defmodule TransportWeb.ExploreController do
   use TransportWeb, :controller
 
-  def index(conn, params) do
+  def index(%Plug.Conn{} = conn, params) when params == %{} do
+    query_params =
+      query_params(%{})
+      |> Map.new(fn {k, _} ->
+        new_key = String.replace(to_string(k), "_", "-")
+        {new_key, "yes"}
+      end)
+
+    conn |> redirect(to: explore_path(conn, :index, query_params))
+  end
+
+  def index(%Plug.Conn{} = conn, params) do
     consolidated_datasets_assigns =
       Transport.ConsolidatedDataset.geo_data_datasets()
       |> Map.new(&{String.to_atom("#{&1}_dataset"), Transport.ConsolidatedDataset.dataset(&1)})
@@ -33,21 +44,13 @@ defmodule TransportWeb.ExploreController do
   end
 
   defp query_params(params) do
-    result =
-      %{
-        gtfs_rt: params["gtfs-rt"] == "yes",
-        bnlc: params["bnlc"] == "yes",
-        parkings_relais: params["parkings-relais"] == "yes",
-        zfe: params["zfe"] == "yes",
-        irve: params["irve"] == "yes",
-        gbfs_stations: params["gbfs-stations"] == "yes"
-      }
-
-    # By default select all layers
-    if params == %{} do
-      Map.new(result, fn {k, _} -> {k, true} end)
-    else
-      result
-    end
+    %{
+      gtfs_rt: params["gtfs-rt"] == "yes",
+      bnlc: params["bnlc"] == "yes",
+      parkings_relais: params["parkings-relais"] == "yes",
+      zfe: params["zfe"] == "yes",
+      irve: params["irve"] == "yes",
+      gbfs_stations: params["gbfs-stations"] == "yes"
+    }
   end
 end

--- a/apps/transport/lib/transport_web/controllers/explore_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/explore_controller.ex
@@ -33,13 +33,21 @@ defmodule TransportWeb.ExploreController do
   end
 
   defp query_params(params) do
-    %{
-      gtfs_rt: params["gtfs-rt"] == "yes",
-      bnlc: params["bnlc"] == "yes",
-      parkings_relais: params["parkings-relais"] == "yes",
-      zfe: params["zfe"] == "yes",
-      irve: params["irve"] == "yes",
-      gbfs_stations: params["gbfs-stations"] == "yes"
-    }
+    result =
+      %{
+        gtfs_rt: params["gtfs-rt"] == "yes",
+        bnlc: params["bnlc"] == "yes",
+        parkings_relais: params["parkings-relais"] == "yes",
+        zfe: params["zfe"] == "yes",
+        irve: params["irve"] == "yes",
+        gbfs_stations: params["gbfs-stations"] == "yes"
+      }
+
+    # By default select all layers
+    if params == %{} do
+      Map.new(result, fn {k, _} -> {k, true} end)
+    else
+      result
+    end
   end
 end

--- a/apps/transport/lib/transport_web/templates/explore/explore.html.heex
+++ b/apps/transport/lib/transport_web/templates/explore/explore.html.heex
@@ -6,7 +6,7 @@
 <% bike_scooter_sharing_datasets_link = dataset_path(@conn, :index, type: "bike-scooter-sharing") %>
 <% car_motorbike_sharing_datasets_link = dataset_path(@conn, :index, type: "car-motorbike-sharing") %>
 <div class="container dataset-page-top explore">
-  <h2><%= dgettext("explore", "Transport Explore") %></h2>
+  <h2><%= dgettext("explore", "Data exploration map") %></h2>
 
   <div class="grid">
     <div class="checkbox-explore gtfs-rt">

--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -22,7 +22,7 @@
               <%= gettext("Data") %>
               <div class="dropdown-content">
                 <%= link(gettext("Datasets"), to: dataset_path(@conn, :index)) %>
-                <%= link(gettext("Exploration map"), to: explore_path(@conn, :index)) %>
+                <%= link(gettext("Data exploration map"), to: explore_path(@conn, :index)) %>
                 <%= link(gettext("National GTFS stops map"), to: explore_path(@conn, :gtfs_stops)) %>
                 <%= link(gettext("Reuses"), to: reuse_path(@conn, :index)) %>
               </div>

--- a/apps/transport/priv/gettext/default.pot
+++ b/apps/transport/priv/gettext/default.pot
@@ -112,7 +112,7 @@ msgid "Declaration of conformity"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Exploration map"
+msgid "Data exploration map"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/default.po
@@ -112,7 +112,7 @@ msgid "Declaration of conformity"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Exploration map"
+msgid "Data exploration map"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/explore.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);"
 
 #, elixir-autogen, elixir-format
-msgid "Transport Explore"
-msgstr "Transport Explore - beta"
+msgid "Data exploration map"
+msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "gtfs-rt-explanation"
@@ -97,7 +97,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Low emission zones database"
-msgstr ""
+msgstr "Low emission zones (ZFE)"
 
 #, elixir-autogen, elixir-format
 msgid "lez-explanation"
@@ -121,7 +121,7 @@ msgstr "Electric Vehicule Charging Infrastructure database"
 
 #, elixir-autogen, elixir-format
 msgid "GBFS stations"
-msgstr "Stations for shared vehicles"
+msgstr "Stations for shared vehicles (VLS)"
 
 #, elixir-autogen, elixir-format
 msgid "gbfs-stations-explanation"

--- a/apps/transport/priv/gettext/explore.pot
+++ b/apps/transport/priv/gettext/explore.pot
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Transport Explore"
+msgid "Data exploration map"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/default.po
@@ -112,8 +112,8 @@ msgid "Declaration of conformity"
 msgstr "Déclaration de conformité"
 
 #, elixir-autogen, elixir-format
-msgid "Exploration map"
-msgstr "Carte d'exploration"
+msgid "Data exploration map"
+msgstr "Carte d'exploration des données"
 
 #, elixir-autogen, elixir-format
 msgid "SIRI query generator"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/explore.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n>1);"
 
 #, elixir-autogen, elixir-format
-msgid "Transport Explore"
-msgstr "Exploration transport - beta"
+msgid "Data exploration map"
+msgstr "Carte d'exploration des données"
 
 #, elixir-autogen, elixir-format
 msgid "gtfs-rt-explanation"
@@ -97,7 +97,7 @@ msgstr "Référence d'Arrêt (un seul)"
 
 #, elixir-autogen, elixir-format
 msgid "Low emission zones database"
-msgstr "Base nationale des Zones à Faibles Émissions"
+msgstr "Base nationale des Zones à Faibles Émissions (ZFE)"
 
 #, elixir-autogen, elixir-format
 msgid "lez-explanation"
@@ -121,7 +121,7 @@ msgstr "Infrastructures de Recharge des Véhicules Électriques (IRVE)"
 
 #, elixir-autogen, elixir-format
 msgid "GBFS stations"
-msgstr "Stations pour véhicules partagés"
+msgstr "Stations pour véhicules en libre-service (VLS)"
 
 #, elixir-autogen, elixir-format
 msgid "gbfs-stations-explanation"

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -14,7 +14,9 @@ defmodule TransportWeb.ExploreControllerTest do
 
   test "GET /explore", %{conn: conn} do
     conn = conn |> get(~p"/explore")
-    html = html_response(conn, 200)
+    redirect_path = conn |> redirected_to(302)
+    assert redirect_path =~ ~r"^/explore\?"
+    html = conn |> get(redirect_path) |> html_response(200)
     assert html =~ "Carte d&#39;exploration des données"
     assert 6 == (html |> String.split("checked") |> Enum.count()) - 1
 

--- a/apps/transport/test/transport_web/controllers/explore_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/explore_controller_test.exs
@@ -15,13 +15,12 @@ defmodule TransportWeb.ExploreControllerTest do
   test "GET /explore", %{conn: conn} do
     conn = conn |> get(~p"/explore")
     html = html_response(conn, 200)
-    assert html =~ "Exploration"
-    refute html =~ "checked"
+    assert html =~ "Carte d&#39;exploration des données"
+    assert 6 == (html |> String.split("checked") |> Enum.count()) - 1
 
     conn = conn |> get(~p"/explore?zfe=yes")
     html = html_response(conn, 200)
-    assert html =~ "Exploration"
-    assert html =~ "checked"
+    assert 1 == (html |> String.split("checked") |> Enum.count()) - 1
   end
 
   test "GET /explore/vehicle-positions", %{conn: conn} do


### PR DESCRIPTION
Fixes #4536

- Retravaille les intitulés
- Coche par défaut les différentes couches (au lieu de GTFS-RT uniquement pour commencer)