### PR TITLE
Session : renomme clé token

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/oauth.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/oauth.ex
@@ -66,7 +66,7 @@ defmodule Datagouvfr.Client.OAuth do
   @spec get_client(Plug.Conn.t()) :: OAuth2.Client.t()
   def get_client(%Plug.Conn{} = conn) do
     conn.assigns
-    |> Map.get(:token, nil)
+    |> Map.get(:datagouv_token, nil)
     |> Authentication.client()
   end
 

--- a/apps/datagouvfr/test/datagouvfr/client/discussions_test.exs
+++ b/apps/datagouvfr/test/datagouvfr/client/discussions_test.exs
@@ -6,7 +6,7 @@ defmodule Datagouvfr.Client.DiscussionTest do
   @token_secret Ecto.UUID.generate()
 
   setup do
-    {:ok, conn: build_conn() |> assign(:token, OAuth2.AccessToken.new(@token_secret))}
+    {:ok, conn: build_conn() |> assign(:datagouv_token, OAuth2.AccessToken.new(@token_secret))}
   end
 
   test "start a new discussion", %{conn: conn} do

--- a/apps/transport/lib/transport_web/controllers/session_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/session_controller.ex
@@ -17,8 +17,8 @@ defmodule TransportWeb.SessionController do
     with %{token: token} <- authentication_module.get_token!(code: code),
          conn <-
            conn
-           |> put_session(:token, token)
-           |> assign(:token, token),
+           |> put_session(:datagouv_token, token)
+           |> assign(:datagouv_token, token),
          {:ok, user} <- user_module.me(conn) do
       user_params = user_params(user)
       find_or_create_contact(user_params)

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -19,7 +19,7 @@ defmodule TransportWeb.Router do
     plug(TransportWeb.Plugs.PutLocale)
     plug(:assign_current_user)
     plug(:assign_contact_email)
-    plug(:assign_token)
+    plug(:assign_datagouv_token)
     plug(:maybe_login_again)
     plug(:assign_mix_env)
     plug(Sentry.PlugContext)
@@ -350,12 +350,13 @@ defmodule TransportWeb.Router do
     assign(conn, :contact_email, Application.get_env(:transport, :contact_email))
   end
 
-  defp assign_token(conn, _) do
-    assign(conn, :token, get_session(conn, :token))
+  defp assign_datagouv_token(conn, _) do
+    legacy_key = get_session(conn, :token)
+    assign(conn, :datagouv_token, get_session(conn, :datagouv_token) || legacy_key)
   end
 
   defp maybe_login_again(conn, _) do
-    case conn.assigns[:token] do
+    case conn.assigns[:datagouv_token] do
       %OAuth2.AccessToken{expires_at: expires_at} ->
         if DateTime.compare(DateTime.from_unix!(expires_at), DateTime.utc_now()) == :lt do
           conn |> configure_session(drop: true) |> assign(:current_user, nil) |> authentication_required(nil)

--- a/apps/transport/test/transport_web/controllers/session_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/session_controller_test.exs
@@ -57,6 +57,9 @@ defmodule TransportWeb.SessionControllerTest do
 
     assert redirected_to(conn, 302) == "/"
 
+    # Token has been saved to `datagouv_token` key.
+    assert conn.assigns[:datagouv_token] == Datagouvfr.Authentication.Dummy.get_token!(%{}) |> Map.fetch!(:token)
+
     # A `DB.Contact` has been created for this user
     assert [
              %DB.Contact{


### PR DESCRIPTION
En session, renomme la clé `token` en `datagouv_token` pour bien distinguer ceci par rapport à un `%DB.Token{}`.