### PR TITLE
Suppression token : gère 500

### DIFF
--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -86,10 +86,16 @@ defmodule TransportWeb.ReuserSpaceController do
   end
 
   defp maybe_default_token(%DB.Contact{} = contact) do
-    case tokens(contact) do
-      [t1] ->
+    default_token_id =
+      case contact.default_tokens do
+        [%DB.Token{id: t_id}] -> t_id
+        _ -> nil
+      end
+
+    case contact |> tokens() do
+      [%DB.Token{id: token_id}] when token_id != default_token_id and is_nil(default_token_id) ->
         %DB.DefaultToken{}
-        |> DB.DefaultToken.changeset(%{token_id: t1.id, contact_id: contact.id})
+        |> DB.DefaultToken.changeset(%{token_id: token_id, contact_id: contact.id})
         |> DB.Repo.insert!()
 
       _ ->

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -438,17 +438,20 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
         organizations: [organization |> Map.from_struct()]
       })
 
-    token = insert_token(%{contact_id: contact.id, organization_id: organization.id})
+    t1 = insert_token(%{contact_id: contact.id, organization_id: organization.id, name: "t1"})
+    insert(:default_token, token: t1, contact: contact)
+
+    t2 = insert_token(%{contact_id: contact.id, organization_id: organization.id, name: "t2"})
 
     conn =
       conn
       |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
-      |> delete(reuser_space_path(conn, :delete_token, token.id))
+      |> delete(reuser_space_path(conn, :delete_token, t2.id))
 
     assert redirected_to(conn, 302) == reuser_space_path(conn, :settings)
     assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Votre token a bien été supprimé"
 
-    assert token |> DB.Repo.reload() |> is_nil()
+    assert t2 |> DB.Repo.reload() |> is_nil()
   end
 
   test "default_token", %{conn: conn} do


### PR DESCRIPTION
Répare une erreur 500, [voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/6659069923/). 🐛 

Survenait dans la situation suivantes : 2 tokens, t1 et t2, tels que t1 est le token par défaut pour l'utilisateur. On supprime t2. Le code d'avant tentait de remettre t1 en tant que token par défaut alors qu'il l'était déjà.