### PR TITLE
Carte GBFS : intègre global_rules pour geofencing_zones

### DIFF
--- a/apps/transport/client/javascripts/resource-viz.js
+++ b/apps/transport/client/javascripts/resource-viz.js
@@ -134,9 +134,9 @@ function setGBFSFreeFloatingStyle (feature, layer) {
     layer.bindPopup(`<pre>${popupContent}</pre>`)
 }
 
-function setGBFSGeofencingStyle (feature, layer) {
+function setGBFSGeofencingStyle (feature, layer, global_rules) {
     const rules = feature.properties.rules
-    const rule = rules.length > 0 ? rules[0] : undefined
+    const rule = (rules && rules.length > 0) ? rules[0] : global_rules
     let color, opacity, popupContent
 
     if (rule) {
@@ -201,7 +201,7 @@ function fillGeofencingZones (geojson, geoFencingZones) {
     geojson.features = geojson.features.reverse()
 
     L.geoJSON(geojson, {
-        onEachFeature: (feature, layer) => setGBFSGeofencingStyle(feature, layer)
+        onEachFeature: (feature, layer) => setGBFSGeofencingStyle(feature, layer, geojson.global_rules)
     }).addTo(geoFencingZones)
 }
 

--- a/apps/transport/lib/transport/gbfs_to_geojson.ex
+++ b/apps/transport/lib/transport/gbfs_to_geojson.ex
@@ -211,8 +211,11 @@ defmodule Transport.GbfsToGeojson do
         resp_data
 
       url ->
-        geojson = geofencing_zones_geojson!(url)
-        resp_data |> Map.put("geofencing_zones", geojson)
+        data = geofencing_zones_geojson!(url)
+        geofencing_zones = data["geofencing_zones"] |> Map.put("global_rules", data["global_rules"])
+
+        resp_data
+        |> Map.put("geofencing_zones", geofencing_zones)
     end
   rescue
     _e -> resp_data
@@ -223,7 +226,6 @@ defmodule Transport.GbfsToGeojson do
     url
     |> fetch_gbfs_endpoint!()
     |> Map.fetch!("data")
-    |> Map.fetch!("geofencing_zones")
   end
 
   @spec fetch_gbfs_endpoint!(binary()) :: map()

--- a/apps/transport/test/transport/gbfs_to_geojson_test.exs
+++ b/apps/transport/test/transport/gbfs_to_geojson_test.exs
@@ -140,6 +140,9 @@ defmodule Transport.GbfsToGeojsonTest do
       geojsons = Transport.GbfsToGeojson.gbfs_geojsons(gbfs_endpoint, %{})
 
       assert geojsons["geofencing_zones"] == %{
+               "global_rules" => [
+                 %{"ride_end_allowed" => true, "ride_start_allowed" => true, "ride_through_allowed" => true}
+               ],
                "type" => "FeatureCollection",
                "features" => [
                  %{
@@ -363,7 +366,12 @@ defmodule Transport.GbfsToGeojsonTest do
                             }
                         }
                     ]
-                }
+                },
+                "global_rules": [{
+                  "ride_start_allowed": true,
+                  "ride_end_allowed": true,
+                  "ride_through_allowed": true
+                }]
             }
         }
         """


### PR DESCRIPTION
Fixes #4717

Intègre les `global_rules` de `geofencing_zones`, ajoutées en v3.0. Ces règles s'appliquent quand une règle n'est pas définie pour chaque polygone de règle dans les geofencing zones.