### PR TITLE
Contournement deadlocks en CI

### DIFF
--- a/apps/transport/test/db/dataset_follower_test.exs
+++ b/apps/transport/test/db/dataset_follower_test.exs
@@ -1,5 +1,7 @@
 defmodule DB.DatasetFollowerTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   import DB.Factory
   alias DB.DatasetFollower
 

--- a/apps/transport/test/transport/consolidated_dataset_test.exs
+++ b/apps/transport/test/transport/consolidated_dataset_test.exs
@@ -1,5 +1,7 @@
 defmodule Transport.ConsolidatedDatasetTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   import DB.Factory
 
   setup do

--- a/apps/transport/test/transport/jobs/dataset_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_history_job_test.exs
@@ -1,5 +1,7 @@
 defmodule Transport.Test.Transport.Jobs.DatasetHistoryJobTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   import DB.Factory
   use Oban.Testing, repo: DB.Repo
   import Ecto.Query

--- a/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
+++ b/apps/transport/test/transport/jobs/geo_data/lez_to_geo_data_test.exs
@@ -1,5 +1,7 @@
 defmodule Transport.Jobs.LowEmissionZonesToGeoDataTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.{BaseGeoData, LowEmissionZonesToGeoData}
   import DB.Factory

--- a/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
+++ b/apps/transport/test/transport/jobs/new_dataset_notifications_job_test.exs
@@ -1,5 +1,7 @@
 defmodule Transport.Test.Transport.Jobs.NewDatasetNotificationsJobTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   use Oban.Testing, repo: DB.Repo
   import DB.Factory
   import Swoosh.TestAssertions

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -1,5 +1,7 @@
 defmodule Transport.Validators.GTFSRTTest do
-  use ExUnit.Case, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use ExUnit.Case, async: false
   use Oban.Testing, repo: DB.Repo
   import Ecto.Query
   import DB.Factory

--- a/apps/transport/test/transport_web/controllers/api/geo_query_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/geo_query_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule TransportWeb.API.GeoQueryControllerTest do
-  use TransportWeb.ConnCase, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use TransportWeb.ConnCase, async: false
   import DB.Factory
 
   setup do

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -1,5 +1,7 @@
 defmodule TransportWeb.EditDatasetLiveTest do
-  use TransportWeb.ConnCase, async: true
+  # The trigger refresh_dataset_geographic_view_trigger makes this test
+  # unreliable in a concurrent setup.
+  use TransportWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
   import Mox
   import DB.Factory


### PR DESCRIPTION
Le trigger refresh_dataset_geographic_view_trigger de la table dataset est coûteux à chaque insertion ou modification. Ce n'est pas problématique en production car ces modifications sont rares et on peut accepter un décalage entre le résultat du calcul et le contenu de la table. C'est en revanche plus génant en CI où les tests sont très aggressifs en insertions et provoquent très fréquemment des deadlocks, pénalisant considérable notre agilité.

Cette PR rend certains tests synchrones explicitement pour contourner ce problème. Cela se fait évidemment au détriment du temps d'exécution, mais la pénalité est probablement de l'ordre des secondes, ce qui est largement acceptable comparé à des échecs répétés, y compris lors du merge des PRs.