### PR TITLE
Couverture de tests du controlleur dataset

### DIFF
--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -301,58 +301,59 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "show GTFS number of errors", %{conn: conn} do
-    %{id: dataset_id} = insert(:dataset, slug: slug = "dataset-slug")
+    dataset = insert(:dataset)
 
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, format: "GTFS", url: "url"})
+    resource = insert(:resource, dataset: dataset, format: "GTFS", url: "url")
 
-    %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource_id})
+    resource_history = insert(:resource_history, resource: resource)
 
-    insert(:multi_validation, %{
-      resource_history_id: resource_history_id,
+    insert(:multi_validation,
+      resource_history_id: resource_history.id,
       validator: Transport.Validators.GTFSTransport.validator_name(),
       result: %{"Slow" => [%{"severity" => "Information"}]},
       metadata: %DB.ResourceMetadata{metadata: %{}, modes: ["ferry", "bus"]}
-    })
-
-    mock_empty_history_resources()
-
-    conn = conn |> get(dataset_path(conn, :details, slug))
-    assert conn |> html_response(200) =~ "1 information"
-    # Dataset modes are not displayed
-    refute conn |> html_response(200) =~ "ferry"
-  end
-
-  test "show number of errors for a GBFS", %{conn: conn} do
-    dataset = insert(:dataset, %{slug: "dataset-slug"})
-
-    resource = insert(:resource, %{dataset_id: dataset.id, format: "gbfs", url: "url"})
-
-    %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource.id})
-
-    insert(:multi_validation, %{
-      resource_history_id: resource_history_id,
-      validator: Transport.Validators.GBFSValidator.validator_name(),
-      result: %{"errors_count" => 1},
-      metadata: %{metadata: %{}}
-    })
+    )
 
     mock_empty_history_resources()
 
     conn = conn |> get(dataset_path(conn, :details, dataset.slug))
-    assert conn |> html_response(200) =~ "1 erreur"
+    assert conn |> html_response(200) |> extract_resource_details() =~ "1 information"
+    # Dataset modes are not displayed
+    refute conn |> html_response(200) |> extract_resource_details() =~ "ferry"
+  end
+
+  test "show number of errors for a GBFS", %{conn: conn} do
+    dataset = insert(:dataset, slug: "dataset-slug")
+
+    resource = insert(:resource, dataset_id: dataset.id, format: "gbfs", url: "url")
+
+    %{id: resource_history_id} = insert(:resource_history, resource_id: resource.id)
+
+    insert(:multi_validation,
+      resource_history_id: resource_history_id,
+      validator: Transport.Validators.GBFSValidator.validator_name(),
+      result: %{"errors_count" => 1},
+      metadata: %{metadata: %{}}
+    )
+
+    mock_empty_history_resources()
+
+    conn = conn |> get(dataset_path(conn, :details, dataset.slug))
+
+    assert conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
   end
 
   test "GBFS with a nil validation", %{conn: conn} do
     dataset = insert(:dataset)
-    resource = insert(:resource, %{dataset_id: dataset.id, format: "gbfs", url: "url"})
-    %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource.id})
+    resource = insert(:resource, dataset_id: dataset.id, format: "gbfs", url: "url")
+    %{id: resource_history_id} = insert(:resource_history, resource_id: resource.id)
 
-    insert(:multi_validation, %{
+    insert(:multi_validation,
       resource_history_id: resource_history_id,
       validator: Transport.Validators.GBFSValidator.validator_name(),
       result: nil,
       metadata: nil
-    })
+    )
 
     mock_empty_history_resources()
 
@@ -360,45 +361,56 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "show NeTEx number of errors", %{conn: conn} do
-    %{id: dataset_id} = insert(:dataset, slug: slug = "dataset-slug")
+    issues = [%{"criticity" => "error"}]
 
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, format: "NeTEx", url: "url"})
+    for version <- ["0.1.0", "0.2.0", "0.2.1"] do
+      dataset = insert(:dataset)
 
-    %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource_id})
+      resource = insert(:resource, dataset: dataset, format: "NeTEx", url: "url")
 
-    insert(:multi_validation, %{
-      resource_history_id: resource_history_id,
-      validator: Transport.Validators.NeTEx.Validator.validator_name(),
-      result: %{"xsd-1871" => [%{"criticity" => "error"}]},
-      metadata: %DB.ResourceMetadata{
-        metadata: %{"elapsed_seconds" => 42},
-        modes: [],
-        features: []
-      }
-    })
+      resource_history = insert(:resource_history, resource: resource)
 
-    mock_empty_history_resources()
+      result =
+        case version do
+          "0.1.0" -> %{"xsd-1871" => issues}
+          _ -> %{"xsd-schema" => issues}
+        end
 
