### PR TITLE
Wording improvements in English

### DIFF
--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -17,7 +17,7 @@
       <div class="home-search">
         <div class="searchBar">
           <%= form_for @conn, dataset_path(@conn, :index), [method: "get"], fn f -> %>
-            <h4><%= dgettext("page-index", "Search data for a region, a city, a network…") %></h4>
+            <h4><%= dgettext("page-index", "Search for data for a region, a city, a network…") %></h4>
             <div class="pt-12">
               <%= search_input(f, :q,
                 id: "autoComplete",

--- a/apps/transport/lib/transport_web/templates/page/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/index.html.heex
@@ -139,14 +139,14 @@
             <div>
               <%= dgettext("page-index", "Territories covered") |> raw() %>
               <br />
-              <%= dgettext("page-index", "on") %> <%= format_number(@count_aoms) %>
+              <%= dgettext("page-index", "out of") %> <%= format_number(@count_aoms) %>
             </div>
           </div>
           <div class="key-number__item">
             <strong><%= @count_regions_completed %></strong>
             <div>
               <%= dgettext("page-index", "Regions covered") %><br />
-              <%= dgettext("page-index", "on") %> <%= @count_regions %>
+              <%= dgettext("page-index", "out of") %> <%= @count_regions %>
             </div>
           </div>
           <div class="key-number__item">

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -91,7 +91,7 @@ msgid "covered"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "on"
+msgid "out of"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-index.po
@@ -131,7 +131,7 @@ msgid "Close the menu"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Search data for a region, a city, a network…"
+msgid "Search for data for a region, a city, a network…"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -91,7 +91,7 @@ msgid "covered"
 msgstr "couverte"
 
 #, elixir-autogen, elixir-format
-msgid "on"
+msgid "out of"
 msgstr "sur"
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-index.po
@@ -131,7 +131,7 @@ msgid "Close the menu"
 msgstr "Fermer le formulaire"
 
 #, elixir-autogen, elixir-format
-msgid "Search data for a region, a city, a network…"
+msgid "Search for data for a region, a city, a network…"
 msgstr "Cherchez les données d’une région, d’une ville, d’un réseau…"
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -91,7 +91,7 @@ msgid "covered"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "on"
+msgid "out of"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/page-index.pot
+++ b/apps/transport/priv/gettext/page-index.pot
@@ -131,7 +131,7 @@ msgid "Close the menu"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Search data for a region, a city, a network…"
+msgid "Search for data for a region, a city, a network…"
 msgstr ""
 
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
Bonjour,

Merci pour ce site fantastique, c'est génial que cette ressource existe. En lisant la version anglaise j'ai remarqué quelques maladresses, donc je vous propose de les corriger:
* pour dire "9 sur 10", c'est "9 out of 10" et non pas "9 on 10"
* la traduction de "chercher quelque-chose" c'est "search *for* something". Si vous écrivez "search something" ça veut dire "fouiller quelque-chose"

N'ayant pas pu utiliser l'outillage officiel pour régénérer les fichiers gettext (#4637) j'ai fait les mises à jour manuellement, ce qui devrait bien marcher.

Bonne continuation !