### PR TITLE
Recherche : liens vers régions

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -275,8 +275,8 @@ defmodule TransportWeb.DatasetController do
 
     Region
     |> join(:left, [r], d in subquery(sub), on: d.region_id == r.id)
-    |> group_by([r], [r.id, r.nom])
-    |> select([r, d], %{nom: r.nom, id: r.id, count: count(d.id, :distinct)})
+    |> group_by([r], [r.insee, r.nom])
+    |> select([r, d], %{nom: r.nom, insee: r.insee, count: count(d.id, :distinct)})
     |> order_by([r], r.nom)
     |> Repo.all()
   end

--- a/apps/transport/lib/transport_web/templates/dataset/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/index.html.heex
@@ -91,7 +91,7 @@
                         <%= region_link(@conn, %{
                           nom: dgettext("page-shortlist", "All"),
                           count: @regions |> Enum.map(& &1.count) |> Enum.sum(),
-                          id: nil
+                          insee: nil
                         }) %>
                       </li>
                       <%= for region <- @regions do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -101,12 +101,12 @@ defmodule TransportWeb.DatasetView do
     end
   end
 
-  def region_link(conn, %{nom: nom, count: count, id: id}) do
+  def region_link(conn, %{nom: nom, count: count, insee: insee}) do
     url =
-      case id do
+      case insee do
         # This is for the "All" region
         nil -> dataset_path(conn, :index)
-        _ -> dataset_path(conn, :by_region, id)
+        _ -> dataset_path(conn, :by_region, insee)
       end
 
     params = conn.query_params
@@ -130,8 +130,8 @@ defmodule TransportWeb.DatasetView do
     |> raw()
   end
 
-  def legal_owner_link(conn, %DB.Region{nom: nom, id: id}) do
-    link(nom, to: dataset_path(conn, :by_region, id))
+  def legal_owner_link(conn, %DB.Region{nom: nom, insee: insee}) do
+    link(nom, to: dataset_path(conn, :by_region, insee))
   end
 
   def legal_owner_link(conn, %DB.AOM{nom: nom, siren: siren}) do

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -107,7 +107,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
     end
 
     test "with gtfs-rt features" do
-      %{id: region_id} = insert(:region)
+      %{id: region_id, insee: region_insee} = insert(:region, insee: "01")
       %{id: dataset_id} = insert(:dataset, type: "public-transit", region_id: region_id)
       %{id: resource_id} = insert(:resource, dataset_id: dataset_id)
       insert(:resource_metadata, resource_id: resource_id, features: ["vehicle_positions"])
@@ -139,7 +139,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
                %{"features" => ["vehicle_positions"]} |> TransportWeb.DatasetController.get_types()
 
       regions_count = %{"features" => ["vehicle_positions"]} |> TransportWeb.DatasetController.get_regions()
-      assert [%{count: 1, id: ^region_id}] = regions_count |> Enum.filter(&(&1.id == region_id))
+      assert [%{count: 1, insee: ^region_insee}] = regions_count |> Enum.filter(&(&1.insee == region_insee))
     end
   end
 


### PR DESCRIPTION
Retravaille #4825. La recherche par région se fait désormais par code INSEE. Les liens n'avaient pas été ajustés dans la barre des filtres.