### PR TITLE
Résultats de validation sérializable

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
@@ -1,7 +1,8 @@
 <%= if GTFSTransport.mine?(@validation) do %>
   <div class="pb-24">
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
-    <% {severity, count} = GTFSTransport.count_max_severity(@validation.result) %>
+    <% %{"max_level" => severity, "worst_occurrences" => count} =
+      GTFSTransport.count_max_severity(@validation.result) %>
     <a href={link}>
       <span class={summary_class(%{severity: severity, count_errors: count})}>
         <%= if GTFSTransport.no_error?(severity) do %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
@@ -2,7 +2,8 @@
   <div class="pb-24">
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
     <% results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(@validation.validator_version) %>
-    <% {severity, count} = results_adapter.count_max_severity(@validation.result) %>
+    <% %{"max_level" => severity, "worst_occurrences" => count} =
+      results_adapter.count_max_severity(@validation.result) %>
     <a href={link}>
       <span class={summary_class(%{severity: String.capitalize(severity), count_errors: count})}>
         <%= if results_adapter.no_error?(severity) do %>

--- a/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors_v0_2_x.html.heex
@@ -1,4 +1,4 @@
-<% {max_level, worst_occurrences} = @max_severity %>
+<% %{"max_level" => max_level, "worst_occurrences" => worst_occurrences} = @max_severity %>
 <% current_category = @conn.params["issues_category"] || "" %>
 
 <h4><%= @results_adapter.format_severity(max_level, worst_occurrences) |> String.capitalize() %></h4>

--- a/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_summary.html.heex
@@ -1,15 +1,15 @@
 <div id="issues" class="validation-navigation">
   <nav class="issues-list validation" role="navigation">
-    <%= for {severity, issues} <- @validation_summary do %>
+    <%= for %{"severity" => severity, "issues" => issues} <- @validation_summary do %>
       <%= if Map.get(@severities_count, severity, 0) > 0 do %>
         <div class="validation-issue">
           <h4><%= @results_adapter.format_severity(severity, @severities_count[severity]) %></h4>
           <ul>
-            <%= for {key, issue} <- issues do %>
+            <%= for %{"key" => key, "issue" => issue} <- issues do %>
               <li>
