### PR TITLE
Validation NeTEx: mise à jour du rule_set de base et désactivation de la validation XSD

### DIFF
--- a/apps/transport/lib/validators/enroute_chouette_valid_client.ex
+++ b/apps/transport/lib/validators/enroute_chouette_valid_client.ex
@@ -29,8 +29,8 @@ defmodule Transport.EnRouteChouetteValidClient do
     form =
       {:multipart,
        [
-         {"validation[rule_set]", "french"},
-         {"validation[include_schema]", "true"},
+         {"validation[rule_set]", "enroute:starter-kit"},
+         {"validation[include_schema]", "false"},
          make_file_part("validation[file]", filepath)
        ]}
 
@@ -87,8 +87,15 @@ defmodule Transport.EnRouteChouetteValidClient do
     url = Path.join([validation_url(validation_id), "messages"])
 
     %HTTPoison.Response{status_code: 200, body: body} = http_client().get!(url, auth_headers())
-    {url, body |> Jason.decode!()}
+    {url, body |> Jason.decode!() |> ignore_some_errors()}
   end
+
+  defp ignore_some_errors(messages) do
+    messages |> Enum.reject(&public_code_length?/1)
+  end
+
+  defp public_code_length?(%{"code" => code}), do: code == "public-code-length"
+  defp public_code_length?(_), do: false
 
   defp make_file_part(field_name, filepath) do
     {:file, filepath, {"form-data", [{:name, field_name}, {:filename, Path.basename(filepath)}]}, []}

--- a/apps/transport/lib/validators/netex_validator.ex
+++ b/apps/transport/lib/validators/netex_validator.ex
@@ -74,7 +74,7 @@ defmodule Transport.Validators.NeTEx do
           resource_history_id,
           result_url,
           %{elapsed_seconds: elapsed_seconds, retries: retries},
-          demote_non_xsd_errors(errors)
+          errors
         )
 
         :ok
@@ -138,7 +138,7 @@ defmodule Transport.Validators.NeTEx do
         # result_url in metadata?
         {:ok,
          %{
-           "validations" => errors |> demote_non_xsd_errors() |> index_messages(),
+           "validations" => errors |> index_messages(),
            "metadata" => %{elapsed_seconds: elapsed_seconds, retries: retries}
          }}
 
@@ -434,24 +434,5 @@ defmodule Transport.Validators.NeTEx do
 
   defp client do
     Transport.EnRouteChouetteValidClient.Wrapper.impl()
-  end
-
-  defp demote_non_xsd_errors(errors), do: Enum.map(errors, &demote_non_xsd_error/1)
-
-  defp demote_non_xsd_error(error) do
-    code = Map.get(error, "code", "")
-
-    if String.starts_with?(code, "xsd-") do
-      error
-    else
-      Map.update!(error, "criticity", &demote_error/1)
-    end
-  end
-
-  defp demote_error(criticity) do
-    case criticity do
-      "error" -> "warning"
-      _ -> criticity
-    end
   end
 end

--- a/apps/transport/test/transport/jobs/netex_poller_job_test.exs
+++ b/apps/transport/test/transport/jobs/netex_poller_job_test.exs
@@ -93,14 +93,14 @@ defmodule Transport.Jobs.NeTExPollerJobTest do
                %{
                  "code" => "uic-operating-period",
                  "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod",
-                 "criticity" => "warning"
+                 "criticity" => "error"
                }
              ],
              "valid-day-bits" => [
                %{
                  "code" => "valid-day-bits",
                  "message" => "Mandatory attribute valid_day_bits not found",
-                 "criticity" => "warning"
+                 "criticity" => "error"
                }
              ],
              "frame-arret-resources" => [
@@ -113,7 +113,7 @@ defmodule Transport.Jobs.NeTExPollerJobTest do
              "unknown-code" => [
                %{
                  "message" => "Reference MOBIITI:Quay:104325 doesn't match any existing Resource",
-                 "criticity" => "warning"
+                 "criticity" => "error"
                }
              ]
            }

