### PR TITLE
Formated format SSIM

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -832,6 +832,9 @@ defmodule Transport.ImportData do
 
       iex> formated_format(%{"format" => "json", "url" => "https://bdx.mecatran.com/utw/ws/siri/2.0/bordeaux/stop-monitoring.json"}, "public-transit", false)
       "SIRI Lite"
+
+      iex> formated_format(%{"format" => "SSIM"}, "public-transit", false)
+      "SSIM"
   """
   @spec formated_format(map(), binary(), bool()) :: binary()
   def formated_format(%{"url" => "https://bdx.mecatran.com/utw/ws/siri/2.0/" <> _}, _, _) do
@@ -850,6 +853,7 @@ defmodule Transport.ImportData do
       siri_lite?(format) -> "SIRI Lite"
       siri?(format) -> "SIRI"
       geojson?(resource, format) -> "geojson"
+      ssim?(format) -> "SSIM"
       type == "public-transit" and not is_documentation and not is_community_resource -> "GTFS"
       type == "vehicles-sharing" and gbfs?(resource) -> "gbfs"
       true -> format


### PR DESCRIPTION
Suite de #4721, il faut mettre à jour `formated_format` aussi sinon le format par défaut pour `public-transit` est `GTFS`… (voir ligne suivante) et https://transport.data.gouv.fr/datasets/programme-des-vols