### PR TITLE
Erreur 404 propre pour resources#details

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -18,27 +18,43 @@ defmodule TransportWeb.ResourceController do
   plug(:assign_current_contact when action in [:details])
 
   def details(conn, %{"id" => id} = params) do
-    resource =
-      Resource |> preload([:resources_related, dataset: [:resources, :declarative_spatial_areas]]) |> Repo.get!(id)
+    case load_resource(id) do
+      nil ->
+        not_found(conn)
 
-    conn =
-      conn
-      |> assign(
-        :uptime_per_day,
-        DB.ResourceUnavailability.uptime_per_day(resource, availability_number_days())
-      )
-      |> assign(:resource_history, DB.ResourceHistory.latest_resource_history(id))
-      |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
-      |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
-      |> assign(:latest_validations_details, latest_validations_details(resource))
-      |> assign(:multi_validation, latest_validation(resource))
-      |> put_resource_flash(resource.dataset.is_active)
+      resource ->
+        conn =
+          conn
+          |> assign(
+            :uptime_per_day,
+            DB.ResourceUnavailability.uptime_per_day(resource, availability_number_days())
+          )
+          |> assign(:resource_history, DB.ResourceHistory.latest_resource_history(id))
+          |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
+          |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
+          |> assign(:latest_validations_details, latest_validations_details(resource))
+          |> assign(:multi_validation, latest_validation(resource))
+          |> put_resource_flash(resource.dataset.is_active)
 
-    cond do
-      Resource.gtfs?(resource) -> render_gtfs_details(conn, params, resource)
-      Resource.netex?(resource) -> render_netex_details(conn, params, resource)
-      true -> render_details(conn, resource)
+        cond do
+          Resource.gtfs?(resource) -> render_gtfs_details(conn, params, resource)
+          Resource.netex?(resource) -> render_netex_details(conn, params, resource)
+          true -> render_details(conn, resource)
+        end
     end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(ErrorView)
+    |> render("404.html")
+  end
+
+  defp load_resource(id) do
+    Resource
+    |> preload([:resources_related, dataset: [:resources, :declarative_spatial_areas]])
+    |> Repo.get(id)
   end
 
   def gtfs_rt_entities(%Resource{format: "gtfs-rt", id: id}) do

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -64,10 +64,10 @@ defmodule TransportWeb.ResourceControllerTest do
     :ok
   end
 
-  test "Non existing resource raises a Ecto.NoResultsError (interpreted as a 404 thanks to phoenix_ecto)", %{conn: conn} do
-    assert_raise Ecto.NoResultsError, fn ->
-      conn |> get(resource_path(conn, :details, 0))
-    end
+  test "Non existing resource returns a 404", %{conn: conn} do
+    conn = conn |> get(resource_path(conn, :details, 0))
+
+    assert conn |> html_response(404) =~ "Page non disponible"
   end
 
   test "GBFS resource with multi-validation sends back 200", %{conn: conn} do


### PR DESCRIPTION
Plutôt que renvoyer une erreur qui pollue AppSignal, renvoyons une page 404 propre.

Comme cela semblait intentionnel à l'origine, il y a peut-être une bonne raison qui m'échappe.