### PR TITLE
Amélioration du wording sur la date de mise à jour d’une resource

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -33,11 +33,11 @@
   <% end %>
 
   <div class="pb-24 light-gry">
-    <span title={dgettext("page-dataset-details", "last content modification")}>
+    <span title={dgettext("page-dataset-details", "latest-content-modification-popover")}>
       <i class="icon icon--sync-alt" aria-hidden="true"></i>
       <%= show_resource_last_update(resources_updated_at, @resource, locale) %>
+      <span class="small"><%= dgettext("page-dataset-details", "latest-content-modification-label") %></span>
     </span>
-    <span class="small"><%= dgettext("page-dataset-details", "Latest modification") %></span>
 
     <% resource_ttl = validation |> get_metadata_info("ttl") %>
     <%= unless is_nil(resource_ttl) do %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -343,10 +343,6 @@ msgid "availability-test-explanations"
 msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI and SIRI Lite feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful. In case of HTTP 500, the feed will be considered unavailable, unless the body appears to contain SOAP."
 
 #, elixir-autogen, elixir-format
-msgid "last content modification"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
@@ -671,8 +667,8 @@ msgid "Availability rate"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Latest modification"
-msgstr ""
+msgid "latest-content-modification-label"
+msgstr "Latest content modification"
 
 #, elixir-autogen, elixir-format
 msgid "This dataset is hidden"
@@ -717,3 +713,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Regulator"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "latest-content-modification-popover"
+msgstr "We check daily at the source server if the content has changed. This date may be different from the one displayed on data.gouv.fr as transport.data.gouv.fr tracks changes on downloaded content."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -343,10 +343,6 @@ msgid "availability-test-explanations"
 msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI et SIRI Lite, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible. En cas d'erreur 500, nous considèrerons que le flux est indisponible, sauf si il semble contenir du SOAP."
 
 #, elixir-autogen, elixir-format
-msgid "last content modification"
-msgstr "date de dernière modification du contenu"
-
-#, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "inconnue"
 
@@ -671,8 +667,8 @@ msgid "Availability rate"
 msgstr "Taux de disponibilité"
 
 #, elixir-autogen, elixir-format
-msgid "Latest modification"
-msgstr "Dernière modification"
+msgid "latest-content-modification-label"
+msgstr "Dernière modification du contenu"
 
 #, elixir-autogen, elixir-format
 msgid "This dataset is hidden"
@@ -717,3 +713,7 @@ msgstr "Ce jeu de données non officiel est publié à titre expérimental. Veui
 #, elixir-autogen, elixir-format
 msgid "Regulator"
 msgstr "Régulateur"
+
+#, elixir-autogen, elixir-format
+msgid "latest-content-modification-popover"
+msgstr "Nous vérifions quotidiennement à la source si le contenu a changé. Cette date peut différer de celle indiquée sur data.gouv.fr car les vérifications de transport.data.gouv.fr portent sur le contenu lui-même."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -343,10 +343,6 @@ msgid "availability-test-explanations"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "last content modification"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
@@ -671,7 +667,7 @@ msgid "Availability rate"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Latest modification"
+msgid "latest-content-modification-label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -716,4 +712,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Regulator"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "latest-content-modification-popover"
 msgstr ""


### PR DESCRIPTION
Les utilisateurs ne comprennent pas à quoi correspond notre date de modification de resource affichée sur la page d’un jeu de données, ils craignent que nous ne prenions pas en compte leurs modifications ou que nous ne vérifions pas suffisamment souvent si quelque chose a été modifié, et s’inquiètent de la différence avec la date affichée sur data.gouv.fr.

Cette PR introduit une amélioration du wording pour tenter d’expliquer et désamorcer les inquiétudes.

Concerne l’issue #4834 qui n’est pas entièrement close, je la laisse ouverte (voir todolist sur l’issue pour ce qui reste à faire, hors wording).

Avant :

<img width="2038" height="1302" alt="image" src="https://github.com/user-attachments/assets/e2cc648f-cbac-4237-9eae-11acf8c368d7" />

Après :

<img width="2038" height="1302" alt="image" src="https://github.com/user-attachments/assets/6aae871a-ed57-4ce0-8960-ae6be94f85e2" />
