### PR TITLE
Validation GTFS-Flex : lien vers MobilityData

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -74,9 +74,12 @@ locale = get_session(@conn, :locale) %>
       <h2 id="validation-report" class="mt-48"><%= dgettext("validations", "Validation report") %></h2>
       <div class="panel" id="issues">
         <p :if={is_gtfs_flex} class="notification">
-          <%= dgettext(
-            "validations",
-            "This file contains the GTFS-Flex extension. We are not able to validate it for now."
+          <%= raw(
+            dgettext(
+              "validations",
+              ~s|This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href="%{url}">Canonical GTFS Schedule Validator from MobilityData</a>.|,
+              url: "https://gtfs-validator.mobilitydata.org"
+            )
           ) %>
         </p>
         <%= if not is_gtfs_flex and is_nil(@validation_summary) do %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -314,10 +314,6 @@ msgstr ""
 msgid "Please note that our GTFS validator does not validate the Flex and Fares v2 extensions."
 msgstr ""
 
-#, elixir-autogen, elixir-format
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
-msgstr ""
-
 #, elixir-autogen, elixir-format, fuzzy
 msgid "calendar span by network:"
 msgstr ""
@@ -385,3 +381,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
 msgstr "Validation of NeTEx resources is still a work in progress. Currently, we only check that any resource in NeTEx respects the XSD schema and follows some best practices. We do not yet check the compliance with the <a href=\"https://normes.transport.data.gouv.fr/\">French profile</a> (nor the dataset structure nor mandatory attributes)."
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\">Canonical GTFS Schedule Validator from MobilityData</a>."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -315,10 +315,6 @@ msgid "Please note that our GTFS validator does not validate the Flex and Fares 
 msgstr "Veuillez noter que notre validateur GTFS n'est pas en mesure de valider les extensions Flex et Fares v2 pour le moment."
 
 #, elixir-autogen, elixir-format
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
-msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment."
-
-#, elixir-autogen, elixir-format
 msgid "calendar span by network:"
 msgstr "couverture calendaire par réseau :"
 
@@ -385,3 +381,7 @@ msgstr "Autres erreurs"
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
 msgstr "La validation des ressources NeTEx est encore à ses débuts. Pour le moment, nous vérifions la conformité à la XSD et certaines bonnes pratiques. Nous ne vérifions pas encore la conformité à la structure et aux spécificités du <a href=\"https://normes.transport.data.gouv.fr/\">profil France</a>."
+
+#, elixir-autogen, elixir-format
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\">Canonical GTFS Schedule Validator from MobilityData</a>."
+msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment. Vous pouvez le valider avec le <a href=\"%{url}\">validateur GTFS canonique de MobilityData</a>."

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -313,10 +313,6 @@ msgid "Please note that our GTFS validator does not validate the Flex and Fares 
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "calendar span by network:"
 msgstr ""
 
@@ -382,4 +378,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "netex-validations-layers"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\">Canonical GTFS Schedule Validator from MobilityData</a>."
 msgstr ""


### PR DESCRIPTION
Ajoute un lien vers le validateur MobilityData lorsqu'on ne peut pas valider un GTFS-Flex.