### PR TITLE
[WIP] Implémentation "items S3" pour le proxy

### DIFF
--- a/apps/transport/lib/S3/s3.ex
+++ b/apps/transport/lib/S3/s3.ex
@@ -56,6 +56,16 @@ defmodule Transport.S3 do
     |> Transport.Wrapper.ExAWS.impl().request!()
   end
 
+  @spec get_object(bucket_feature(), binary()) :: binary()
+  def get_object(feature, remote_path) do
+    Logger.debug("Getting object from #{remote_path} into RAM")
+
+    feature
+    |> Transport.S3.bucket_name()
+    |> ExAws.S3.get_object(remote_path)
+    |> Transport.Wrapper.ExAWS.impl().request!()
+  end
+
   @spec remote_copy_file!(bucket_feature(), binary(), binary()) :: any()
   def remote_copy_file!(feature, remote_path_src, remote_path_dest) do
     bucket = Transport.S3.bucket_name(feature)

--- a/apps/unlock/lib/cached_fetch.ex
+++ b/apps/unlock/lib/cached_fetch.ex
@@ -11,12 +11,33 @@ defmodule Unlock.CachedFetch do
   # RAM consumption
   @max_allowed_cached_byte_size 20 * 1024 * 1024
 
-  def fetch_data(%Unlock.Config.Item.Generic.HTTP{} = item, http_client_options \\ []) do
+  # defaults
+  def fetch_data(_item, _http_client_options \\ [])
+
+  def fetch_data(%Unlock.Config.Item.Generic.HTTP{} = item, http_client_options) do
     response = Unlock.HTTP.Client.impl().get!(item.target_url, item.request_headers, http_client_options)
     size = byte_size(response.body)
 
     if size > @max_allowed_cached_byte_size do
       Logger.warning("Payload is too large (#{size} bytes > #{@max_allowed_cached_byte_size}). Skipping cache.")
+      {:ignore, response}
+    else
+      {:commit, response, ttl: :timer.seconds(item.ttl)}
+    end
+  end
+
+  # For S3 hosted files (which we control), which are currently larger, go a bit further
+  @max_allowed_s3_cached_byte_size 4 * 20 * 1024 * 1024
+
+  def fetch_data(%Unlock.Config.Item.S3{} = item, _http_client_options) do
+    bucket = item.bucket |> String.to_existing_atom()
+    path = item.path
+
+    response = Transport.S3.get_object(bucket, path)
+    size = byte_size(response.body)
+
+    if size > @max_allowed_s3_cached_byte_size do
+      Logger.warning("S3 Payload is too large (#{size} bytes > #{@max_allowed_s3_cached_byte_size}). Skipping cache.")
       {:ignore, response}
     else
       {:commit, response, ttl: :timer.seconds(item.ttl)}

--- a/apps/unlock/lib/config.ex
+++ b/apps/unlock/lib/config.ex
@@ -46,6 +46,15 @@ defmodule Unlock.Config do
     defstruct [:identifier, :feeds, :ttl]
   end
 
+  defmodule Item.S3 do
+    @moduledoc """
+    Intermediate structure for S3-based configured items.
+    """
+
+    @enforce_keys [:identifier, :bucket, :path, :ttl]
+    defstruct [:identifier, :bucket, :path, :ttl]
+  end
+
   defmodule Fetcher do
     @moduledoc """
     A behaviour + shared methods for config fetching.
@@ -96,6 +105,15 @@ defmodule Unlock.Config do
         subtype: subtype,
         request_headers: parse_config_http_headers(Map.get(item, "request_headers", [])),
         response_headers: parse_config_http_headers(Map.get(item, "response_headers", []))
+      }
+    end
+
+    def convert_yaml_item_to_struct(%{"type" => "s3"} = item) do
+      %Item.S3{
+        identifier: Map.fetch!(item, "identifier"),
+        bucket: Map.fetch!(item, "bucket"),
+        path: Map.fetch!(item, "path"),
+        ttl: Map.get(item, "ttl", 10)
       }
     end
 

--- a/apps/unlock/mix.exs
+++ b/apps/unlock/mix.exs
@@ -43,6 +43,8 @@ defmodule Unlock.MixProject do
       {:jason, "~> 1.1"},
       {:nimble_csv, "~> 1.1"},
       {:finch, "~> 0.8"},
+      {:ex_aws, "~> 2.1"},
+      {:ex_aws_s3, "~> 2.0"},
       {:yaml_elixir, "~> 2.7"},
       {:cachex, "~> 3.5"},
       {:cors_plug, "~> 3.0"},


### PR DESCRIPTION
:warning: ne pas reviewer formellement pour l'instant, car je vais devoir faire une PR intermédiaire de refactoring (la gestion S3 doit passer dans `apps/shared` pour que tout fonctionne bien)

Pour publier les fichiers générés par:
- #4492

j'ajoute un nouveau type d'item dans le proxy: item S3 "interne".

La configuration permet de référencer un item privé de nos buckets. 

La récupération passe par `Transport.S3`, qui se sert de la configuration établie pour `ex_aws` (via `CELLAR_ACCESS_KEY_ID`, `CELLAR_SECRET_ACCESS_KEY`, `https://~s.cellar-c2.services.clever-cloud.com` dans notre configuration).

Exemple de configuration qui fonctionne:

```yaml
feeds:
  - identifier: "consolidation-nationale-irve-statique"
    type: s3
    bucket: aggregates
    path: irve_static_consolidation_.csv
    ttl: 300
```

La clé "bucket" correspond au "petit nom interne" qui est donné aux buckets ici:

https://github.com/etalab/transport-site/blob/7dd745e6278889faa27c97cb90d1afe3ccf7fd77/apps/transport/lib/S3/s3.ex#L6

### Tâches restantes

- [ ] Faire une PR à part pour refactorer les dépendances (je dois déplacer le support `S3` de `apps/transport` vers `apps/
- [ ] "Blanker" le contenu quand HTTP status code != 200 (pour éviter de leaker quelque chose)
- [ ] Faire le point avec @etalab/transport-bizdev pour le format de stockage (là c'est un gros CSV de 40MB + un deuxième petit fichier, un ZIP global serait en fait beaucoup plus commode autant pour l'occupation RAM, que pour éviter une double configuration proxy, une pour le fichier consolidé, une pour le rapport)
- [ ] Ajouter des tests là où c'est pertinent
- [ ] Tester sur prochainement avec un peu de charge