### PR TITLE
Utilise le counter cache pour les features

### DIFF
--- a/apps/transport/lib/jobs/update_counter_cache_job.ex
+++ b/apps/transport/lib/jobs/update_counter_cache_job.ex
@@ -1,13 +1,13 @@
 defmodule Transport.Jobs.UpdateCounterCacheJob do
   @moduledoc """
-  This job is in charge updating the counter cache for `DB.Resource` with the modes
+  This job is in charge updating the counter cache for `DB.Resource` with modes and features
   """
   use Oban.Worker, max_attempts: 3
 
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: :ok
   def perform(%Oban.Job{args: args}) when is_nil(args) or args == %{} do
-    Transport.CounterCache.cache_modes_on_resources()
+    Transport.CounterCache.cache_modes_features_on_resources()
 
     :ok
   end

--- a/apps/transport/test/transport/jobs/counter_cache_test.exs
+++ b/apps/transport/test/transport/jobs/counter_cache_test.exs
@@ -8,7 +8,9 @@ defmodule Transport.Test.Transport.CounterCacheTest do
 
   test "write cache" do
     # First resource with everything good
-    %{resource: %{id: resource_id} = resource} = insert_up_to_date_resource_and_friends(modes: ["rollerblades", "bus"])
+    %{resource: %{id: resource_id} = resource} =
+      insert_up_to_date_resource_and_friends(modes: ["rollerblades", "bus"], features: ["tarifs"])
+
     # Second resource with empty modes
     %{resource: %{id: resource_empty_metadata_id} = resource_empty_metadata} = insert_up_to_date_resource_and_friends()
     # Third resource has no validation
@@ -20,9 +22,9 @@ defmodule Transport.Test.Transport.CounterCacheTest do
     assert resource_empty_metadata.counter_cache == %{}
     assert resource_no_validation.counter_cache == %{}
 
-    Transport.CounterCache.cache_modes_on_resources()
+    Transport.CounterCache.cache_modes_features_on_resources()
 
-    assert %DB.Resource{counter_cache: %{"gtfs_modes" => ["rollerblades", "bus"]}} =
+    assert %DB.Resource{counter_cache: %{"gtfs_modes" => ["rollerblades", "bus"], "gtfs_features" => ["tarifs"]}} =
              DB.Repo.get!(DB.Resource, resource_id)
 
     assert %DB.Resource{counter_cache: %{"gtfs_modes" => []}} = DB.Repo.get!(DB.Resource, resource_empty_metadata_id)

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -90,26 +90,20 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     end
 
     test "with features" do
-      %{dataset: dataset_1} = insert_resource_and_friends(Date.utc_today(), features: ["repose pieds en velour"])
+      %DB.Resource{dataset_id: dataset_1_id} =
+        insert(:resource, counter_cache: %{gtfs_features: ["repose pieds en velour"]}, dataset: insert(:dataset))
 
-      # we insert a dataset + resource + resource_history, and "features" contains "repose pieds en velour"
-      %{dataset: dataset_2, resource: resource} =
-        insert_resource_and_friends(Date.utc_today(), features: ["repose pieds en velour"])
-
-      # we insert a more recent resource_history for the same resource, but features is now empty.
-      # This dataset should appear in the results!
-      insert_resource_and_friends(Date.utc_today(), features: nil, dataset: dataset_2, resource: resource)
-
-      %{dataset: _dataset_2} = insert_resource_and_friends(Date.utc_today(), features: nil)
-
-      %{dataset: dataset_3} =
-        insert_resource_and_friends(Date.utc_today(), features: ["repose pieds en velour", "DJ à bord"])
+      %DB.Resource{dataset_id: dataset_2_id} =
+        insert(:resource,
+          counter_cache: %{gtfs_features: ["repose pieds en velour", "DJ à bord"]},
+          dataset: insert(:dataset)
+        )
 
       datasets = %{"features" => ["repose pieds en velour"]} |> DB.Dataset.list_datasets() |> DB.Repo.all()
-      assert datasets |> Enum.map(& &1.id) |> Enum.sort() == [dataset_1.id, dataset_3.id]
+      assert datasets |> Enum.map(& &1.id) |> Enum.sort() == [dataset_1_id, dataset_2_id]
 
       [dataset] = %{"features" => ["DJ à bord"]} |> DB.Dataset.list_datasets() |> DB.Repo.all()
-      assert dataset.id == dataset_3.id
+      assert dataset.id == dataset_2_id
     end
 
     test "with gtfs-rt features" do


### PR DESCRIPTION
Utilise le counter cache introduit dans #4006 pour cacher les features d'un GTFS (accessibilité, tarifs etc.) en plus des modes.