### PR TITLE
Edition du territoire couvert déclaré dans le backoffice

### DIFF
--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -44,7 +44,7 @@ window.addEventListener('phx:backoffice-form-owner-reset', () => {
 })
 
 window.addEventListener('phx:backoffice-form-spatial-areas-reset', () => {
-    document.getElementById('declarative_spatial_areas_input').value = ''
+    document.getElementById('spatial_areas_search_input').value = ''
 })
 
 window.addEventListener('phx:gtfs-diff:scroll-to-steps', () => {

--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -43,6 +43,10 @@ window.addEventListener('phx:backoffice-form-owner-reset', () => {
     document.getElementById('js-owner-input').value = ''
 })
 
+window.addEventListener('phx:backoffice-form-spatial-areas-reset', () => {
+    document.getElementById('declarative_spatial_areas_input').value = ''
+})
+
 window.addEventListener('phx:gtfs-diff:scroll-to-steps', () => {
     document.getElementById('gtfs-diff-steps').parentElement.scrollIntoView({ behavior: 'smooth' })
 })

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -188,6 +188,15 @@
   &.blue {
     background-color: var(--lighter-blue);
   }
+  &.orange {
+    background-color: var(--light-orange);
+  }
+  &.grey {
+    background-color: var(--lighter-grey);
+  }
+  &.red {
+    background-color: var(--light-red);
+  }
   .delete-tag {
     cursor: pointer;
     display: inline-block;

--- a/apps/transport/lib/db/administrative_division.ex
+++ b/apps/transport/lib/db/administrative_division.ex
@@ -22,6 +22,7 @@ defmodule DB.AdministrativeDivision do
   use Ecto.Schema
   use TypedEctoSchema
   import Ecto.Changeset
+  use Gettext, backend: TransportWeb.Gettext
 
   @types ~w(commune departement epci region pays)a
 
@@ -83,4 +84,13 @@ defmodule DB.AdministrativeDivision do
   def search(territoires, term) do
     Transport.SearchCommunes.filter(territoires, term)
   end
+
+  def display_type(%DB.AdministrativeDivision{type: :commune}), do: dgettext("administrative_division", "municipality")
+
+  def display_type(%DB.AdministrativeDivision{type: :departement}),
+    do: dgettext("administrative_division", "department")
+
+  def display_type(%DB.AdministrativeDivision{type: :epci}), do: dgettext("administrative_division", "EPCI")
+  def display_type(%DB.AdministrativeDivision{type: :region}), do: dgettext("administrative_division", "region")
+  def display_type(%DB.AdministrativeDivision{type: :pays}), do: dgettext("administrative_division", "country")
 end

--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -34,6 +34,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
       |> transform_custom_tags_to_list()
       |> transform_legal_owners_aom_to_list()
       |> transform_legal_owners_region_to_list()
+      |> transform_declarative_spatial_areas_to_list()
 
     with datagouv_id when not is_nil(datagouv_id) <- dataset_datagouv_id,
          {:ok, dg_dataset} <- ImportData.import_from_data_gouv(datagouv_id, form_params["type"]),
@@ -83,6 +84,13 @@ defmodule TransportWeb.Backoffice.DatasetController do
   defp transform_legal_owners_aom_to_list(form_params) do
     aoms = for {"legal_owners_aom" <> _, aom_id} <- form_params, do: aom_id |> String.to_integer()
     Map.put(form_params, "legal_owners_aom", aoms)
+  end
+
+  defp transform_declarative_spatial_areas_to_list(form_params) do
+    declarative_spatial_areas =
+      for {"declarative_spatial_area" <> _, division_id} <- form_params, do: division_id |> String.to_integer()
+
+    Map.put(form_params, "declarative_spatial_areas", declarative_spatial_areas)
   end
 
   @spec insert_dataset(Ecto.Changeset.t()) :: {:ok, Dataset.t()} | {:error, binary}

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -183,7 +183,8 @@ defmodule TransportWeb.Backoffice.PageController do
       [notification_subscriptions: :contact],
       [organization_object: :contacts],
       :legal_owners_aom,
-      :legal_owners_region
+      :legal_owners_region,
+      :declarative_spatial_areas
     ])
     |> Repo.get(dataset_id)
   end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -1,12 +1,13 @@
 defmodule TransportWeb.DeclarativeSpatialAreasLive do
   use Phoenix.LiveComponent
   alias TransportWeb.InputHelpers
+  use Gettext, backend: TransportWeb.Gettext
 
   def render(assigns) do
     ~H"""
     <div class="pt-24">
       <label>
-        Une ou plusieurs communes, EPCI, département, région
+        <%= dgettext("backoffice", "spatial areas label") %>
       </label>
       <%= InputHelpers.text_input(
         @form,
@@ -44,9 +45,6 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
         </span>
         <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>
       </div>
-      # TODO : make search names and tag names pretty (with accents etc)
-      # TODO : localize the label
-      # TODO : avoid duplicates
     </div>
     """
   end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -30,7 +30,9 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
               <li class="autoComplete_result" phx-target={@myself} phx-click="select_division" phx-value-id={match.id} }>
                 <div>
                   <span class="autocomplete_name"><%= match.nom %></span>
