### PR TITLE
Import des offres PASSIM

### DIFF
--- a/apps/transport/client/javascripts/app.js
+++ b/apps/transport/client/javascripts/app.js
@@ -47,6 +47,10 @@ window.addEventListener('phx:backoffice-form-spatial-areas-reset', () => {
     document.getElementById('spatial_areas_search_input').value = ''
 })
 
+window.addEventListener('phx:backoffice-form-offer-reset', () => {
+    document.getElementById('js-offer-input').value = ''
+})
+
 window.addEventListener('phx:gtfs-diff:scroll-to-steps', () => {
     document.getElementById('gtfs-diff-steps').parentElement.scrollIntoView({ behavior: 'smooth' })
 })

--- a/apps/transport/lib/db/offer.ex
+++ b/apps/transport/lib/db/offer.ex
@@ -1,0 +1,68 @@
+defmodule DB.Offer do
+  @moduledoc """
+  Represents transport offers.
+  """
+  use TypedEctoSchema
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  typed_schema "offer" do
+    field(:nom_commercial, :string)
+    field(:identifiant_offre, :integer)
+    field(:type_transport, :string)
+    field(:modes, {:array, :string})
+    field(:nom_aom, :string)
+    field(:aom_siren, :string)
+    field(:niveau, :string)
+    field(:exploitant, :string)
+    field(:type_contrat, :string)
+    field(:territoire, :string)
+
+    timestamps(type: :utc_datetime_usec)
+
+    belongs_to(:aom, DB.AOM)
+  end
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, [
+      :nom_commercial,
+      :identifiant_offre,
+      :type_transport,
+      :nom_aom,
+      :aom_siren,
+      :niveau,
+      :exploitant,
+      :type_contrat,
+      :territoire
+    ])
+    |> transform_modes(attrs)
+    |> add_aom(attrs)
+    |> validate_required([
+      :nom_commercial,
+      :identifiant_offre,
+      :type_transport,
+      :modes,
+      :nom_aom,
+      :aom_siren,
+      :niveau,
+      :territoire
+    ])
+  end
+
+  defp transform_modes(%Ecto.Changeset{} = changeset, %{"modes" => modes}) do
+    put_change(changeset, :modes, String.split(modes, " "))
+  end
+
+  defp add_aom(%Ecto.Changeset{} = changeset, %{"aom_siren" => aom_siren, "nom_aom" => nom_aom}) do
+    aom =
+      try do
+        DB.Repo.get_by(DB.AOM, siren: aom_siren)
+      rescue
+        Ecto.MultipleResultsError ->
+          DB.Repo.get_by(DB.AOM, nom: nom_aom)
+      end
+
+    put_assoc(changeset, :aom, aom)
+  end
+end

--- a/apps/transport/lib/mix/tasks/transport/import_offers.ex
+++ b/apps/transport/lib/mix/tasks/transport/import_offers.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.Transport.ImportOffers do
+  @moduledoc """
+  Import transport offers from the Cerema.
+  Run with `mix Transport.ImportOffers`.
+  """
+  @shortdoc "Import transport offers from the Cerema"
+  use Mix.Task
+  require Logger
+
+  # From https://docs.google.com/spreadsheets/d/1ItY-ozUk2IiR0-12_6hvAS5K2Ew2bziY/edit
+  @url "https://gist.githubusercontent.com/AntoineAugusti/1f43bbe8b4674905333cd7b998845c5d/raw/aa13b1c57a9a948ca28a2badd946f326c29a8093/offers.csv"
+
+  def run(_params) do
+    Logger.info("Importing offers")
+
+    Mix.Task.run("app.start")
+
+    DB.Repo.transaction(fn ->
+      truncate_offers()
+      import_offers()
+    end)
+  end
+
+  defp import_offers do
+    %Req.Response{status: 200, body: body} = Req.get!(@url)
+
+    [body]
+    |> CSV.decode!(headers: true, separator: ?,, escape_max_lines: 500)
+    |> Enum.map(&DB.Offer.changeset(%DB.Offer{}, &1))
+    |> Enum.each(&DB.Repo.insert!/1)
+  end
+
+  defp truncate_offers, do: DB.Repo.delete_all(DB.Offer)
+end

