### PR TITLE
Client d'API pour l'API Rulesets de enRoute Chouette Valid

### DIFF
--- a/apps/shared/lib/wrapper/wrapper_req.ex
+++ b/apps/shared/lib/wrapper/wrapper_req.ex
@@ -11,8 +11,21 @@ defmodule Transport.Req.Behaviour do
   # Ref: https://github.com/wojtekmach/req/blob/b40de7b7a0e7cc97a2c398ffcc42aa14962f3963/lib/req.ex#L545
   @type url() :: URI.t() | String.t()
   # Simplified version for our needs
+  @callback get(url()) :: {:ok, Req.Response.t()} | {:error, Exception.t()}
   @callback get(url(), options :: keyword()) :: {:ok, Req.Response.t()} | {:error, Exception.t()}
+
+  @callback get!(url() | keyword() | Req.Request.t()) :: Req.Response.t()
   @callback get!(url() | keyword() | Req.Request.t(), options :: keyword()) :: Req.Response.t()
+
+  @callback request(request :: Req.Request.t() | keyword()) ::
+              {:ok, Req.Response.t()} | {:error, Exception.t()}
+  @callback request(request :: Req.Request.t() | keyword(), options :: keyword()) ::
+              {:ok, Req.Response.t()} | {:error, Exception.t()}
+
+  @callback delete(url() | keyword() | Req.Request.t()) ::
+              {:ok, Req.Response.t()} | {:error, Exception.t()}
+  @callback delete(url() | keyword() | Req.Request.t(), options :: keyword()) ::
+              {:ok, Req.Response.t()} | {:error, Exception.t()}
 end
 
 defmodule Transport.Req do
@@ -24,8 +37,10 @@ defmodule Transport.Req do
   def impl, do: Application.get_env(:transport, :req_impl, __MODULE__)
 
   @behaviour Transport.Req.Behaviour
-  defdelegate get(url, options), to: Req
-  defdelegate get!(url, options), to: Req
+  defdelegate get(url, options \\ []), to: Req
+  defdelegate get!(url, options \\ []), to: Req
+  defdelegate request(request, options \\ []), to: Req
+  defdelegate delete(request, options \\ []), to: Req
 end
 
 defmodule Transport.HTTPClient do

