### PR TITLE
Téléchargement avec URLs authentifiées pour ressources PAN

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -201,6 +201,23 @@ defmodule DB.Resource do
     uri.scheme == "https" and uri.host != "raw.githubusercontent.com"
   end
 
+  @doc """
+  Is the resource published by the National Access Point?
+
+  iex> pan_resource?(%DB.Resource{dataset: %DB.Dataset{organization_id: "5abca8d588ee386ee6ece479"}})
+  true
+  iex> pan_resource?(%DB.Resource{dataset: %DB.Dataset{organization_id: "other"}})
+  false
+  iex> pan_resource?(%DB.Resource{format: "gbfs"})
+  false
+  """
+  @spec pan_resource?(__MODULE__.t()) :: boolean()
+  def pan_resource?(%__MODULE__{dataset: %DB.Dataset{organization_id: organization_id}}) do
+    organization_id == Application.fetch_env!(:transport, :datagouvfr_transport_publisher_id)
+  end
+
+  def pan_resource?(%__MODULE__{}), do: false
+
   @spec other_resources_query(__MODULE__.t()) :: Ecto.Query.t()
   def other_resources_query(%__MODULE__{} = resource),
     do:

--- a/apps/transport/lib/db/resource_download.ex
+++ b/apps/transport/lib/db/resource_download.ex
@@ -1,0 +1,15 @@
+defmodule DB.ResourceDownload do
+  @moduledoc """
+  Represents a resource download.
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  @primary_key false
+
+  typed_schema "resource_download" do
+    field(:time, :utc_datetime_usec)
+    belongs_to(:token, DB.Token)
+    belongs_to(:resource, DB.Resource)
+  end
+end

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -271,7 +271,7 @@ defmodule TransportWeb.ResourceController do
   end
 
   defp download_pan_resource(%Plug.Conn{} = conn, %DB.Resource{} = resource) do
-    case find_client(Map.get(conn.query_params, "token")) do
+    case find_token(Map.get(conn.query_params, "token")) do
       {:ok, token} ->
         log_download_request(resource, token)
         redirect(conn, external: resource.latest_url)
@@ -297,9 +297,9 @@ defmodule TransportWeb.ResourceController do
     |> DB.Repo.insert!()
   end
 
-  defp find_client(nil), do: {:ok, nil}
+  defp find_token(nil), do: {:ok, nil}
 
-  defp find_client(secret_hash) do
+  defp find_token(secret_hash) do
     case DB.Repo.get_by(DB.Token, secret_hash: secret_hash) do
       %DB.Token{} = token -> {:ok, token}
       nil -> :error

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -221,11 +221,11 @@ defmodule TransportWeb.ResourceController do
     resource = DB.Resource |> DB.Repo.get!(id) |> DB.Repo.preload(:dataset)
 
     cond do
-      DB.Resource.can_direct_download?(resource) ->
-        conn |> Plug.Conn.send_resp(:not_found, "")
-
       DB.Resource.pan_resource?(resource) ->
         conn |> Plug.Conn.send_resp(:ok, "")
+
+      DB.Resource.can_direct_download?(resource) ->
+        conn |> Plug.Conn.send_resp(:not_found, "")
 
       true ->
         case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do
@@ -242,11 +242,11 @@ defmodule TransportWeb.ResourceController do
     resource = DB.Resource |> DB.Repo.get!(id) |> DB.Repo.preload(:dataset)
 
     cond do
-      DB.Resource.can_direct_download?(resource) ->
-        redirect(conn, external: resource.url)
-
       DB.Resource.pan_resource?(resource) ->
         download_pan_resource(conn, resource)
+
+      DB.Resource.can_direct_download?(resource) ->
+        redirect(conn, external: resource.url)
 
       true ->
         case Transport.Shared.Wrapper.HTTPoison.impl().get(resource.url, [], hackney: [follow_redirect: true]) do

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -218,47 +218,91 @@ defmodule TransportWeb.ResourceController do
   they are referenced on an HTTPS page.
   """
   def download(%Plug.Conn{assigns: %{original_method: "HEAD"}} = conn, %{"id" => id}) do
-    resource = Resource |> Repo.get!(id)
+    resource = DB.Resource |> DB.Repo.get!(id) |> DB.Repo.preload(:dataset)
 
