### PR TITLE
GeojsonConversionController: requiert admin

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -279,7 +279,8 @@ defmodule TransportWeb.Router do
       end
     end
 
-    scope "/gtfs-geojson-conversion-#{System.get_env("TRANSPORT_TOOLS_SECRET_TOKEN")}" do
+    scope "/gtfs-geojson-conversion" do
+      pipe_through([:admin_rights])
       get("/", GeojsonConversionController, :index)
       post("/", GeojsonConversionController, :convert)
     end


### PR DESCRIPTION
Fixes #4499

Au lieu d'avoir un paramètre secret dans l'URL, requiert d'être admin. Cet outil est caché et ne devrait pouvoir être testé que par un dev, en cas de besoin.