### PR TITLE
Tokens : par défaut pour plusieurs contacts

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -45,6 +45,8 @@ defmodule DB.Contact do
     many_to_many(:organizations, DB.Organization, join_through: "contacts_organizations", on_replace: :delete)
     many_to_many(:followed_datasets, DB.Dataset, join_through: "dataset_followers", on_replace: :delete)
     has_many(:user_feedbacks, DB.UserFeedback, on_delete: :nilify_all)
+    # Defined as a `many_to_many` in the database but a contact can only have **1** default token
+    many_to_many(:default_tokens, DB.Token, join_through: "default_token")
   end
 
   def base_query, do: from(c in __MODULE__, as: :contact)

--- a/apps/transport/lib/db/default_token.ex
+++ b/apps/transport/lib/db/default_token.ex
@@ -1,0 +1,26 @@
+defmodule DB.DefaultToken do
+  @moduledoc """
+  Represents a default token for a contact.
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  typed_schema "default_token" do
+    belongs_to(:contact, DB.Contact)
+    belongs_to(:token, DB.Token)
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def base_query, do: from(df in __MODULE__, as: :default_token)
+
+  def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, [:contact_id, :token_id])
+    |> validate_required([:contact_id, :token_id])
+    |> assoc_constraint(:token)
+    |> assoc_constraint(:contact)
+    |> unique_constraint([:contact_id])
+  end
+end

--- a/apps/transport/lib/db/token.ex
+++ b/apps/transport/lib/db/token.ex
@@ -17,7 +17,7 @@ defmodule DB.Token do
     field(:secret_hash, Cloak.Ecto.SHA256)
     belongs_to(:contact, DB.Contact)
     belongs_to(:organization, DB.Organization, type: :string)
-    belongs_to(:default_for_contact, DB.Contact)
+    many_to_many(:default_for_contacts, DB.Contact, join_through: "default_token")
     timestamps(type: :utc_datetime_usec)
   end
 

--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -37,19 +37,16 @@ defmodule TransportWeb.ReuserSpaceController do
     |> redirect(to: reuser_space_path(conn, :settings))
   end
 
-  def default_token(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn, %{"id" => token_id}) do
-    tokens = DB.Repo.preload(contact, :organizations) |> tokens()
+  def default_token(%Plug.Conn{assigns: %{contact: %DB.Contact{id: contact_id} = contact}} = conn, %{"id" => token_id}) do
+    DB.DefaultToken.base_query()
+    |> where([default_token: df], df.contact_id == ^contact_id)
+    |> DB.Repo.delete_all()
 
-    case Enum.find(tokens, &(&1.default_for_contact_id == contact.id)) do
-      %DB.Token{} = token -> token |> Ecto.Changeset.change(%{default_for_contact_id: nil}) |> DB.Repo.update!()
-      nil -> :ok
-    end
+    token = contact |> tokens() |> Enum.find(&(to_string(&1.id) == token_id))
 
-    token = tokens |> Enum.find(&(to_string(&1.id) == token_id))
-
-    token
-    |> Ecto.Changeset.change(%{default_for_contact_id: contact.id})
-    |> DB.Repo.update!()
+    %DB.DefaultToken{}
+    |> DB.DefaultToken.changeset(%{token_id: token.id, contact_id: contact_id})
+    |> DB.Repo.insert!()
 
     conn
     |> put_flash(:info, dgettext("reuser-space", "The token %{name} is now the default token", name: token.name))
@@ -91,7 +88,9 @@ defmodule TransportWeb.ReuserSpaceController do
   defp maybe_default_token(%DB.Contact{} = contact) do
     case tokens(contact) do
       [t1] ->
-        t1 |> Ecto.Changeset.change(%{default_for_contact_id: contact.id}) |> DB.Repo.update!()
+        %DB.DefaultToken{}
+        |> DB.DefaultToken.changeset(%{token_id: t1.id, contact_id: contact.id})
+        |> DB.Repo.insert!()
 
       _ ->
         :ok
@@ -198,7 +197,7 @@ defmodule TransportWeb.ReuserSpaceController do
     contact =
       DB.Contact
       |> DB.Repo.get_by!(datagouv_user_id: datagouv_user_id)
-      |> DB.Repo.preload(:organizations)
+      |> DB.Repo.preload([:organizations, :default_tokens])
 
     conn |> assign(:contact, contact)
   end

--- a/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/settings.html.heex
@@ -19,7 +19,7 @@
           </tr>
         </thead>
         <tbody>
-          <%= for token <- @tokens |> Enum.sort_by(& {&1.organization.name, &1.name}) |> Enum.sort_by(& &1.default_for_contact_id != @contact.id) do %>
+          <%= for token <- @tokens |> Enum.sort_by(& {&1.organization.name, &1.name}) |> Enum.sort_by(& default_for_contact?(&1, @contact), :desc) do %>
             <tr>
               <td><%= token.organization.name %></td>
               <td :if={default_for_contact?(token, @contact)}>

--- a/apps/transport/lib/transport_web/views/reuser_space_view.ex
+++ b/apps/transport/lib/transport_web/views/reuser_space_view.ex
@@ -2,9 +2,11 @@ defmodule TransportWeb.ReuserSpaceView do
   use TransportWeb, :view
   import TransportWeb.BreadCrumbs, only: [breadcrumbs: 1]
 
-  def default_for_contact?(%DB.Token{default_for_contact_id: default_for_contact_id}, %DB.Contact{id: contact_id}) do
-    default_for_contact_id == contact_id
+  def default_for_contact?(%DB.Token{id: token_id}, %DB.Contact{default_tokens: [%DB.Token{id: id}]}) do
+    token_id == id
   end
+
+  def default_for_contact?(%DB.Token{}, %DB.Contact{default_tokens: _}), do: false
 
   def eligible_for_tokens?(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn) do
     eligible_org_ids = [

--- a/apps/transport/priv/repo/migrations/20250603104959_default_token.exs
+++ b/apps/transport/priv/repo/migrations/20250603104959_default_token.exs
@@ -1,0 +1,17 @@
+defmodule DB.Repo.Migrations.DefaultToken do
+  use Ecto.Migration
+
+  def change do
+    alter table(:token) do
+      remove(:default_for_contact_id)
+    end
+
+    create table(:default_token) do
+      add(:contact_id, references(:contact, on_delete: :delete_all), null: false)
+      add(:token_id, references(:token, on_delete: :delete_all), null: false)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:default_token, [:contact_id]))
+  end
+end

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -315,6 +315,10 @@ defmodule DB.Factory do
     %DB.ResourceRelated{}
   end
 
+  def default_token_factory do
+    %DB.DefaultToken{}
+  end
+
   def reuser_improved_data_factory do
     dataset = build(:dataset)
 

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -253,9 +253,10 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
         insert_token(%{
           organization_id: organization.id,
           contact_id: contact.id,
-          name: "Default",
-          default_for_contact_id: contact.id
+          name: "Default"
         })
+
+      insert(:default_token, token: token, contact: contact)
 
       organization_name = organization.name
       token_name = "#{token.name} (par défaut)"
@@ -340,13 +341,15 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
 
       assert [
                %DB.Token{
+                 id: token_id,
                  contact_id: ^contact_id,
                  organization_id: ^organization_id,
-                 name: ^name,
-                 default_for_contact_id: ^contact_id
+                 name: ^name
                }
              ] =
                DB.Repo.all(DB.Token)
+
+      assert [%DB.Token{id: ^token_id}] = DB.Repo.preload(contact, :default_tokens) |> Map.fetch!(:default_tokens)
     end
 
     test "creating a new token, with an error", %{conn: conn} do
@@ -401,7 +404,8 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
           organizations: [organization |> Map.from_struct()]
         })
 
-      insert_token(%{contact_id: contact_id, organization_id: organization_id, default_for_contact_id: contact_id})
+      token = insert_token(%{contact_id: contact_id, organization_id: organization_id})
+      insert(:default_token, token: token, contact: contact)
 
       conn =
         conn
@@ -412,15 +416,16 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Votre token a bien été créé"
 
       assert [
-               %DB.Token{default_for_contact_id: ^contact_id},
+               %DB.Token{id: t1_id},
                %DB.Token{
                  contact_id: ^contact_id,
                  organization_id: ^organization_id,
-                 name: ^name,
-                 default_for_contact_id: nil
+                 name: ^name
                }
              ] =
-               DB.Token |> DB.Repo.all() |> Enum.sort_by(& &1.inserted_at)
+               DB.Token |> DB.Repo.all() |> Enum.sort_by(& &1.inserted_at, DateTime)
+
+      assert [%DB.Token{id: ^t1_id}] = DB.Repo.preload(contact, :default_tokens) |> Map.fetch!(:default_tokens)
     end
   end
 
@@ -456,15 +461,19 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
         organizations: [organization |> Map.from_struct()]
       })
 
+    %DB.Contact{id: c2_id} = c2 = insert_contact()
+
     t1 =
       insert_token(%{
         contact_id: contact.id,
         organization_id: organization.id,
-        name: "t1",
-        default_for_contact_id: contact.id
+        name: "t1"
       })
 
-    t2 = insert_token(%{contact_id: contact.id, organization_id: organization.id, name: "t2"})
+    insert(:default_token, token: t1, contact: contact)
+
+    %DB.Token{id: t2_id} = t2 = insert_token(%{contact_id: contact.id, organization_id: organization.id, name: "t2"})
+    insert(:default_token, token: t2, contact: c2)
 
     conn =
       conn
@@ -474,8 +483,26 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
     assert redirected_to(conn, 302) == reuser_space_path(conn, :settings)
     assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Le token t2 est maintenant le token par défaut"
 
-    assert %DB.Token{default_for_contact_id: nil} = t1 |> DB.Repo.reload!()
-    assert %DB.Token{default_for_contact_id: ^contact_id} = t2 |> DB.Repo.reload!()
+    assert [] = DB.Repo.preload(t1, :default_for_contacts) |> Map.fetch!(:default_for_contacts)
+
+    assert [%DB.Contact{id: ^contact_id}, %DB.Contact{id: ^c2_id}] =
+             DB.Repo.preload(t2, :default_for_contacts)
+             |> Map.fetch!(:default_for_contacts)
+             |> Enum.sort_by(& &1.inserted_at, DateTime)
+
+    assert [%DB.Token{id: ^t2_id}] = DB.Repo.preload(contact, :default_tokens) |> Map.fetch!(:default_tokens)
+  end
+
+  test "contact can only have 1 default_token" do
+    contact = insert_contact()
+    t1 = insert_token()
+    t2 = insert_token()
+
+    insert(:default_token, contact: contact, token: t1)
+
+    assert_raise Ecto.ConstraintError, ~r/default_token_contact_id_index/, fn ->
+      insert(:default_token, contact: contact, token: t2)
+    end
   end
 
   def index_href_attributes(%Plug.Conn{} = conn) do


### PR DESCRIPTION
Retravaille #4611 : un token peut être par défaut pour **plusieurs contacts**. Introduit une table `default_token` pour gérer ce cas. Définit les associations nécessaires et met à jour les tests.