### PR TITLE
CreateTokensJob : création d'un token pour contacts sans org

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -45,6 +45,9 @@ defmodule DB.Contact do
     many_to_many(:organizations, DB.Organization, join_through: "contacts_organizations", on_replace: :delete)
     many_to_many(:followed_datasets, DB.Dataset, join_through: "dataset_followers", on_replace: :delete)
     has_many(:user_feedbacks, DB.UserFeedback, on_delete: :nilify_all)
+    # This fetches both purely personal tokens (the ones with a `contact_id` matching the parent
+    # but without an `organization_id`) and tokens linked to an organization, but associated to the
+    # current contact as "admin".
     has_many(:tokens, DB.Token, on_delete: :nilify_all)
     # Defined as a `many_to_many` in the database but a contact can only have **1** default token
     many_to_many(:default_tokens, DB.Token, join_through: "default_token")

--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -45,6 +45,7 @@ defmodule DB.Contact do
     many_to_many(:organizations, DB.Organization, join_through: "contacts_organizations", on_replace: :delete)
     many_to_many(:followed_datasets, DB.Dataset, join_through: "dataset_followers", on_replace: :delete)
     has_many(:user_feedbacks, DB.UserFeedback, on_delete: :nilify_all)
+    has_many(:tokens, DB.Token, on_delete: :nilify_all)
     # Defined as a `many_to_many` in the database but a contact can only have **1** default token
     many_to_many(:default_tokens, DB.Token, join_through: "default_token")
   end

--- a/apps/transport/lib/db/token.ex
+++ b/apps/transport/lib/db/token.ex
@@ -26,12 +26,23 @@ defmodule DB.Token do
   def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
     struct
     |> cast(attrs, [:name, :contact_id, :organization_id])
-    |> validate_required([:name, :contact_id, :organization_id])
+    |> validate_required([:name, :contact_id])
     |> assoc_constraint(:contact)
-    |> assoc_constraint(:organization)
-    |> unique_constraint([:organization_id, :name])
+    |> organization_id()
     |> generate_secret()
     |> put_hashed_fields()
+  end
+
+  def organization_id(%Ecto.Changeset{} = changeset) do
+    case get_field(changeset, :organization_id) do
+      nil ->
+        changeset
+
+      _ ->
+        changeset
+        |> assoc_constraint(:organization)
+        |> unique_constraint([:organization_id, :name])
+    end
   end
 
   defp generate_secret(%Ecto.Changeset{} = changeset) do

--- a/apps/transport/lib/jobs/create_tokens_job.ex
+++ b/apps/transport/lib/jobs/create_tokens_job.ex
@@ -1,14 +1,17 @@
 defmodule Transport.Jobs.CreateTokensJob do
   @moduledoc """
-  This job is in charge of creating a default token for each
-  organization without a token.
-
-  The created token is then set as the default token for all
-  members of this organization.
+  This job is in charge of:
+  - creating a default token for each organization without a token.
+    The created token is then set as the default token for all
+    members of this organization.
+  - creating a default token for each contact without an organization.
+    The created token is then set as the default.
   """
   use Oban.Worker, max_attempts: 3, tags: ["tokens"]
   import Ecto.Query
 
+  # - Create a default token for an organization
+  # - Set this token as the default token for each member of the organization
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"organization_id" => organization_id}}) do
     contact = DB.Repo.get_by!(DB.Contact, email_hash: Application.fetch_env!(:transport, :contact_email))
@@ -35,8 +38,45 @@ defmodule Transport.Jobs.CreateTokensJob do
     end)
   end
 
+  # - Create tokens for contacts without an organization
+  # - Set this token as the default token
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
+  def perform(%Oban.Job{args: %{"action" => "create_tokens_for_contacts_without_org"}}) do
+    contact_ids_default_token =
+      DB.DefaultToken.base_query()
+      |> select([default_token: dt], dt.contact_id)
+
+    contact_ids_in_org =
+      DB.Contact.base_query()
+      |> join(:inner, [contact: c], o in assoc(c, :organizations), as: :organizations)
+      |> select([contact: c], c.id)
+      |> distinct(true)
+
+    DB.Contact.base_query()
+    |> where([contact: c], c.id not in subquery(contact_ids_default_token))
+    |> where([contact: c], c.id not in subquery(contact_ids_in_org))
+    |> select([contact: c], %{contact_id: c.id})
+    |> DB.Repo.all()
+    |> Enum.each(fn %{contact_id: contact_id} ->
+      token =
+        %DB.Token{}
+        |> DB.Token.changeset(%{
+          contact_id: contact_id,
+          organization_id: nil,
+          name: "Défaut"
+        })
+        |> DB.Repo.insert!()
+
+      %DB.DefaultToken{}
+      |> DB.DefaultToken.changeset(%{token_id: token.id, contact_id: contact_id})
+      |> DB.Repo.insert!()
+    end)
+  end
+
+  # - Finds organizations without a token
+  # - Enqueue job to create a token for this organization
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"action" => "create_tokens_for_organizations"}}) do
     token_org_ids =
       DB.Token.base_query()
       |> select([token: t], t.organization_id)

--- a/apps/transport/lib/jobs/create_tokens_job.ex
+++ b/apps/transport/lib/jobs/create_tokens_job.ex
@@ -42,7 +42,7 @@ defmodule Transport.Jobs.CreateTokensJob do
   # - Set this token as the default token
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"action" => "create_tokens_for_contacts_without_org"}}) do
-    contact_ids_default_token =
+    contact_ids_with_a_default_token =
       DB.DefaultToken.base_query()
       |> select([default_token: dt], dt.contact_id)
 
@@ -53,7 +53,7 @@ defmodule Transport.Jobs.CreateTokensJob do
       |> distinct(true)
 
     DB.Contact.base_query()
-    |> where([contact: c], c.id not in subquery(contact_ids_default_token))
+    |> where([contact: c], c.id not in subquery(contact_ids_with_a_default_token))
     |> where([contact: c], c.id not in subquery(contact_ids_in_org))
     |> select([contact: c], %{contact_id: c.id})
     |> DB.Repo.all()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -151,7 +151,8 @@ oban_prod_crontab = [
   {"45 2 * * *", Transport.Jobs.RemoveHistoryJob, args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}},
   {"0 16 * * *", Transport.Jobs.DatasetQualityScoreDispatcher},
   {"40 3 * * *", Transport.Jobs.UpdateContactsJob},
-  {"50 3 * * *", Transport.Jobs.CreateTokensJob},
+  {"50 3 * * *", Transport.Jobs.CreateTokensJob, args: %{action: "create_tokens_for_organizations"}},
+  {"30 4 * * *", Transport.Jobs.CreateTokensJob, args: %{action: "create_tokens_for_contacts_without_org"}},
   {"10 5 * * *", Transport.Jobs.NotificationSubscriptionProducerJob},
   # "At 08:15 on Monday in March, June, and November.""
   # The job will make sure that it's executed only on the first Monday of these months


### PR DESCRIPTION
Cette PR adapte `CreateTokensJob` pour créer un nouveau job en charge de créer un token (et de le mettre par défaut) pour les contacts qui ne sont pas membres d'une organization data.gouv.fr.

Ceci concerne 597 contacts actuellement.

```sql
select id
from contact
where datagouv_user_id is not null and id not in (select contact_id from contacts_organizations)
```

Avoir un token pour ces contacts permettra d'avoir des liens authentifiés pour ces contacts. Les contacts membre d'une organisation auront un token via leur organisation.