-    conn = conn |> get(dataset_path(conn, :details, slug))
-    assert conn |> html_response(200) =~ "1 erreur"
+      insert(:multi_validation,
+        resource_history: resource_history,
+        validator: Transport.Validators.NeTEx.Validator.validator_name(),
+        validator_version: version,
+        result: result,
+        metadata: %DB.ResourceMetadata{
+          metadata: %{"elapsed_seconds" => 42},
+          modes: [],
+          features: []
+        }
+      )
+
+      mock_empty_history_resources()
+
+      conn = conn |> get(dataset_path(conn, :details, dataset.slug))
+      assert conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
+    end
   end
 
   test "don't show NeTEx number of errors if no validation", %{conn: conn} do
     %{id: dataset_id} = insert(:dataset, slug: slug = "dataset-slug")
 
-    %{id: resource_id} = insert(:resource, %{dataset_id: dataset_id, format: "NeTEx", url: "url"})
+    %{id: resource_id} = insert(:resource, dataset_id: dataset_id, format: "NeTEx", url: "url")
 
-    insert(:resource_history, %{resource_id: resource_id})
+    insert(:resource_history, resource_id: resource_id)
 
     mock_empty_history_resources()
 
     conn = conn |> get(dataset_path(conn, :details, slug))
-    refute conn |> html_response(200) =~ "1 erreur"
+    refute conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
   end
 
   test "GTFS-RT without validation", %{conn: conn} do
-    %{id: dataset_id} = insert(:dataset, %{slug: slug = "dataset-slug"})
-    insert(:resource, %{dataset_id: dataset_id, format: "gtfs-rt", url: "url"})
+    %{id: dataset_id} = insert(:dataset, slug: slug = "dataset-slug")
+    insert(:resource, dataset_id: dataset_id, format: "gtfs-rt", url: "url")
 
     mock_empty_history_resources()
 
@@ -408,7 +420,7 @@ defmodule TransportWeb.DatasetControllerTest do
 
   describe "licence description" do
     test "ODbL licence with specific conditions", %{conn: conn} do
-      insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl"})
+      insert(:dataset, slug: slug = "dataset-slug", licence: "odc-odbl")
 
       mock_empty_history_resources()
 
@@ -417,7 +429,7 @@ defmodule TransportWeb.DatasetControllerTest do
     end
 
     test "ODbL licence with openstreetmap tag", %{conn: conn} do
-      insert(:dataset, %{slug: slug = "dataset-slug", licence: "odc-odbl", tags: ["openstreetmap"]})
+      insert(:dataset, slug: slug = "dataset-slug", licence: "odc-odbl", tags: ["openstreetmap"])
 
       mock_empty_history_resources()
 
@@ -427,7 +439,7 @@ defmodule TransportWeb.DatasetControllerTest do
     end
 
     test "licence ouverte licence", %{conn: conn} do
-      insert(:dataset, %{slug: slug = "dataset-slug", licence: "lov2"})
+      insert(:dataset, slug: slug = "dataset-slug", licence: "lov2")
 
       mock_empty_history_resources()
 
@@ -438,21 +450,21 @@ defmodule TransportWeb.DatasetControllerTest do
   end
 
   test "does not crash when validation_performed is false", %{conn: conn} do
-    %{id: dataset_id} = insert(:dataset, %{slug: slug = "dataset-slug"})
+    %{id: dataset_id} = insert(:dataset, slug: slug = "dataset-slug")
 
     %{id: resource_id} =
-      insert(:resource, %{
+      insert(:resource,
         dataset_id: dataset_id,
         format: "geojson",
         schema_name: schema_name = "etalab/zfe",
         url: "https://example.com/file"
-      })
+      )
 
     Transport.Shared.Schemas.Mock
     |> expect(:transport_schemas, 1, fn -> %{schema_name => %{"title" => "foo"}} end)
 
     insert(:multi_validation, %{
-      resource_history: insert(:resource_history, %{resource_id: resource_id}),
+      resource_history: insert(:resource_history, resource_id: resource_id),
       validator: Transport.Validators.EXJSONSchema.validator_name(),
       result: %{"validation_performed" => false}
     })
@@ -1189,5 +1201,12 @@ defmodule TransportWeb.DatasetControllerTest do
       |> Floki.text()
 
     assert content =~ text
+  end
+
+  defp extract_resource_details(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("section#dataset-resources div.ressources-list div.resource")
+    |> Floki.text()
   end
 end


### PR DESCRIPTION
- améliore l'extraction des résultats du body (rend les tests négatifs plus facile à analyser)
- couvre les différentes versions du validateur NeTEx.

_Extrait de #4890 pour faciliter la review de cette dernière._