### PR TITLE
Hot-fix du dimanche pour #4598

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -336,7 +336,7 @@ defmodule TransportWeb.API.DatasetController do
   end
 
   def prepare_datasets_index_data do
-    # NOTE: week-end patch ; putting a heavy timeout to temporarily 
+    # NOTE: week-end patch ; putting a heavy timeout to temporarily
     # work-around https://github.com/etalab/transport-site/issues/4598
     # which causes the whole API & backoffice to crash for hours.
     # On the next weekday, this query must be optimized :-)


### PR DESCRIPTION
Voir:
- #4597 
- #4598 

Après des tests en production en SSH connecté au noeud, je vois qu'au minimum cette requête dépasse les délais autorisés.

Elle est appelé normalement par le cache préemptif, toutefois il timeout, et du coup la requête contrôleur doit calculer à son tour la payload, non disponible du fait du premier timeout, donc ça cascade.

À corriger dès demain par quelque chose de plus solide (optimiser la requête ou revoir la façon de procéder complètement).

🚨 je vais me permettre de bypasser la review pour traiter car le problème dure depuis ce matin 8h et ne se règlera a priori pas tout seul, et on verra avec @etalab/transport-tech demain.