### PR TITLE
Unlock aggregate : content-disposition header

### DIFF
--- a/apps/unlock/lib/controller.ex
+++ b/apps/unlock/lib/controller.ex
@@ -167,7 +167,11 @@ defmodule Unlock.Controller do
     ]
 
     body_response = Unlock.AggregateProcessor.process_resource(item, options)
-    send_resp(conn, 200, body_response)
+    filename = "#{item.identifier}-#{DateTime.utc_now() |> DateTime.to_iso8601()}.csv"
+
+    conn
+    |> put_resp_header("content-disposition", "attachment; filename=#{filename}")
+    |> send_resp(200, body_response)
   end
 
   # `process_resource` variant for `Item.S3` items.

--- a/apps/unlock/test/controllers/unlock_controller_test.exs
+++ b/apps/unlock/test/controllers/unlock_controller_test.exs
@@ -570,6 +570,8 @@ defmodule Unlock.ControllerTest do
       assert resp.status == 200
       # Note: TIL: NimbleCSV.RFC4180.dump_to_iodata generates "\r\n" (apparently)
       assert resp.resp_body == Helper.data_as_csv(@expected_headers, [first_data_row, second_data_row], "\r\n")
+      headers = resp.resp_headers |> Enum.into(%{})
+      assert headers["content-disposition"] =~ ~r/^attachment; filename=an-existing-aggregate-identifier-.*\.csv$/
 
       assert_received {:telemetry_event, [:proxy, :request, :external], %{},
                        %{target: "proxy:an-existing-aggregate-identifier"}}


### PR DESCRIPTION
Fixes #4672

Force le téléchargement d'une consolidation dans `unlock`