### PR TITLE
ops_tests: suppression de contribuer

### DIFF
--- a/ops_tests/ops_tests.exs
+++ b/ops_tests/ops_tests.exs
@@ -74,7 +74,6 @@ defmodule Transport.OpsTests do
 
       # Satellite websites
       assert {:ok, [~c"transport-blog.netlify.app"]} == DNS.resolve("blog.#{@domain_name}", :cname)
-      assert {:ok, [~c"transport-contribuer.netlify.app"]} == DNS.resolve("contribuer.#{@domain_name}", :cname)
       assert {:ok, [~c"hosting.gitbook.com"]} == DNS.resolve("doc.#{@domain_name}", :cname)
       assert {:ok, [~c"stats.uptimerobot.com"]} == DNS.resolve("status.#{@domain_name}", :cname)
     end


### PR DESCRIPTION
Suite à https://github.com/etalab/transport-site/issues/4147#issuecomment-2996616314, suppression de la vérification de cet enregistrement DNS qui n'existe plus.