-    if Resource.can_direct_download?(resource) do
-      # should not happen
-      # if direct download is possible, we don't expect the function `download` to be called
-      conn |> Plug.Conn.send_resp(:not_found, "")
-    else
-      case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do
-        {:ok, %HTTPoison.Response{status_code: status_code, headers: headers}} ->
-          send_head_response(conn, status_code, headers)
+    cond do
+      DB.Resource.can_direct_download?(resource) ->
+        conn |> Plug.Conn.send_resp(:not_found, "")
 
-        _ ->
-          conn |> Plug.Conn.send_resp(:bad_gateway, "")
-      end
+      DB.Resource.pan_resource?(resource) ->
+        conn |> Plug.Conn.send_resp(:ok, "")
+
+      true ->
+        case Transport.Shared.Wrapper.HTTPoison.impl().head(resource.url, []) do
+          {:ok, %HTTPoison.Response{status_code: status_code, headers: headers}} ->
+            send_head_response(conn, status_code, headers)
+
+          _ ->
+            conn |> Plug.Conn.send_resp(:bad_gateway, "")
+        end
     end
   end
 
-  def download(conn, %{"id" => id}) do
-    resource = Resource |> Repo.get!(id)
+  def download(%Plug.Conn{method: "GET"} = conn, %{"id" => id}) do
+    resource = DB.Resource |> DB.Repo.get!(id) |> DB.Repo.preload(:dataset)
 
-    if Resource.can_direct_download?(resource) do
-      redirect(conn, external: resource.url)
-    else
-      case Transport.Shared.Wrapper.HTTPoison.impl().get(resource.url, [], hackney: [follow_redirect: true]) do
-        {:ok, %HTTPoison.Response{status_code: 200} = response} ->
-          headers = Enum.into(response.headers, %{}, &downcase_header(&1))
-          %{"content-type" => content_type} = headers
+    cond do
+      DB.Resource.can_direct_download?(resource) ->
+        redirect(conn, external: resource.url)
 
-          send_download(conn, {:binary, response.body},
-            content_type: content_type,
-            disposition: :attachment,
-            filename: Transport.FileDownloads.guess_filename(headers, resource.url)
-          )
+      DB.Resource.pan_resource?(resource) ->
+        download_pan_resource(conn, resource)
 
-        _ ->
-          conn
-          |> put_flash(:error, dgettext("resource", "Resource is not available on remote server"))
-          |> put_status(:not_found)
-          |> put_view(ErrorView)
-          |> render("404.html")
+      true ->
+        case Transport.Shared.Wrapper.HTTPoison.impl().get(resource.url, [], hackney: [follow_redirect: true]) do
+          {:ok, %HTTPoison.Response{status_code: 200} = response} ->
+            headers = Enum.into(response.headers, %{}, &downcase_header(&1))
+            %{"content-type" => content_type} = headers
+
+            send_download(conn, {:binary, response.body},
+              content_type: content_type,
+              disposition: :attachment,
+              filename: Transport.FileDownloads.guess_filename(headers, resource.url)
+            )
+
+          _ ->
+            conn
+            |> put_flash(:error, dgettext("resource", "Resource is not available on remote server"))
+            |> put_status(:not_found)
+            |> put_view(ErrorView)
+            |> render("404.html")
+        end
+    end
+  end
+
+  defp download_pan_resource(%Plug.Conn{} = conn, %DB.Resource{} = resource) do
+    case find_client(Map.get(conn.query_params, "token")) do
+      {:ok, token} ->
+        log_download_request(resource, token)
+        redirect(conn, external: resource.latest_url)
+
+      :error ->
+        conn |> Plug.Conn.send_resp(:unauthorized, "You must set a valid Authorization header")
+    end
+  end
+
+  defp log_download_request(%DB.Resource{id: resource_id}, token) do
+    token_id =
+      case token do
+        %DB.Token{id: token_id} -> token_id
+        nil -> nil
       end
+
+    %DB.ResourceDownload{}
+    |> Ecto.Changeset.change(%{
+      time: DateTime.utc_now(),
+      resource_id: resource_id,
+      token_id: token_id
+    })
+    |> DB.Repo.insert!()
+  end
+
+  defp find_client(nil), do: {:ok, nil}
+
+  defp find_client(secret_hash) do
+    case DB.Repo.get_by(DB.Token, secret_hash: secret_hash) do
+      %DB.Token{} = token -> {:ok, token}
+      nil -> :error
     end
   end
 