--- a/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
+++ b/apps/transport/test/transport/validators/enroute_chouette_valid_client_test.exs
@@ -15,9 +15,9 @@ defmodule Transport.EnRouteChouetteValidClientTest do
       """
       {
         "id": "d8e2b6c2-b1e5-4890-84d4-9b761a445882",
-        "rule_set": "french",
+        "rule_set": "enroute:starter-kit",
         "user_status": "pending",
-        "include_schema": true,
+        "include_schema": false,
         "created_at": "2024-07-05T14:41:19.933Z",
         "updated_at": "2024-07-05T14:41:19.933Z"
       }
@@ -31,8 +31,8 @@ defmodule Transport.EnRouteChouetteValidClientTest do
       assert @expected_headers == headers
 
       assert [
-               {"validation[rule_set]", "french"},
-               {"validation[include_schema]", "true"},
+               {"validation[rule_set]", "enroute:starter-kit"},
+               {"validation[include_schema]", "false"},
                {:file, tmp_file, {"form-data", [{:name, "validation[file]"}, {:filename, Path.basename(tmp_file)}]}, []}
              ] == parts
 
@@ -50,9 +50,9 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         """
         {
           "id": "#{validation_id}",
-          "rule_set": "french",
+          "rule_set": "enroute:starter-kit",
           "user_status": "pending",
-          "include_schema": true,
+          "include_schema": false,
           "started_at": "2024-07-05T14:41:20.680Z",
           "created_at": "2024-07-05T14:41:19.933Z",
           "updated_at": "2024-07-05T14:41:20.933Z"
@@ -76,9 +76,9 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         """
         {
           "id": "#{validation_id}",
-          "rule_set": "french",
+          "rule_set": "enroute:starter-kit",
           "user_status": "successful",
-          "include_schema": true,
+          "include_schema": false,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:25.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",
@@ -103,9 +103,9 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         """
         {
           "id": "#{validation_id}",
-          "rule_set": "french",
+          "rule_set": "enroute:starter-kit",
           "user_status": "warning",
-          "include_schema": true,
+          "include_schema": false,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:24.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",
@@ -130,9 +130,9 @@ defmodule Transport.EnRouteChouetteValidClientTest do
         """
         {
           "id": "#{validation_id}",
-          "rule_set": "french",
+          "rule_set": "enroute:starter-kit",
           "user_status": "failed",
-          "include_schema": true,
+          "include_schema": false,
           "started_at": "2024-07-05T14:41:20.680Z",
           "ended_at": "2024-07-05T14:41:28.685Z",
           "created_at": "2024-07-05T14:41:19.933Z",

--- a/apps/transport/test/transport/validators/netex_validator_test.exs
+++ b/apps/transport/test/transport/validators/netex_validator_test.exs
@@ -107,14 +107,14 @@ defmodule Transport.Validators.NeTExTest do
                  %{
                    "code" => "uic-operating-period",
                    "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod",
-                   "criticity" => "warning"
+                   "criticity" => "error"
                  }
                ],
                "valid-day-bits" => [
                  %{
                    "code" => "valid-day-bits",
                    "message" => "Mandatory attribute valid_day_bits not found",
-                   "criticity" => "warning"
+                   "criticity" => "error"
                  }
                ],
                "frame-arret-resources" => [
@@ -127,7 +127,7 @@ defmodule Transport.Validators.NeTExTest do
                "unknown-code" => [
                  %{
                    "message" => "Reference MOBIITI:Quay:104325 doesn't match any existing Resource",
-                   "criticity" => "warning"
+                   "criticity" => "error"
                  }
                ]
              }
@@ -170,14 +170,14 @@ defmodule Transport.Validators.NeTExTest do
           %{
             "code" => "uic-operating-period",
             "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod",
-            "criticity" => "warning"
+            "criticity" => "error"
           }
         ],
         "valid-day-bits" => [
           %{
             "code" => "valid-day-bits",
             "message" => "Mandatory attribute valid_day_bits not found",
-            "criticity" => "warning"
+            "criticity" => "error"
           }
         ],
         "frame-arret-resources" => [
@@ -190,7 +190,7 @@ defmodule Transport.Validators.NeTExTest do
         "unknown-code" => [
           %{
             "message" => "Reference MOBIITI:Quay:104325 doesn't match any existing Resource",
-            "criticity" => "warning"
+            "criticity" => "error"
           }
         ]
       }


### PR DESCRIPTION
Le rule_set utilisé date de 2024, avant la publication de l'API de définition de règles.

Il est désormais possible d'en définir de personnelles mais avant de s'engager sur ce chemin long et difficile il est possible d'utiliser celui basique fourni par enRoute, nommé [enroute:starter-kit].

Puisqu'il existe désormais des règles utiles :
- les erreurs autres que XSD ne sont plus converties en avertissements
- la validation XSD n'est plus demandée

De ces premières règles, une d'entre elle est ignorée car jugée peu pertinente en l'état : `public-code-length` `"A Public Code have 12 or less than characters"`.

[enroute:starter-kit]: https://enroute.atlassian.net/wiki/spaces/PUBLIC/pages/2761687047/Sprint+123#Provide-a-NeTEx-Starter-Kit-ruleset