### PR TITLE
Validation OnDemand: version du validateur NeTEx

### DIFF
--- a/apps/transport/lib/jobs/on_demand_netex_poller_job.ex
+++ b/apps/transport/lib/jobs/on_demand_netex_poller_job.ex
@@ -77,6 +77,7 @@ defmodule Transport.Jobs.OnDemandNeTExPollerJob do
       metadata: metadata,
       data_vis: nil,
       validator: Validator.validator_name(),
+      validator_version: Validator.validator_version(),
       validated_data_name: url,
       max_error: ResultsAdapter.get_max_severity_error(validation),
       oban_args: Helpers.completed()
@@ -86,7 +87,8 @@ defmodule Transport.Jobs.OnDemandNeTExPollerJob do
   defp build_error_validation_result(%{message: msg}) do
     %{
       oban_args: Helpers.error(msg),
-      validator: Validator.validator_name()
+      validator: Validator.validator_name(),
+      validator_version: Validator.validator_version()
     }
   end
 end

--- a/apps/transport/test/transport/jobs/on_demand_netex_poller_job_test.exs
+++ b/apps/transport/test/transport/jobs/on_demand_netex_poller_job_test.exs
@@ -51,7 +51,9 @@ defmodule Transport.Test.Transport.Jobs.OnDemandNeTExPollerJobTest do
                         "error_reason" => "enRoute Chouette Valid: Timeout while fetching results"
                       },
                       result: nil,
-                      validation_timestamp: date
+                      validation_timestamp: date,
+                      validator: "enroute-chouette-netex-validator",
+                      validator_version: "saas-production"
                     } = validation |> DB.Repo.reload() |> DB.Repo.preload(:metadata)
 
              assert DateTime.diff(date, DateTime.utc_now()) <= 1
@@ -71,7 +73,9 @@ defmodule Transport.Test.Transport.Jobs.OnDemandNeTExPollerJobTest do
              metadata: %{},
              oban_args: %{"state" => "completed", "type" => "netex"},
              result: %{},
-             validation_timestamp: date
+             validation_timestamp: date,
+             validator: "enroute-chouette-netex-validator",
+             validator_version: "saas-production"
            } = validation |> DB.Repo.reload() |> DB.Repo.preload(:metadata)
 
     assert DateTime.diff(date, DateTime.utc_now()) <= 1


### PR DESCRIPTION
La version n'était pas sauvegardée pour les validations OnDemand. Avoir la version permet d'adapter l'affichage des résultats.