### PR TITLE
API : utilise territoires pour covered_area

### DIFF
--- a/apps/transport/lib/db/administrative_division.ex
+++ b/apps/transport/lib/db/administrative_division.ex
@@ -85,6 +85,47 @@ defmodule DB.AdministrativeDivision do
     Transport.SearchCommunes.filter(territoires, term)
   end
 
+  @doc """
+  iex> departement = %DB.AdministrativeDivision{type: :departement, nom: "B"}
+  iex> commune = %DB.AdministrativeDivision{type: :commune, nom: "A"}
+  iex> names([commune, departement])
+  "B, A"
+  """
+  @spec names([__MODULE__.t()]) :: binary()
+  def names(territories) do
+    territories |> sorted() |> Enum.map_join(", ", & &1.nom)
+  end
+
+  @doc """
+  iex> departement = %DB.AdministrativeDivision{type: :departement, nom: "B"}
+  iex> departement_a = %DB.AdministrativeDivision{type: :departement, nom: "A"}
+  iex> commune = %DB.AdministrativeDivision{type: :commune, nom: "A"}
+  iex> sorted([commune, departement])
+  [departement, commune]
+  iex> sorted([departement, departement_a])
+  [departement_a, departement]
+  """
+  @spec sorted([__MODULE__.t()]) :: [__MODULE__.t()]
+  def sorted(territories) do
+    mapper = fn %DB.AdministrativeDivision{type: type, nom: nom} ->
+      type =
+        Map.fetch!(
+          %{
+            commune: 5,
+            departement: 3,
+            epci: 4,
+            pays: 1,
+            region: 2
+          },
+          type
+        )
+
+      "#{type}-#{nom}"
+    end
+
+    Enum.sort_by(territories, mapper, :asc)
+  end
+
   def display_type(%DB.AdministrativeDivision{type: :commune}), do: dgettext("administrative_division", "municipality")
 
   def display_type(%DB.AdministrativeDivision{type: :departement}),

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -344,96 +344,26 @@ defmodule TransportWeb.API.Schemas do
     })
   end
 
-  defmodule CoveredArea.Country do
+  defmodule AdministrativeDivision do
     @moduledoc false
     require OpenApiSpex
 
     OpenApiSpex.schema(%{
-      title: "CoveredArea.Country",
+      title: "AdministrativeDivision",
       type: :object,
       required: [
-        :country,
-        :name,
-        :type
+        :type,
+        :insee,
+        :nom
       ],
       properties: %{
-        name: %Schema{type: :string},
-        type: %Schema{type: :string, enum: ["country"], required: true},
-        country: %Schema{
-          type: :object,
-          required: [:name],
-          properties: %{
-            name: %Schema{type: :string}
-          },
-          additionalProperties: false
-        }
-      },
-      additionalProperties: false
-    })
-  end
-
-  # Very similar to `AOMShortRef` but ultimately only CoveredAreas should be kept (?)
-  defmodule CoveredArea.AOM do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "CoveredArea.AOM",
-      type: :object,
-      required: [
-        :aom,
-        :name,
-        :type
-      ],
-      properties: %{
-        name: %Schema{type: :string},
-        type: %Schema{type: :string, enum: ["aom"], required: true},
-        aom: AOM.schema()
-      },
-      additionalProperties: false
-    })
-  end
-
-  defmodule CoveredArea.Cities do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "CoveredArea.Cities",
-      type: :object,
-      required: [
-        :cities,
-        :name,
-        :type
-      ],
-      properties: %{
-        name: %Schema{type: :string},
-        type: %Schema{type: :string, enum: ["cities"], required: true},
-        cities: %Schema{
-          type: :array,
-          items: City.schema()
-        }
-      },
-      additionalProperties: false
-    })
-  end
-
-  defmodule CoveredArea.Region do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "CoveredArea.Region",
-      type: :object,
-      required: [
-        :region,
-        :name,
-        :type
-      ],
-      properties: %{
-        name: %Schema{type: :string},
-        type: %Schema{type: :string, enum: ["region"], required: true},
-        region: Region.schema()
+        type: %Schema{
+          type: :string,
+          enum: Ecto.Enum.dump_values(DB.AdministrativeDivision, :type),
+          required: true
+        },
+        insee: %Schema{type: :string, required: true},
+        nom: %Schema{type: :string, required: true}
       },
       additionalProperties: false
     })
@@ -445,13 +375,8 @@ defmodule TransportWeb.API.Schemas do
 
     OpenApiSpex.schema(%{
       title: "CoveredArea",
-      type: :object,
-      oneOf: [
-        CoveredArea.Country.schema(),
-        CoveredArea.AOM.schema(),
-        CoveredArea.Region.schema(),
-        CoveredArea.Cities.schema()
-      ],
+      type: :array,
+      items: AdministrativeDivision.schema(),
       additionalProperties: false
     })
   end

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -135,7 +135,10 @@ defmodule TransportWeb.API.DatasetControllerTest do
         created_at: ~U[2021-12-23 13:30:40.000000Z],
         organization: "org",
         organization_id: "org_id",