--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -183,7 +183,8 @@ defmodule TransportWeb.Backoffice.PageController do
       [organization_object: :contacts],
       :legal_owners_aom,
       :legal_owners_region,
-      :declarative_spatial_areas
+      :declarative_spatial_areas,
+      :offers
     ])
     |> Repo.get(dataset_id)
   end

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -41,6 +41,7 @@ defmodule TransportWeb.EditDatasetLive do
       |> assign(:trigger_submit, false)
       |> assign(:form_params, form_params(dataset))
       |> assign(:custom_tags, get_custom_tags(dataset))
+      |> assign(:offers, get_offers(dataset))
       |> assign(:declarative_spatial_areas, get_declarative_spatial_areas(dataset))
       |> assign(:matches, [])
 
@@ -84,6 +85,12 @@ defmodule TransportWeb.EditDatasetLive do
   end
 
   def get_custom_tags(_), do: []
+
+  def get_offers(%DB.Dataset{} = dataset) do
+    Enum.map(dataset.offers, &%{id: &1.id, label: &1.nom_commercial})
+  end
+
+  def get_offers(_), do: []
 
   def get_declarative_spatial_areas(%Dataset{} = dataset) do
     dataset.declarative_spatial_areas || []
@@ -152,6 +159,10 @@ defmodule TransportWeb.EditDatasetLive do
 
   def handle_info({:updated_custom_tags, custom_tags}, socket) do
     {:noreply, socket |> assign(:custom_tags, custom_tags)}
+  end
+
+  def handle_info({:updated_offers, offers}, socket) do
+    {:noreply, socket |> assign(:offers, offers)}
   end
 
   def handle_info({:updated_spatial_areas, updated_spatial_areas}, socket) do

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -88,6 +88,13 @@
 
   <div class="panel mt-48">
     <div class="panel-explanation">
+      <%= dgettext("backoffice", "Offers") %>
+    </div>
+    <.live_component module={TransportWeb.OfferSelectLive} id="offers_selection" form={f} offers={@offers} />
+  </div>
+
+  <div class="panel mt-48">
+    <div class="panel-explanation">
       <%= dgettext("backoffice", "Legal owners") %>
     </div>
     <.live_component module={TransportWeb.LegalOwnerSelectLive} id="owners_selection" form={f} owners={@legal_owners} />

