### PR TITLE
Unlock aggregate : ajout d'une colonne slug

### DIFF
--- a/apps/unlock/lib/config.ex
+++ b/apps/unlock/lib/config.ex
@@ -14,7 +14,15 @@ defmodule Unlock.Config do
     Default subtype is "gtfs-rt" for historical reasons, see `convert_yaml_item_to_struct` in the code.
     """
     @enforce_keys [:identifier, :target_url, :ttl]
-    defstruct [:identifier, :target_url, :ttl, subtype: "gtfs-rt", request_headers: [], response_headers: []]
+    defstruct [
+      :identifier,
+      :slug,
+      :target_url,
+      :ttl,
+      subtype: "gtfs-rt",
+      request_headers: [],
+      response_headers: []
+    ]
   end
 
   defmodule Item.SIRI do
@@ -80,6 +88,7 @@ defmodule Unlock.Config do
     def convert_yaml_item_to_struct(%{"type" => subtype} = item) when subtype in ["generic-http", "gtfs-rt"] do
       %Item.Generic.HTTP{
         identifier: Map.fetch!(item, "identifier"),
+        slug: Map.get(item, "slug"),
         target_url: Map.fetch!(item, "target_url"),
         # By default, no TTL
         ttl: Map.get(item, "ttl", 0),

--- a/apps/unlock/test/config_fetcher_test.exs
+++ b/apps/unlock/test/config_fetcher_test.exs
@@ -117,9 +117,11 @@ defmodule Unlock.ConfigFetcherTest do
           type: "aggregate"
           feeds:
             - identifier: abdcd
+              slug: foo
               target_url: http://localhost:1234
               ttl: 100
             - identifier: efghi
+              slug: bar
               target_url: https://localhost:1235
       """
 
@@ -130,12 +132,14 @@ defmodule Unlock.ConfigFetcherTest do
                  feeds: [
                    %Unlock.Config.Item.Generic.HTTP{
                      identifier: "abdcd",
+                     slug: "foo",
                      target_url: "http://localhost:1234",
                      ttl: 100,
                      subtype: "generic-http"
                    },
                    %Unlock.Config.Item.Generic.HTTP{
                      identifier: "efghi",
+                     slug: "bar",
                      target_url: "https://localhost:1235",
                      ttl: 10,
                      subtype: "generic-http"

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -517,11 +517,13 @@ defmodule Unlock.ControllerTest do
           feeds: [
             %Unlock.Config.Item.Generic.HTTP{
               identifier: "first-remote",
+              slug: "foo",
               target_url: url = "http://localhost:1234",
               ttl: 10
             },
             %Unlock.Config.Item.Generic.HTTP{
               identifier: "second-remote",
+              slug: "bar",
               target_url: second_url = "http://localhost:5678",
               ttl: 10
             }
@@ -811,10 +813,9 @@ defmodule Unlock.ControllerTest do
         |> get("/resource/an-existing-aggregate-identifier", include_origin: 1)
 
       assert resp.status == 200
-
-      expected_headers = @expected_headers ++ ["origin"]
-      first_output_row = first_data_row |> Map.put("origin", "first-remote")
-      second_output_row = second_data_row |> Map.put("origin", "second-remote")
+      expected_headers = @expected_headers ++ ["origin", "slug"]
+      first_output_row = first_data_row |> Map.put("origin", "first-remote") |> Map.put("slug", "foo")
+      second_output_row = second_data_row |> Map.put("origin", "second-remote") |> Map.put("slug", "bar")
 
       assert resp.resp_body ==
                Helper.data_as_csv(expected_headers, [first_output_row, second_output_row], "\r\n")


### PR DESCRIPTION
Fixes #4580

Ajoute une colonne `slug` quand on met `?include_origin=1` dans l'URL en plus de l'identifiant datagouv.

:warning: À merger après le changement de configuration https://github.com/etalab/transport-proxy-config/pull/142