### PR TITLE
Resource#download : forward la requête pour requête HEAD

### DIFF
--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -350,7 +350,12 @@ defmodule TransportWeb.ResourceControllerTest do
 
   test "HEAD request for a dataset with the experimental tag", %{conn: conn} do
     dataset = insert(:dataset, custom_tags: ["authentification_experimentation"])
-    resource = insert(:resource, dataset: dataset)
+    resource = insert(:resource, url: url = "https://example.com/head", dataset: dataset)
+
+    Transport.HTTPoison.Mock
+    |> expect(:head, fn ^url, [] ->
+      {:ok, %HTTPoison.Response{status_code: 200}}
+    end)
 
     assert conn |> head(resource_path(conn, :download, resource.id)) |> response(200)
   end


### PR DESCRIPTION
Voir [bug :bug: sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/o1nkg7grgifa8qe8tzpxb88zza)

Auparavant on considérait toujours que la ressource est disponible dès lors que le JDD avait :label: `authentification_experimentation`. Désormais on effectue une requête HEAD vers l'URL de la ressource et on forward la réponse.
