### PR TITLE
Mise à jour readme pour nouvelle version de ASDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ Make sure you have **Elixir**, **Node.js** and **Yarn** installed and up-to-date
 
 If you wish to use `asdf` (recommended), make sure to install the correct plugins:
 
-* `asdf plugin-add erlang` (https://github.com/asdf-vm/asdf-erlang)
-* `asdf plugin-add elixir` (https://github.com/asdf-vm/asdf-elixir)
-* `asdf plugin-add nodejs` (https://github.com/asdf-vm/asdf-nodejs)
+* `asdf plugin add erlang` (https://github.com/asdf-vm/asdf-erlang)
+* `asdf plugin add elixir` (https://github.com/asdf-vm/asdf-elixir)
+* `asdf plugin add nodejs` (https://github.com/asdf-vm/asdf-nodejs)
 
 Installation for Erlang, Elixir and Node.js can then be done with:
 * `asdf install`
 
 For Yarn, bring your version or also use asdf:
-* `asdf plugin-add yarn` (https://github.com/twuni/asdf-yarn)
-* `asdf install yarn 1.22.19` (or any other version)
-* `asdf global yarn 1.22.19`
+* `asdf plugin add yarn` (https://github.com/twuni/asdf-yarn)
+* `asdf install yarn latest` (or any other version)
+* `asdf set -u yarn latest`
 
 ### 2. Install PostgreSQL
 


### PR DESCRIPTION
ASDF a fait une mise à jour majeure (0.16.0), ils sont passés de scripts bash à un exécutable précompilé, et en ont profité pour changer la syntaxe. J’ai refait une installation clean en local de ASDF, Elixir, Erlang, Node et Yarn, vérifié que tout marche bien, et voici les quelques changements de syntaxe de ASDF.