### PR TITLE
Oban Telemetry : utilise attach_default_logger

### DIFF
--- a/apps/transport/lib/jobs/oban_logger.ex
+++ b/apps/transport/lib/jobs/oban_logger.ex
@@ -48,15 +48,10 @@ defmodule Transport.Jobs.ObanLogger do
     # We leave out `job` events because job start/end can be quite noisy.
     # https://hexdocs.pm/oban/preparing_for_production.html#logging
     # https://hexdocs.pm/oban/Oban.Telemetry.html
-    # We may simplify this when
-    # https://github.com/oban-bg/oban/commit/13eabe3f8019e350ef979369a26f186bdf7be63e
-    # will be released.
-    events = [
-      [:oban, :notifier, :switch],
-      [:oban, :queue, :shutdown],
-      [:oban, :stager, :switch]
-    ]
-
-    :telemetry.attach_many("oban-default-logger", events, &Oban.Telemetry.handle_event/4, encode: true, level: :info)
+    Oban.Telemetry.attach_default_logger(
+      events: ~w(notifier plugin peer queue stager)a,
+      encode: true,
+      level: :info
+    )
   end
 end

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -14,7 +14,8 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
   import Swoosh.TestAssertions
 
   test "sends an email on failure if the appropriate tag is set" do
-    assert {:error, "failed"} == perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{}, tags: [])
+    assert {:error, "failed"} ==
+             perform_job(Transport.Test.Transport.Jobs.ObanLoggerJobTag, %{}, tags: [])
 
     # When the specific tag is set, an email should be sent
 
@@ -46,15 +47,16 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
   end
 
   test "oban default logger is set up for important components" do
-    registered_handlers = Enum.filter(:telemetry.list_handlers([]), &(&1.id == "oban-default-logger"))
+    registered_handlers =
+      Enum.filter(:telemetry.list_handlers([]), &(&1.id == Oban.Telemetry.default_handler_id()))
 
     assert Enum.count(registered_handlers) > 0
 
     components =
       registered_handlers
-      |> Enum.map(fn %{event_name: [:oban, component, _]} -> component end)
+      |> Enum.map(fn %{event_name: event_name} -> Enum.at(event_name, 1) end)
       |> MapSet.new()
 
-    assert MapSet.new([:notifier, :queue, :stager]) == MapSet.new(components)
+    assert MapSet.new(~w(notifier plugin peer queue stager)a) == MapSet.new(components)
   end
 end


### PR DESCRIPTION
Utilise ce qui est proposé par Oban pour enregistrer les logs importants.