### PR TITLE
Gère le téléchargement de ressources dont le dataset a le tag expérimental

### DIFF
--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -348,6 +348,55 @@ defmodule TransportWeb.ResourceControllerTest do
     assert [%DB.ResourceDownload{token_id: ^token_id, resource_id: ^resource_id}] = DB.ResourceDownload |> DB.Repo.all()
   end
 
+  test "HEAD request for a dataset with the experimental tag", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+    resource = insert(:resource, dataset: dataset)
+
+    assert conn |> head(resource_path(conn, :download, resource.id)) |> response(200)
+  end
+
+  test "download a dataset with the experimental tag, invalid token", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+    resource = insert(:resource, dataset: dataset)
+
+    assert "You must set a valid Authorization header" ==
+             conn
+             |> get(resource_path(conn, :download, resource.id, token: "invalid"))
+             |> response(401)
+
+    assert [] = DB.ResourceDownload |> DB.Repo.all()
+  end
+
+  test "download a dataset with the experimental tag, no token", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+
+    %DB.Resource{id: resource_id} =
+      resource = insert(:resource, dataset: dataset, latest_url: latest_url = "https://example.com/latest_url")
+
+    assert latest_url ==
+             conn
+             |> get(resource_path(conn, :download, resource.id))
+             |> redirected_to(302)
+
+    assert [%DB.ResourceDownload{token_id: nil, resource_id: ^resource_id}] = DB.ResourceDownload |> DB.Repo.all()
+  end
+
+  test "download a dataset with the experimental tag, valid token", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+
+    %DB.Resource{id: resource_id} =
+      resource = insert(:resource, dataset: dataset, latest_url: latest_url = "https://example.com/latest_url")
+
+    %DB.Token{id: token_id} = token = insert_token()
+
+    assert latest_url ==
+             conn
+             |> get(resource_path(conn, :download, resource.id, token: token.secret))
+             |> redirected_to(302)
+
+    assert [%DB.ResourceDownload{token_id: ^token_id, resource_id: ^resource_id}] = DB.ResourceDownload |> DB.Repo.all()
+  end
+
   test "resource#details, PAN resource, logged-in user with a default token", %{conn: conn} do
     dataset = insert(:dataset, organization_id: @pan_org_id)
     resource = insert(:resource, dataset: dataset)


### PR DESCRIPTION
Suite de #4746, je n'avais pas fait la partie `HEAD|GET /resources/:id/download` ce qui fait que les ressources apparaissent comme indisponibles.

Cette PR corrige ceci.