### PR TITLE
Validation NeTEx: retravail du résumé des erreurs

### DIFF
--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -349,22 +349,23 @@ defmodule TransportWeb.ResourceView do
     <li>
       <.validity_icon errors={@stats[:count]} />
       <div class="selector">
-        <%= compatibility_filter(@conn, @category, @token) %>
-        <%= if @stats[:count] > 0 do %>
-          (<%= @results_adapter.format_severity(
-            @stats[:criticity],
-            @stats[:count]
-          ) %>)
-        <% end %>
+        <%= compatibility_filter(@conn, @category, @token, @stats[:count]) %>
+        <.stats :if={@stats[:count] > 0} stats={@stats} results_adapter={@results_adapter} />
       </div>
-      <p :if={netex_category_description(@category) && @stats[:count] > 0}>
+      <p :if={netex_category_description(@category)}>
         <%= netex_category_description(@category) %>
       </p>
     </li>
     """
   end
 
-  defp compatibility_filter(conn, category, token) do
+  defp stats(%{stats: _, results_adapter: _} = assigns) do
+    ~H"""
+    (<%= @results_adapter.format_severity(@stats[:criticity], @stats[:count]) %>)
+    """
+  end
+
+  defp compatibility_filter(conn, category, token, count) when count > 0 do
     query_params =
       %{"token" => token, "issues_category" => category}
       |> drop_empty_query_params()
@@ -375,6 +376,14 @@ defmodule TransportWeb.ResourceView do
     |> netex_category_label()
     |> link(class: "compatibility_filter", to: "#{url}#issues")
   end
+
+  defp compatibility_filter(_conn, category, _token, _count) do
+    category
+    |> netex_category_label()
+    |> strong()
+  end
+
+  defp strong(text), do: raw("<strong>#{text}</strong>")
 
   def validity_icon(%{errors: errors} = assigns) when errors > 0 do
     ~H"""


### PR DESCRIPTION
- les catégories ne sont pas cliquables s'il n'y aucune erreur
- les descriptions sont affichées même s'il n'y a pas d'erreur
- les catégories sont désormais séparés par une bordure

Deux screenshots pour illustrer :

<img width="65%" alt="image" src="https://github.com/user-attachments/assets/9ad69b68-db22-4fb1-b923-b823f24c6f4c" />

<img width="75%" alt="image" src="https://github.com/user-attachments/assets/59fc283e-9bff-4e7c-9fd2-172548bec1ac" />

* * *

Note: les screenshots incluent les changements de #4774 pour améliorer l'impression générale. Les changements de #4774 ne sont pas visuels.