### PR TITLE
Recherche par commune avec couverture spatiale

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -383,8 +383,6 @@ defmodule DB.Dataset do
 
   @spec filter_by_commune(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_commune(query, %{"insee_commune" => commune_insee}) do
-    # return the datasets available for a city.
-    # This dataset can either be linked to a city or to an AOM/region covering this city
     query
     |> where(
       [d],
@@ -392,29 +390,43 @@ defmodule DB.Dataset do
         """
         (
           ? IN (
-              (
-                SELECT DISTINCT dc.dataset_id FROM dataset_communes AS dc
-                JOIN commune ON commune.id = dc.commune_id
-                WHERE commune.insee = ?
-              )
-              UNION
-              (
-                SELECT dataset.id FROM dataset
-                JOIN aom ON aom.id = dataset.aom_id
-                JOIN commune ON commune.aom_res_id = aom.composition_res_id
-                WHERE commune.insee = ?
-              )
-              UNION
-              (
-                SELECT dataset.id FROM dataset
-                JOIN region ON region.id = dataset.region_id
-                JOIN commune ON commune.region_id = region.id
-                WHERE commune.insee = ?
-              )
+              select dataset_id
+              from (
+                -- region
+                select distinct d.id dataset_id, 1 as filter
+                from dataset d
+                join commune c on c.insee = ?
+                join region r on r.id = c.region_id
+                join administrative_division ad on ad.type = 'region' and r.insee = ad.insee
+                join dataset_declarative_spatial_area ddsa on ddsa.administrative_division_id = ad.id and d.id = ddsa.dataset_id
+                union
+                -- departement
+                select distinct d.id dataset_id, 2 as filter
+                from dataset d
+                join commune c on c.insee = ?
+                join administrative_division ad on ad.type = 'departement' and c.departement_insee = ad.insee
+                join dataset_declarative_spatial_area ddsa on ddsa.administrative_division_id = ad.id and d.id = ddsa.dataset_id
+                union
+                -- epci
+                select distinct d.id dataset_id, 3 as filter
+                from dataset d
+                join commune c on c.insee = ?
+                join administrative_division ad on ad.type = 'epci' and c.epci_insee = ad.insee
+                join dataset_declarative_spatial_area ddsa on ddsa.administrative_division_id = ad.id and d.id = ddsa.dataset_id
+                union
+                -- commune
+                select distinct d.id dataset_id, 4 as filter
+                from dataset d
+                join commune c on c.insee = ?
+                join administrative_division ad on ad.type = 'commune' and c.insee = ad.insee
+                join dataset_declarative_spatial_area ddsa on ddsa.administrative_division_id = ad.id and d.id = ddsa.dataset_id
+              ) t
+              order by filter
             )
         )
         """,
         d.id,
+        ^commune_insee,
         ^commune_insee,
         ^commune_insee,
         ^commune_insee

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -264,21 +264,6 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     assert list_datasets.(%{}) != list_datasets.(%{"region" => aom.region_id |> to_string()})
   end
 
-  test "datasets associated to a region are displayed last when searching for a commune" do
-    aom = insert(:aom, region: region = insert(:region))
-    commune = insert(:commune, aom_res_id: aom.composition_res_id, insee: "33400", region: region)
-
-    region_dataset = insert(:dataset, region_id: region.id, is_active: true)
-    aom_dataset = insert(:dataset, is_active: true, aom: aom)
-
-    list_datasets = fn %{} = args ->
-      args |> Dataset.list_datasets() |> Repo.all() |> Enum.map(& &1.id)
-    end
-
-    assert [aom_dataset.id, region_dataset.id] == list_datasets.(%{"insee_commune" => commune.insee |> to_string()})
-    assert list_datasets.(%{}) != list_datasets.(%{"insee_commune" => commune.insee |> to_string()})
-  end
-
   test "when searching for a region, use the population to sort" do
     small_aom = insert(:aom, region: region = insert(:region), population: 100)
     big_aom = insert(:aom, region: region, population: 200)
@@ -381,6 +366,43 @@ defmodule TransportWeb.DatasetSearchControllerTest do
 
     assert [d1.id, d2.id, d3.id, d4.id] ==
              %{"insee_departement" => departement.insee}
+             |> DB.Dataset.list_datasets()
+             |> DB.Repo.all()
+             |> Enum.map(& &1.id)
+  end
+
+  test "search by commune" do
+    departement = insert(:departement)
+    region = insert(:region, insee: "1")
+    epci = insert(:epci, insee: "2")
+
+    commune =
+      insert(:commune, insee: "3", departement_insee: departement.insee, region_id: region.id, epci_insee: epci.insee)
+
+    departement_ad =
+      insert(:administrative_division,
+        type: :departement,
+        type_insee: "departement_#{departement.insee}",
+        insee: departement.insee
+      )
+
+    commune_ad =
+      insert(:administrative_division, type: :commune, type_insee: "commune_#{commune.insee}", insee: commune.insee)
+
+    epci_ad = insert(:administrative_division, type: :epci, type_insee: "epci_#{epci.insee}", insee: epci.insee)
+
+    region_ad =
+      insert(:administrative_division, type: :region, type_insee: "region_#{region.insee}", insee: region.insee)
+
+    d1 = insert(:dataset, population: 4, declarative_spatial_areas: [region_ad])
+    d2 = insert(:dataset, population: 3, declarative_spatial_areas: [departement_ad])
+    d3 = insert(:dataset, population: 2, declarative_spatial_areas: [epci_ad])
+    d4 = insert(:dataset, population: 1, declarative_spatial_areas: [commune_ad])
+    # Other dataset is not included
+    insert(:dataset)
+
+    assert [d1.id, d2.id, d3.id, d4.id] ==
+             %{"insee_commune" => commune.insee}
              |> DB.Dataset.list_datasets()
              |> DB.Repo.all()
              |> Enum.map(& &1.id)


### PR DESCRIPTION
Comme #4822 pour les départements, retravaille la recherche par commune pour inclure la commune, l'EPCI de la commune, le département de la commune et la région de la commune.