### PR TITLE
Espace réutilisateur : gestion des tokens pour tous

### DIFF
--- a/apps/transport/lib/transport_web/templates/reuser_space/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuser_space/index.html.heex
@@ -32,7 +32,7 @@
           </div>
         </div>
       </div>
-      <div :if={eligible_for_tokens?(@conn)} class="panel action-panel">
+      <div class="panel action-panel">
         <img
           class="picto"
           src={static_path(@conn, "/images/reutilisateurs/gear.svg")}

--- a/apps/transport/lib/transport_web/views/reuser_space_view.ex
+++ b/apps/transport/lib/transport_web/views/reuser_space_view.ex
@@ -7,16 +7,4 @@ defmodule TransportWeb.ReuserSpaceView do
   end
 
   def default_for_contact?(%DB.Token{}, %DB.Contact{default_tokens: _}), do: false
-
-  def eligible_for_tokens?(%Plug.Conn{assigns: %{contact: %DB.Contact{} = contact}} = conn) do
-    eligible_org_ids = [
-      # BlaBlaCar
-      "5b9f70f18b4c4101942a27ff",
-      # Futureco
-      "655f8ef36a24e8d0522aa2a6"
-    ]
-
-    member_of_eligible_orgs = Enum.count(contact.organizations, &(&1.id in eligible_org_ids)) > 0
-    TransportWeb.Session.admin?(conn) or member_of_eligible_orgs
-  end
 end

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -199,28 +199,8 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
   end
 
   describe "settings" do
-    test "link to settings is visible by admins", %{conn: conn} do
+    test "link to notifications and settings", %{conn: conn} do
       contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
-
-      # When contact is NOT an admin
-      assert conn
-             |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
-             |> index_href_attributes() == [reuser_space_path(conn, :notifications)]
-
-      # When contact is an admin
-      assert conn
-             |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id, "is_admin" => true}})
-             |> index_href_attributes() == [reuser_space_path(conn, :notifications), reuser_space_path(conn, :settings)]
-    end
-
-    test "link to settings when member of an eligible org", %{conn: conn} do
-      organization = insert(:organization, id: "5b9f70f18b4c4101942a27ff", name: "BlaBlaCar")
-
-      contact =
-        insert_contact(%{
-          datagouv_user_id: Ecto.UUID.generate(),
-          organizations: [organization |> Map.from_struct()]
-        })
 
       assert conn
              |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})


### PR DESCRIPTION
Ouvre cette fonctionnalité à tous les contacts.