### PR TITLE
Optimisation des preloads de dataset_controler#details

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -221,6 +221,15 @@ defmodule DB.Dataset do
     query |> preload(resources: ^s)
   end
 
+  defp preload_legal_owners(query) do
+    a = from(a in AOM, select: %DB.AOM{nom: a.nom, siren: a.siren})
+    r = from(r in Region, select: %DB.Region{nom: r.nom, insee: r.insee})
+
+    query
+    |> preload(legal_owners_aom: ^a)
+    |> preload(legal_owners_region: ^r)
+  end
+
   @spec filter_by_fulltext(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_by_fulltext(query, %{"q" => ""}), do: query
 
@@ -809,11 +818,10 @@ defmodule DB.Dataset do
     preload_without_validations()
     |> where(slug: ^slug)
     |> preload([
-      :legal_owners_aom,
-      :legal_owners_region,
       :declarative_spatial_areas,
       resources: [:resources_related, :dataset]
     ])
+    |> preload_legal_owners()
     |> Repo.one()
     |> case do
       nil -> {:error, "Dataset with slug #{slug} not found"}


### PR DESCRIPTION
Des petites choses :
- On n’utilise plus les AOM, régions et communes historiques dans cette page (yay @AntoineAugusti) donc on peut les retirer des preloads
- Vu qu’on a besoin que du nom et de l’INSEE pour créer un lien vers les responsables légaux, je ne sélectionne pas le reste (fixes #4870)

En gros lors du chargement de la page, voici la comparaison du début des requêtes PostgreSQL faites (attention, il y a bien plus de requêtes qui sont faites par la suite pour le reste de la page…) :

AVANT :

```
[debug] QUERY OK source="dataset" db=0.1ms idle=1847.5ms
SELECT d0."id", d0."datagouv_id", d0."custom_title", d0."created_at", d0."description", d0."frequency", d0."last_update", d0."licence", d0."logo", d0."full_logo", d0."slug", d0."tags", d0."datagouv_title", d0."type", d0."organization", d0."organization_type", d0."has_realtime", d0."is_active", d0."is_hidden", d0."population", d0."nb_reuses", d0."latest_data_gouv_comment_timestamp", d0."archived_at", d0."custom_tags", d0."custom_logo", d0."custom_full_logo", d0."custom_logo_changed_at", d0."inserted_at", d0."updated_at", d0."legal_owner_company_siren", d0."region_id", d0."aom_id", d0."organization_id", d0."associated_territory_name", d0."search_payload" FROM "dataset" AS d0 WHERE (d0."slug" = $1) ["arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1"]
[debug] QUERY OK source="region" db=0.3ms idle=848.0ms
SELECT r0."id", r0."nom", r0."insee", r0."is_completed", r0."geom", r0."id" FROM "region" AS r0 WHERE (r0."id" = $1) [9]
[debug] QUERY OK source="resource" db=0.5ms idle=848.0ms
SELECT r0."dataset_id", r0."format", r0."title", r0."url", r0."id", r0."dataset_id", r0."datagouv_id", r0."last_update", r0."latest_url", r0."is_community_resource", r0."is_available", r0."description", r0."community_resource_publisher", r0."original_resource_url", r0."schema_name", r0."schema_version", r0."type", r0."display_position" FROM "resource" AS r0 WHERE (r0."dataset_id" = $1) ORDER BY r0."dataset_id" [976]
[debug] QUERY OK source="region" db=0.7ms idle=848.0ms
SELECT r0."id", r0."nom", r0."insee", r0."is_completed", r0."geom", d1."dataset_id"::bigint FROM "region" AS r0 INNER JOIN "dataset_region_legal_owner" AS d1 ON r0."id" = d1."region_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="commune" db=0.9ms idle=1766.7ms
SELECT c0."id", c0."insee", c0."nom", c0."surf_ha", c0."geom", c0."population", c0."siren", c0."arrondissement_insee", c0."aom_res_id", c0."region_id", c0."departement_insee", c0."epci_insee", d1."dataset_id"::bigint FROM "commune" AS c0 INNER JOIN "dataset_communes" AS d1 ON c0."id" = d1."commune_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="administrative_division" db=2.7ms idle=1847.9ms
SELECT a0."id", a0."type_insee", a0."insee", a0."type", a0."nom", a0."geom", a0."population", d1."dataset_id"::bigint FROM "administrative_division" AS a0 INNER JOIN "dataset_declarative_spatial_area" AS d1 ON a0."id" = d1."administrative_division_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="aom" db=2.9ms idle=848.0ms
SELECT a0."id", a0."composition_res_id", a0."insee_commune_principale", a0."siren", a0."nom", a0."forme_juridique", a0."nombre_communes", a0."population", a0."surface", a0."geom", a0."region_id", a0."departement", d1."dataset_id"::bigint FROM "aom" AS a0 INNER JOIN "dataset_aom_legal_owner" AS d1 ON a0."id" = d1."aom_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="dataset" db=0.3ms queue=0.1ms idle=7.6ms
SELECT d0."id", d0."datagouv_id", d0."custom_title", d0."created_at", d0."description", d0."frequency", d0."last_update", d0."licence", d0."logo", d0."full_logo", d0."slug", d0."tags", d0."datagouv_title", d0."type", d0."organization", d0."organization_type", d0."has_realtime", d0."is_active", d0."is_hidden", d0."population", d0."nb_reuses", d0."latest_data_gouv_comment_timestamp", d0."archived_at", d0."custom_tags", d0."custom_logo", d0."custom_full_logo", d0."custom_logo_changed_at", d0."inserted_at", d0."updated_at", d0."legal_owner_company_siren", d0."region_id", d0."aom_id", d0."organization_id", d0."associated_territory_name", d0."search_payload", d0."id" FROM "dataset" AS d0 WHERE (d0."id" = $1) [976]
[debug] QUERY OK source="resource_related" db=0.5ms idle=770.7ms
SELECT r0."resource_src_id", r0."resource_dst_id", r0."reason", r0."resource_src_id" FROM "resource_related" AS r0 WHERE (r0."resource_src_id" = ANY($1)) ORDER BY r0."resource_src_id" [[82322, 82321, 82323]]
[…]
```

APRÈS :

```
[debug] QUERY OK source="dataset" db=0.3ms idle=375.4ms
SELECT d0."id", d0."datagouv_id", d0."custom_title", d0."created_at", d0."description", d0."frequency", d0."last_update", d0."licence", d0."logo", d0."full_logo", d0."slug", d0."tags", d0."datagouv_title", d0."type", d0."organization", d0."organization_type", d0."has_realtime", d0."is_active", d0."is_hidden", d0."population", d0."nb_reuses", d0."latest_data_gouv_comment_timestamp", d0."archived_at", d0."custom_tags", d0."custom_logo", d0."custom_full_logo", d0."custom_logo_changed_at", d0."inserted_at", d0."updated_at", d0."legal_owner_company_siren", d0."region_id", d0."aom_id", d0."organization_id", d0."associated_territory_name", d0."search_payload" FROM "dataset" AS d0 WHERE (d0."slug" = $1) ["arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1"]
[debug] QUERY OK source="resource" db=0.5ms idle=218.0ms
SELECT r0."dataset_id", r0."format", r0."title", r0."url", r0."id", r0."dataset_id", r0."datagouv_id", r0."last_update", r0."latest_url", r0."is_community_resource", r0."is_available", r0."description", r0."community_resource_publisher", r0."original_resource_url", r0."schema_name", r0."schema_version", r0."type", r0."display_position" FROM "resource" AS r0 WHERE (r0."dataset_id" = $1) ORDER BY r0."dataset_id" [976]
[debug] QUERY OK source="region" db=0.5ms idle=218.0ms
SELECT d1."dataset_id"::bigint, r0."nom", r0."insee" FROM "region" AS r0 INNER JOIN "dataset_region_legal_owner" AS d1 ON r0."id" = d1."region_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="aom" db=0.7ms idle=218.0ms
SELECT d1."dataset_id"::bigint, a0."nom", a0."siren" FROM "aom" AS a0 INNER JOIN "dataset_aom_legal_owner" AS d1 ON a0."id" = d1."aom_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="administrative_division" db=3.7ms idle=217.9ms
SELECT a0."id", a0."type_insee", a0."insee", a0."type", a0."nom", a0."geom", a0."population", d1."dataset_id"::bigint FROM "administrative_division" AS a0 INNER JOIN "dataset_declarative_spatial_area" AS d1 ON a0."id" = d1."administrative_division_id" WHERE (d1."dataset_id" = ANY($1)) ORDER BY d1."dataset_id"::bigint [[976]]
[debug] QUERY OK source="dataset" db=0.6ms idle=223.4ms
SELECT d0."id", d0."datagouv_id", d0."custom_title", d0."created_at", d0."description", d0."frequency", d0."last_update", d0."licence", d0."logo", d0."full_logo", d0."slug", d0."tags", d0."datagouv_title", d0."type", d0."organization", d0."organization_type", d0."has_realtime", d0."is_active", d0."is_hidden", d0."population", d0."nb_reuses", d0."latest_data_gouv_comment_timestamp", d0."archived_at", d0."custom_tags", d0."custom_logo", d0."custom_full_logo", d0."custom_logo_changed_at", d0."inserted_at", d0."updated_at", d0."legal_owner_company_siren", d0."region_id", d0."aom_id", d0."organization_id", d0."associated_territory_name", d0."search_payload", d0."id" FROM "dataset" AS d0 WHERE (d0."id" = $1) [976]
[debug] QUERY OK source="resource_related" db=0.8ms idle=223.2ms
SELECT r0."resource_src_id", r0."resource_dst_id", r0."reason", r0."resource_src_id" FROM "resource_related" AS r0 WHERE (r0."resource_src_id" = ANY($1)) ORDER BY r0."resource_src_id" [[82322, 82321, 82323]]
[…]
```