-                  <span class="autocomplete_type"><%= DB.AdministrativeDivision.display_type(match) %></span>
+                  <span class="autocomplete_type">
+                    <%= match.insee %> – <%= DB.AdministrativeDivision.display_type(match) %>
+                  </span>
                 </div>
               </li>
             <% end %>
@@ -40,7 +42,7 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
 
       <div :for={{division, index} <- Enum.with_index(@declarative_spatial_areas)} class="pt-6">
         <span class={["label", "custom-tag"] ++ [color_class(division)]}>
-          <%= division.nom %> (<%= DB.AdministrativeDivision.display_type(division) %>)
+          <%= division.nom %> (<%= division.insee %> – <%= DB.AdministrativeDivision.display_type(division) %>)
           <span class="delete-tag" phx-click="remove_division" phx-value-id={division.id} phx-target={@myself}></span>
         </span>
         <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -29,7 +29,7 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
               <li class="autoComplete_result" phx-target={@myself} phx-click="select_division" phx-value-id={match.id} }>
                 <div>
                   <span class="autocomplete_name"><%= match.nom %></span>
-                  <span class="autocomplete_type"><%= match.type %></span>
+                  <span class="autocomplete_type"><%= DB.AdministrativeDivision.display_type(match) %></span>
                 </div>
               </li>
             <% end %>
@@ -39,14 +39,14 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
 
       <div :for={{division, index} <- Enum.with_index(@declarative_spatial_areas)} class="pt-6">
         <span class={["label", "custom-tag"] ++ [color_class(division)]}>
-          <%= division.nom %> (<%= division.type %>)
+          <%= division.nom %> (<%= DB.AdministrativeDivision.display_type(division) %>)
           <span class="delete-tag" phx-click="remove_division" phx-value-id={division.id} phx-target={@myself}></span>
         </span>
         <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>
       </div>
       # TODO : make search names and tag names pretty (with accents etc)
       # TODO : localize the label
-      # TODO : I’ve removed         list: "administrative_divisions_suggestions" to the text input, I don’t think it was needed
+      # TODO : avoid duplicates
     </div>
     """
   end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -5,8 +5,18 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
   def render(assigns) do
     ~H"""
     <div class="pt-24">
