### PR TITLE
Accroissement nombre de PDC - auto-conversion du Latin-1 vers UTF-8

### DIFF
--- a/apps/transport/test/transport/irve/irve_raw_static_consolidation_test.exs
+++ b/apps/transport/test/transport/irve/irve_raw_static_consolidation_test.exs
@@ -1,0 +1,4 @@
+defmodule Transport.IRVE.RawStaticConsolidationTest do
+  use ExUnit.Case, async: true
+  doctest Transport.IRVE.RawStaticConsolidation, import: true
+end


### PR DESCRIPTION
Après avoir refait une passe de lecture du rapport IRVE nocturne (voir #4715), j'ai vu qu'on pouvait probablement repêcher pas mal de PDC dans le cas suivant : la payload n'est ni une chaîne UTF-8 valide, ni un fichier zip.

Dans la PR présente, je réalise une conversion du "body" de la ressource IRVE si je détecte que ce n'est ni une chaîne UTF-8 valide, ni un fichier ZIP, en supposant que c'est du Latin-1.

J'ai fait cela après avoir été observer les ressources, et constaté que je trouvais effectivement du Latin-1 sur les échantillons que j'ai testé.

En pratique c'est un quick-win qui réduit un peu + l'écart avec data gouv sur le nombre d'identifiants PDC uniques:

```elixir
# PAN du jour avant ce changement
consolidation-pan.csv: %{
  count: 215137,
  distinct_count: 113165,
  duplicates: 101972
}

# data gouv du jour
consolidation-data-gouv-.csv: %{
  count: 163930,
  distinct_count: 121590,
  duplicates: 42340
}

# après cette PR, testé en local:
dev_improved: %{
  count: 246588,
  distinct_count: 118160,
  duplicates: 128428
}
```

On passe donc de 113165 à 118160 (plus que 3,5k d'écart sur les PDC uniques, avec data gouv).

### Limitations

En pratique, n'importe quoi peut être considéré comme du Latin-1 (contrairement à l'UTF-8 où une suite d'octets peut être invalide d'un point de vue UTF-8).

On pourrait donc avoir des cas où on traite mal certaines chaînes. 

Toutefois vu les sources (françaises) de la majorité des données qui posaient ce problème, je ne pense pas qu'on sera très embêtés.