### PR TITLE
BO territoires : tri les résultats de recherche

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -127,6 +127,7 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
     matches =
       socket.assigns.searchable_administrative_divisions
       |> DB.AdministrativeDivision.search(query)
+      |> DB.AdministrativeDivision.sorted()
       |> Enum.reject(&(&1.id in existing_ids))
       |> Enum.take(5)
 


### PR DESCRIPTION
Fixes #4778

Ordonne les résultats de recherche du plus grand territoire au plus petit.