### PR TITLE
Validation NeTEx : abstraction de l’affichage des résultats

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -76,7 +76,7 @@
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
-        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ModuleNames, ignore: [~r/Transport.Validators.NeTEx.ResultsAdapters.V/]},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},

--- a/apps/transport/lib/jobs/on_demand_netex_poller_job.ex
+++ b/apps/transport/lib/jobs/on_demand_netex_poller_job.ex
@@ -16,6 +16,7 @@ defmodule Transport.Jobs.OnDemandNeTExPollerJob do
     unique: [fields: [:args, :worker]]
 
   alias Transport.Jobs.OnDemandValidationHelpers, as: Helpers
+  alias Transport.Validators.NeTEx.ResultsAdapters.V0_1_0, as: ResultsAdapter
   alias Transport.Validators.NeTEx.Validator
 
   # Override the backoff to play nice and avoiding falling in very slow retry
@@ -77,7 +78,7 @@ defmodule Transport.Jobs.OnDemandNeTExPollerJob do
       data_vis: nil,
       validator: Validator.validator_name(),
       validated_data_name: url,
-      max_error: Validator.get_max_severity_error(validation),
+      max_error: ResultsAdapter.get_max_severity_error(validation),
       oban_args: Helpers.completed()
     }
   end

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -133,41 +133,29 @@ defmodule TransportWeb.ResourceController do
   end
 
   defp render_gtfs_details(conn, params, resource) do
-    validator = Transport.Validators.GTFSTransport
-
     validation = latest_validation(resource)
 
-    validation_details = {_, _, _, _, issues} = build_validation_details(params, resource, validator)
+    validation_details = {_, _, _, _, issues} = build_gtfs_validation_details(params, resource)
 
     issue_type =
       case params["issue_type"] do
-        nil -> validator.issue_type(issues)
+        nil -> Transport.Validators.GTFSTransport.issue_type(issues)
         issue_type -> issue_type
       end
 
     conn
-    |> assign_base_resource_details(params, resource, validation_details, validator)
+    |> assign_base_resource_details(params, resource, validation_details)
+    |> assign(:validator, Transport.Validators.GTFSTransport)
     |> assign(:data_vis, encoded_data_vis(issue_type, validation))
     |> render("gtfs_details.html")
   end
 
-  defp render_netex_details(conn, params, resource) do
-    validator = Transport.Validators.NeTEx.Validator
-
-    validation_details = build_validation_details(params, resource, validator)
-
-    conn
-    |> assign_base_resource_details(params, resource, validation_details, validator)
-    |> assign(:data_vis, nil)
-    |> render("netex_details.html")
-  end
-
-  defp build_validation_details(params, resource, validator) do
+  defp build_gtfs_validation_details(params, resource) do
     case latest_validation(resource) do
       %{result: validation_result, metadata: metadata = %DB.ResourceMetadata{}} ->
-        summary = validator.summary(validation_result)
-        stats = validator.count_by_severity(validation_result)
-        issues = validator.get_issues(validation_result, params)
+        summary = Transport.Validators.GTFSTransport.summary(validation_result)
+        stats = Transport.Validators.GTFSTransport.count_by_severity(validation_result)
+        issues = Transport.Validators.GTFSTransport.get_issues(validation_result, params)
 
         {summary, stats, metadata.metadata, metadata.modes, issues}
 
@@ -176,7 +164,32 @@ defmodule TransportWeb.ResourceController do
     end
   end
 
-  defp assign_base_resource_details(conn, params, resource, validation_details, validator) do
+  defp render_netex_details(conn, params, resource) do
+    {results_adapter, validation_details} = build_netex_validation_details(params, resource)
+
+    conn
+    |> assign_base_resource_details(params, resource, validation_details)
+    |> assign(:results_adapter, results_adapter)
+    |> assign(:data_vis, nil)
+    |> render("netex_details.html")
+  end
+
+  defp build_netex_validation_details(params, resource) do
+    case latest_validation(resource) do
+      %{validator_version: version, result: validation_result, metadata: metadata = %DB.ResourceMetadata{}} ->
+        results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(version)
+        summary = results_adapter.summary(validation_result)
+        stats = results_adapter.count_by_severity(validation_result)
+        issues = results_adapter.get_issues(validation_result, params)
+
+        {results_adapter, {summary, stats, metadata.metadata, metadata.modes, issues}}
+
+      nil ->
+        {nil, {nil, nil, nil, [], []}}
+    end
+  end
+
+  defp assign_base_resource_details(conn, params, resource, validation_details) do
     config = make_pagination_config(params)
 
     {validation_summary, severities_count, metadata, modes, issues} = validation_details
