### PR TITLE
Dataset#details : renomme variable

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/details.html.heex
@@ -221,7 +221,7 @@
     ) %>
     <%= unless is_nil(@other_datasets) or @other_datasets == [] do %>
       <section class="pt-48" id="dataset-other-datasets">
-        <h2><%= dgettext("page-dataset-details", "Other datasets of %{name}", name: @territory) %></h2>
+        <h2><%= dgettext("page-dataset-details", "Other datasets of %{name}", name: @covered_area) %></h2>
         <div class="panel">
           <ul>
             <%= for dataset <- @other_datasets do %>


### PR DESCRIPTION
https://github.com/etalab/transport-site/pull/4791 j'ai oublié un renommage dans https://github.com/etalab/transport-site/pull/4791/commits/dc6ec68cf3ad2f8a9ccda24384fbd8e4cbbacb30

Visiblement il n'y a pas de couverture de test sur ce cas… Il faut des "other datasets". Je vais ajouter un test dans une PR à suivre.

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/6852103112/)