### PR TITLE
Test liens documentation : accepte 307

### DIFF
--- a/apps/transport/test/documentation_links_test.exs
+++ b/apps/transport/test/documentation_links_test.exs
@@ -12,7 +12,7 @@ defmodule Transport.DocumentationLinksTest do
       urls
       |> Enum.map(fn url ->
         case HTTPoison.head(url) do
-          {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in [200, 302] -> :success
+          {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in [200, 302, 307] -> :success
           response -> {:error, url, response}
         end
       end)
@@ -20,7 +20,7 @@ defmodule Transport.DocumentationLinksTest do
 
     message = """
     Unexpected HTTP responses for:
-    #{failures |> Enum.map_join("\n - ", fn {:error, url, _response} -> url end)}
+    - #{failures |> Enum.map_join("\n - ", fn {:error, url, _response} -> url end)}
 
     Debug:
     #{inspect(failures)}


### PR DESCRIPTION
Accepte un statut HTTP [307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/307) pour le test vérifiant que nos liens vers la documentation sont valides.