### PR TITLE
BO territoires : gère flèches haut/bas

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -48,6 +48,53 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
         </span>
         <%= Phoenix.HTML.Form.hidden_input(@form, "declarative_spatial_area_#{index}", value: division.id) %>
       </div>
+
+      <script nonce={@nonce}>
+      // Handle arrow up/down to select autocomplete items
+      const searchInput = document.getElementById('spatial_areas_search_input');
+      let currentSelectedIndex = -1;
+
+      function updateSelection() {
+        const searchResults = document.getElementById('autoCompleteResults');
+        const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
+
+        results.forEach((item, index) => {
+          item.classList.remove("autoComplete_selected")
+          if (index === currentSelectedIndex) {
+            item.classList.add("autoComplete_selected");
+          }
+        });
+      }
+
+      searchInput.addEventListener('keydown', (event) => {
+        const searchResults = document.getElementById('autoCompleteResults');
+        const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
+        if (results.length === 0) {
+          return;
+        }
+
+        switch (event.key) {
+          case 'ArrowDown':
+            event.preventDefault(); // Prevent cursor from moving in input
+            currentSelectedIndex = (currentSelectedIndex + 1) % results.length;
+            updateSelection();
+            break;
+          case 'ArrowUp':
+            event.preventDefault(); // Prevent cursor from moving in input
+            currentSelectedIndex = (currentSelectedIndex - 1 + results.length) % results.length;
+            updateSelection();
+            break;
+          case 'Enter':
+            if (currentSelectedIndex > -1 && currentSelectedIndex < results.length) {
+              event.preventDefault();
+              const selectedItem = results[currentSelectedIndex];
+              selectedItem.click();
+              currentSelectedIndex = -1; // Reset selection
+            }
+            break;
+        }
+      });
+      </script>
     </div>
     """
   end

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -50,50 +50,50 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
       </div>
 
       <script nonce={@nonce}>
-      // Handle arrow up/down to select autocomplete items
-      const searchInput = document.getElementById('spatial_areas_search_input');
-      let currentSelectedIndex = -1;
+        // Handle arrow up/down to select autocomplete items
+        const searchInput = document.getElementById('spatial_areas_search_input');
+        let currentSelectedIndex = -1;
 
-      function updateSelection() {
-        const searchResults = document.getElementById('autoCompleteResults');
-        const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
+        function updateSelection() {
+          const searchResults = document.getElementById('autoCompleteResults');
+          const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
 
-        results.forEach((item, index) => {
-          item.classList.remove("autoComplete_selected")
-          if (index === currentSelectedIndex) {
-            item.classList.add("autoComplete_selected");
+          results.forEach((item, index) => {
+            item.classList.remove("autoComplete_selected")
+            if (index === currentSelectedIndex) {
+              item.classList.add("autoComplete_selected");
+            }
+          });
+        }
+
+        searchInput.addEventListener('keydown', (event) => {
+          const searchResults = document.getElementById('autoCompleteResults');
+          const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
+          if (results.length === 0) {
+            return;
+          }
+
+          switch (event.key) {
+            case 'ArrowDown':
+              event.preventDefault(); // Prevent cursor from moving in input
+              currentSelectedIndex = (currentSelectedIndex + 1) % results.length;
+              updateSelection();
+              break;
+            case 'ArrowUp':
+              event.preventDefault(); // Prevent cursor from moving in input
+              currentSelectedIndex = (currentSelectedIndex - 1 + results.length) % results.length;
+              updateSelection();
+              break;
+            case 'Enter':
+              if (currentSelectedIndex > -1 && currentSelectedIndex < results.length) {
+                event.preventDefault();
+                const selectedItem = results[currentSelectedIndex];
+                selectedItem.click();
+                currentSelectedIndex = -1; // Reset selection
+              }
+              break;
           }
         });
-      }
-
-      searchInput.addEventListener('keydown', (event) => {
-        const searchResults = document.getElementById('autoCompleteResults');
-        const results = Array.from(searchResults.querySelectorAll('.autoComplete_result[phx-click]'));
-        if (results.length === 0) {
-          return;
-        }
-
-        switch (event.key) {
-          case 'ArrowDown':
-            event.preventDefault(); // Prevent cursor from moving in input
-            currentSelectedIndex = (currentSelectedIndex + 1) % results.length;
-            updateSelection();
-            break;
-          case 'ArrowUp':
-            event.preventDefault(); // Prevent cursor from moving in input
-            currentSelectedIndex = (currentSelectedIndex - 1 + results.length) % results.length;
-            updateSelection();
-            break;
-          case 'Enter':
-            if (currentSelectedIndex > -1 && currentSelectedIndex < results.length) {
-              event.preventDefault();
-              const selectedItem = results[currentSelectedIndex];
-              selectedItem.click();
-              currentSelectedIndex = -1; // Reset selection
-            }
-            break;
-        }
-      });
       </script>
     </div>
     """

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -11,7 +11,8 @@ defmodule TransportWeb.EditDatasetLive do
         %{
           "dataset" => dataset,
           "dataset_types" => dataset_types,
-          "regions" => regions
+          "regions" => regions,
+          "csp_nonce_value" => nonce
         },
         socket
       ) do
@@ -31,6 +32,7 @@ defmodule TransportWeb.EditDatasetLive do
       socket
       |> assign(:dataset, dataset)
       |> assign(:dataset_types, dataset_types)
+      |> assign(:nonce, nonce)
       |> assign(:regions, regions)
       |> assign(:form_url, form_url)
       |> assign(:dataset_organization, dataset_organization)

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -177,6 +177,7 @@
       id="declarative_spatial_areas"
       form={f}
       declarative_spatial_areas={@declarative_spatial_areas}
+      nonce={@nonce}
     />
   </div>
 

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -1,6 +1,6 @@
 <div class="pt-48">
   <%= live_render(@conn, TransportWeb.EditDatasetLive,
-    session: %{"dataset" => @dataset, "dataset_types" => @dataset_types, "regions" => @regions}
+    session: %{"dataset" => @dataset, "dataset_types" => @dataset_types, "regions" => @regions, "csp_nonce_value" => Plug.Conn.get_session(@conn, :nonce)}
   ) %>
 
   <%= unless is_nil(@dataset) do %>

--- a/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/backoffice/page/form_dataset.html.heex
@@ -1,6 +1,11 @@
 <div class="pt-48">
   <%= live_render(@conn, TransportWeb.EditDatasetLive,
-    session: %{"dataset" => @dataset, "dataset_types" => @dataset_types, "regions" => @regions, "csp_nonce_value" => Plug.Conn.get_session(@conn, :nonce)}
+    session: %{
+      "dataset" => @dataset,
+      "dataset_types" => @dataset_types,
+      "regions" => @regions,
+      "csp_nonce_value" => Plug.Conn.get_session(@conn, :nonce)
+    }
   ) %>
 
   <%= unless is_nil(@dataset) do %>

--- a/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
@@ -27,7 +27,8 @@ defmodule TransportWeb.CustomTagsLiveTest do
           "dataset" => dataset,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -21,7 +21,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => nil,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -54,7 +55,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => nil,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -94,7 +96,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => nil,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -146,7 +149,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => dataset,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -175,7 +179,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => dataset,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 
@@ -193,7 +198,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
           "dataset" => nil,
           "dataset_types" => [],
           "regions" => [],
-          "form_url" => "url_used_to_post_result"
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
         }
       )
 


### PR DESCRIPTION
En lien avec #4739 : gère les flèches haut et bas pour sélectionner des résultats dans l'autocomplete.