### PR TITLE
Datasets: utilise le MultiValidation.digest

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -145,7 +145,7 @@ defmodule TransportWeb.DatasetController do
     %{
       unavailabilities: unavailabilities(dataset),
       resources_updated_at: DB.Dataset.resources_content_updated_at(dataset),
-      validations: DB.MultiValidation.dataset_latest_validation(dataset.id, validators_to_use(), include_result: true),
+      validations: DB.MultiValidation.dataset_latest_validation(dataset.id, validators_to_use()),
       gtfs_rt_entities: gtfs_rt_entities(dataset)
     }
   end

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
@@ -1,8 +1,7 @@
 <%= if GTFSTransport.mine?(@validation) do %>
   <div class="pb-24">
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
-    <% %{"max_level" => severity, "worst_occurrences" => count} =
-      GTFSTransport.count_max_severity(@validation.result) %>
+    <% %{"max_level" => severity, "worst_occurrences" => count} = @validation.digest["max_severity"] %>
     <a href={link}>
       <span class={summary_class(%{severity: severity, count_errors: count})}>
         <%= if GTFSTransport.no_error?(severity) do %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
@@ -2,8 +2,7 @@
   <div class="pb-24">
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
     <% results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(@validation.validator_version) %>
-    <% %{"max_level" => severity, "worst_occurrences" => count} =
-      results_adapter.count_max_severity(@validation.result) %>
+    <% %{"max_level" => severity, "worst_occurrences" => count} = @validation.digest["max_severity"] %>
     <a href={link}>
       <span class={summary_class(%{severity: String.capitalize(severity), count_errors: count})}>
         <%= if results_adapter.no_error?(severity) do %>

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -238,6 +238,16 @@ defmodule TransportWeb.DatasetView do
   def summary_class(%{count_errors: 0}), do: "resource__summary--Success"
   def summary_class(%{severity: severity}), do: "resource__summary--#{severity}"
 
+  def summary_class(%DB.MultiValidation{digest: %{"errors_count" => errors_count}})
+      when is_integer(errors_count) and errors_count > 0 do
+    "resource__summary--Error"
+  end
+
+  def summary_class(%DB.MultiValidation{digest: %{"warnings_count" => warnings_count}})
+      when is_integer(warnings_count) and warnings_count > 0 do
+    "resource__summary--Warning"
+  end
+
   def summary_class(%DB.MultiValidation{result: %{"errors_count" => errors_count}})
       when is_integer(errors_count) and errors_count > 0 do
     "resource__summary--Error"
@@ -250,12 +260,20 @@ defmodule TransportWeb.DatasetView do
 
   def summary_class(%DB.MultiValidation{}), do: "resource__summary--Success"
 
+  def warnings_count(%DB.MultiValidation{digest: %{"warnings_count" => warnings_count}})
+      when is_integer(warnings_count) and warnings_count >= 0,
+      do: warnings_count
+
   def warnings_count(%DB.MultiValidation{result: %{"warnings_count" => warnings_count}})
       when is_integer(warnings_count) and warnings_count >= 0,
       do: warnings_count
 
   def warnings_count(%DB.MultiValidation{validator: @gtfs_rt_validator_name}), do: 0
   def warnings_count(%DB.MultiValidation{}), do: nil
+
+  def errors_count(%DB.MultiValidation{digest: %{"errors_count" => errors_count}})
+      when is_integer(errors_count) and errors_count >= 0,
+      do: errors_count
 
   def errors_count(%DB.MultiValidation{result: %{"errors_count" => errors_count}})
       when is_integer(errors_count) and errors_count >= 0,

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -307,10 +307,14 @@ defmodule TransportWeb.DatasetControllerTest do
 
     resource_history = insert(:resource_history, resource: resource)
 
+    result = %{"Slow" => [%{"severity" => "Information"}]}
+    digest = Transport.Validators.GTFSTransport.digest(result)
+
     insert(:multi_validation,
       resource_history_id: resource_history.id,
       validator: Transport.Validators.GTFSTransport.validator_name(),
-      result: %{"Slow" => [%{"severity" => "Information"}]},
+      result: result,
+      digest: digest,
       metadata: %DB.ResourceMetadata{metadata: %{}, modes: ["ferry", "bus"]}
     )
 
@@ -329,10 +333,14 @@ defmodule TransportWeb.DatasetControllerTest do
 
     %{id: resource_history_id} = insert(:resource_history, resource_id: resource.id)
 
+    result = %{"errors_count" => 1}
+    digest = Transport.Validators.GBFSValidator.digest(result)
+
     insert(:multi_validation,
       resource_history_id: resource_history_id,
       validator: Transport.Validators.GBFSValidator.validator_name(),
-      result: %{"errors_count" => 1},
+      result: result,
+      digest: digest,
       metadata: %{metadata: %{}}
     )
 
@@ -376,11 +384,16 @@ defmodule TransportWeb.DatasetControllerTest do
           _ -> %{"xsd-schema" => issues}
         end
 
+      results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(version)
+
+      digest = results_adapter.digest(result)
+
       insert(:multi_validation,
         resource_history: resource_history,
         validator: Transport.Validators.NeTEx.Validator.validator_name(),
         validator_version: version,
         result: result,
+        digest: digest,
         metadata: %DB.ResourceMetadata{
           metadata: %{"elapsed_seconds" => 42},
           modes: [],


### PR DESCRIPTION
## Présentation

Utilise le digest introduit dans #4924 plutôt que les résultats de validation pour afficher les erreurs et avertissements sur la page de détails de dataset.

En évitant de charger la colonne results on s'évite des temps de réponse dramatiques pour les GTFS et NeTEx avec beaucoup d’erreurs. Cela devrait également décongestionner légèrement le pool SQL (notamment en cas de scrapping aggressif).

## Interface utilisateur

Pas de changement. Les templates et views sont adaptées pour exploiter la nouvelle colonne sans changer l'information affichée (couvert par les tests unitaires).

## TODO avant de merger

- [x] backfill des digest avec le script fourni par #4924.