+      <div :for={{division, index} <- Enum.with_index(@declarative_spatial_areas)} class="pt-6">
+        <span class={["label", "custom-tag"] ++ [color_class(division)]}>
+          <%= division.nom %> (<%= division.type %>)
+          <span class="delete-tag" phx-click="remove_tag" phx-value-id={division.id} phx-target={@myself}></span>
+        </span>
+        <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>
+      </div>
     </div>
     """
+  end
 
+  def color_class(division) do
+    "red"
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -89,12 +89,11 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
   def handle_event("select_division", %{"id" => id}, socket) do
     division = DB.AdministrativeDivision |> DB.Repo.get!(id)
 
-
     declarative_spatial_areas = socket.assigns.declarative_spatial_areas ++ [division]
 
     send(self(), {:updated_spatial_areas, declarative_spatial_areas})
 
-    {:noreply, socket |> assign(administrative_division_search_matches: []) |> clear_input()}
+    {:noreply, socket |> assign(administrative_division_search_matches: [])}
   end
 
   def clear_input(socket) do
@@ -105,8 +104,4 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
   defp color_class(division) do
     "red"
   end
-
-
-
-
 end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -40,7 +40,7 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
       <div :for={{division, index} <- Enum.with_index(@declarative_spatial_areas)} class="pt-6">
         <span class={["label", "custom-tag"] ++ [color_class(division)]}>
           <%= division.nom %> (<%= division.type %>)
-          <span class="delete-tag" phx-click="remove_tag" phx-value-id={division.id} phx-target={@myself}></span>
+          <span class="delete-tag" phx-click="remove_division" phx-value-id={division.id} phx-target={@myself}></span>
         </span>
         <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>
       </div>
@@ -94,6 +94,18 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
     send(self(), {:updated_spatial_areas, declarative_spatial_areas})
 
     {:noreply, socket |> assign(administrative_division_search_matches: [])}
+  end
+
+  def handle_event("remove_division", %{"id" => id}, socket) do
+    declarative_spatial_areas =
+      socket.assigns.declarative_spatial_areas
+      |> Enum.reject(fn division ->
+        division.id == String.to_integer(id)
+      end)
+
+    send(self(), {:updated_spatial_areas, declarative_spatial_areas})
+
+    {:noreply, socket}
   end
 
   def clear_input(socket) do

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -10,11 +10,11 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
       </label>
       <%= InputHelpers.text_input(
         @form,
-        :declarative_spatial_areas_input,
+        :spatial_areas_search_input,
         placeholder: "Paris",
         phx_keydown: "search_division",
         phx_target: @myself,
-        id: "declarative_spatial_areas_input"
+        id: "spatial_areas_search_input"
       ) %>
       <div
         :if={@administrative_division_search_matches != []}

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -113,7 +113,9 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
     push_event(socket, "backoffice-form-spatial-areas-reset", %{})
   end
 
-  defp color_class(division) do
-    "red"
-  end
+  defp color_class(%DB.AdministrativeDivision{type: :commune}), do: "green"
+  defp color_class(%DB.AdministrativeDivision{type: :epci}), do: "blue"
+  defp color_class(%DB.AdministrativeDivision{type: :departement}), do: "orange"
+  defp color_class(%DB.AdministrativeDivision{type: :region}), do: "grey"
+  defp color_class(%DB.AdministrativeDivision{type: :pays}), do: "red"
 end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -1,0 +1,12 @@
+defmodule TransportWeb.DeclarativeSpatialAreasLive do
+  use Phoenix.LiveComponent
+  alias TransportWeb.InputHelpers
+
+  def render(assigns) do
+    ~H"""
+    <div class="pt-24">
+    </div>
+    """
+
+  end
+end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -86,7 +86,27 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
     {:noreply, socket}
   end
 
-  def color_class(division) do
+  def handle_event("select_division", %{"id" => id}, socket) do
+    division = DB.AdministrativeDivision |> DB.Repo.get!(id)
+
+
+    declarative_spatial_areas = socket.assigns.declarative_spatial_areas ++ [division]
+
+    send(self(), {:updated_spatial_areas, declarative_spatial_areas})
+
+    {:noreply, socket |> assign(administrative_division_search_matches: []) |> clear_input()}
+  end
+
+  def clear_input(socket) do
+    # TODO: this doesn’t work, the input is not cleared
+    push_event(socket, "backoffice-form-spatial-areas-reset", %{})
+  end
+
+  defp color_class(division) do
     "red"
   end
+
+
+
+
 end

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -160,6 +160,10 @@ defmodule TransportWeb.EditDatasetLive do
     {:noreply, socket |> assign(:custom_tags, custom_tags)}
   end
 
+  def handle_info({:updated_spatial_areas, updated_spatial_areas}, socket) do
+    {:noreply, socket |> assign(:declarative_spatial_areas, updated_spatial_areas)}
+  end
+
   # get the result from the async Task triggered by "change_dataset"
   def handle_info({ref, datagouv_infos}, socket) do
     # we stop monitoring the process after receiving the result

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -39,6 +39,7 @@ defmodule TransportWeb.EditDatasetLive do
       |> assign(:trigger_submit, false)
       |> assign(:form_params, form_params(dataset))
       |> assign(:custom_tags, get_custom_tags(dataset))
+      |> assign(:declarative_spatial_areas, get_declarative_spatial_areas(dataset))
       |> assign(:matches, [])
 
     {:ok, socket}
@@ -89,6 +90,12 @@ defmodule TransportWeb.EditDatasetLive do
   end
 
   def get_custom_tags(_), do: []
+
+  def get_declarative_spatial_areas(%Dataset{} = dataset) do
+    dataset.declaravive_spatial_areas || []
+  end
+
+  def get_declarative_spatial_areas(_), do: []
 
   def organization_types,
     do: [

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -161,7 +161,12 @@ defmodule TransportWeb.EditDatasetLive do
   end
 
   def handle_info({:updated_spatial_areas, updated_spatial_areas}, socket) do
-    {:noreply, socket |> assign(:declarative_spatial_areas, updated_spatial_areas)}
+    {
+      :noreply,
+      socket
+      |> assign(:declarative_spatial_areas, updated_spatial_areas)
+      |> TransportWeb.DeclarativeSpatialAreasLive.clear_input()
+    }
   end
 
   # get the result from the async Task triggered by "change_dataset"

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -92,7 +92,7 @@ defmodule TransportWeb.EditDatasetLive do
   def get_custom_tags(_), do: []
 
   def get_declarative_spatial_areas(%Dataset{} = dataset) do
-    dataset.declaravive_spatial_areas || []
+    dataset.declarative_spatial_areas || []
   end
 
   def get_declarative_spatial_areas(_), do: []

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -106,7 +106,7 @@
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>
-        <%= dgettext("backoffice", "Associated territory") %>
+        <%= dgettext("backoffice", "Associated territory (legacy)") %>
       </h4>
       <%= dgettext("backoffice", "Choose one") %>
     </div>
@@ -165,6 +165,21 @@
       </div>
     </div>
   </div>
+
+  <div class="panel mt-48">
+    <div class="panel__header">
+      <h4>
+        <%= dgettext("backoffice", "Associated territory (new)") %>
+      </h4>
+    </div>
+    <.live_component
+      module={TransportWeb.DeclarativeSpatialAreasLive}
+      id="declarative_spatial_areas"
+      form={f}
+      declarative_spatial_areas={@declarative_spatial_areas}
+    />
+  </div>
+
   <div id="backoffice_dataset_submit_buttons" class={if is_nil(@dataset), do: "pb-48"}>
     <div>
       <%= if is_nil(@dataset) do %>

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -106,7 +106,7 @@
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>
-        <%= dgettext("backoffice", "Associated territory (legacy)") %>
+        <%= dgettext("backoffice", "Spatial area (legacy)") %>
       </h4>
       <%= dgettext("backoffice", "Choose one") %>
     </div>
@@ -169,7 +169,7 @@
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>
-        <%= dgettext("backoffice", "Associated territory (new)") %>
+        <%= dgettext("backoffice", "Spatial area (new)") %>
       </h4>
     </div>
     <.live_component

--- a/apps/transport/priv/gettext/administrative_division.pot
+++ b/apps/transport/priv/gettext/administrative_division.pot
@@ -1,0 +1,32 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "EPCI"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "country"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "department"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "municipality"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "region"
+msgstr ""

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -79,10 +79,6 @@ msgid "Edit a dataset"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Associated territory"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Choose one"
 msgstr ""
 
@@ -311,3 +307,15 @@ msgid "reuser-count"
 msgid_plural "reusers-count"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (legacy)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (new)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "spatial areas label"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/administrative_division.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/administrative_division.po
@@ -1,0 +1,32 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "EPCI"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "country"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "department"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "municipality"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "region"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -79,12 +79,8 @@ msgid "Edit a dataset"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Associated territory"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Choose one"
-msgstr ""
+msgstr "Choose one. This is the displayed area to users."
 
 #, elixir-autogen, elixir-format
 msgid "Dataset linked to a list of cities in data.gouv.fr"
@@ -311,3 +307,15 @@ msgid "reuser-count"
 msgid_plural "reusers-count"
 msgstr[0] "%{reusers_count} reuser."
 msgstr[1] "%{reusers_count} reusers."
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (legacy)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (new)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "spatial areas label"
+msgstr "Choose one or many municipalities, EPCIs, departments, regions or country. This is not displayed to users (website, API) for now."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/administrative_division.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/administrative_division.po
@@ -1,0 +1,32 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n>1);\n"
+
+#, elixir-autogen, elixir-format
+msgid "EPCI"
+msgstr "EPCI"
+
+#, elixir-autogen, elixir-format
+msgid "country"
+msgstr "pays"
+
+#, elixir-autogen, elixir-format
+msgid "department"
+msgstr "département"
+
+#, elixir-autogen, elixir-format
+msgid "municipality"
+msgstr "commune"
+
+#, elixir-autogen, elixir-format
+msgid "region"
+msgstr "région"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -79,12 +79,8 @@ msgid "Edit a dataset"
 msgstr "Édition d'un jeu de données"
 
 #, elixir-autogen, elixir-format
-msgid "Associated territory"
-msgstr "Territoire associé"
-
-#, elixir-autogen, elixir-format
 msgid "Choose one"
-msgstr "Choisissez l'une des options"
+msgstr "Choisissez l'une des options. Ce territoire est celui actuellement affiché publiquement."
 
 #, elixir-autogen, elixir-format
 msgid "Dataset linked to a list of cities in data.gouv.fr"
@@ -311,3 +307,15 @@ msgid "reuser-count"
 msgid_plural "reusers-count"
 msgstr[0] "%{reusers_count} réutilisateur."
 msgstr[1] "%{reusers_count} réutilisateurs."
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (legacy)"
+msgstr "Territoire couvert déclaré (ancienne version)"
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area (new)"
+msgstr "Territoire couvert déclaré (nouvelle version)"
+
+#, elixir-autogen, elixir-format
+msgid "spatial areas label"
+msgstr "Choisissez un ou plusieurs communes, EPCI, départements, régions ou pays. Ceci n’est pas affiché publiquement (site, API) pour l’instant."

--- a/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
@@ -16,7 +16,9 @@ defmodule TransportWeb.CustomTagsLiveTest do
         # needs to be preloaded
         legal_owners_aom: [],
         # same
-        legal_owners_region: []
+        legal_owners_region: [],
+        # again
+        declarative_spatial_areas: []
       )
 
     {:ok, view, _html} =

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -121,7 +121,7 @@ defmodule TransportWeb.EditDatasetLiveTest do
     assert render(view) =~ "Ce jeu de données est déjà référencé"
   end
 
-  test "dataset form, show legal AOM owners saved in database", %{conn: conn} do
+  test "dataset form, show legal AOM owners and spatial areas saved in database", %{conn: conn} do
     conn = conn |> setup_admin_in_session()
 
     dataset =
@@ -130,7 +130,14 @@ defmodule TransportWeb.EditDatasetLiveTest do
         legal_owners_aom: [insert(:aom, nom: aom_name = "Bordeaux Métropole")],
         legal_owners_region: [insert(:region, nom: region_name = "jolie région")],
         # needs to be preloaded
-        declarative_spatial_areas: []
+        declarative_spatial_areas: [
+          insert(:administrative_division,
+            type: :epci,
+            insee: "123456789",
+            type_insee: "epci_123456789",
+            nom: "Mon EPCI"
+          )
+        ]
       )
 
     {:ok, view, _html} =
@@ -146,6 +153,7 @@ defmodule TransportWeb.EditDatasetLiveTest do
     assert render(view) =~ "Représentants légaux"
     assert render(view) =~ aom_name
     assert render(view) =~ region_name
+    assert render(view) =~ "Mon EPCI (123456789 – EPCI)"
   end
 
   test "dataset form, show legal company owner saved in database", %{conn: conn} do

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -128,7 +128,9 @@ defmodule TransportWeb.EditDatasetLiveTest do
       insert(:dataset,
         datagouv_id: "1234",
         legal_owners_aom: [insert(:aom, nom: aom_name = "Bordeaux Métropole")],
-        legal_owners_region: [insert(:region, nom: region_name = "jolie région")]
+        legal_owners_region: [insert(:region, nom: region_name = "jolie région")],
+        # needs to be preloaded
+        declarative_spatial_areas: []
       )
 
     {:ok, view, _html} =
@@ -154,7 +156,9 @@ defmodule TransportWeb.EditDatasetLiveTest do
         datagouv_id: "1234",
         legal_owner_company_siren: siren = "552049447",
         legal_owners_aom: [],
-        legal_owners_region: []
+        legal_owners_region: [],
+        # needs to be preloaded
+        declarative_spatial_areas: []
       )
 
     {:ok, view, _html} =


### PR DESCRIPTION
En images :

<img width="1247" height="694" alt="image" src="https://github.com/user-attachments/assets/3404c2ce-dc38-4290-b044-968481a8a8c3" />
<img width="1253" height="739" alt="image" src="https://github.com/user-attachments/assets/534b0537-5767-4106-bf4f-c336a2dbd1d0" />

Ce n’est pas testé, dans l’ensemble le backoffice ne l’est pas beaucoup. À voir si c’est bloquant pour merger.

Graphiquement, il y a une chose de sale : j’ai réutilisé le css d’autocomplete de la homepage, et il y a une phrase de hardcodée dedans (« ou recherchez par lieu »). Ça ne me choque pas pour du backoffice qui est un outil interne utilisé par les chargés de déploiement, mais ça peut se régler.

closes #4353 