### PR TITLE
Pool size configurable

### DIFF
--- a/config/database.exs
+++ b/config/database.exs
@@ -2,7 +2,7 @@ import Config
 
 config :transport, DB.Repo,
   url: System.get_env("PG_URL") || "ecto://postgres:postgres@localhost/transport_repo",
-  # NOTE: this default pool_size is overriden by "prod.exs" !
+  # NOTE: this default pool_size is overriden by "runtime.exs" !
   pool_size: (System.get_env("PG_POOL_SIZE") || "10") |> String.to_integer(),
   types: DB.PostgrexTypes
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -224,8 +224,8 @@ end
 if config_env() == :prod do
   pool_size =
     case app_env do
-      :production -> 15
-      :staging -> 6
+      :production -> (System.get_env("PG_POOL_SIZE") || "15") |> String.to_integer()
+      :staging -> (System.get_env("PG_POOL_SIZE") || "6") |> String.to_integer()
     end
 
   config :transport, DB.Repo,


### PR DESCRIPTION
Apporte la possibilité de configurer la taille du pool Ecto via une variable d'environnement, `PG_POOL_SIZE`.