### PR TITLE
GTFSExportStops : supprime aom_id et region_id

### DIFF
--- a/apps/transport/lib/transport/gtfs_export_stops.ex
+++ b/apps/transport/lib/transport/gtfs_export_stops.ex
@@ -19,8 +19,7 @@ defmodule Transport.GTFSExportStops do
     |> join(:inner, [_, di], rh in DB.ResourceHistory, on: di.resource_history_id == rh.id)
     |> join(:inner, [_, _, rh], r in DB.Resource, on: rh.resource_id == r.id)
     |> join(:inner, [_, _, _, r], d in DB.Dataset, on: r.dataset_id == d.id)
-    |> join(:left, [_, _, _, _, d], aom in assoc(d, :legal_owners_aom), as: :aom)
-    |> select([s, di, rh, r, d, a], %{
+    |> select([s, di, rh, r, d], %{
       dataset_custom_title: d.custom_title,
       dataset_organisation: d.organization,
       dataset_id: d.id,
@@ -28,8 +27,6 @@ defmodule Transport.GTFSExportStops do
       resource_id: r.id,
       resource_datagouv_id: r.datagouv_id,
       resource_title: r.title,
-      dataset_aom_id: a.id,
-      dataset_region_id: d.region_id,
       di_id: di.id,
       stop_id: s.stop_id,
       stop_name: s.stop_name,
@@ -47,8 +44,6 @@ defmodule Transport.GTFSExportStops do
     :resource_id,
     :resource_datagouv_id,
     :resource_title,
-    :dataset_aom_id,
-    :dataset_region_id,
     :di_id,
     :stop_id,
     :stop_name,


### PR DESCRIPTION
Les colonnes `dataset_aom_id` et `dataset_region_id` sont supprimées de l'export car ces colonnes seront prochainement supprimées de `dataset`.

À noter que : dataset < `1…n` > AOM et on veut une seule ligne par stop dans l'export.