### PR TITLE
API datasets : URL authentifiées pour les ressources

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -22,6 +22,7 @@ defmodule TransportWeb.API.DatasetController do
     :legal_owners_region,
     resources: [:dataset]
   ]
+  @pan_org_id Application.compile_env!(:transport, :datagouvfr_transport_publisher_id)
 
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])
@@ -45,7 +46,10 @@ defmodule TransportWeb.API.DatasetController do
   @spec datasets(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def datasets(%Plug.Conn{} = conn, _params) do
     comp_fn = fn -> prepare_datasets_index_data() end
-    data = Transport.Cache.fetch("api-datasets-index", comp_fn, @index_cache_ttl)
+
+    data =
+      Transport.Cache.fetch("api-datasets-index", comp_fn, @index_cache_ttl)
+      |> Enum.map(&maybe_add_token_urls(&1, conn))
 
     render(conn, %{data: data})
   end
@@ -99,7 +103,10 @@ defmodule TransportWeb.API.DatasetController do
       conn |> put_status(404) |> render(%{errors: "dataset not found"})
     else
       comp_fn = fn -> prepare_dataset_detail_data(dataset) end
-      data = Transport.Cache.fetch("api-datasets-#{datagouv_id}", comp_fn, @by_id_cache_ttl)
+
+      data =
+        Transport.Cache.fetch("api-datasets-#{datagouv_id}", comp_fn, @by_id_cache_ttl)
+        |> maybe_add_token_urls(conn)
 
       conn |> assign(:data, data) |> render()
     end
@@ -194,6 +201,7 @@ defmodule TransportWeb.API.DatasetController do
   defp get_publisher(dataset),
     do: %{
       "name" => dataset.organization,
+      "id" => dataset.organization_id,
       "type" => "organization"
     }
 
@@ -466,4 +474,24 @@ defmodule TransportWeb.API.DatasetController do
 
     conn
   end
+
+  # Add a token to the `latest_url` for resources published by the NAP organization.
+  # This is done at this stage to still be able to cache responses:
+  # - an anonymous HTTP request will be served the cache
+  # - an authenticated HTTP request with a token will get download URLs
+  #   with the passed token
+  defp maybe_add_token_urls(
+         %{"resources" => resources, "publisher" => %{"id" => organization_id}} = dataset,
+         %Plug.Conn{assigns: %{token: %DB.Token{secret: secret}}}
+       )
+       when organization_id == @pan_org_id do
+    resources =
+      Enum.map(resources, fn %{"url" => url} = resource ->
+        Map.put(resource, "url", url <> "?token=#{secret}")
+      end)
+
+    Map.put(dataset, "resources", resources)
+  end
+
+  defp maybe_add_token_urls(dataset, _conn), do: dataset
 end

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -519,8 +519,8 @@ defmodule TransportWeb.API.Schemas do
       description: "Publisher",
       type: :object,
       properties: %{
-        # as seen in production data
-        name: %Schema{type: :string, nullable: true},
+        name: %Schema{type: :string},
+        id: %Schema{type: :string},
         type: %Schema{type: :string}
       },
       additionalProperties: false


### PR DESCRIPTION
Suite de #4625 et https://github.com/etalab/transport-site/pull/4625/commits/d0bb0289a5706bb266bba52541cc92bc570da737 en particulier.

Modifie les réponses de l'API quand une requête est effectuée avec succès avec un token pour les URLs de téléchargement des ressources publiées par le PAN. Ces URLs contiendront désormais un token, celui qui a été passé en requête.

Le cache de l'API n'est pas modifié, la modification est effectuée après avoir récupéré les données depuis le cache afin de conserver du cache sur les réponses.

```
$ curl -s -H "Authorization: WxVYufEaDzAWr0qaazc9gWamb8YnUzeRT6RjkZQXFAY" http://localhost:5000/api/datasets/625438b890bf88454b283a55 | jq -r '.resources[] | .url'
http://127.0.0.1:5000/resources/79567/download?token=WxVYufEaDzAWr0qaazc9gWamb8YnUzeRT6RjkZQXFAY
http://127.0.0.1:5000/resources/79760/download?token=WxVYufEaDzAWr0qaazc9gWamb8YnUzeRT6RjkZQXFAY
http://127.0.0.1:5000/resources/79568/download?token=WxVYufEaDzAWr0qaazc9gWamb8YnUzeRT6RjkZQXFAY
```