### PR TITLE
Extraction du template des erreurs de validation NeTEx

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors.html.heex
@@ -1,0 +1,19 @@
+<nav class="issues-list validation" role="navigation">
+  <%= render("_validation_summary.html",
+    conn: @conn,
+    data_vis: nil,
+    issues: @issues,
+    severities_count: @severities_count,
+    token: nil,
+    validation_summary: @validation_summary,
+    validator: @validator
+  ) %>
+</nav>
+<div class="main-pane">
+  <%= pagination_links(@conn, @issues, [@resource.id],
+    issue_type: Transport.Validators.NeTEx.issue_type(@issues.entries),
+    path: &resource_path/4,
+    action: :details
+  ) %>
+  <%= render(netex_template(@issues), issues: @issues || [], conn: @conn) %>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
@@ -30,25 +30,15 @@
           <%= if @issues.total_entries == 0 do %>
             <%= dgettext("validations", "No validation error") %>.
           <% else %>
-            <nav class="issues-list validation" role="navigation">
-              <%= render("_validation_summary.html",
-                validation_summary: @validation_summary,
-                severities_count: @severities_count,
-                issues: @issues,
-                conn: @conn,
-                data_vis: nil,
-                token: nil,
-                validator: @validator
-              ) %>
-            </nav>
-            <div class="main-pane">
-              <%= pagination_links(@conn, @issues, [@resource.id],
-                issue_type: Transport.Validators.NeTEx.issue_type(@issues.entries),
-                path: &resource_path/4,
-                action: :details
-              ) %>
-              <%= render(netex_template(@issues), issues: @issues || [], conn: @conn) %>
-            </div>
+            <%= render("_netex_validation_errors.html",
+              conn: @conn,
+              issues: @issues,
+              metadata: @metadata,
+              resource: @resource,
+              severities_count: @severities_count,
+              validation_summary: @validation_summary,
+              validator: @validator
+            ) %>
           <% end %>
           <p>
             <%= raw(


### PR DESCRIPTION
Il s'agit d'une extraction de code d'un template existant un peu lourd dans un template dédié plus concis.

Les extractions de code ou les renommages de fichiers polluent les PRs que je m'apprête à poster (validation NeTEx niveau 1).