### PR TITLE
CreateTokensJob : crée un token pour chaque organisation

### DIFF
--- a/apps/transport/lib/db/organization.ex
+++ b/apps/transport/lib/db/organization.ex
@@ -21,6 +21,7 @@ defmodule DB.Organization do
 
     many_to_many(:contacts, DB.Contact, join_through: "contacts_organizations", on_replace: :delete)
     has_many(:datasets, DB.Dataset)
+    has_many(:tokens, DB.Token)
   end
 
   def base_query, do: from(o in __MODULE__, as: :organization)

--- a/apps/transport/lib/jobs/create_tokens_job.ex
+++ b/apps/transport/lib/jobs/create_tokens_job.ex
@@ -1,0 +1,54 @@
+defmodule Transport.Jobs.CreateTokensJob do
+  @moduledoc """
+  This job is in charge of creating a default token for each
+  organization without a token.
+
+  The created token is then set as the default token for all
+  members of this organization.
+  """
+  use Oban.Worker, max_attempts: 3, tags: ["tokens"]
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"organization_id" => organization_id}}) do
+    contact = DB.Repo.get_by!(DB.Contact, email_hash: Application.fetch_env!(:transport, :contact_email))
+
+    organization =
+      DB.Organization
+      |> DB.Repo.get!(organization_id)
+      |> DB.Repo.preload(contacts: [:default_tokens])
+
+    token =
+      DB.Token.changeset(%DB.Token{}, %{
+        "contact_id" => contact.id,
+        "organization_id" => organization.id,
+        "name" => "Défaut"
+      })
+      |> DB.Repo.insert!()
+
+    organization.contacts
+    |> Enum.filter(fn %DB.Contact{default_tokens: default_tokens} -> default_tokens == [] end)
+    |> Enum.each(fn %DB.Contact{} = contact ->
+      %DB.DefaultToken{}
+      |> DB.DefaultToken.changeset(%{token_id: token.id, contact_id: contact.id})
+      |> DB.Repo.insert!()
+    end)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    token_org_ids =
+      DB.Token.base_query()
+      |> select([token: t], t.organization_id)
+      |> distinct(true)
+
+    DB.Organization.base_query()
+    |> where([organization: o], o.id not in subquery(token_org_ids))
+    |> select([organization: o], %{organization_id: o.id})
+    |> DB.Repo.all()
+    |> Enum.map(&__MODULE__.new/1)
+    |> Oban.insert_all()
+
+    :ok
+  end
+end

--- a/apps/transport/lib/jobs/default_tokens_job.ex
+++ b/apps/transport/lib/jobs/default_tokens_job.ex
@@ -6,7 +6,7 @@ defmodule Transport.Jobs.DefaultTokensJob do
   if the organization has a single token and the contact
   doesn't have a default token already.
   """
-  use Oban.Worker, max_attempts: 3
+  use Oban.Worker, max_attempts: 3, tags: ["tokens"]
   import Ecto.Query
 
   @impl Oban.Worker

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -374,14 +374,19 @@ defmodule DB.Factory do
       %{
         secret: "secret",
         name: "name",
-        contact_id: insert_contact().id,
-        organization_id: insert(:organization).id
+        contact_id: insert_contact().id
       }
       |> Map.merge(args)
 
-    DB.Token.changeset(%DB.Token{}, args)
-    |> Ecto.Changeset.change(Map.take(args, [:default_for_contact_id]))
-    |> DB.Repo.insert!()
+    # Insert an organization only if `organization_id` was not passed
+    args =
+      if Map.has_key?(args, :organization_id) do
+        args
+      else
+        Map.merge(args, %{organization_id: insert(:organization).id})
+      end
+
+    DB.Token.changeset(%DB.Token{}, args) |> DB.Repo.insert!()
   end
 
   def insert_contact(%{} = args \\ %{}) do

--- a/apps/transport/test/transport/jobs/create_tokens_job_test.exs
+++ b/apps/transport/test/transport/jobs/create_tokens_job_test.exs
@@ -1,0 +1,61 @@
+defmodule Transport.Test.Transport.Jobs.CreateTokensJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.CreateTokensJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "enqueues jobs" do
+    o1 = insert(:organization)
+    %DB.Organization{id: o2_id} = o2 = insert(:organization)
+    insert_token(%{organization_id: o1.id})
+
+    refute DB.Repo.preload(o1, :tokens).tokens |> Enum.empty?()
+    assert DB.Repo.preload(o2, :tokens).tokens |> Enum.empty?()
+
+    assert :ok == perform_job(CreateTokensJob, %{})
+
+    assert [
+             %Oban.Job{
+               state: "available",
+               worker: "Transport.Jobs.CreateTokensJob",
+               args: %{"organization_id" => ^o2_id}
+             }
+           ] = all_enqueued()
+  end
+
+  test "creates a default token for an organization" do
+    %DB.Contact{id: pan_contact_id} = insert_contact(%{email: "contact@transport.data.gouv.fr"})
+    %DB.Organization{id: organization_id} = organization = insert(:organization)
+    c1 = insert_contact(%{organizations: [organization |> Map.from_struct()]})
+    c2 = insert_contact(%{organizations: [organization |> Map.from_struct()]})
+
+    # `c3` already has a default token, we should not try to create
+    # a new one even if they are a member of `organization`.
+    o2 = insert(:organization)
+
+    c3 =
+      insert_contact(%{
+        organizations: [
+          organization |> Map.from_struct(),
+          o2 |> Map.from_struct()
+        ]
+      })
+
+    token = insert_token(%{organization_id: o2.id, contact_id: c3.id})
+    insert(:default_token, %{token: token, contact: c3})
+
+    assert DB.Repo.preload(organization, :tokens).tokens |> Enum.empty?()
+
+    assert :ok == perform_job(CreateTokensJob, %{organization_id: organization.id})
+
+    assert [%DB.Token{id: token_id, organization_id: ^organization_id, contact_id: ^pan_contact_id, name: "Défaut"}] =
+             DB.Repo.preload(organization, :tokens).tokens
+
+    assert [%DB.Token{id: ^token_id}] = DB.Repo.preload(c1, :default_tokens).default_tokens
+    assert [%DB.Token{id: ^token_id}] = DB.Repo.preload(c2, :default_tokens).default_tokens
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -151,6 +151,7 @@ oban_prod_crontab = [
   {"45 2 * * *", Transport.Jobs.RemoveHistoryJob, args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}},
   {"0 16 * * *", Transport.Jobs.DatasetQualityScoreDispatcher},
   {"40 3 * * *", Transport.Jobs.UpdateContactsJob},
+  {"50 3 * * *", Transport.Jobs.CreateTokensJob},
   {"10 5 * * *", Transport.Jobs.NotificationSubscriptionProducerJob},
   # "At 08:15 on Monday in March, June, and November.""
   # The job will make sure that it's executed only on the first Monday of these months


### PR DESCRIPTION
Ajoute un job en charge de créer un token `"Défaut"` pour toutes les organisations présentes sur notre plateforme. Ce token est ensuite mis en tant que token par défaut pour les membres de cette organisation.