### PR TITLE
Tokens : texte de documentation

### DIFF
--- a/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/new_token.html.heex
@@ -6,9 +6,21 @@
     <div class="panel">
       <h2><%= dgettext("reuser-space", "Create a new token") %></h2>
 
-      <p :if={Enum.empty?(@organizations)} class="notification error">
-        <%= dgettext("reuser-space", "You need to be a member of an organisation to create new tokens.") %>
-      </p>
+      <%= if Enum.empty?(@organizations) do %>
+        <p class="notification error">
+          <%= dgettext("reuser-space", "You need to be a member of an organisation to create new tokens.") %>
+        </p>
+
+        <p>
+          <%= raw(
+            dgettext(
+              "reuser-space",
+              ~s|You can create or join an organisation on data.gouv.fr. <a href="%{doc_url}" target="_blank">See the documentation</a>.|,
+              doc_url: "https://guides.data.gouv.fr/guide-data.gouv.fr/organisation"
+            )
+          ) %>
+        </p>
+      <% end %>
 
       <div :if={Enum.count(@errors) > 0} class="notification error">
         <ul>
@@ -31,6 +43,15 @@
               :organization_id,
               Enum.map(@organizations, &{&1.name, &1.id})
             ) %>
+            <p class="small">
+              <%= raw(
+                dgettext(
+                  "reuser-space",
+                  ~s|You can create or join an organisation on data.gouv.fr. <a href="%{doc_url}" target="_blank">See the documentation</a>.|,
+                  doc_url: "https://guides.data.gouv.fr/guide-data.gouv.fr/organisation"
+                )
+              ) %>
+            </p>
           <% end %>
           <%= submit(dgettext("reuser-space", "Create")) %>
         <% end %>

--- a/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
@@ -39,6 +39,16 @@
         <i class="fa fa-plus icon"></i>
         <%= dgettext("reuser-space", "Create a new token") %>
       </a>
+      <h3><%= dgettext("reuser-space", "Using tokens") %></h3>
+      <p>
+        <%= raw(
+          dgettext(
+            "reuser-space",
+            ~s|Tokens can be used when using <a href="%{swagger_url}" target="_blank">the API</a>. The token should be included in the <code>Authorization</code> HTTP header. If your token is <code>foo</code>, you should send HTTP requests with the header <code>Authorization: foo</code>.|,
+            swagger_url: "/swaggerui"
+          )
+        ) %>
+      </p>
     </div>
   </div>
 </section>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuser-space.po
@@ -226,3 +226,15 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your token has been deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Tokens can be used when using <a href=\"%{swagger_url}\" target=\"_blank\">the API</a>. The token should be included in the <code>Authorization</code> HTTP header. If your token is <code>foo</code>, you should send HTTP requests with the header <code>Authorization: foo</code>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Using tokens"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You can create or join an organisation on data.gouv.fr. <a href=\"%{doc_url}\" target=\"_blank\">See the documentation</a>."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuser-space.po
@@ -226,3 +226,15 @@ msgstr "Votre token a bien été créé"
 #, elixir-autogen, elixir-format
 msgid "Your token has been deleted"
 msgstr "Votre token a bien été supprimé"
+
+#, elixir-autogen, elixir-format
+msgid "Tokens can be used when using <a href=\"%{swagger_url}\" target=\"_blank\">the API</a>. The token should be included in the <code>Authorization</code> HTTP header. If your token is <code>foo</code>, you should send HTTP requests with the header <code>Authorization: foo</code>."
+msgstr "Les tokens peuvent être utilisés lors d'appels à <a href=\"%{swagger_url}\" target=\"_blank\">l'API</a>. Le token doit être inclus dans l'en-tête HTTP <code>Authorization</code>. Si votre token est <code>foo</code>, vous devez envoyer des requêtes HTTP avec l'en-tête <code>Authorization: foo</code>."
+
+#, elixir-autogen, elixir-format
+msgid "Using tokens"
+msgstr "Utiliser les tokens"
+
+#, elixir-autogen, elixir-format
+msgid "You can create or join an organisation on data.gouv.fr. <a href=\"%{doc_url}\" target=\"_blank\">See the documentation</a>."
+msgstr "Vous pouvez créer ou rejoindre une organisation sur data.gouv.fr. <a href=\"%{doc_url}\" target=\"_blank\">Voir la documentation</a>."

--- a/apps/transport/priv/gettext/reuser-space.pot
+++ b/apps/transport/priv/gettext/reuser-space.pot
@@ -226,3 +226,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Your token has been deleted"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Tokens can be used when using <a href=\"%{swagger_url}\" target=\"_blank\">the API</a>. The token should be included in the <code>Authorization</code> HTTP header. If your token is <code>foo</code>, you should send HTTP requests with the header <code>Authorization: foo</code>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Using tokens"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "You can create or join an organisation on data.gouv.fr. <a href=\"%{doc_url}\" target=\"_blank\">See the documentation</a>."
+msgstr ""


### PR DESCRIPTION
Ajout de texte pour :
- documenter l'usage lors d'appels à l'API
- documenter qu'il faut créer ou rejoindre une organisation

![image](https://github.com/user-attachments/assets/49e95aca-5c8a-4ee4-a012-9868c10c64d2)
![image](https://github.com/user-attachments/assets/a107b1f1-8241-4de9-9e00-cfa94f25536d)
