### PR TITLE
Modification contraste de la couleur verte des réutilisateurs

### DIFF
--- a/apps/transport/client/stylesheets/globals/_variables.scss
+++ b/apps/transport/client/stylesheets/globals/_variables.scss
@@ -90,5 +90,5 @@ $space-xs: 0.5em !default;
 
 :root {
   --primary-color-producer: var(--theme-primary);
-  --primary-color-reuser: #00ac8c;
+  --primary-color-reuser: #287233;
 }


### PR DESCRIPTION
En lien avec l'issue #4882 et la carte notion [amélioration de l'accessibilité](https://www.notion.so/transport-data-gouv-fr/Am-liorer-l-accessibilit-du-site-Page-d-accueil-1e3ba07fbe2a80b083abf8572adf8ae7?source=copy_link)