### PR TITLE
dataset#details : cache history_resources

### DIFF
--- a/apps/transport/lib/jobs/resource_history_job.ex
+++ b/apps/transport/lib/jobs/resource_history_job.ex
@@ -171,6 +171,7 @@ defmodule Transport.Jobs.ResourceHistoryJob do
         Transport.S3.stream_to_s3!(:history, resource_path, filename, acl: :public_read)
         %{id: resource_history_id} = store_resource_history!(resource_or_improved_data, data)
         Appsignal.increment_counter("resource_history_job.success", 1)
+        delete_cache(resource_or_improved_data)
         %{resource_history_id: resource_history_id}
 
       {false, history} ->
@@ -184,6 +185,13 @@ defmodule Transport.Jobs.ResourceHistoryJob do
         {:error, "historization failed"}
     end
   end
+
+  defp delete_cache(%DB.Resource{dataset_id: dataset_id}) do
+    cache_key = TransportWeb.DatasetController.history_resources_cache_key(%DB.Dataset{id: dataset_id})
+    Transport.Cache.del(cache_key)
+  end
+
+  defp delete_cache(_), do: :ok
 
   @doc """
   Determine if we would historicise a payload now.

--- a/apps/transport/lib/transport/cache.ex
+++ b/apps/transport/lib/transport/cache.ex
@@ -10,6 +10,9 @@ defmodule Transport.Cache do
 
   def put(cache_key, value, expire_value \\ :timer.seconds(60)), do: impl().put(cache_key, value, expire_value)
 
+  @callback del(cache_key :: binary()) :: {:ok | :error, boolean()}
+  def del(cache_key), do: impl().del(cache_key)
+
   defp impl, do: Application.get_env(:transport, :cache_impl)
 end
 
@@ -94,6 +97,10 @@ defmodule Transport.Cache.Cachex do
     )
   end
 
+  def del(cache_key) do
+    Cachex.del(cache_name(), cache_key)
+  end
+
   def cache_name, do: Transport.Application.cache_name()
 end
 
@@ -106,4 +113,6 @@ defmodule Transport.Cache.Null do
   def fetch(_cache_key, value_fn, _expire_value), do: value_fn.()
 
   def put(_cache_key, _value, _expire_value), do: {:ok, true}
+
+  def del(_cache_key), do: {:ok, true}
 end


### PR DESCRIPTION
En lien avec #4613 et #4502

Met en cache la partie du calcul des ressources historisées pour la page `dataset#details`. Cette requête a été identifiée comme étant consommatrice de ressources et lente.