### PR TITLE
Suppression d'un menu caché

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/_header.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/_header.html.heex
@@ -5,13 +5,6 @@
       <%= img_tag("/images/logo-black.svg", alt: gettext("transport.data.gouv.fr"), class: "navbar__logo-black") %>
     </a>
     <nav>
-      <a href="#menu">
-        <div class="nav__hamburger">
-          <div></div>
-          <div></div>
-          <div></div>
-        </div>
-      </a>
       <div id="menu">
         <a id="close-menu" href="#" aria-label={dgettext("page-index", "Close the menu")}>
           <i class="fas icon--times-circle"></i>&nbsp


### PR DESCRIPTION
Si l'hypothèse 1 de l'issue #4915 est bonne, ceci est une proposition de correctif qui ne devrait pas impacter la navigation dans le menu principal dans le header de la page d'accueil.