### PR TITLE
Stabilisation de quelques tests

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -133,7 +133,11 @@ defmodule TransportWeb.API.DatasetController do
     |> Repo.preload([:declarative_spatial_areas])
     |> case do
       %Dataset{} = dataset ->
-        data = Enum.map(dataset.declarative_spatial_areas, &to_feature(&1.geom, &1.nom)) |> keep_valid_features()
+        data =
+          dataset.declarative_spatial_areas
+          |> DB.AdministrativeDivision.sorted()
+          |> Enum.map(&to_feature(&1.geom, &1.nom))
+          |> keep_valid_features()
 
         conn
         |> assign(:data, to_geojson(dataset, data))

--- a/apps/transport/test/transport_web/controllers/dataset_search_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_search_test.exs
@@ -308,6 +308,7 @@ defmodule TransportWeb.DatasetSearchControllerTest do
              |> DB.Dataset.list_datasets()
              |> DB.Repo.all()
              |> Enum.map(& &1.id)
+             |> Enum.sort()
   end
 
   test "search by region" do


### PR DESCRIPTION
Il était rare que deux de nos tests échouent car le tri n'était pas explicite et reposait sur le comportement de la base de données.