### PR TITLE
BO territoires : ordre des blocs

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -106,6 +106,21 @@
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>
+        <%= dgettext("backoffice", "Spatial area (new)") %>
+      </h4>
+    </div>
+    <.live_component
+      module={TransportWeb.DeclarativeSpatialAreasLive}
+      id="declarative_spatial_areas"
+      form={f}
+      declarative_spatial_areas={@declarative_spatial_areas}
+      nonce={@nonce}
+    />
+  </div>
+
+  <div class="panel mt-48">
+    <div class="panel__header">
+      <h4>
         <%= dgettext("backoffice", "Spatial area (legacy)") %>
       </h4>
       <%= dgettext("backoffice", "Choose one") %>
@@ -164,21 +179,6 @@
         </div>
       </div>
     </div>
-  </div>
-
-  <div class="panel mt-48">
-    <div class="panel__header">
-      <h4>
-        <%= dgettext("backoffice", "Spatial area (new)") %>
-      </h4>
-    </div>
-    <.live_component
-      module={TransportWeb.DeclarativeSpatialAreasLive}
-      id="declarative_spatial_areas"
-      form={f}
-      declarative_spatial_areas={@declarative_spatial_areas}
-      nonce={@nonce}
-    />
   </div>
 
   <div id="backoffice_dataset_submit_buttons" class={if is_nil(@dataset), do: "pb-48"}>


### PR DESCRIPTION
Fixes #4730

Remonte la nouvelle façon de déclarer des territoires au-dessus de l'ancienne.