-        aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
+        aom: insert(:aom, nom: "Angers Métropole", siren: "siren"),
+        declarative_spatial_areas: [
+          build(:administrative_division, nom: "Angers Métropole", insee: "123456", type: :epci)
+        ]
       )
 
     resource_1 =
@@ -199,11 +202,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     dataset_res = %{
       "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
       "community_resources" => [],
-      "covered_area" => %{
-        "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-        "name" => "Angers Métropole",
-        "type" => "aom"
-      },
+      "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
       "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
       "created_at" => "2021-12-23",
       "datagouv_id" => "datagouv",
@@ -299,7 +298,10 @@ defmodule TransportWeb.API.DatasetControllerTest do
             created_at: ~U[2021-12-23 13:30:40.000000Z],
             organization: "org",
             organization_id: "org_id",
-            aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
+            aom: insert(:aom, nom: "Angers Métropole", siren: "siren"),
+            declarative_spatial_areas: [
+              build(:administrative_division, nom: "Angers Métropole", insee: "123456", type: :epci)
+            ]
           ),
         url: "https://link.to/gbfs.json",
         datagouv_id: "2",
@@ -315,11 +317,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
              %{
                "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
                "community_resources" => [],
-               "covered_area" => %{
-                 "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-                 "name" => "Angers Métropole",
-                 "type" => "aom"
-               },
+               "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
                "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
                "created_at" => "2021-12-23",
                "datagouv_id" => "datagouv",
@@ -440,7 +438,10 @@ defmodule TransportWeb.API.DatasetControllerTest do
         last_update: DateTime.utc_now(),
         aom: aom,
         legal_owners_aom: [aom],
-        legal_owners_region: [region]
+        legal_owners_region: [region],
+        declarative_spatial_areas: [
+          build(:administrative_division, nom: "Angers Métropole", insee: "123456", type: :epci)
+        ]
       )
 
     setup_empty_history_resources()
@@ -452,11 +453,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     assert %{
              "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
              "community_resources" => [],
-             "covered_area" => %{
-               "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-               "name" => "Angers Métropole",
-               "type" => "aom"
-             },
+             "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
              "legal_owners" => %{
                "aoms" => [
                  %{"name" => "Angers Métropole", "siren" => "siren"}
@@ -522,7 +519,10 @@ defmodule TransportWeb.API.DatasetControllerTest do
         created_at: ~U[2021-12-23 13:30:40.000000Z],
         organization: "org",
         organization_id: "org_id",
-        aom: insert(:aom, nom: "Angers Métropole", siren: "siren")
+        aom: insert(:aom, nom: "Angers Métropole", siren: "siren"),
+        declarative_spatial_areas: [
+          build(:administrative_division, nom: "Angers Métropole", insee: "123456", type: :epci)
+        ]
       )
 
     resource =
@@ -580,11 +580,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     assert %{
              "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
              "community_resources" => [],
-             "covered_area" => %{
-               "aom" => %{"name" => "Angers Métropole", "siren" => "siren"},
-               "name" => "Angers Métropole",
-               "type" => "aom"
-             },
+             "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
              "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
              "created_at" => "2021-12-23",
              "datagouv_id" => "datagouv",
@@ -872,6 +868,22 @@ defmodule TransportWeb.API.DatasetControllerTest do
 
     auth_url = resource.url <> "?token=#{secret}"
     assert [%{"url" => ^auth_url}] = json |> hd() |> Map.get("resources")
+  end
+
+  test "covered_area" do
+    dataset =
+      insert(:dataset,
+        declarative_spatial_areas: [
+          build(:administrative_division, nom: "A", insee: "123", type_insee: "epci_123", type: :epci),
+          build(:administrative_division, nom: "B", insee: "456", type_insee: "region_456", type: :region)
+        ]
+      )
+      |> DB.Repo.preload(:declarative_spatial_areas)
+
+    assert TransportWeb.API.DatasetController.covered_area(dataset) == [
+             %{type: :region, nom: "B", insee: "456"},
+             %{type: :epci, nom: "A", insee: "123"}
+           ]
   end
 
   defp setup_empty_history_resources do


### PR DESCRIPTION
En lien avec #4791

Retravaille la définition de `covered_area` dans l'API pour utiliser les nouveaux territoires. Pour chaque territoire on indique le type, INSEE et son nom. L'ordre est du "plus grand" au "plus petit". Le schéma et les tests ont été adaptés.