@@ -191,7 +204,6 @@ defmodule TransportWeb.ResourceController do
     |> assign(:validation, latest_validation(resource))
     |> assign(:metadata, metadata)
     |> assign(:modes, modes)
-    |> assign(:validator, validator)
   end
 
   def encoded_data_vis(_, nil), do: nil

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -111,21 +111,22 @@ defmodule TransportWeb.ValidationController do
 
         conn
         |> assign_base_validation_details(validator, validation, params, current_issues)
+        |> assign(:validator, validator)
         |> assign(:metadata, validation.metadata.metadata)
         |> assign(:modes, validation.metadata.modes)
         |> assign(:data_vis, data_vis(validation, issue_type))
         |> render("show_gtfs.html")
 
       %MultiValidation{oban_args: %{"state" => "completed", "type" => "netex"}} = validation ->
-        validator = Transport.Validators.NeTEx.Validator
-        current_issues = validator.get_issues(validation.result, params)
+        results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(validation.validator_version)
+
+        current_issues = results_adapter.get_issues(validation.result, params)
 
         conn
-        |> assign_base_validation_details(validator, validation, params, current_issues)
+        |> assign_base_validation_details(results_adapter, validation, params, current_issues)
+        |> assign(:results_adapter, results_adapter)
         |> assign(:metadata, validation.metadata.metadata)
-        |> assign(:modes, [])
-        |> assign(:data_vis, nil)
-        |> render("show_netex.html")
+        |> render("show_netex_v0_1_0.html")
 
       # Handles waiting for validation to complete, errors and
       # validation for schemas
@@ -140,14 +141,13 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
-  defp assign_base_validation_details(conn, validator, validation, params, current_issues) do
+  defp assign_base_validation_details(conn, results_adapter, validation, params, current_issues) do
     conn
-    |> assign(:validator, validator)
     |> assign(:validation_id, params["id"])
     |> assign(:other_resources, [])
     |> assign(:issues, Scrivener.paginate(current_issues, make_pagination_config(params)))
-    |> assign(:validation_summary, validator.summary(validation.result))
-    |> assign(:severities_count, validator.count_by_severity(validation.result))
+    |> assign(:validation_summary, results_adapter.summary(validation.result))
+    |> assign(:severities_count, results_adapter.count_by_severity(validation.result))
     |> assign(:token, params["token"])
   end
 

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
@@ -1,13 +1,14 @@
 <%= unless is_nil(@validation) do %>
   <div class="pb-24">
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
-    <% {severity, count} = NeTEx.count_max_severity(@validation.result) %>
+    <% results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(@validation.validator_version) %>
+    <% {severity, count} = results_adapter.count_max_severity(@validation.result) %>
     <a href={link}>
       <span class={summary_class(%{severity: String.capitalize(severity), count_errors: count})}>
-        <%= if NeTEx.no_error?(severity) do %>
+        <%= if results_adapter.no_error?(severity) do %>
           <%= dgettext("page-dataset-details", "No error detected") %>
         <% else %>
-          <%= NeTEx.format_severity(severity, count) %>
+          <%= results_adapter.format_severity(severity, count) %>
         <% end %>
       </span>
     </a>

--- a/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors.html.heex
@@ -6,12 +6,12 @@
     severities_count: @severities_count,
     token: nil,
     validation_summary: @validation_summary,
-    validator: @validator
+    results_adapter: @results_adapter
   ) %>
 </nav>
 <div class="main-pane">
   <%= pagination_links(@conn, @issues, [@resource.id],
-    issue_type: Transport.Validators.NeTEx.Validator.issue_type(@issues.entries),
+    issue_type: @results_adapter.issue_type(@issues.entries),
     path: &resource_path/4,
     action: :details
   ) %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
@@ -3,7 +3,7 @@
     <%= for {severity, issues} <- @validation_summary do %>
       <%= if Map.get(@severities_count, severity, 0) > 0 do %>
         <div class="validation-issue">
