### PR TITLE
Suppression du check Credo sur `Enum/reject/2` chainés

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -98,6 +98,8 @@
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.PipeChainStart, false},
+        # Too unpractical ; we want to keep pipes of separate rejects
+        {Credo.Check.Refactor.RejectReject, false},
         {Credo.Check.Refactor.UnlessWithElse},
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck},


### PR DESCRIPTION
Je propose de désactiver ce check

```
One `Enum.reject/2` is more efficient than `Enum.reject/2 |> Enum.reject/2`
```

Motivation:
- garder des rejects séparés permet de déplacer / copier coller par "ligne" sans risquer d'introduire un bug (facilite la maintenance / refacto)
- le souci de perf est rarement uniquement lié à ça, et l'absence de check n'empêche pas d'optimiser non plus

Discussion [ici](https://mattermost.incubateur.net/betagouv/pl/nr5agga573yh7q36jf9exxn3co).

Backport de #4492 