--- a/apps/transport/lib/enroute/chouette_valid_rulesets_client.ex
+++ b/apps/transport/lib/enroute/chouette_valid_rulesets_client.ex
@@ -1,0 +1,93 @@
+defmodule Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper do
+  @moduledoc """
+  API client for Chouette Valid rulesets management.
+  Documentation: https://enroute.atlassian.net/wiki/spaces/PUBLIC/pages/2761687047/Sprint+123#Manage-rulesets-by-API
+  """
+  @type ruleset_id :: binary
+  @type slug :: binary
+
+  @callback list_rulesets() :: list()
+
+  @callback create_ruleset(definition :: binary(), name :: binary(), slug :: slug()) ::
+              {:ok, ruleset_id()}
+              | {:error, binary()}
+
+  @callback update_ruleset(ruleset_id :: ruleset_id(), definition :: binary(), name :: binary(), slug :: slug()) ::
+              {:ok, ruleset_id()}
+              | {:error, binary()}
+
+  @callback delete_ruleset(ruleset_id :: ruleset_id()) :: :ok | {:error, binary()}
+
+  def impl, do: Application.get_env(:transport, :enroute_rulesets_client)
+end
+
+defmodule Transport.EnRoute.ChouetteValidRulesetsClient do
+  @moduledoc """
+  Implementation of the enRoute Chouette Valid rulesets management API client.
+  """
+  @behaviour Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper
+
+  @base_url "https://chouette-valid.enroute.mobi/api/rulesets"
+
+  @impl Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper
+  def list_rulesets do
+    http_client().get!(base_request()).body
+  end
+
+  @impl Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper
+  def create_ruleset(definition, name, slug) do
+    upsert_ruleset(:post, "", definition, name, slug)
+  end
+
+  @impl Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper
+  def update_ruleset(ruleset_id, definition, name, slug) do
+    upsert_ruleset(:patch, "/#{ruleset_id}.json", definition, name, slug)
+  end
+
+  @impl Transport.EnRoute.ChouetteValidRulesetsClient.Wrapper
+  def delete_ruleset(ruleset_id) do
+    case http_client().delete(base_request(), url: "/#{ruleset_id}.json") do
+      {:ok, resp} when resp.status in 200..299 -> :ok
+      {:ok, resp} -> {:error, "Bad API response: Status code: #{resp.status}"}
+      {:error, e} -> {:error, Exception.message(e)}
+    end
+  end
+
+  defp upsert_ruleset(method, path, definition, name, slug) do
+    body =
+      %{
+        ruleset: %{
+          name: name,
+          slug: slug,
+          definition: definition
+        }
+      }
+
+    case http_client().request(base_request(), method: method, url: path, json: body) do
+      {:ok, %Req.Response{status: status, body: %{"id" => ruleset_id}}} when status in [200, 201] ->
+        {:ok, ruleset_id}
+
+      {:ok, %Req.Response{status: 422, body: %{"slug" => ["has already been taken"]}}} ->
+        {:error, "Slug already taken"}
+
+      {:ok, %Req.Response{status: sc}} ->
+        {:error, "Bad API response: Status code: #{sc}"}
+
+      {:ok, _unsupported} ->
+        {:error, "Unsupported response type"}
+
+      {:error, e} ->
+        {:error, Exception.message(e)}
+    end
+  end
+
+  defp base_request do
+    Req.new(base_url: @base_url, auth: auth())
+  end
+
+  defp auth do
+    "Token token=#{Application.fetch_env!(:transport, :enroute_rulesets_token)}"
+  end
+
+  defp http_client, do: Transport.Req.impl()
+end

--- a/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
+++ b/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
@@ -34,6 +34,34 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
     assert response_body == ChouetteValidRulesetsClient.list_rulesets()
   end
 
+  test "get ruleset by slug" do
+    name = "PAN - French Profile"
+    slug = "pan:french_profile:1"
+    definition = "[]"
+
+    response_body =
+      %{
+        "id" => "2d9ffada-d923-40ee-8c76-02f262b1d8d5",
+        "name" => name,
+        "slug" => slug,
+        "definition" => definition,
+        "created_at" => "2024-07-05T14:41:19.933Z",
+        "updated_at" => "2024-07-05T14:41:20.933Z"
+      }
+
+    Transport.Req.Mock
+    |> expect(:get, fn request, [url: url] ->
+      assert @fake_auth == request.options.auth
+      assert @base_url == request.options.base_url
+
+      assert "/#{slug}" == url
+
+      {:ok, %Req.Response{status: 200, body: response_body}}
+    end)
+
+    assert {:ok, response_body} == ChouetteValidRulesetsClient.get_ruleset(slug)
+  end
+
   test "create ruleset" do
     name = "PAN - French Profile"
     slug = "pan:french_profile:1"
@@ -82,11 +110,11 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
       }
 
     Transport.Req.Mock
