### PR TITLE
Recherche par format, exclut nil

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -392,6 +392,7 @@ defmodule TransportWeb.DatasetController do
       |> clean_datasets_query("format")
       |> exclude(:order_by)
       |> DB.Resource.join_dataset_with_resource()
+      |> where([resource: r], not is_nil(r.format))
       |> select([resource: r], %{
         dataset_id: r.dataset_id,
         format: r.format


### PR DESCRIPTION
Fixes #4628

2 ressources ont un format `null`, ce qui est considéré comme toujours actif par le filtre des recherches par format quand les JDDs remontent. Les bizdevs vont corriger le format et le code exclut désormais cette situation.