### PR TITLE
NeTEx: Ajustement textes pour catégorie XSD & le commentaire général

### DIFF
--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -338,7 +338,7 @@ defmodule TransportWeb.ResourceView do
     <li class="comment">
       <i class="fa fa-circle-exclamation"></i>
       <div>
-        <%= dgettext("validations", "netex-validations-layers") %>
+        <%= dgettext("validations", "netex-validations-layers") |> raw() %>
       </div>
     </li>
     """

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -380,4 +380,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
-msgstr "Validation of NeTEx resources is still a work in progress. Currently, we only check that any resource in NeTEx respects the XSD schema and follows some best practices. We do not yet check the conformity to the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> (nor the dataset structure nor mandatory attributes)."
+msgstr "Validation of NeTEx resources is still a work in progress. Currently, we only check that any resource in NeTEx respects the XSD schema and follows some best practices. We do not yet check the compliance with the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> (nor the dataset structure nor mandatory attributes)."

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -364,7 +364,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "xsd-schema-description"
-msgstr "A NeTEx resource must respect the NeTEx XSD. <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">Learn more</a>.<br/>This doesn't cover the extensions of the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a>."
+msgstr "Every NeTEx resource must comply with the <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">NeTEX XSD</a>, regardless of the national profile used. The XSD validation doesn't cover choices made by <a href=\"https://normes.transport.data.gouv.fr/\">the French profile</a>.<br/>Amongst most frequent errors, check that identifiers are unique, that tags are in proper order, and that no mandatory attribute is missing."
 
 #, elixir-autogen, elixir-format
 msgid "Base rules"
@@ -380,4 +380,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
-msgstr "NeTEx validation is still in its infancy. Currently we only check that a given NeTEx archive respects the XSD schema. It doesn't support exceptions made to that XSD in France yet."
+msgstr "Validation of NeTEx resources is still in its infancy. Currently we only check that a given NeTEx archive respects the XSD schema and follows some good practices. We don't check conformity of archives layout nor specific features of the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> yet."

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -364,7 +364,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "xsd-schema-description"
-msgstr "Every NeTEx resource must comply with the <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">NeTEX XSD</a>, regardless of the national profile used. The XSD validation doesn't cover choices made by <a href=\"https://normes.transport.data.gouv.fr/\">the French profile</a>.<br/>Amongst most frequent errors, check that identifiers are unique, that tags are in proper order, and that no mandatory attribute is missing."
+msgstr "Every NeTEx resource must comply with the <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">NeTEX XSD</a>, regardless of its profile. The XSD validation does not cover choices made by <a href=\"https://normes.transport.data.gouv.fr/\">the French profile</a>.<br/>Amongst most frequent errors, check that ids are unique, that elements are in the expected order, and that no mandatory attribute is missing."
 
 #, elixir-autogen, elixir-format
 msgid "Base rules"
@@ -380,4 +380,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
-msgstr "Validation of NeTEx resources is still in its infancy. Currently we only check that a given NeTEx archive respects the XSD schema and follows some good practices. We don't check conformity of archives layout nor specific features of the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> yet."
+msgstr "Validation of NeTEx resources is still a work in progress. Currently, we only check that any resource in NeTEx respects the XSD schema and follows some best practices. We do not yet check the conformity to the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> (nor the dataset structure nor mandatory attributes)."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -364,7 +364,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "xsd-schema-description"
-msgstr "Une ressource NeTEx doit avant tout respecter la XSD NeTEx. <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">En savoir plus</a>.<br/>Ceci ne tient pas compte des particularismes du <a href=\"https://normes.transport.data.gouv.fr/\">profil France</a>."
+msgstr "Toute ressource NeTEx doit être conforme à la <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">XSD de NeTEx</a>, quel que soit le profil utilisé. La validation de la XSD ne tient pas compte des choix faits dans <a href=\"https://normes.transport.data.gouv.fr/\">le profil France</a>.<br/>Parmi les erreurs les plus fréquentes, pensez à vérifier que vos identifiants sont uniques, que l'ordre des balises est bien respecté et/ou qu'il ne vous manque aucun attribut obligatoire."
 
 #, elixir-autogen, elixir-format
 msgid "Base rules"
@@ -380,4 +380,4 @@ msgstr "Autres erreurs"
 
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
-msgstr "La validation des archives NeTEx en est encore qu’à ses débuts. Actuellement nous ne validons que la conformité à la XSD. Nous ne supportons pas encore les exceptions françaises."
+msgstr "La validation des ressources NeTEx est encore à ses débuts. Pour le moment, nous vérifions la conformité à la XSD et certaines bonnes pratiques. Nous ne vérifions pas encore la conformité à la structure et aux spécificités du <a href=\"https://normes.transport.data.gouv.fr/\">profil France</a>."


### PR DESCRIPTION
Voir https://github.com/etalab/transport-site/issues/4781.

Merci à Tu-Tho Thai pour ses éléments de langage.

En français :

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/acc5eec3-68a1-4a65-8ee8-77c264a324fa" />

En anglais :

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/1f2b67cc-45e7-4275-9519-deaec99cb55a" />