### PR TITLE
CSS icone loi climat et résilience

### DIFF
--- a/apps/transport/client/stylesheets/components/_icons.scss
+++ b/apps/transport/client/stylesheets/components/_icons.scss
@@ -113,3 +113,20 @@
 .fa-heart.producer {
   color: var(--blue);
 }
+
+.icon---climate-resilience-bill {
+  width: 2.5em;
+  height: 2.5em;
+  margin-right: 1em;
+  vertical-align: middle;
+  &.xl {
+    width: 5em;
+    height: 5em;
+    margin-right: 3em;
+  }
+  &.small {
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: .5em;
+  }
+}


### PR DESCRIPTION
Fixes #4665

Réintroduit du code supprimé dans #4647 qui est en réalité utilisé