### PR TITLE
DB.Resource.download_url/1 : uniquement ressources statiques

### DIFF
--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -321,7 +321,7 @@ defmodule DB.Resource do
         } = conn
       ) do
     cond do
-      DB.Dataset.has_custom_tag?(dataset, "authentification_experimentation") ->
+      DB.Dataset.has_custom_tag?(dataset, "authentification_experimentation") and not real_time?(resource) ->
         resource_url(conn, :download, resource.id, token: token.secret)
 
       pan_resource?(resource) ->
@@ -337,7 +337,7 @@ defmodule DB.Resource do
 
   def download_url(%__MODULE__{dataset: %DB.Dataset{} = dataset} = resource, conn_or_endpoint) do
     cond do
-      DB.Dataset.has_custom_tag?(dataset, "authentification_experimentation") ->
+      DB.Dataset.has_custom_tag?(dataset, "authentification_experimentation") and not real_time?(resource) ->
         resource_url(conn_or_endpoint, :download, resource.id)
 
       pan_resource?(resource) ->

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -319,7 +319,8 @@ defmodule TransportWeb.API.DatasetController do
 
   defp use_download_url?(%DB.Resource{} = resource) do
     DB.Resource.pan_resource?(resource) or DB.Resource.served_by_proxy?(resource) or
-      DB.Dataset.has_custom_tag?(resource.dataset, "authentification_experimentation")
+      (DB.Dataset.has_custom_tag?(resource.dataset, "authentification_experimentation") and
+         not DB.Resource.real_time?(resource))
   end
 
   @spec transform_aom(AOM.t() | nil) :: map()

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -824,6 +824,21 @@ defmodule TransportWeb.API.DatasetControllerTest do
     assert [%{"url" => ^auth_url}] = json |> hd() |> Map.get("resources")
   end
 
+  test "GET /api/datasets with a dataset with experimentation tag and a real-time resource", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+    resource = insert(:resource, latest_url: "https://example.com/gbfs", format: "gbfs", dataset: dataset)
+
+    assert DB.Resource.real_time?(resource)
+
+    json =
+      conn
+      |> get(Helpers.dataset_path(conn, :datasets))
+      |> json_response(200)
+
+    download_url = resource.latest_url
+    assert [%{"url" => ^download_url}] = json |> hd() |> Map.get("resources")
+  end
+
   test "GET /api/datasets/:id with a proxy resource", %{conn: conn} do
     dataset = insert(:dataset)
     resource = insert(:resource, dataset: dataset, url: "https://proxy.transport.data.gouv.fr/#{Ecto.UUID.generate()}")

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -1032,6 +1032,16 @@ defmodule TransportWeb.DatasetControllerTest do
              conn |> dataset_href_download_button(dataset)
   end
 
+  test "dataset#details, dataset with experimentation tag, real-time resource", %{conn: conn} do
+    dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
+    resource = insert(:resource, url: "https://example.com/gbfs", format: "gbfs", dataset: dataset)
+
+    assert DB.Resource.real_time?(resource)
+    mock_empty_history_resources()
+
+    assert [resource.url] == conn |> dataset_href_download_button(dataset)
+  end
+
   test "dataset#details, proxy resource, logged-in user with a default token", %{conn: conn} do
     dataset = insert(:dataset)
     resource = insert(:resource, dataset: dataset, url: "https://proxy.transport.data.gouv.fr/#{Ecto.UUID.generate()}")


### PR DESCRIPTION
Fait en sorte que l'URL de téléchargement soit remplacée par l'URL PAN quand on a le :label: d'expérimentation uniquement pour les ressources statiques.

Sinon on avait le cas où un JDD a une ressource temps-réel du proxy, le :label: d'expérimentation et on met une URL en `https://transport.data.gouv.fr/resources/:id/download` qui redirige ensuite vers le proxy. On compte alors les requêtes 2 fois.