### PR TITLE
Conseils à la validation NeTEx

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -158,44 +158,40 @@ table.netex_generic_issue tr.debug td code {
 .netex {
   ul.summary {
     list-style: none;
-    padding-left: var(--space-xs);
-    margin-bottom: var(--space-l);
+    padding-inline: var(--space-xs);
 
     li {
       display: grid;
-      gap: var(--space-xs);
-      grid-template-columns: 1.5rem 1fr;
-      grid-template-areas:
-        "icon selector"
-        ".    explanation";
+      gap: var(--space-s) var(--space-m);
+      grid-template-columns: [icon-start] 1.5rem [icon-end content-start] 50rem [content-end];
       padding-bottom: var(--space-m);
+      padding-left: var(--space-s);
+      margin-bottom: var(--space-m);
+      border-bottom: 1px solid var(--light-grey);
 
       i.fa {
         align-self: center;
         justify-self: center;
-        grid-area: icon;
+        grid-column: icon;
       }
-      div.selector {
-        grid-area: selector;
+      > * {
+        grid-column: content;
       }
       p {
         margin: 0;
-        grid-area: explanation;
+
+        a {
+          text-decoration: underline;
+        }
       }
     }
 
     li.comment {
-      grid-template-columns: 1.5rem 40rem;
-      grid-template-areas:
-        "icon comment";
       padding-bottom: unset;
+      border-bottom: unset;
 
-      i.fa {
-        align-self: center;
-        color: var(--dark-blue);
-      }
-      div.comment {
-        grid-area: comment;
+      div a {
+        text-decoration: underline;
       }
     }
   }
@@ -214,6 +210,10 @@ table.netex_generic_issue tr.debug td code {
 
   .fa-minus {
     color: var(--light-grey);
+  }
+
+  .fa-circle-info {
+    color: var(--dark-blue);
   }
 
   .compatibility_filter {

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -336,7 +336,7 @@ defmodule TransportWeb.ResourceView do
   defp netex_validations_layers(%{} = assigns) do
     ~H"""
     <li class="comment">
-      <i class="fa fa-circle-exclamation"></i>
+      <.info_icon />
       <div>
         <%= dgettext("validations", "netex-validations-layers") |> raw() %>
       </div>
@@ -355,7 +355,15 @@ defmodule TransportWeb.ResourceView do
       <p :if={netex_category_description(@category)}>
         <%= netex_category_description(@category) %>
       </p>
+      <.category_hints :if={netex_category_hints(@category) && @stats[:count] > 0} category={@category} />
     </li>
+    """
+  end
+
+  defp category_hints(%{category: _} = assigns) do
+    ~H"""
+    <.info_icon />
+    <p><%= netex_category_hints(@category) %></p>
     """
   end
 
@@ -397,6 +405,12 @@ defmodule TransportWeb.ResourceView do
     """
   end
 
+  def info_icon(assigns) do
+    ~H"""
+    <i class="fa fa-circle-info"></i>
+    """
+  end
+
   def netex_category_label("xsd-schema"), do: dgettext("validations", "XSD NeTEx")
   def netex_category_label("base-rules"), do: dgettext("validations", "Base rules")
   def netex_category_label(_), do: dgettext("validations", "Other errors")
@@ -404,6 +418,9 @@ defmodule TransportWeb.ResourceView do
   def netex_category_description("xsd-schema"), do: dgettext("validations", "xsd-schema-description") |> raw()
   def netex_category_description("base-rules"), do: dgettext("validations", "base-rules-description") |> raw()
   def netex_category_description(_), do: nil
+
+  def netex_category_hints("xsd-schema"), do: dgettext("validations", "xsd-schema-hints") |> raw()
+  def netex_category_hints(_), do: nil
 
   defp drop_empty_query_params(query_params) do
     Map.reject(query_params, fn {_, v} -> is_nil(v) end)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -364,7 +364,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "xsd-schema-description"
-msgstr "Every NeTEx resource must comply with the <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">NeTEX XSD</a>, regardless of its profile. The XSD validation does not cover choices made by <a href=\"https://normes.transport.data.gouv.fr/\">the French profile</a>.<br/>Amongst most frequent errors, check that ids are unique, that elements are in the expected order, and that no mandatory attribute is missing."
+msgstr "Every NeTEx resource must comply with the <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">NeTEX XSD</a>, regardless of its profile. The XSD validation does not cover choices made by <a href=\"https://normes.transport.data.gouv.fr/\">the French profile</a>."
+
+#, elixir-autogen, elixir-format
+msgid "xsd-schema-hints"
+msgstr "Amongst most frequent errors, check that ids are unique, that elements are in the expected order, and that no mandatory attribute is missing."
 
 #, elixir-autogen, elixir-format
 msgid "Base rules"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -364,7 +364,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "xsd-schema-description"
-msgstr "Toute ressource NeTEx doit être conforme à la <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">XSD de NeTEx</a>, quel que soit le profil utilisé. La validation de la XSD ne tient pas compte des choix faits dans <a href=\"https://normes.transport.data.gouv.fr/\">le profil France</a>.<br/>Parmi les erreurs les plus fréquentes, pensez à vérifier que vos identifiants sont uniques, que l'ordre des balises est bien respecté et/ou qu'il ne vous manque aucun attribut obligatoire."
+msgstr "Toute ressource NeTEx doit être conforme à la <a href=\"https://github.com/NeTEx-CEN/NeTEx\" target=\"_blank\">XSD de NeTEx</a>, quel que soit le profil utilisé. La validation de la XSD ne tient pas compte des choix faits dans <a href=\"https://normes.transport.data.gouv.fr/\">le profil France</a>."
+
+#, elixir-autogen, elixir-format
+msgid "xsd-schema-hints"
+msgstr "Parmi les erreurs les plus fréquentes, pensez à vérifier que vos identifiants sont uniques, que l'ordre des balises est bien respecté et/ou qu'il ne vous manque aucun attribut obligatoire."
 
 #, elixir-autogen, elixir-format
 msgid "Base rules"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -365,6 +365,10 @@ msgid "xsd-schema-description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "xsd-schema-hints"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "Base rules"
 msgstr ""
 


### PR DESCRIPTION
En cas d'erreurs, pour certaines catégories, nous pouvons afficher des conseils relatifs aux erreurs fréquentes. En espérant que cela évite des allers-retours au support ou que l'AOM ne se décourage.

<img width="2997" height="1387" alt="image" src="https://github.com/user-attachments/assets/58ad2366-7c17-4643-b113-90d9cbb671f0" />

Ces conseils ne sont pas affichés sur la catégorie est OK.