### PR TITLE
Resource#details: Suppression double binding MultiValidation

### DIFF
--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -35,7 +35,7 @@ defmodule TransportWeb.ResourceController do
           |> assign(:gtfs_rt_feed, gtfs_rt_feed(conn, resource))
           |> assign(:gtfs_rt_entities, gtfs_rt_entities(resource))
           |> assign(:latest_validations_details, latest_validations_details(resource))
-          |> assign(:multi_validation, validation)
+          |> assign(:validation, validation)
           |> put_resource_flash(resource.dataset.is_active)
 
         cond do
@@ -161,7 +161,7 @@ defmodule TransportWeb.ResourceController do
       end
 
     conn
-    |> assign_base_resource_details(params, resource, validation, validation_details)
+    |> assign_base_resource_details(params, resource, validation_details)
     |> assign(:validator, Transport.Validators.GTFSTransport)
     |> assign(:data_vis, encoded_data_vis(issue_type, validation))
     |> render("gtfs_details.html")
@@ -182,7 +182,7 @@ defmodule TransportWeb.ResourceController do
       build_netex_validation_details(validation, params)
 
     conn
-    |> assign_base_resource_details(params, resource, validation, validation_details)
+    |> assign_base_resource_details(params, resource, validation_details)
     |> assign(:errors_template, errors_template)
     |> assign(:results_adapter, results_adapter)
     |> assign(:max_severity, max_severity)
@@ -210,7 +210,7 @@ defmodule TransportWeb.ResourceController do
   defp pick_netex_errors_template("0.2.0"), do: "_netex_validation_errors_v0_2_x.html"
   defp pick_netex_errors_template(_), do: "_netex_validation_errors_v0_1_0.html"
 
-  defp assign_base_resource_details(conn, params, resource, validation, validation_details) do
+  defp assign_base_resource_details(conn, params, resource, validation_details) do
     config = make_pagination_config(params)
 
     {validation_summary, severities_count, metadata, modes, issues} = validation_details
@@ -222,7 +222,6 @@ defmodule TransportWeb.ResourceController do
     |> assign(:issues, Scrivener.paginate(issues, config))
     |> assign(:validation_summary, validation_summary)
     |> assign(:severities_count, severities_count)
-    |> assign(:validation, validation)
     |> assign(:metadata, metadata)
     |> assign(:modes, modes)
   end

--- a/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validate_gtfs_rt_now.html.heex
@@ -1,4 +1,4 @@
-<% associated_gtfs = gtfs_for_gtfs_rt(@resource, @multi_validation) %>
+<% associated_gtfs = gtfs_for_gtfs_rt(@resource, @validation) %>
 <%= if is_nil(associated_gtfs) do %>
   <div class="notification error full-width">
     <p>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report.html.heex
@@ -1,24 +1,24 @@
-<% show_schema_validation = not is_nil(@resource.schema_name) and multi_validation_performed?(@multi_validation) %>
-<% show_gtfs_rt_validation = DB.Resource.gtfs_rt?(@resource) and multi_validation_performed?(@multi_validation) %>
-<% show_gbfs_validation = DB.Resource.gbfs?(@resource) and multi_validation_performed?(@multi_validation) %>
+<% show_schema_validation = not is_nil(@resource.schema_name) and multi_validation_performed?(@validation) %>
+<% show_gtfs_rt_validation = DB.Resource.gtfs_rt?(@resource) and multi_validation_performed?(@validation) %>
+<% show_gbfs_validation = DB.Resource.gbfs?(@resource) and multi_validation_performed?(@validation) %>
 
 <h2 id="validation-report"><%= dgettext("validations", "Validation details") %></h2>
 
 <%= if show_schema_validation do %>
-  <%= render("_validation_report_schema.html", resource: @resource, conn: @conn, multi_validation: @multi_validation) %>
+  <%= render("_validation_report_schema.html", resource: @resource, conn: @conn, validation: @validation) %>
 <% end %>
 
 <%= if show_gtfs_rt_validation do %>
   <%= render("_validation_report_gtfs_rt.html",
     resource: @resource,
     conn: @conn,
-    multi_validation: @multi_validation,
+    validation: @validation,
     latest_validations_details: @latest_validations_details
   ) %>
 <% end %>
 
 <%= if show_gbfs_validation do %>
-  <%= render("_validation_report_gbfs.html", resource: @resource, conn: @conn, multi_validation: @multi_validation) %>
+  <%= render("_validation_report_gbfs.html", resource: @resource, conn: @conn, validation: @validation) %>
 <% end %>
 
 <%= if not Enum.any?([show_schema_validation, show_gtfs_rt_validation, show_gbfs_validation]) do %>
@@ -27,7 +27,7 @@
       <%= dgettext("validations", "No validation available") %>
     </div>
     <%= if DB.Resource.gtfs_rt?(@resource) do %>
-      <%= render("_validate_gtfs_rt_now.html", conn: @conn, resource: @resource, multi_validation: @multi_validation) %>
+      <%= render("_validate_gtfs_rt_now.html", conn: @conn, resource: @resource, validation: @validation) %>
     <% end %>
     <%= if DB.Resource.gbfs?(@resource) do %>
       <%= render("_validate_gbfs_now.html", conn: @conn, resource: @resource) %>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_gbfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_gbfs.html.heex
