### PR TITLE
StatsController : fix encodage

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -99,7 +99,7 @@ defmodule TransportWeb.API.StatsController do
       %{
         "geometry" => r.geometry |> JSON.encode!(),
         "type" => "Feature",
-        "properties" => Map.take(r, Enum.filter(Map.keys(r), fn k -> k != "geometry" end))
+        "properties" => Map.take(r, Enum.filter(Map.keys(r), fn k -> to_string(k) != "geometry" end))
       }
     end)
   end

--- a/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/stats_controller_test.exs
@@ -69,11 +69,6 @@ defmodule TransportWeb.API.StatsControllerTest do
           "type" => "Polygon"
         },
         "properties" => %{
-          geometry: %Geo.Polygon{
-            coordinates: [[{55.5832, -21.3723}, {55.551, -21.3743}, {55.5359, -21.3631}, {55.5832, -21.3723}]],
-            properties: %{},
-            srid: 4326
-          },
           names: [dataset2.custom_title, dataset1.custom_title],
           slugs: [dataset2.slug, dataset1.slug]
         },
@@ -84,6 +79,9 @@ defmodule TransportWeb.API.StatsControllerTest do
     assert TransportWeb.API.StatsController.vehicles_sharing_features_query()
            |> DB.Repo.all()
            |> TransportWeb.API.StatsController.vehicles_sharing_features() == expected
+
+    # result can be encoded
+    refute expected |> Jason.encode!() |> is_nil()
   end
 
   test "can load the /stats page", %{conn: conn} do


### PR DESCRIPTION
Répare l'affichage de la page stats (https://transport.data.gouv.fr/stats) où certains polygones ne sont plus affichés.

Ceci est lié à un problème d'encodage : les attributs des polygones doivent être encodés ou retirés car la payload est enregistrée telle quelle dans le cache, et il faut que ce soit sérialisable.
