### PR TITLE
Détails d'un GTFS : infos si fares v2

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details_gtfs.html.heex
@@ -128,6 +128,18 @@ stats = @metadata["stats"] %>
         <td><%= format_nil_or_number(stats["fares_rules_count"], locale) %></td>
       </tr>
       <tr>
+        <td><%= dgettext("page-dataset-details", "Fare products") %></td>
+        <td lang="en"><code>fare_rules.txt</code></td>
+        <td><%= yes_no_icon(stats["fares_products_count"]) %></td>
+        <td><%= format_nil_or_number(stats["fares_products_count"], locale) %></td>
+      </tr>
+      <tr>
+        <td><%= dgettext("page-dataset-details", "Fare media") %></td>
+        <td lang="en"><code>fare_rules.txt</code></td>
+        <td><%= yes_no_icon(stats["fares_media_count"]) %></td>
+        <td><%= format_nil_or_number(stats["fares_media_count"], locale) %></td>
+      </tr>
+      <tr>
         <td><%= dgettext("page-dataset-details", "Transfers") %></td>
         <td lang="en"><code>transfers.txt</code></td>
         <td><%= yes_no_icon(stats["transfers_count"]) %></td>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -717,3 +717,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "latest-content-modification-popover"
 msgstr "We check daily at the source server if the content has changed. This date may be different from the one displayed on data.gouv.fr as transport.data.gouv.fr tracks changes on downloaded content."
+
+#, elixir-autogen, elixir-format
+msgid "Fare media"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Fare products"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -717,3 +717,11 @@ msgstr "Régulateur"
 #, elixir-autogen, elixir-format
 msgid "latest-content-modification-popover"
 msgstr "Nous vérifions quotidiennement à la source si le contenu a changé. Cette date peut différer de celle indiquée sur data.gouv.fr car les vérifications de transport.data.gouv.fr portent sur le contenu lui-même."
+
+#, elixir-autogen, elixir-format
+msgid "Fare media"
+msgstr "Supports tarifaires"
+
+#, elixir-autogen, elixir-format
+msgid "Fare products"
+msgstr "Produits tarifaires"

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -717,3 +717,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "latest-content-modification-popover"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Fare media"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Fare products"
+msgstr ""


### PR DESCRIPTION
Suite à l'ajout de métadonnées https://github.com/etalab/transport-validator/pull/223 indiquant si le fichier contient des informations de fares v2, affiche cette information sur la page de détails d'un GTFS.