-                <%= if issue.count > 0 do %>
+                <%= if issue["count"] > 0 do %>
                   <%= link(
-                    "#{issue.title} (#{issue.count})",
+                    "#{issue["title"]} (#{issue["count"]})",
                     to:
                       "#{current_url(@conn, %{"issue_type" => key, "token" => @token} |> Map.reject(fn {_, v} -> is_nil(v) end))}#issues",
                     class: if(key == @results_adapter.issue_type(@issues.entries), do: "active")

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
@@ -18,7 +18,7 @@
 
   <div class="validation-content">
     <div id="issues" class="container">
-      <% {_, worst_occurrences} = @max_severity %>
+      <% %{"worst_occurrences" => worst_occurrences} = @max_severity %>
       <% current_category = @conn.params["issues_category"] || "" %>
       <div id="issues" class="validation-navigation">
         <nav class="issues-list validation" role="navigation">

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -321,7 +321,7 @@ defmodule TransportWeb.ResourceView do
     ~H"""
     <ul class="summary">
       <.netex_errors_category
-        :for={{category, stats} <- @validation_summary}
+        :for={%{"category" => category, "stats" => stats} <- @validation_summary}
         conn={@conn}
         results_adapter={@results_adapter}
         category={category}
@@ -357,15 +357,15 @@ defmodule TransportWeb.ResourceView do
   defp netex_errors_category(%{conn: _, category: _, stats: _, token: _, results_adapter: _} = assigns) do
     ~H"""
     <li>
-      <.validity_icon errors={@stats[:count]} />
+      <.validity_icon errors={@stats["count"]} />
       <div class="selector">
-        <%= compatibility_filter(@conn, @category, @token, @stats[:count]) %>
-        <.stats :if={@stats[:count] > 0} stats={@stats} results_adapter={@results_adapter} />
+        <%= compatibility_filter(@conn, @category, @token, @stats["count"]) %>
+        <.stats :if={@stats["count"] > 0} stats={@stats} results_adapter={@results_adapter} />
       </div>
       <p :if={netex_category_description(@category)}>
         <%= netex_category_description(@category) %>
       </p>
-      <.category_hints :if={netex_category_hints(@category) && @stats[:count] > 0} category={@category} />
+      <.category_hints :if={netex_category_hints(@category) && @stats["count"] > 0} category={@category} />
     </li>
     """
   end
@@ -379,7 +379,7 @@ defmodule TransportWeb.ResourceView do
 
   defp stats(%{stats: _, results_adapter: _} = assigns) do
     ~H"""
-    (<%= @results_adapter.format_severity(@stats[:criticity], @stats[:count]) %>)
+    (<%= @results_adapter.format_severity(@stats["criticity"], @stats["count"]) %>)
     """
   end
 

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
@@ -34,7 +34,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
   """
   @spec get_max_severity_error(map()) :: binary()
   def get_max_severity_error(validation_result) do
-    {severity, _} = validation_result |> count_max_severity()
+    %{"max_level" => severity} = validation_result |> count_max_severity()
     severity
   end
 
@@ -43,12 +43,12 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
 
   iex> validation_result = %{"xsd-schema" => [%{"criticity" => "error"}], "french-profile" => [%{"criticity" => "error"}], "frame-arret-resources" => [%{"criticity" => "warning"}]}
   iex> count_max_severity(validation_result)
-  {"error", 2}
+  %{"max_level" => "error", "worst_occurrences" => 2}
   iex> validation_result = %{"french-profile" => [%{"criticity" => "warning"}]}
   iex> count_max_severity(validation_result)
-  {"warning", 1}
+  %{"max_level" => "warning", "worst_occurrences" => 1}
   iex> count_max_severity(%{})
-  {"NoError", 0}
+  %{"max_level" => "NoError", "worst_occurrences" => 0}
   """
   @impl Transport.Validators.NeTEx.ResultsAdapter
   defdelegate count_max_severity(validation_result), to: V0_1_0
@@ -126,13 +126,13 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
   iex> validation_result = %{"xsd-schema" => [%{"code" => "xsd-123", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "base-rules" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}]}
   iex> summary(validation_result)
   [
-    {"xsd-schema", %{count: 1, criticity: "error"}},
-    {"base-rules", %{count: 1, criticity: "error"}}
+    %{"category" => "xsd-schema", "stats" => %{"count" => 1, "criticity" => "error"}},
+    %{"category" => "base-rules", "stats" => %{"count" => 1, "criticity" => "error"}}
   ]
   iex> summary(%{})
   [
-    {"xsd-schema", %{count: 0, criticity: "NoError"}},
-    {"base-rules", %{count: 0, criticity: "NoError"}}
+    %{"category" => "xsd-schema", "stats" => %{"count" => 0, "criticity" => "NoError"}},
+    %{"category" => "base-rules", "stats" => %{"count" => 0, "criticity" => "NoError"}}
   ]
   """
   @impl Transport.Validators.NeTEx.ResultsAdapter
@@ -146,9 +146,9 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
         |> Enum.map(fn error -> Map.get(error, "criticity", @no_error) end)
         |> Enum.min_by(&severity_level/1, fn -> @no_error end)
 
-      stats = %{count: length(errors), criticity: worst_criticity}
+      stats = %{"count" => length(errors), "criticity" => worst_criticity}
 
-      {category, stats}
+      %{"category" => category, "stats" => stats}
     end)
   end
 

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
@@ -73,15 +73,15 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
   iex> validation_result = %{"xsd-schema" => [%{"code" => "xsd-123", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}], "french-profile"=>[%{"code"=>"pan:french_profile:123", "criticity" => "error"}], "base-rules" => [%{"code" => "valid-day-bits", "message" => "Mandatory attribute valid_day_bits not found", "criticity" => "error"}]}
   iex> summary(validation_result)
   [
-    {"xsd-schema", %{count: 1, criticity: "error"}},
-    {"french-profile", %{count: 1, criticity: "error"}},
-    {"base-rules", %{count: 1, criticity: "error"}}
+    %{"category" => "xsd-schema", "stats" => %{"count" => 1, "criticity" => "error"}},
+    %{"category" => "french-profile", "stats" => %{"count" => 1, "criticity" => "error"}},
+    %{"category" => "base-rules", "stats" => %{"count" => 1, "criticity" => "error"}}
   ]
   iex> summary(%{})
   [
-    {"xsd-schema", %{count: 0, criticity: "NoError"}},
-    {"french-profile", %{count: 0, criticity: "NoError"}},
-    {"base-rules", %{count: 0, criticity: "NoError"}}
+    %{"category" => "xsd-schema", "stats" => %{"count" => 0, "criticity" => "NoError"}},
+    %{"category" => "french-profile", "stats" => %{"count" => 0, "criticity" => "NoError"}},
+    %{"category" => "base-rules", "stats" => %{"count" => 0, "criticity" => "NoError"}}
   ]
   """
   @impl Transport.Validators.NeTEx.ResultsAdapter
@@ -95,9 +95,9 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
         |> Enum.map(fn error -> Map.get(error, "criticity", @no_error) end)
         |> Enum.min_by(&severity_level/1, fn -> @no_error end)
 
-      stats = %{count: length(errors), criticity: worst_criticity}
+      stats = %{"count" => length(errors), "criticity" => worst_criticity}
 
-      {category, stats}
+      %{"category" => category, "stats" => stats}
     end)
   end
 
@@ -113,6 +113,8 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
   iex> get_issues(validation_result, %{"issues_category" => "broken-file"})
   []
   iex> get_issues(validation_result, nil)
+  [%{"code" => "xsd-123", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
+  iex> get_issues(validation_result, %{})
   [%{"code" => "xsd-123", "message" => "Resource 23504000009 hasn't expected class but Netex::OperatingPeriod", "criticity" => "error"}]
   iex> get_issues(%{}, nil)
   []


### PR DESCRIPTION
Les résultats de validation sont affichés dans la page de détails d'une ressource. Pour permettre la navigation dans ces résultats l'on dérive de ces résultats un "résumé" (une liste des types d'erreurs ainsi que quelques éléments statistiques). On calcule également ces statistiques pour la page de détail d'un dataset. Dans ces deux cas il faut charger les résultats ce qui peut s'avérer couteux.

La solution explorée dans #4890 consiste donc à calculer ces informations dérivées des résultats en amont et les stocker en base de données pour s'éviter de charger l'intégralité des résultats. Cela implique également de rendre ces résultats sérialisables en JSON (pour une colonne JSONB).

Cette PR prépare donc le terrain en évitant d'utiliser des tuples et en les remplaçant par des maps pour permettre cette sérialisation.

Les changements introduits dans cette PR portent donc sur :
- la construction de ces résultats synthétiques par les différents validateurs
- l'usage de ces résultats synthétiques dans les templates de datasets et ressources.

_Extrait de #4890 pour rendre la review plus digeste._