### PR TITLE
Script de calcul de petites statistiques sur la consolidation IRVE brute statique

### DIFF
--- a/scripts/irve/stats.exs
+++ b/scripts/irve/stats.exs
@@ -4,7 +4,7 @@ Mix.install([
 ])
 
 url = "https://proxy.transport.data.gouv.fr/resource/consolidation-nationale-irve-statique"
-file = Path.join(__DIR__, "data/consolidation-nationale-irve-statique.csv")
+file = Path.join(__DIR__, "../../cache-dir/consolidation-nationale-irve-statique.csv")
 
 # File.rm!(file)
 

--- a/scripts/irve/stats.exs
+++ b/scripts/irve/stats.exs
@@ -25,4 +25,4 @@ defmodule Stats do
   end
 end
 
-IO.inspect(Stats.compute(file), IEx.inspect_opts)
+IO.inspect(Stats.compute(file), IEx.inspect_opts())

--- a/scripts/irve/stats.exs
+++ b/scripts/irve/stats.exs
@@ -1,0 +1,28 @@
+Mix.install([
+  {:req, "~> 0.5.15"},
+  {:explorer, "~> 0.11.0"}
+])
+
+url = "https://proxy.transport.data.gouv.fr/resource/consolidation-nationale-irve-statique"
+file = Path.join(__DIR__, "data/consolidation-nationale-irve-statique.csv")
+
+# File.rm!(file)
+
+unless File.exists?(file) do
+  %{status: 200} = Req.get!(url, into: File.stream!(file))
+end
+
+defmodule Stats do
+  require Explorer.DataFrame
+
+  def compute(file) do
+    df = Explorer.DataFrame.from_csv!(file, infer_schema_length: nil)
+
+    %{
+      count: df["id_pdc_itinerance"] |> Explorer.Series.size(),
+      distinct_count: df["id_pdc_itinerance"] |> Explorer.Series.distinct() |> Explorer.Series.size()
+    }
+  end
+end
+
+IO.inspect(Stats.compute(file), IEx.inspect_opts)


### PR DESCRIPTION
Dans la lignée de :
- #4397 qui introduisait l'agrégat brut
- #4492 qui générait l'agrégat chaque nuit et le stocke dans S3
- #4639 qui a modifié le proxy pour servir des fichiers depuis S3
- https://github.com/etalab/transport-proxy-config/pull/145 qui a configuré le proxy

je peux introduire à présent ce script, qui va me servir à suivre les améliorations du code qui ingère et traite les fichiers ici:
- #4715