### PR TITLE
ConsolidateBNLC : ignore XLSX

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -474,6 +474,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
     analyze_dataset = fn %{"resources" => resources} = dataset_details ->
       resources
       |> Enum.filter(&with_appropriate_schema?/1)
+      |> Enum.reject(&xlsx?/1)
       |> Enum.map(fn %{"url" => _} = resource -> analyze_resource.(dataset_details, resource) end)
     end
 
@@ -573,6 +574,19 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   @spec with_appropriate_schema?(map()) :: boolean()
   def with_appropriate_schema?(%{"schema" => %{"name" => name}}) when name == @schema_name, do: true
   def with_appropriate_schema?(%{}), do: false
+
+  @doc """
+  iex> xlsx?(%{"format" => "csv"})
+  false
+  iex> xlsx?(%{"format" => "xlsx"})
+  true
+  iex> xlsx?(%{"title" => "hello.xlsx"})
+  true
+  """
+  @spec xlsx?(map()) :: boolean()
+  def xlsx?(%{"format" => "xlsx"}), do: true
+  def xlsx?(%{"title" => title}), do: String.contains?(title |> String.downcase(), "xlsx")
+  def xlsx?(_), do: false
 
   @doc """
   iex> dataset_slug_to_url("foo")

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -138,6 +138,11 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
           },
           # Ignored, not the expected schema
           %{"format" => "GTFS"},
+          # Ignored: XLSX
+          %{
+            "schema" => %{"name" => @target_schema},
+            "format" => "xlsx"
+          },
           other_resource = %{
             "schema" => %{"name" => @target_schema},
             "url" => other_url = "https://example.com/other_file.csv"


### PR DESCRIPTION
Ignore les ressources XLSX taggués avec le schéma covoiturage dans la consolidation.