@@ -4,13 +4,12 @@
       dgettext(
         "validations",
         ~s(Validation carried out the %{date} using the <a href="%{validator_url}" target="_blank">MobilityData validator</a>.),
-        date:
-          DateTimeDisplay.format_datetime_to_paris(@multi_validation.validation_timestamp, get_session(@conn, :locale)),
+        date: DateTimeDisplay.format_datetime_to_paris(@validation.validation_timestamp, get_session(@conn, :locale)),
         validator_url: gbfs_validator_url()
       )
     ) %>
   </p>
-  <% nb_errors = errors_count(@multi_validation) %>
+  <% nb_errors = errors_count(@validation) %>
   <%= render("_errors_warnings_count.html", nb_errors: nb_errors, nb_warnings: 0) %>
   <%= render("_validate_gbfs_now.html", conn: @conn, resource: @resource) %>
 

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
@@ -1,14 +1,13 @@
 <% locale = get_session(@conn, :locale) %>
 <div class="panel">
-  <% validation = @multi_validation %>
-  <% errors = Map.fetch!(validation.result, "errors") %>
+  <% errors = Map.fetch!(@validation.result, "errors") %>
   <% errors_error_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "ERROR")) %>
   <% errors_warning_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "WARNING")) %>
   <%= render("_errors_warnings_count.html",
-    nb_errors: errors_count(validation),
-    nb_warnings: warnings_count(validation)
+    nb_errors: errors_count(@validation),
+    nb_warnings: warnings_count(@validation)
   ) %>
-  <p :if={Map.get(validation.result, "ignore_shapes", false)} class="notification">
+  <p :if={Map.get(@validation.result, "ignore_shapes", false)} class="notification">
     <%= dgettext("validations", "Shapes present in the GTFS have been ignored, some rules are not enforced.") %>
   </p>
   <p>
@@ -16,9 +15,9 @@
       dgettext(
         "validations",
         ~s(Validation carried out using the <a href="%{gtfs_link}">current GTFS file</a> and the <a href="%{gtfs_rt_link}">GTFS-RT</a> the %{date} using the <a href="%{validator_url}" target="_blank">MobilityData GTFS-RT validator</a>.),
-        gtfs_link: Map.fetch!(validation.result["files"], "gtfs_permanent_url"),
-        gtfs_rt_link: Map.fetch!(validation.result["files"], "gtfs_rt_permanent_url"),
-        date: DateTimeDisplay.format_datetime_to_paris(validation.validation_timestamp, locale),
+        gtfs_link: Map.fetch!(@validation.result["files"], "gtfs_permanent_url"),
+        gtfs_rt_link: Map.fetch!(@validation.result["files"], "gtfs_rt_permanent_url"),
+        date: DateTimeDisplay.format_datetime_to_paris(@validation.validation_timestamp, locale),
         validator_url: gtfs_rt_validator_url()
       )
     ) %>
@@ -31,6 +30,6 @@
     <h4><%= dgettext("validations", "Warnings") %></h4>
     <%= render("_gtfs_rt_errors_for_severity.html", errors_for_severity: errors_warning_level) %>
   <% end %>
-  <%= render("_validate_gtfs_rt_now.html", conn: @conn, resource: @resource, multi_validation: @multi_validation) %>
+  <%= render("_validate_gtfs_rt_now.html", conn: @conn, resource: @resource, validation: @validation) %>
   <%= render("_gtfs_rt_previous_validations_details.html", latest_validations_details: @latest_validations_details) %>
 </div>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_schema.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_schema.html.heex
@@ -6,16 +6,16 @@
       )
     ) %>
   </p>
-  <%= unless is_nil(@multi_validation) do %>
-    <% nb_errors = errors_count(@multi_validation) %>
+  <%= unless is_nil(@validation) do %>
+    <% nb_errors = errors_count(@validation) %>
     <%= render("_errors_warnings_count.html", nb_errors: nb_errors, nb_warnings: 0) %>
     <%= if nb_errors > 0 do %>
       <%= render("_on_demand_validation_hint.html", conn: @conn, resource: @resource) %>
       <p><%= dgettext("validations", "Errors:") %></p>
-      <% validation_schema_name = @multi_validation.resource_history.payload["schema_name"] %>
+      <% validation_schema_name = @validation.resource_history.payload["schema_name"] %>
       <% schema_type = schema_type(validation_schema_name) %>
       <ul lang={if schema_type == "jsonschema", do: "en"}>
-        <%= for error <- errors_sample(@multi_validation) do %>
+        <%= for error <- errors_sample(@validation) do %>
           <li><%= error %></li>
         <% end %>
       </ul>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -22,7 +22,7 @@
       <%= unless DB.Resource.documentation?(@resource) do %>
         <%= render("_validation_report.html",
           resource: @resource,
-          multi_validation: @multi_validation,
+          validation: @validation,
           latest_validations_details: @latest_validations_details,
           conn: @conn
         ) %>


### PR DESCRIPTION
On assignait la même structure dans 2 assigns `multi_validation` et `validation`, ce qui est source de confusion et rend des refactoring ultérieurs pénibles.

J’ai d’abord pensé que cela apporterait un gain de perfomance. Comme les bindings sont des références il n’en est rien. Cependant l’intérêt demeure pour refactorer les usages du champ `result` de `MultiValidation`.