### PR TITLE
Dataset : utilise les territoires pour les autres jeux de données

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -49,7 +49,7 @@ defmodule TransportWeb.DatasetController do
       |> assign(:resources_related_files, DB.Dataset.get_resources_related_files(dataset))
       |> assign(:covered_area, covered_area)
       |> assign(:site, Application.get_env(:oauth2, Authentication)[:site])
-      |> assign(:other_datasets, Dataset.get_other_datasets(dataset))
+      |> assign(:other_datasets, DB.Dataset.get_other_datasets(dataset))
       |> assign(:resources_infos, resources_infos(dataset))
       |> assign(
         :history_resources,

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -1108,6 +1108,28 @@ defmodule TransportWeb.DatasetControllerTest do
     |> html_response(200) =~ "Test Département, Test Commune"
   end
 
+  test "dataset#details, other datasets", %{conn: conn} do
+    departement =
+      insert(:administrative_division,
+        type: :departement,
+        type_insee: "departement_76",
+        insee: "76",
+        nom: "Seine-Maritime"
+      )
+
+    dataset = insert(:dataset, declarative_spatial_areas: [departement]) |> DB.Repo.preload(:declarative_spatial_areas)
+    other_dataset = insert(:dataset, custom_title: "Foo", declarative_spatial_areas: [departement])
+
+    mock_empty_history_resources()
+
+    assert conn
+           |> get(dataset_path(conn, :details, dataset.slug))
+           |> html_response(200)
+           |> Floki.parse_document!()
+           |> Floki.find("#dataset-other-datasets")
+           |> Floki.text() == "Autres jeux de données de #{departement.nom}#{other_dataset.custom_title}"
+  end
+
   def dataset_href_download_button(%Plug.Conn{} = conn, %DB.Dataset{} = dataset) do
     conn
     |> get(dataset_path(conn, :details, dataset.slug))


### PR DESCRIPTION
En lien avec #4796

Utilise les nouveaux territoires pour le bloc "Autres jeux de données". Ajoute des tests sur cette fonctionnalité qui en manquait.