### PR TITLE
Consolidation IRVE : continuer en cas de code HTTP != 200 sur une ressource

### DIFF
--- a/apps/transport/lib/irve/raw_static_consolidation.ex
+++ b/apps/transport/lib/irve/raw_static_consolidation.ex
@@ -46,17 +46,21 @@ defmodule Transport.IRVE.RawStaticConsolidation do
   Download content separately from processing, because we need to provide an estimate of the number of lines
   even if the processing fails. Asserting 200 is fine here, because the target server is data gouv & quite reliable.
   """
-  @spec download_resource_content!(String.t()) :: binary()
+  @spec download_resource_content!(String.t()) :: map()
   def download_resource_content!(url) do
-    %{status: 200, body: body} = Transport.IRVE.Fetcher.get!(url, compressed: false, decode_body: false)
-    body
+    %{status: status, body: body} = Transport.IRVE.Fetcher.get!(url, compressed: false, decode_body: false)
+    %{status: status, body: body}
   end
 
   @doc """
   Process a row (resource). The full content (body) is expected together with the original file extension.
   """
-  @spec process_resource(map(), binary(), String.t()) :: {:ok, Explorer.DataFrame.t()} | {:error, any()}
-  def process_resource(row, body, extension) do
+  @spec process_resource(map(), binary(), integer(), String.t()) :: {:ok, Explorer.DataFrame.t()} | {:error, any()}
+  def process_resource(row, body, status, extension) do
+    if status != 200 do
+      raise "HTTP status is not 200 (#{status})"
+    end
+
     # A number of checks are carried out before attempting to parse the data, using a couple of heuristics,
     # in order to get meaningful error messages in the report.
     run_cheap_blocking_checks(body, extension)
@@ -163,11 +167,11 @@ defmodule Transport.IRVE.RawStaticConsolidation do
       |> Enum.reduce(%{df: nil, report: []}, fn row, %{df: main_df, report: report} ->
         Logger.info("Processing resource #{row.resource_id} (url=#{row.url})")
 
-        body = download_resource_content!(row.url)
+        %{body: body, status: status} = download_resource_content!(row.url)
         extension = Path.extname(row.url)
 
         {main_df, optional_error} =
-          case process_resource(row, body, extension) do
+          case process_resource(row, body, status, extension) do
             {:ok, df} -> {concat_rows(main_df, df), nil}
             {:error, error} -> {main_df, error}
           end


### PR DESCRIPTION
Voir:
- #200

Avant cette PR, si un téléchargement retourne HTTP != 200, tout s'arrête.

Après cette PR, le fichier apparaît dans le log d'erreur avec un message spécifique (`HTTP status is not 200 (#{status})`) et la consolidation continue.