-          <h4><%= @validator.format_severity(severity, @severities_count[severity]) %></h4>
+          <h4><%= @results_adapter.format_severity(severity, @severities_count[severity]) %></h4>
           <ul>
             <%= for {key, issue} <- issues do %>
               <li>
@@ -12,7 +12,7 @@
                     "#{issue.title} (#{issue.count})",
                     to:
                       "#{current_url(@conn, %{"issue_type" => key, "token" => @token} |> Map.reject(fn {_, v} -> is_nil(v) end))}#issues",
-                    class: if(key == @validator.issue_type(@issues.entries), do: "active")
+                    class: if(key == @results_adapter.issue_type(@issues.entries), do: "active")
                   ) %>
                 <% end %>
               </li>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -94,7 +94,7 @@ locale = get_session(@conn, :locale) %>
                 conn: @conn,
                 data_vis: @data_vis,
                 token: nil,
-                validator: @validator
+                results_adapter: @validator
               ) %>
             </nav>
             <div class="main-pane">

--- a/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
@@ -37,7 +37,7 @@
               resource: @resource,
               severities_count: @severities_count,
               validation_summary: @validation_summary,
-              validator: @validator
+              results_adapter: @results_adapter
             ) %>
           <% end %>
           <p>

--- a/apps/transport/lib/transport_web/templates/validation/show_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_gtfs.html.heex
@@ -28,7 +28,7 @@
           issues: @issues,
           data_vis: @data_vis,
           token: @token,
-          validator: @validator
+          results_adapter: @validator
         ) %>
       <% end %>
 

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_1_0.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_1_0.html.heex
@@ -28,9 +28,9 @@
           severities_count: @severities_count,
           conn: @conn,
           issues: @issues,
-          data_vis: @data_vis,
           token: @token,
-          validator: @validator
+          results_adapter: @results_adapter,
+          data_vis: nil
         ) %>
       <% end %>
 