--- a/apps/transport/priv/repo/migrations/20250604082439_resource_download.exs
+++ b/apps/transport/priv/repo/migrations/20250604082439_resource_download.exs
@@ -1,0 +1,31 @@
+defmodule DB.Repo.Migrations.ResourceDownload do
+  use Ecto.Migration
+  import Timescale.Migration
+
+  def change do
+    create table(:resource_download, primary_key: false) do
+      add(:time, :utc_datetime_usec, null: false)
+      add(:token_id, references(:token, on_delete: :delete_all))
+      add(:resource_id, references(:resource, on_delete: :nothing))
+    end
+
+    timescaledb_available = Enum.member?(postgresql_extensions(), "timescaledb")
+
+    if direction() == :up and timescaledb_available do
+      create_timescaledb_extension()
+      create_hypertable(:resource_download, :time)
+    end
+
+    if System.get_env("CI") == "true" and not timescaledb_available do
+      raise "TimescaleDB should be available in CI"
+    end
+
+    create_if_not_exists(index(:resource_download, [:token_id]))
+    create_if_not_exists(index(:resource_download, [:resource_id]))
+  end
+
+  def postgresql_extensions do
+    %Postgrex.Result{rows: rows} = Ecto.Adapters.SQL.query!(DB.Repo, "SELECT extname FROM pg_extension")
+    List.flatten(rows)
+  end
+end

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -8,6 +8,7 @@ defmodule TransportWeb.ResourceControllerTest do
   setup :verify_on_exit!
 
   @service_alerts_file "#{__DIR__}/../../fixture/files/bibus-brest-gtfs-rt-alerts.pb"
+  @pan_org_id "5abca8d588ee386ee6ece479"
 
   setup do
     Mox.stub_with(Transport.DataVisualization.Mock, Transport.DataVisualization.Impl)
@@ -296,6 +297,55 @@ defmodule TransportWeb.ResourceControllerTest do
     for status_code <- [500, 502] do
       test_remote_download_error(conn, status_code)
     end
+  end
+
+  test "HEAD request for a PAN resource", %{conn: conn} do
+    dataset = insert(:dataset, organization_id: @pan_org_id)
+    resource = insert(:resource, dataset: dataset)
+
+    assert conn |> head(resource_path(conn, :download, resource.id)) |> response(200)
+  end
+
+  test "download a PAN resource, invalid token", %{conn: conn} do
+    dataset = insert(:dataset, organization_id: @pan_org_id)
+    resource = insert(:resource, dataset: dataset)
+
+    assert "You must set a valid Authorization header" ==
+             conn
+             |> get(resource_path(conn, :download, resource.id, token: "invalid"))
+             |> response(401)
+
+    assert [] = DB.ResourceDownload |> DB.Repo.all()
+  end
+
+  test "download a PAN resource, no token", %{conn: conn} do
+    dataset = insert(:dataset, organization_id: @pan_org_id)
+
+    %DB.Resource{id: resource_id} =
+      resource = insert(:resource, dataset: dataset, latest_url: latest_url = "https://example.com/latest_url")
+
+    assert latest_url ==
+             conn
+             |> get(resource_path(conn, :download, resource.id))
+             |> redirected_to(302)
+
+    assert [%DB.ResourceDownload{token_id: nil, resource_id: ^resource_id}] = DB.ResourceDownload |> DB.Repo.all()
+  end
+
+  test "download a PAN resource, valid token", %{conn: conn} do
+    dataset = insert(:dataset, organization_id: @pan_org_id)
+
+    %DB.Resource{id: resource_id} =
+      resource = insert(:resource, dataset: dataset, latest_url: latest_url = "https://example.com/latest_url")
+
+    %DB.Token{id: token_id} = token = insert_token()
+
+    assert latest_url ==
+             conn
+             |> get(resource_path(conn, :download, resource.id, token: token.secret))
+             |> redirected_to(302)
+
+    assert [%DB.ResourceDownload{token_id: ^token_id, resource_id: ^resource_id}] = DB.ResourceDownload |> DB.Repo.all()
   end
 
   test "flash message when parent dataset is inactive", %{conn: conn} do


### PR DESCRIPTION
Cette PR :
- ajoute une table pour stocker des informations sur le téléchargement des ressources
- crée des URLs de téléchargement pour les ressources du PAN `/resources/:id/download?token=xxxxx`
- teste les fonctionnalités ajoutées

Les URLs ne sont pas modifiées dans l'interface/API pour le moment.