### PR TITLE
Espace réutilisateur : supprimer un token

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -128,6 +128,7 @@ defmodule TransportWeb.Router do
       get("/settings", ReuserSpaceController, :settings)
       get("/settings/new_token", ReuserSpaceController, :new_token)
       post("/settings/new_token", ReuserSpaceController, :create_new_token)
+      delete("/settings/tokens/:id", ReuserSpaceController, :delete_token)
 
       live_session :reuser_space, session: %{"role" => :reuser}, root_layout: {TransportWeb.LayoutView, :app} do
         live("/notifications", Live.NotificationsLive, :notifications, as: :reuser_space)

--- a/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
@@ -15,6 +15,7 @@
             <th><%= dgettext("reuser-space", "Organisation") %></th>
             <th><%= dgettext("reuser-space", "Name") %></th>
             <th><%= dgettext("reuser-space", "Secret") %></th>
+            <th><%= dgettext("reuser-space", "Actions") %></th>
           </tr>
         </thead>
         <tbody>
@@ -23,6 +24,13 @@
               <td><%= token.organization.name %></td>
               <td><%= token.name %></td>
               <td><code><%= token.secret %></code></td>
+              <td>
+                <%= form_for @conn, reuser_space_path(@conn, :delete_token, token.id), [method: "delete"], fn _ -> %>
+                  <button class="small button-outline no-border warning">
+                    <i class="fas fa-trash"></i>
+                  </button>
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -222,3 +222,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Your token has been created"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Your token has been deleted"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -222,3 +222,7 @@ msgstr "Vous devez être membre d'une organisation pour créer un nouveau token.
 #, elixir-autogen, elixir-format
 msgid "Your token has been created"
 msgstr "Votre token a bien été créé"
+
+#, elixir-autogen, elixir-format
+msgid "Your token has been deleted"
+msgstr "Votre token a bien été supprimé"

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -222,3 +222,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Your token has been created"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Your token has been deleted"
+msgstr ""


### PR DESCRIPTION
Cette PR ajoute la possibilité de supprimer un token précédemment créé. Il y a le test associé.