@@ -38,7 +38,7 @@
         <div class="panel">
           <%= if has_errors?(@validation_summary) do %>
             <%= pagination_links(@conn, @issues, [@validation_id],
-              issue_type: @validator.issue_type(@issues.entries),
+              issue_type: @results_adapter.issue_type(@issues.entries),
               token: @token,
               path: &validation_path/4,
               action: :show
@@ -46,7 +46,7 @@
             <%= render(netex_template(@issues), issues: @issues || [], conn: @conn) %>
             <div class="pt-24">
               <%= pagination_links(@conn, @issues, [@validation_id],
-                issue_type: @validator.issue_type(@issues.entries),
+                issue_type: @results_adapter.issue_type(@issues.entries),
                 token: @token,
                 path: &validation_path/4,
                 action: :show

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -12,7 +12,6 @@ defmodule TransportWeb.DatasetView do
   import DB.MultiValidation, only: [get_metadata_info: 2, get_metadata_info: 3]
   alias Shared.DateTimeDisplay
   alias Transport.Validators.GTFSTransport
-  alias Transport.Validators.NeTEx.Validator, as: NeTEx
 
   @gtfs_rt_validator_name Transport.Validators.GTFSRT.validator_name()
 

--- a/apps/transport/lib/validators/netex/results_adapter.ex
+++ b/apps/transport/lib/validators/netex/results_adapter.ex
@@ -1,0 +1,15 @@
+defmodule Transport.Validators.NeTEx.ResultsAdapter do
+  @moduledoc """
+  Interface for result adapters: helpers designed to interpret results of NeTEx validation.
+  """
+
+  @callback summary(map()) :: list()
+  @callback count_by_severity(map()) :: map()
+  @callback get_issues(map(), map()) :: list()
+  @callback issue_type(list()) :: nil | binary()
+  @callback format_severity(binary(), non_neg_integer()) :: binary()
+  @callback count_max_severity(map()) :: {binary(), integer()}
+  @callback no_error?(binary()) :: boolean()
+
+  def resolve(_), do: Transport.Validators.NeTEx.ResultsAdapters.V0_1_0
+end

--- a/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
@@ -1,0 +1,220 @@
+defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0 do
+  @moduledoc """
+  Helper module to build and interpret results for NeTEx validation prior to 0.2.0.
+  """
+
+  use Gettext, backend: TransportWeb.Gettext
+
+  @behaviour Transport.Validators.NeTEx.ResultsAdapter
+
+  @no_error "NoError"
+
+  @unknown_code "unknown-code"
+
+  @doc """
+  Returns the maximum issue severity found
+
+  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "error"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "error"}]}
+  iex> get_max_severity_error(validation_result)
+  "error"
+
+  iex> get_max_severity_error(%{})
+  "NoError"
+  """
+  @spec get_max_severity_error(map()) :: binary() | nil
+  def get_max_severity_error(validation_result) do
+    {severity, _} = validation_result |> count_max_severity()
+    severity
+  end
+
+  @doc """
+  Returns the maximum severity, with the issues count
+
+  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "error"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "warning"}]}
+  iex> count_max_severity(validation_result)
+  {"error", 2}
+  iex> validation_result = %{"frame-arret-resources" => [%{"criticity" => "warning"}]}
+  iex> count_max_severity(validation_result)
+  {"warning", 1}
+  iex> count_max_severity(%{})
+  {"NoError", 0}
+  """
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def count_max_severity(validation_result) when validation_result == %{} do
+    {@no_error, 0}
+  end
+
+  def count_max_severity(%{} = validation_result) do
+    validation_result
+    |> count_by_severity()
+    |> Enum.min_by(fn {severity, _count} -> severity |> severity_level() end)
+  end
+
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def no_error?(severity), do: @no_error == severity
+
+  @spec severity_level(binary()) :: integer()
+  defp severity_level(key) do
+    case key do
+      "error" -> 1
+      "warning" -> 2
+      "information" -> 3
+      _ -> 4
+    end
+  end
+
+  @doc """
+  iex> Gettext.put_locale("en")
+  iex> format_severity("error", 1)
+  "1 error"
+  iex> format_severity("error", 2)
+  "2 errors"
+  iex> Gettext.put_locale("fr")
+  iex> format_severity("error", 1)
+  "1 erreur"
+  iex> format_severity("error", 2)
+  "2 erreurs"
+  """
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def format_severity(key, count) do
+    case key do
+      "error" -> dngettext("netex-validator", "error", "errors", count)
+      "warning" -> dngettext("netex-validator", "warning", "warnings", count)
+      "information" -> dngettext("netex-validator", "information", "informations", count)
+    end
+  end
+
+  @doc """
+  Returns the number of issues by severity level
+
+  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "warning"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "error"}]}
+  iex> count_by_severity(validation_result)
+  %{"warning" => 1, "error" => 2}
+
+  iex> count_by_severity(%{})
+  %{}
+  """
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def count_by_severity(%{} = validation_result) do
+    validation_result
+    |> Enum.flat_map(fn {_, v} -> v end)
+    |> Enum.reduce(%{}, fn v, acc -> Map.update(acc, v["criticity"], 1, &(&1 + 1)) end)
+  end
+
+  def count_by_severity(_), do: %{}
+
+  @doc """
+  iex> index_messages([])
+  %{}
+
+  iex> index_messages([%{"code"=>"a", "id"=> 1}, %{"code"=>"a", "id"=> 2}, %{"code"=>"b", "id"=> 3}])
+  %{"a"=>[%{"code"=>"a", "id"=> 1}, %{"code"=>"a", "id"=> 2}], "b"=>[%{"code"=>"b", "id"=> 3}]}
+
+  Sometimes the message has no code
+  iex> index_messages([%{"code"=>"a", "id"=> 1}, %{"code"=>"b", "id"=> 2}, %{"id"=> 3}])
+  %{"a"=>[%{"code"=>"a", "id"=> 1}], "b"=>[%{"code"=>"b", "id"=> 2}], "unknown-code"=>[%{"id"=> 3}]}
+  """
+  def index_messages(messages), do: Enum.group_by(messages, &get_code/1)
+
+  defp get_code(%{"code" => code}), do: code
+  defp get_code(%{}), do: @unknown_code
+
+  @doc """
+  iex> validation_result = %{"uic-operating-period" => [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "valid-day-bits" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}], "frame-arret-resources" => [%{"code" => "frame-arret-resources", "message" => "Tag frame_id doesn't match ''", "criticity" => "warning"}]}
+  iex> summary(validation_result)
+  [
+    {"error", [
+      {"uic-operating-period", %{count: 1, criticity: "error", title: "UIC operating period"}},
+      {"valid-day-bits", %{count: 1, criticity: "error", title: "Valid day bits"}}
+    ]},
+    {"warning", [{"frame-arret-resources", %{count: 1, criticity: "warning", title: "Frame arret resources"}}]}
+  ]
+  iex> summary(%{})
+  []
+  """
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def summary(%{} = validation_result) do
+    validation_result
+    |> Enum.map(fn {code, errors} ->
+      {code,
+       %{
+         count: length(errors),
+         criticity: errors |> hd() |> Map.get("criticity"),
+         title: issues_short_translation_per_code(code)
+       }}
+    end)
+    |> Enum.group_by(fn {_, details} -> details.criticity end)
+    |> Enum.sort_by(fn {criticity, _} -> severity_level(criticity) end)
+  end
+
+  @spec issues_short_translation_per_code(binary()) :: binary()
+  defp issues_short_translation_per_code(code) do
+    if String.starts_with?(code, "xsd-") do
+      dgettext("netex-validator", "XSD validation")
+    else
+      Map.get(issues_short_translation(), code, code)
+    end
+  end
+
+  @spec issues_short_translation() :: %{binary() => binary()}
+  defp issues_short_translation,
+    do: %{
+      "composite-frame-ligne-mandatory" => dgettext("netex-validator", "Composite frame ligne mandatory"),
+      "frame-arret-resources" => dgettext("netex-validator", "Frame arret resources"),
+      "frame-calendrier-resources" => dgettext("netex-validator", "Frame calendrier resources"),
+      "frame-horaire-resources" => dgettext("netex-validator", "Frame horaire resources"),
+      "frame-ligne-resources" => dgettext("netex-validator", "Frame ligne resources"),
+      "frame-reseau-resources" => dgettext("netex-validator", "Frame reseau resources"),
+      "latitude-mandatory" => dgettext("netex-validator", "Latitude mandatory"),
+      "longitude-mandatory" => dgettext("netex-validator", "Longitude mandatory"),
+      "uic-operating-period" => dgettext("netex-validator", "UIC operating period"),
+      "valid-day-bits" => dgettext("netex-validator", "Valid day bits"),
+      "version-any" => dgettext("netex-validator", "Version any"),
+      @unknown_code => dgettext("netex-validator", "Unspecified error")
+    }
+
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def issue_type([]), do: nil
+  def issue_type([h | _]), do: h["code"] || @unknown_code
+
+  @doc """
+  Get issues from validation results. For a specific issue type if specified, or the most severe.
+
+  iex> validation_result = %{"uic-operating-period" => [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "valid-day-bits" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}], "frame-arret-resources" => [%{"code" => "frame-arret-resources", "message" => "Tag frame_id doesn't match ''", "criticity" => "warning"}]}
+  iex> get_issues(validation_result, %{"issue_type" => "uic-operating-period"})
+  [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
+  iex> get_issues(validation_result, %{"issue_type" => "broken-file"})
+  []
+  iex> get_issues(validation_result, nil)
+  [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
+  iex> get_issues(%{}, nil)
+  []
+  iex> get_issues([], nil)
+  []
+  """
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def get_issues(%{} = validation_result, %{"issue_type" => issue_type}) do
+    Map.get(validation_result, issue_type, []) |> order_issues_by_location()
+  end
+
+  def get_issues(%{} = validation_result, _) do
+    validation_result
+    |> Map.values()
+    |> Enum.sort_by(fn [%{"criticity" => severity} | _] -> severity_level(severity) end)
+    |> List.first([])
+    |> order_issues_by_location()
+  end
+
+  def get_issues(_, _), do: []
+
+  defp order_issues_by_location(issues) do
+    issues
+    |> Enum.sort_by(fn issue ->
+      message = Map.get(issue, "message", "")
+      resource = Map.get(issue, "resource", %{})
+      filename = Map.get(resource, "filename", "")
+      line = Map.get(resource, "line", "")
+      {filename, line, message}
+    end)
+  end
+end

--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -4,18 +4,14 @@ defmodule Transport.Validators.NeTEx.Validator do
   (by polling the tier API) and can take quite some time upon completion.
   """
 
-  use Gettext, backend: TransportWeb.Gettext
   require Logger
   alias Transport.Jobs.NeTExPollerJob, as: Poller
+  alias Transport.Validators.NeTEx.ResultsAdapters.V0_1_0, as: ResultsAdapter
 
   @behaviour Transport.Validators.Validator
 
-  @no_error "NoError"
-
   # 180 * 20 seconds = 1 hour
   @max_attempts 180
-
-  @unknown_code "unknown-code"
 
   defmacro too_many_attempts(attempt) do
     quote do
@@ -131,14 +127,17 @@ defmodule Transport.Validators.NeTEx.Validator do
         Logger.info("Result URL: #{result_url}")
 
         {:ok,
-         %{"validations" => index_messages([]), "metadata" => %{elapsed_seconds: elapsed_seconds, retries: retries}}}
+         %{
+           "validations" => ResultsAdapter.index_messages([]),
+           "metadata" => %{elapsed_seconds: elapsed_seconds, retries: retries}
+         }}
 
       {:error, %{details: {result_url, errors}, elapsed_seconds: elapsed_seconds, retries: retries}} ->
         Logger.info("Result URL: #{result_url}")
         # result_url in metadata?
         {:ok,
          %{
-           "validations" => errors |> index_messages(),
+           "validations" => errors |> ResultsAdapter.index_messages(),
            "metadata" => %{elapsed_seconds: elapsed_seconds, retries: retries}
          }}
 
@@ -187,7 +186,7 @@ defmodule Transport.Validators.NeTEx.Validator do
   end
 
   def insert_validation_results(resource_history_id, result_url, metadata, errors \\ []) do
-    result = index_messages(errors)
+    result = ResultsAdapter.index_messages(errors)
 
     %DB.MultiValidation{
       validation_timestamp: DateTime.utc_now(),
@@ -196,102 +195,11 @@ defmodule Transport.Validators.NeTEx.Validator do
       resource_history_id: resource_history_id,
       validator_version: validator_version(),
       command: result_url,
-      max_error: get_max_severity_error(result),
+      max_error: ResultsAdapter.get_max_severity_error(result),
       metadata: %DB.ResourceMetadata{metadata: metadata}
     }
     |> DB.Repo.insert!()
   end
-
-  @doc """
-  Returns the maximum issue severity found
-
-  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "error"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "error"}]}
-  iex> get_max_severity_error(validation_result)
-  "error"
-
-  iex> get_max_severity_error(%{})
-  "NoError"
-  """
-  @spec get_max_severity_error(map()) :: binary() | nil
-  def get_max_severity_error(validation_result) do
-    {severity, _} = validation_result |> count_max_severity()
-    severity
-  end
-
-  @doc """
-  Returns the maximum severity, with the issues count
-
-  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "error"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "warning"}]}
-  iex> count_max_severity(validation_result)
-  {"error", 2}
-  iex> validation_result = %{"frame-arret-resources" => [%{"criticity" => "warning"}]}
-  iex> count_max_severity(validation_result)
-  {"warning", 1}
-  iex> count_max_severity(%{})
-  {"NoError", 0}
-  """
-  @spec count_max_severity(map()) :: {binary(), integer()}
-  def count_max_severity(validation_result) when validation_result == %{} do
-    {@no_error, 0}
-  end
-
-  def count_max_severity(%{} = validation_result) do
-    validation_result
-    |> count_by_severity()
-    |> Enum.min_by(fn {severity, _count} -> severity |> severity_level() end)
-  end
-
-  def no_error?(severity), do: @no_error == severity
-
-  @spec severity_level(binary()) :: integer()
-  def severity_level(key) do
-    case key do
-      "error" -> 1
-      "warning" -> 2
-      "information" -> 3
-      _ -> 4
-    end
-  end
-
-  @doc """
-  iex> Gettext.put_locale("en")
-  iex> format_severity("error", 1)
-  "1 error"
-  iex> format_severity("error", 2)
-  "2 errors"
-  iex> Gettext.put_locale("fr")
-  iex> format_severity("error", 1)
-  "1 erreur"
-  iex> format_severity("error", 2)
-  "2 erreurs"
-  """
-  @spec format_severity(binary(), non_neg_integer()) :: binary()
-  def format_severity(key, count) do
-    case key do
-      "error" -> dngettext("netex-validator", "error", "errors", count)
-      "warning" -> dngettext("netex-validator", "warning", "warnings", count)
-      "information" -> dngettext("netex-validator", "information", "informations", count)
-    end
-  end
-
-  @doc """
-  Returns the number of issues by severity level
-
-  iex> validation_result = %{"uic-operating-period" => [%{"criticity" => "warning"}], "valid-day-bits" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "error"}]}
-  iex> count_by_severity(validation_result)
-  %{"warning" => 1, "error" => 2}
-
-  iex> count_by_severity(%{})
-  %{}
-  """
-  @spec count_by_severity(map()) :: map()
-  def count_by_severity(%{} = validation_result) do
-    validation_result
-    |> Enum.flat_map(fn {_, v} -> v end)
-    |> Enum.reduce(%{}, fn v, acc -> Map.update(acc, v["criticity"], 1, &(&1 + 1)) end)
-  end
-
-  def count_by_severity(_), do: %{}
 
   defp validate_with_enroute(filepath) do
     setup_validation(filepath) |> poll_validation_results(0)
@@ -316,120 +224,6 @@ defmodule Transport.Validators.NeTEx.Validator do
       :unexpected_validation_status ->
         {:error, :unexpected_validation_status}
     end
-  end
-
-  @doc """
-  iex> index_messages([])
-  %{}
-
-  iex> index_messages([%{"code"=>"a", "id"=> 1}, %{"code"=>"a", "id"=> 2}, %{"code"=>"b", "id"=> 3}])
-  %{"a"=>[%{"code"=>"a", "id"=> 1}, %{"code"=>"a", "id"=> 2}], "b"=>[%{"code"=>"b", "id"=> 3}]}
-
-  Sometimes the message has no code
-  iex> index_messages([%{"code"=>"a", "id"=> 1}, %{"code"=>"b", "id"=> 2}, %{"id"=> 3}])
-  %{"a"=>[%{"code"=>"a", "id"=> 1}], "b"=>[%{"code"=>"b", "id"=> 2}], "unknown-code"=>[%{"id"=> 3}]}
-  """
-  def index_messages(messages), do: Enum.group_by(messages, &get_code/1)
-
-  defp get_code(%{"code" => code}), do: code
-  defp get_code(%{}), do: @unknown_code
-
-  @doc """
-  iex> validation_result = %{"uic-operating-period" => [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "valid-day-bits" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}], "frame-arret-resources" => [%{"code" => "frame-arret-resources", "message" => "Tag frame_id doesn't match ''", "criticity" => "warning"}]}
-  iex> summary(validation_result)
-  [
-    {"error", [
-      {"uic-operating-period", %{count: 1, criticity: "error", title: "UIC operating period"}},
-      {"valid-day-bits", %{count: 1, criticity: "error", title: "Valid day bits"}}
-    ]},
-    {"warning", [{"frame-arret-resources", %{count: 1, criticity: "warning", title: "Frame arret resources"}}]}
-  ]
-  iex> summary(%{})
-  []
-  """
-  @spec summary(map()) :: list()
-  def summary(%{} = validation_result) do
-    validation_result
-    |> Enum.map(fn {code, errors} ->
-      {code,
-       %{
-         count: length(errors),
-         criticity: errors |> hd() |> Map.get("criticity"),
-         title: issues_short_translation_per_code(code)
-       }}
-    end)
-    |> Enum.group_by(fn {_, details} -> details.criticity end)
-    |> Enum.sort_by(fn {criticity, _} -> severity_level(criticity) end)
-  end
-
-  @spec issues_short_translation_per_code(binary()) :: binary()
-  def issues_short_translation_per_code(code) do
-    if String.starts_with?(code, "xsd-") do
-      dgettext("netex-validator", "XSD validation")
-    else
-      Map.get(issues_short_translation(), code, code)
-    end
-  end
-
-  @spec issues_short_translation() :: %{binary() => binary()}
-  def issues_short_translation,
-    do: %{
-      "composite-frame-ligne-mandatory" => dgettext("netex-validator", "Composite frame ligne mandatory"),
-      "frame-arret-resources" => dgettext("netex-validator", "Frame arret resources"),
-      "frame-calendrier-resources" => dgettext("netex-validator", "Frame calendrier resources"),
-      "frame-horaire-resources" => dgettext("netex-validator", "Frame horaire resources"),
-      "frame-ligne-resources" => dgettext("netex-validator", "Frame ligne resources"),
-      "frame-reseau-resources" => dgettext("netex-validator", "Frame reseau resources"),
-      "latitude-mandatory" => dgettext("netex-validator", "Latitude mandatory"),
-      "longitude-mandatory" => dgettext("netex-validator", "Longitude mandatory"),
-      "uic-operating-period" => dgettext("netex-validator", "UIC operating period"),
-      "valid-day-bits" => dgettext("netex-validator", "Valid day bits"),
-      "version-any" => dgettext("netex-validator", "Version any"),
-      @unknown_code => dgettext("netex-validator", "Unspecified error")
-    }
-
-  @spec issue_type(list()) :: nil | binary()
-  def issue_type([]), do: nil
-  def issue_type([h | _]), do: h["code"] || @unknown_code
-
-  @doc """
-  Get issues from validation results. For a specific issue type if specified, or the most severe.
-
-  iex> validation_result = %{"uic-operating-period" => [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "valid-day-bits" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}], "frame-arret-resources" => [%{"code" => "frame-arret-resources", "message" => "Tag frame_id doesn't match ''", "criticity" => "warning"}]}
-  iex> get_issues(validation_result, %{"issue_type" => "uic-operating-period"})
-  [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
-  iex> get_issues(validation_result, %{"issue_type" => "broken-file"})
-  []
-  iex> get_issues(validation_result, nil)
-  [%{"code" => "uic-operating-period", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
-  iex> get_issues(%{}, nil)
-  []
-  iex> get_issues([], nil)
-  []
-  """
-  def get_issues(%{} = validation_result, %{"issue_type" => issue_type}) do
-    Map.get(validation_result, issue_type, []) |> order_issues_by_location()
-  end
-
-  def get_issues(%{} = validation_result, _) do
-    validation_result
-    |> Map.values()
-    |> Enum.sort_by(fn [%{"criticity" => severity} | _] -> severity_level(severity) end)
-    |> List.first([])
-    |> order_issues_by_location()
-  end
-
-  def get_issues(_, _), do: []
-
-  def order_issues_by_location(issues) do
-    issues
-    |> Enum.sort_by(fn issue ->
-      message = Map.get(issue, "message", "")
-      resource = Map.get(issue, "resource", %{})
-      filename = Map.get(resource, "filename", "")
-      line = Map.get(resource, "line", "")
-      {filename, line, message}
-    end)
   end
 
   defp client do

--- a/apps/transport/test/transport/validators/netex/results_adapters/v0_1_0_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/v0_1_0_test.exs
@@ -1,0 +1,4 @@
+defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0Test do
+  use ExUnit.Case, async: true
+  doctest Transport.Validators.NeTEx.ResultsAdapters.V0_1_0, import: true
+end

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -7,8 +7,6 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
 
   alias Transport.Validators.NeTEx.Validator
 
-  doctest Transport.Validators.NeTEx.Validator, import: true
-
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end


### PR DESCRIPTION
Cette PR sépare le code de validation (appels d’API enRoute, construction de l’entité MultiValidation, stockage en base, mécanismes de polling et gestion d’erreurs) du code qui sait interpréter les résultats de validation NeTEx.

Cette séparation sera importante pour ensuite faire évoluer la représentation des résultats tout en état capable d’afficher les anciennes validations.

Cette PR introduit notamment l’interface `ResultsAdapter`, abstraction des fonctionnalités d’inspection des résultats (essentiellement utilisées dans les écrans). Cette interface est le compagnon de `Validator`.

Dans cette PR il n’y a donc qu’une implémentation de `ResultsAdapter`, `V0_1_0`, chargée d’inspecter les résultats de validation présents en production à date de cette PR.

Cette PR ne change pas le comportement de la validation NeTEx.

L’essentiel de la différence consiste donc en 2 changements :
- une bonne partie du code de `Transports.Validators.NeTEx.Validator` est extrait dans `Transports.Validators.NeTEx.ResultsAdapter.V0_1_0`
- les écrans sont adaptés pour utilisé l’interface `ResultsAdapter` moyennant une fonction de "dispatch" (`ResultsAdapter.resolve`). Cette fonction est triviale puisqu’une seule version est actuellement supportée. Elle est également un "catch-all" pour l’avenir.