### PR TITLE
Réutilisations : recherche par type de JDD

### DIFF
--- a/apps/transport/client/stylesheets/reuses.scss
+++ b/apps/transport/client/stylesheets/reuses.scss
@@ -5,16 +5,22 @@
 }
 
 #reuses_search_container {
-  margin: 0;
-  .form__group {
-    display: inline-block;
+  margin: 1em 0;
+  display: flex;
+  flex-direction: row;
+
+  .form__group + .form__group {
+    margin-left: 2em;
+    margin-top: 0;
+  }
+
+  .reuses_search_button {
+    margin: 0 0 0 2em;
+    display: flex;
+    justify-content: center;
   }
 }
 
-.reuses_search_button {
-  display: inline-block;
-  margin-left: 16px !important;
-}
 
 .reuses .card__cover {
   background: transparent;

--- a/apps/transport/lib/transport_web/templates/reuse/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/reuse/index.html.heex
@@ -1,15 +1,6 @@
 <div class="container">
   <div class="cards reuses">
     <h1><%= dgettext("reuses", "Reuses") %></h1>
-    <%= form_for @conn, reuse_path(@conn, :index), [id: "reuses_search_container", method: "get"], fn f -> %>
-      <%= search_input(f, :q,
-        id: "reuses_search",
-        value: @q,
-        placeholder: dgettext("reuses", "Find reuses")
-      ) %>
-      <button type="submit" class="button reuses_search_button"><i class="fa fa-search"></i></button>
-    <% end %>
-
     <p>
       <%= raw(dgettext("reuses", "index-intro")) %>
       <%= link(dgettext("reuses", "Publish a reuse"),
@@ -17,6 +8,25 @@
         target: "_blank"
       ) %>
     </p>
+
+    <%= form_for @conn, reuse_path(@conn, :index), [id: "reuses_search_container", method: "get"], fn f -> %>
+      <%= select(
+        f,
+        :type,
+        Map.merge(
+          %{dgettext("reuses", "-- All --") => ""},
+          DB.Dataset.type_to_str_map() |> Map.new(fn {k, v} -> {v, k} end)
+        )
+      ) %>
+      <%= search_input(f, :q,
+        id: "reuses_search",
+        value: @q,
+        placeholder: dgettext("reuses", "Find reuses")
+      ) %>
+      <button type="submit" class="button reuses_search_button">
+        <i class="fa fa-search"></i>
+      </button>
+    <% end %>
 
     <%= for reuses <- Enum.chunk_every(@reuses, 4) do %>
       <div class="row pt-24">

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/reuses.po
@@ -64,3 +64,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Find reuses"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "-- All --"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/reuses.po
@@ -64,3 +64,7 @@ msgstr "Publier une réutilisation"
 #, elixir-autogen, elixir-format
 msgid "Find reuses"
 msgstr "Rechercher des réutilisations"
+
+#, elixir-autogen, elixir-format
+msgid "-- All --"
+msgstr "-- Tout --"

--- a/apps/transport/priv/gettext/reuses.pot
+++ b/apps/transport/priv/gettext/reuses.pot
@@ -64,3 +64,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Find reuses"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "-- All --"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuse_controller_test.exs
@@ -13,21 +13,24 @@ defmodule TransportWeb.ReuseControllerTest do
     end
 
     test "searching reuses", %{conn: conn} do
-      foo = insert(:reuse, title: "Foo")
-      bar = insert(:reuse, owner: "Bar")
+      d1 = insert(:dataset, type: "public-transit")
+      d2 = insert(:dataset, type: "private-parking")
+      foo = insert(:reuse, title: "Foo", datasets: [d1])
+      bar = insert(:reuse, owner: "Bar", datasets: [d2])
 
-      reuse_titles = fn search ->
+      reuse_titles = fn q, type ->
         conn
-        |> get(reuse_path(conn, :index), q: search)
+        |> get(reuse_path(conn, :index), q: q, type: type)
         |> html_response(200)
         |> Floki.parse_document!()
         |> Floki.find(".card__content h3")
         |> Enum.map(&Floki.text/1)
       end
 
-      assert [bar.title, foo.title] == reuse_titles.("")
-      assert [foo.title] == reuse_titles.("foo")
-      assert [bar.title] == reuse_titles.("ba")
+      assert [bar.title, foo.title] == reuse_titles.("", "")
+      assert [foo.title] == reuse_titles.("foo", "")
+      assert [bar.title] == reuse_titles.("ba", "")
+      assert [bar.title] == reuse_titles.("", d2.type)
     end
   end
 end


### PR DESCRIPTION
Permet de rechercher des réutilisations par type de jeu de données réutilisé.

<img width="3278" height="1798" alt="image" src="https://github.com/user-attachments/assets/dbd0aec3-cf35-416c-b695-4900d4e27241" />
