### PR TITLE
GTFS Diff explanations supplémentaires pour agency.txt

### DIFF
--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
@@ -24,6 +24,8 @@ defmodule TransportWeb.GTFSDiffExplain.Explanations do
       |> explanation_route_type(diff)
       |> explanation_stop_location_type(diff)
       |> explanation_agency_url(diff)
+      |> explanation_agency_fare_url(diff)
+      |> explanation_agency_phone(diff)
       |> explanation_trip_headsign(diff)
     end)
   end
@@ -313,6 +315,58 @@ defmodule TransportWeb.GTFSDiffExplain.Explanations do
   end
 
   defp explanation_agency_url(explanations, _), do: explanations
+
+  defp explanation_agency_fare_url(
+         explanations,
+         %{
+           "action" => "update",
+           "file" => "agency.txt",
+           "target" => "row",
+           "identifier" => %{"agency_id" => agency_id},
+           "new_value" => %{"agency_fare_url" => new_agency_fare_url},
+           "initial_value" => %{"agency_fare_url" => initial_agency_fare_url}
+         }
+       ) do
+    [
+      %{
+        file: "agency.txt",
+        type: "agency_fare_url",
+        message: dgettext("gtfs-diff", "Agency fare URL for agency %{agency_id} has been changed", agency_id: agency_id),
+        before: initial_agency_fare_url,
+        after: new_agency_fare_url,
+        sort_key: agency_id
+      }
+      | explanations
+    ]
+  end
+
+  defp explanation_agency_fare_url(explanations, _), do: explanations
+
+  defp explanation_agency_phone(
+         explanations,
+         %{
+           "action" => "update",
+           "file" => "agency.txt",
+           "target" => "row",
+           "identifier" => %{"agency_id" => agency_id},
+           "new_value" => %{"agency_phone" => new_agency_phone},
+           "initial_value" => %{"agency_phone" => initial_agency_phone}
+         }
+       ) do
+    [
+      %{
+        file: "agency.txt",
+        type: "agency_phone",
+        message: dgettext("gtfs-diff", "Agency phone for agency %{agency_id} has been changed", agency_id: agency_id),
+        before: initial_agency_phone,
+        after: new_agency_phone,
+        sort_key: agency_id
+      }
+      | explanations
+    ]
+  end
+
+  defp explanation_agency_phone(explanations, _), do: explanations
 
   defp explanation_trip_headsign(
          explanations,

--- a/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
+++ b/apps/transport/lib/transport_web/live/gtfs_diff_explain/explanations.ex
@@ -331,7 +331,8 @@ defmodule TransportWeb.GTFSDiffExplain.Explanations do
       %{
         file: "agency.txt",
         type: "agency_fare_url",
-        message: dgettext("gtfs-diff", "Agency fare URL for agency %{agency_id} has been changed", agency_id: agency_id),
+        message:
+          dgettext("gtfs-diff", "Agency fare URL for agency %{agency_id} has been changed", agency_id: agency_id),
         before: initial_agency_fare_url,
         after: new_agency_fare_url,
         sort_key: agency_id

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-diff.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-diff.po
@@ -386,3 +386,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "URL of the transit agency."
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Agency fare URL for agency %{agency_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Agency phone for agency %{agency_id} has been changed"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-diff.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-diff.po
@@ -386,3 +386,11 @@ msgstr "Texte qui apparaît sur la signalisation identifiant la destination du v
 #, elixir-autogen, elixir-format
 msgid "URL of the transit agency."
 msgstr "URL de l’entité."
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Agency fare URL for agency %{agency_id} has been changed"
+msgstr "L’URL des tarifs de l’entité %{agency_id} a été modifiée"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Agency phone for agency %{agency_id} has been changed"
+msgstr "Le téléphone de l’entité %{agency_id} a été modifié"

--- a/apps/transport/priv/gettext/gtfs-diff.pot
+++ b/apps/transport/priv/gettext/gtfs-diff.pot
@@ -386,3 +386,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "URL of the transit agency."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency fare URL for agency %{agency_id} has been changed"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Agency phone for agency %{agency_id} has been changed"
+msgstr ""

--- a/apps/transport/test/transport_web/live_views/gtfs_diff_explain_test.exs
+++ b/apps/transport/test/transport_web/live_views/gtfs_diff_explain_test.exs
@@ -68,6 +68,14 @@ defmodule TransportWeb.GtfsDiffExplainTest do
       },
       %{
         "action" => "update",
+        "file" => "agency.txt",
+        "identifier" => "{\"agency_id\":\"1\"}",
+        "initial_value" => ~s|{"agency_fare_url":"","agency_phone":""}|,
+        "new_value" => ~s|{"agency_fare_url":"https://example.com/tarifs","agency_phone":"0123456"}|,
+        "target" => "row"
+      },
+      %{
+        "action" => "update",
         "file" => "trips.txt",
         "identifier" => "{\"trip_id\":\"1\"}",
         "initial_value" => "{\"trip_headsign\":\"Foo\"}",
@@ -155,6 +163,22 @@ defmodule TransportWeb.GtfsDiffExplainTest do
                message: "L’URL de l’entité 1 a été modifiée",
                before: "http://localhost/foo",
                after: "http://localhost/bar",
+               sort_key: "1"
+             },
+             %{
+               file: "agency.txt",
+               type: "agency_phone",
+               message: "Le téléphone de l’entité 1 a été modifié",
+               before: "",
+               after: "0123456",
+               sort_key: "1"
+             },
+             %{
+               file: "agency.txt",
+               type: "agency_fare_url",
+               message: "L’URL des tarifs de l’entité 1 a été modifiée",
+               before: "",
+               after: "https://example.com/tarifs",
                sort_key: "1"
              },
              %{


### PR DESCRIPTION
Fixes #4860 4860

Dans le GTFS Diff, documente les changements effectués sur `agency_fare_url` et `agency_phone`.

<img width="826" height="471" alt="Screenshot 2025-10-06 at 13 52 23" src="https://github.com/user-attachments/assets/dbf5cddd-4baf-424f-8056-2be059bbaff8" />
