### PR TITLE
DatabaseVacuumJob : spécifie un timeout

### DIFF
--- a/apps/transport/lib/jobs/database_vacuum_job.ex
+++ b/apps/transport/lib/jobs/database_vacuum_job.ex
@@ -8,7 +8,7 @@ defmodule Transport.Jobs.DatabaseVacuumJob do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    Ecto.Adapters.SQL.query!(DB.Repo, "VACUUM FULL")
+    Ecto.Adapters.SQL.query!(DB.Repo, "VACUUM FULL", [], timeout: :timer.minutes(5))
     :ok
   end
 end


### PR DESCRIPTION
Ajoute un timeout de 5 minutes au job qui VACUUM 1 fois par semaine. Le timeout par défaut de 15s n'était pas suffisant.

https://github.com/etalab/transport-site/pull/4586 précédemment