-    |> expect(:request, fn request, [method: :patch, url: url, json: json] ->
+    |> expect(:request, fn request, [method: :put, url: url, json: json] ->
       assert @fake_auth == request.options.auth
       assert @base_url == request.options.base_url
 
-      assert "/#{ruleset_id}.json" == url
+      assert "/#{slug}" == url
 
       assert name == json.ruleset.name
       assert slug == json.ruleset.slug
@@ -96,7 +124,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
     end)
 
     assert {:ok, "2d9ffada-d923-40ee-8c76-02f262b1d8d5"} ==
-             ChouetteValidRulesetsClient.update_ruleset(ruleset_id, definition, name, slug)
+             ChouetteValidRulesetsClient.update_ruleset(definition, name, slug)
   end
 
   test "delete ruleset" do

--- a/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
+++ b/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
@@ -23,8 +23,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
 
     Transport.Req.Mock
     |> expect(:get!, fn request ->
-      assert @fake_auth == request.options.auth
-      assert @base_url == request.options.base_url
+      expect_commons(request)
 
       assert URI.parse("") == request.url
 
@@ -51,8 +50,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
 
     Transport.Req.Mock
     |> expect(:get, fn request, [url: url] ->
-      assert @fake_auth == request.options.auth
-      assert @base_url == request.options.base_url
+      expect_commons(request)
 
       assert "/#{slug}" == url
 
@@ -79,8 +77,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
 
     Transport.Req.Mock
     |> expect(:request, fn request, [method: :post, url: "", json: json] ->
-      assert @fake_auth == request.options.auth
-      assert @base_url == request.options.base_url
+      expect_commons(request)
 
       assert name == json.ruleset.name
       assert slug == json.ruleset.slug
@@ -111,8 +108,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
 
     Transport.Req.Mock
     |> expect(:request, fn request, [method: :put, url: url, json: json] ->
-      assert @fake_auth == request.options.auth
-      assert @base_url == request.options.base_url
+      expect_commons(request)
 
       assert "/#{slug}" == url
 
@@ -132,8 +128,7 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
 
     Transport.Req.Mock
     |> expect(:delete, fn request, [url: url] ->
-      assert @fake_auth == request.options.auth
-      assert @base_url == request.options.base_url
+      expect_commons(request)
 
       assert "/#{ruleset_id}.json" == url
 
@@ -141,5 +136,10 @@ defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
     end)
 
     assert :ok == ChouetteValidRulesetsClient.delete_ruleset(ruleset_id)
+  end
+
+  defp expect_commons(request) do
+    assert @fake_auth == request.options.auth
+    assert @base_url == request.options.base_url
   end
 end

--- a/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
+++ b/apps/transport/test/enroute/chouette_valid_rulesets_client_test.exs
@@ -1,0 +1,117 @@
+defmodule Transport.EnRoute.ChouetteValidRulesetsClientTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  alias Transport.EnRoute.ChouetteValidRulesetsClient
+
+  setup :verify_on_exit!
+
+  @base_url "https://chouette-valid.enroute.mobi/api/rulesets"
+  @fake_auth "Token token=fake_enroute_token"
+
+  test "list rulesets" do
+    response_body = [
+      %{
+        "id" => "2d9ffada-d923-40ee-8c76-02f262b1d8d5",
+        "name" => "enRoute Starter-Kit",
+        "slug" => "enroute:starter-kit:1",
+        "definition" => "[]",
+        "created_at" => "2024-07-05T14:41:19.933Z",
+        "updated_at" => "2024-07-05T14:41:20.933Z"
+      }
+    ]
+
+    Transport.Req.Mock
+    |> expect(:get!, fn request ->
+      assert @fake_auth == request.options.auth
+      assert @base_url == request.options.base_url
+
+      assert URI.parse("") == request.url
+
+      %Req.Response{status: 200, body: response_body}
+    end)
+
+    assert response_body == ChouetteValidRulesetsClient.list_rulesets()
+  end
+
+  test "create ruleset" do
+    name = "PAN - French Profile"
+    slug = "pan:french_profile:1"
+    definition = "[]"
+
+    response_body =
+      %{
+        "id" => "2d9ffada-d923-40ee-8c76-02f262b1d8d5",
+        "name" => name,
+        "slug" => slug,
+        "definition" => definition,
+        "created_at" => "2024-07-05T14:41:19.933Z",
+        "updated_at" => "2024-07-05T14:41:20.933Z"
+      }
+
+    Transport.Req.Mock
+    |> expect(:request, fn request, [method: :post, url: "", json: json] ->
+      assert @fake_auth == request.options.auth
+      assert @base_url == request.options.base_url
+
+      assert name == json.ruleset.name
+      assert slug == json.ruleset.slug
+      assert definition == json.ruleset.definition
+
+      {:ok, %Req.Response{status: 201, body: response_body}}
+    end)
+
+    assert {:ok, "2d9ffada-d923-40ee-8c76-02f262b1d8d5"} ==
+             ChouetteValidRulesetsClient.create_ruleset(definition, name, slug)
+  end
+
+  test "update ruleset" do
+    ruleset_id = "2d9ffada-d923-40ee-8c76-02f262b1d8d5"
+    name = "PAN - French Profile"
+    slug = "pan:french_profile:1"
+    definition = "[]"
+
+    response_body =
+      %{
+        "id" => ruleset_id,
+        "name" => name,
+        "slug" => slug,
+        "definition" => definition,
+        "created_at" => "2024-07-05T14:41:19.933Z",
+        "updated_at" => "2025-09-10T18:34:43.644Z"
+      }
+
+    Transport.Req.Mock
+    |> expect(:request, fn request, [method: :patch, url: url, json: json] ->
+      assert @fake_auth == request.options.auth
+      assert @base_url == request.options.base_url
+
+      assert "/#{ruleset_id}.json" == url
+
+      assert name == json.ruleset.name
+      assert slug == json.ruleset.slug
+      assert definition == json.ruleset.definition
+
+      {:ok, %Req.Response{status: 200, body: response_body}}
+    end)
+
+    assert {:ok, "2d9ffada-d923-40ee-8c76-02f262b1d8d5"} ==
+             ChouetteValidRulesetsClient.update_ruleset(ruleset_id, definition, name, slug)
+  end
+
+  test "delete ruleset" do
+    ruleset_id = "2d9ffada-d923-40ee-8c76-02f262b1d8d5"
+
+    Transport.Req.Mock
+    |> expect(:delete, fn request, [url: url] ->
+      assert @fake_auth == request.options.auth
+      assert @base_url == request.options.base_url
+
+      assert "/#{ruleset_id}.json" == url
+
+      {:ok, %Req.Response{status: 200}}
+    end)
+
+    assert :ok == ChouetteValidRulesetsClient.delete_ruleset(ruleset_id)
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -92,6 +92,7 @@ config :transport,
   data_visualization: Transport.DataVisualization.Impl,
   workflow_notifier: Transport.Jobs.Workflow.ObanNotifier,
   enroute_validator_client: Transport.EnRouteChouetteValidClient,
+  enroute_rulesets_client: Transport.EnRoute.ChouetteValidRulesetsClient,
   netex_validator: Transport.Validators.NeTEx.Validator
 
 # Datagouv IDs for national databases created automatically.
@@ -173,6 +174,7 @@ config :transport,
   api_auth_clients: System.get_env("API_AUTH_CLIENTS"),
   enroute_token: System.get_env("ENROUTE_TOKEN"),
   enroute_validation_token: System.get_env("ENROUTE_VALIDATION_TOKEN"),
+  enroute_rulesets_token: System.get_env("ENROUTE_RULESETS_TOKEN"),
   max_import_concurrent_jobs: (System.get_env("MAX_IMPORT_CONCURRENT_JOBS") || "1") |> String.to_integer(),
   nb_days_to_keep_validations: 60,
   contact_email: "contact@transport.data.gouv.fr",

--- a/config/test.exs
+++ b/config/test.exs
@@ -53,7 +53,9 @@ config :transport,
   api_auth_clients: "client1:secret_token;client2:other_token",
   enroute_token: "fake_enroute_token",
   enroute_validation_token: "fake_enroute_token",
+  enroute_rulesets_token: "fake_enroute_token",
   enroute_validator_client: Transport.EnRouteChouetteValidClient.Mock,
+  enroute_rulesets_client: Transport.EnRoute.ChouetteValidRulesetsClient.Mock,
   netex_validator: Transport.Validators.NeTEx.Validator.Mock
 
 config :ex_aws,


### PR DESCRIPTION
Ce client d'API a été implémenté en s'inspirant du CLI officiel ainsi que par essais erreurs. Il est possible qu'il faille plus tard corriger certains détails.