### PR TITLE
Historisation des données routières

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -1055,15 +1055,13 @@ defmodule DB.Dataset do
   @doc """
   Should this dataset not be historicized?
 
-  iex> should_skip_history?(%DB.Dataset{type: "road-data"})
-  true
   iex> should_skip_history?(%DB.Dataset{type: "public-transit"})
   false
   iex> should_skip_history?(%DB.Dataset{type: "public-transit", custom_tags: ["skip_history", "foo"]})
   true
   """
   def should_skip_history?(%__MODULE__{type: type} = dataset) do
-    type in ["vehicles-sharing", "road-data"] or has_custom_tag?(dataset, "skip_history")
+    type in ["vehicles-sharing"] or has_custom_tag?(dataset, "skip_history")
   end
 
   def has_licence_ouverte?(%__MODULE__{licence: licence}), do: licence in @licences_ouvertes

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -160,8 +160,6 @@ defmodule DB.Resource do
   false
   iex> real_time?(%DB.Resource{format: "csv", description: "Données mises à jour en temps réel"})
   true
-  iex> real_time?(%DB.Resource{format: "xml", title: "API DiaLog"})
-  true
   """
   @spec real_time?(__MODULE__.t()) :: boolean
   def real_time?(%__MODULE__{} = resource) do
@@ -170,7 +168,6 @@ defmodule DB.Resource do
       &gbfs?/1,
       &siri_lite?/1,
       &siri?/1,
-      &String.contains?(String.downcase(&1.title || ""), "api"),
       &String.contains?(&1.description || "", ["mis à jour en temps réel", "mises à jour en temps réel"])
     ]
     |> Enum.any?(fn function -> function.(resource) end)

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -160,6 +160,8 @@ defmodule DB.Resource do
   false
   iex> real_time?(%DB.Resource{format: "csv", description: "Données mises à jour en temps réel"})
   true
+  iex> real_time?(%DB.Resource{format: "xml", title: "API DiaLog"})
+  true
   """
   @spec real_time?(__MODULE__.t()) :: boolean
   def real_time?(%__MODULE__{} = resource) do
@@ -168,6 +170,7 @@ defmodule DB.Resource do
       &gbfs?/1,
       &siri_lite?/1,
       &siri?/1,
+      &String.contains?(String.downcase(&1.title || ""), "api"),
       &String.contains?(&1.description || "", ["mis à jour en temps réel", "mises à jour en temps réel"])
     ]
     |> Enum.any?(fn function -> function.(resource) end)


### PR DESCRIPTION
Avec la nouvelle catégorie des données routières introduit dans #4633 (parkings + ZFE + données routières), il est nécessaire de revoir l'exclusion de l'historisation des données routières. En effet il est nécessaire d'historiser les données des ZFE et des parkings pour des besoins de consolidation.

Ceci est fait dans cette PR.