### PR TITLE
DefaultTokensJob : crée un token par défaut pour les contacts

### DIFF
--- a/apps/transport/lib/jobs/default_tokens_job.ex
+++ b/apps/transport/lib/jobs/default_tokens_job.ex
@@ -1,0 +1,58 @@
+defmodule Transport.Jobs.DefaultTokensJob do
+  @moduledoc """
+  This job is in charge of creating a default token for relevant contacts.
+
+  A default token is created for all members of an organization
+  if the organization has a single token and the contact
+  doesn't have a default token already.
+  """
+
+  use Oban.Worker, max_attempts: 3
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"contact_id" => contact_id, "organization_id" => organization_id}}) do
+    contact = DB.Repo.get!(DB.Contact, contact_id) |> DB.Repo.preload(:default_tokens)
+
+    if contact.default_tokens |> Enum.count() == 1 do
+      {:cancel, "Contact##{contact_id} already has a default token"}
+    else
+      token = DB.Repo.get_by!(DB.Token, organization_id: organization_id)
+
+      %DB.DefaultToken{}
+      |> DB.DefaultToken.changeset(%{token_id: token.id, contact_id: contact.id})
+      |> DB.Repo.insert!()
+
+      :ok
+    end
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    query = """
+    select
+      c.id contact_id,
+      co.organization_id
+    from contact c
+    join contacts_organizations co on co.contact_id = c.id
+    where
+      co.organization_id in (
+        select t.organization_id
+        from token t
+        group by 1
+        having count(1) = 1
+      )
+     and c.id not in (select contact_id from default_token)
+    """
+
+    %Postgrex.Result{columns: columns, rows: rows} = Ecto.Adapters.SQL.query!(DB.Repo, query)
+
+    rows
+    |> Enum.map(fn row ->
+      args = columns |> Enum.zip(row) |> Map.new()
+      __MODULE__.new(args)
+    end)
+    |> Oban.insert_all()
+
+    :ok
+  end
+end

--- a/apps/transport/test/transport/jobs/default_token_job_test.exs
+++ b/apps/transport/test/transport/jobs/default_token_job_test.exs
@@ -1,0 +1,79 @@
+defmodule Transport.Test.Transport.Jobs.DefaultTokensJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.DefaultTokensJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "enqueues jobs" do
+    %DB.Organization{id: organization_id} = organization = insert(:organization)
+    o2 = insert(:organization)
+
+    %DB.Contact{id: c1_id} =
+      insert_contact(%{
+        organizations: [organization |> Map.from_struct()]
+      })
+
+    c2 =
+      insert_contact(%{
+        organizations: [o2 |> Map.from_struct()]
+      })
+
+    insert_token(%{organization_id: organization.id})
+
+    # 2 tokens for the same org, should not be enqueued
+    t2 = insert_token()
+    insert_token(%{organization_id: t2.organization_id, name: "other"})
+
+    # c2 already has a default token
+    t4 = insert_token(%{organization_id: o2.id})
+    insert(:default_token, %{token: t4, contact: c2})
+
+    assert :ok == perform_job(DefaultTokensJob, %{})
+
+    assert [
+             %Oban.Job{
+               state: "available",
+               worker: "Transport.Jobs.DefaultTokensJob",
+               args: %{"contact_id" => ^c1_id, "organization_id" => ^organization_id}
+             }
+           ] = all_enqueued()
+  end
+
+  describe "perform" do
+    test "creates a default token" do
+      organization = insert(:organization)
+
+      contact =
+        insert_contact(%{
+          organizations: [organization |> Map.from_struct()]
+        })
+
+      %DB.Token{id: t1_id} = insert_token(%{organization_id: organization.id})
+
+      assert :ok == perform_job(DefaultTokensJob, %{contact_id: contact.id, organization_id: organization.id})
+
+      assert [%DB.Token{id: ^t1_id}] = DB.Repo.preload(contact, :default_tokens).default_tokens
+    end
+
+    test "does not create a default token if the contact already has one" do
+      organization = insert(:organization)
+
+      contact =
+        insert_contact(%{
+          organizations: [organization |> Map.from_struct()]
+        })
+
+      %DB.Token{id: token_id} = token = insert_token(%{organization_id: organization.id})
+      insert(:default_token, %{token: token, contact: contact})
+
+      assert {:cancel, "Contact##{contact.id} already has a default token"} ==
+               perform_job(DefaultTokensJob, %{contact_id: contact.id, organization_id: organization.id})
+
+      assert [%DB.Token{id: ^token_id}] = DB.Repo.preload(contact, :default_tokens).default_tokens
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -165,7 +165,8 @@ oban_prod_crontab = [
   {"45 5 * * *", Transport.Jobs.ImportResourceMonthlyMetricsJob},
   {"0 8 * * *", Transport.Jobs.WarnUserInactivityJob},
   {"*/5 * * * *", Transport.Jobs.UpdateCounterCacheJob},
-  {"0 4 * * *", Transport.Jobs.StopsRegistrySnapshotJob}
+  {"0 4 * * *", Transport.Jobs.StopsRegistrySnapshotJob},
+  {"10 * * * *", Transport.Jobs.DefaultTokensJob}
 ]
 
 # Make sure that all modules exist


### PR DESCRIPTION
Suite de #4618 qui introduit le concept de "token par défaut". Cette PR ajoute un job en charge de mettre un token par défaut pour des contacts.

Ceci est fait automatiquement, toutes les heures, quand :
- une organisation a 1 seul token
- le contact n'a pas déjà un token par défaut

## Exemple

c1 et c2 sont membres d'une organisation. c1 crée un token t1, lié à l'organisation. c1 a t1 pour token par défaut. Grâce à ce job, au plus tard 1h après, c2 aura t1 comme token par défaut.

Le but est que les contacts aient un token par défaut, qui peut toujours être redéfini dans l'Espace Réutilisateur.