--- a/apps/transport/lib/transport_web/live/backoffice/offer_select_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/offer_select_live.ex
@@ -1,0 +1,80 @@
+defmodule TransportWeb.OfferSelectLive do
+  use Phoenix.LiveComponent
+  alias TransportWeb.InputHelpers
+  import Ecto.Query
+
+  def render(assigns) do
+    ~H"""
+    <div class="pt-24">
+      <label>
+        Offre de transport <%= InputHelpers.text_input(@form, :offer_input,
+          placeholder: "Astuce",
+          list: "offers",
+          phx_keydown: "add_offer",
+          phx_target: @myself,
+          id: "js-offer-input"
+        ) %>
+      </label>
+      <datalist id="offers" phx-keydown="add_offer">
+        <%= for offer_suggestion <- @offers_list do %>
+          <option value={offer_suggestion.id}><%= offer_suggestion.label %></option>
+        <% end %>
+      </datalist>
+      <div class="pt-6">
+        <%= for {offer, index} <- Enum.with_index(@offers) do %>
+          <span class="label custom-tag">
+            <%= offer.label %>
+            <span class="delete-tag" phx-click="remove_offer" phx-value-offer-id={offer.id} phx-target={@myself}></span>
+          </span>
+          <% {field_name, field_value} = field_info(offer, index) %>
+          <%= Phoenix.HTML.Form.hidden_input(@form, field_name, value: field_value) %>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  def update(assigns, socket) do
+    offers =
+      DB.Offer
+      |> select([offer], %{label: offer.nom_commercial, id: offer.id})
+      |> DB.Repo.all()
+
+    {:ok, socket |> assign(assigns) |> assign(:offers_list, offers)}
+  end
+
+  def handle_event("add_offer", %{"key" => "Enter", "value" => value}, socket) do
+    new_offer = Enum.find(socket.assigns.offers_list, fn offer -> offer.id == String.to_integer(value) end)
+    offers = (socket.assigns.offers ++ [new_offer]) |> Enum.uniq()
+
+    if is_nil(new_offer) do
+      {:noreply, socket}
+    else
+      # new offers list is sent to the parent liveview form
+      # because this is a LiveComponent, the process of the parent is the same.
+      send(self(), {:updated_offers, offers})
+      {:noreply, socket |> clear_input()}
+    end
+  end
+
+  def handle_event("add_offer", _, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("remove_offer", %{"offer-id" => offer_id}, socket) do
+    offers = Enum.reject(socket.assigns.offers, fn offer -> offer.id == String.to_integer(offer_id) end)
+
+    send(self(), {:updated_offers, offers})
+
+    {:noreply, socket}
+  end
+
+  # clear the input using a js hook
+  def clear_input(socket) do
+    push_event(socket, "backoffice-form-offer-reset", %{})
+  end
+
+  def field_info(offer, index) do
+    {"offers[#{index}]", offer.id}
+  end
+end

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -291,3 +291,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Offers"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -291,3 +291,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr "Choose one or many municipalities, EPCIs, departments, regions or country. This is not displayed to users (website, API) for now."
+
+#, elixir-autogen, elixir-format
+msgid "Offers"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -291,3 +291,7 @@ msgstr "Territoire couvert déclaré (nouvelle version)"
 #, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr "Choisissez un ou plusieurs communes, EPCI, départements, régions ou pays. Ceci n’est pas affiché publiquement (site, API) pour l’instant."
+
+#, elixir-autogen, elixir-format
+msgid "Offers"
+msgstr "Offres"

--- a/apps/transport/priv/repo/migrations/20251120121226_create_offer.exs
+++ b/apps/transport/priv/repo/migrations/20251120121226_create_offer.exs
@@ -1,0 +1,20 @@
+defmodule DB.Repo.Migrations.CreateOffer do
+  use Ecto.Migration
+
+  def change do
+    create table(:offer) do
+      add(:nom_commercial, :string, null: false)
+      add(:identifiant_offre, :integer, null: false)
+      add(:type_transport, :string, null: false)
+      add(:modes, {:array, :string}, null: false)
+      add(:nom_aom, :string, null: false)
+      add(:aom_siren, :string, null: false)
+      add(:aom_id, references(:aom))
+      add(:niveau, :string, null: false)
+      add(:exploitant, :string, null: true)
+      add(:type_contrat, :string, null: true)
+      add(:territoire, :string, null: false, size: 5_000)
+      timestamps(type: :utc_datetime_usec)
+    end
+  end
+end

--- a/apps/transport/priv/repo/migrations/20251120125829_create_dataset_offer.exs
+++ b/apps/transport/priv/repo/migrations/20251120125829_create_dataset_offer.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.CreateDatasetOffer do
+  use Ecto.Migration
+
+  def change do
+    create table(:dataset_offer, primary_key: false) do
+      add(:dataset_id, references(:dataset, on_delete: :delete_all), null: false)
+      add(:offer_id, references(:offer, on_delete: :delete_all), null: false)
+    end
+
+    create(index("dataset_offer", [:dataset_id]))
+    create(index("dataset_offer", [:offer_id]))
+  end
+end

--- a/apps/transport/test/db/db_dataset_test.exs
+++ b/apps/transport/test/db/db_dataset_test.exs
@@ -634,6 +634,19 @@ defmodule DB.DatasetDBTest do
     assert [%DB.Region{id: ^region_id}] = dataset.legal_owners_region
   end
 
+  test "changeset with offers" do
+    %DB.Offer{id: offer_id} = offer = insert(:offer)
+    dataset = insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate(), offers: [offer])
+    assert [offer] == dataset.offers
+
+    # this time we test the changeset function with the datagouv_id
+    {:ok, changeset} = DB.Dataset.changeset(%{"datagouv_id" => datagouv_id, "custom_title" => "Nouveau titre"})
+    DB.Repo.update!(changeset)
+
+    dataset = DB.Dataset |> preload(:offers) |> DB.Repo.get!(dataset.id)
+    assert [%DB.Offer{id: ^offer_id}] = dataset.offers
+  end
+
   test "cannot insert a dataset with a nil organization_id" do
     message = ~r|null value in column "organization_id" of relation "dataset" violates not-null constraint|
 

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -380,6 +380,21 @@ defmodule DB.Factory do
     }
   end
 
+  def offer_factory do
+    %DB.Offer{
+      nom_commercial: sequence(:nom_commercial, &"nom_commercial-#{&1}"),
+      identifiant_offre: sequence(:identifiant_offre, & &1),
+      type_transport: "Transport urbain",
+      modes: ["Bus"],
+      nom_aom: sequence(:nom_aom, &"nom_aom-#{&1}"),
+      aom_siren: sequence(:aom_siren, &"aom_siren-#{&1}"),
+      niveau: "Local",
+      exploitant: "Keolis",
+      type_contrat: "",
+      territoire: sequence(:territoire, &"territoire-#{&1}")
+    }
+  end
+
   def insert_token(%{} = args \\ %{}) do
     args =
       %{

--- a/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/custom_tags_live_test.exs
@@ -18,7 +18,8 @@ defmodule TransportWeb.CustomTagsLiveTest do
         # same
         legal_owners_region: [],
         # again
-        declarative_spatial_areas: []
+        declarative_spatial_areas: [],
+        offers: []
       )
 
     {:ok, view, _html} =

--- a/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/edit_dataset_live_test.exs
@@ -142,7 +142,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
             type_insee: "epci_123456789",
             nom: "Mon EPCI"
           )
-        ]
+        ],
+        offers: []
       )
 
     {:ok, view, _html} =
@@ -172,7 +173,8 @@ defmodule TransportWeb.EditDatasetLiveTest do
         legal_owners_aom: [],
         legal_owners_region: [],
         # needs to be preloaded
-        declarative_spatial_areas: []
+        declarative_spatial_areas: [],
+        offers: []
       )
 
     {:ok, view, _html} =
@@ -188,6 +190,34 @@ defmodule TransportWeb.EditDatasetLiveTest do
 
     assert render(view) =~ "Représentants légaux"
     assert render(view) =~ siren
+  end
+
+  test "dataset form, show offers saved in the database", %{conn: conn} do
+    conn = conn |> setup_admin_in_session()
+
+    dataset =
+      insert(:dataset,
+        datagouv_id: "1234",
+        offers: [insert(:offer, nom_commercial: nom_commercial = "Astuce")],
+        # needs to be preloaded
+        legal_owners_aom: [],
+        legal_owners_region: [],
+        declarative_spatial_areas: []
+      )
+
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.EditDatasetLive,
+        session: %{
+          "dataset" => dataset,
+          "dataset_types" => [],
+          "regions" => [],
+          "form_url" => "url_used_to_post_result",
+          "csp_nonce_value" => Ecto.UUID.generate()
+        }
+      )
+
+    assert render(view) =~ "Offres"
+    assert render(view) =~ nom_commercial
   end
 
   test "form inputs are persisted", %{conn: conn} do


### PR DESCRIPTION
Import des offres de transport PASSIM du Cerema et sélection de celles-ci dans le backoffice.

- Migration pour ajouter les tables `offer` et `dataset_offer`
- Import des données depuis un fichier CSV distant
- Modèle de données
- Mise à jour de la LiveView du backoffice pour gérer ces offres

<img width="639" height="280" alt="Screenshot 2025-11-20 at 15 37 36" src="https://github.com/user-attachments/assets/e7d5dbdc-721c-4b36-b08a-a1333cd7ce12" />
