### PR TITLE
Backoffice offres : transformation en array

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/dataset_controller.ex
@@ -35,6 +35,7 @@ defmodule TransportWeb.Backoffice.DatasetController do
       |> transform_legal_owners_aom_to_list()
       |> transform_legal_owners_region_to_list()
       |> transform_declarative_spatial_areas_to_list()
+      |> transform_offers_to_list()
 
     with datagouv_id when not is_nil(datagouv_id) <- dataset_datagouv_id,
          {:ok, dg_dataset} <- ImportData.import_from_data_gouv(datagouv_id, form_params["type"]),
@@ -91,6 +92,11 @@ defmodule TransportWeb.Backoffice.DatasetController do
       for {"declarative_spatial_area" <> _, division_id} <- form_params, do: division_id |> String.to_integer()
 
     Map.put(form_params, "declarative_spatial_areas", declarative_spatial_areas)
+  end
+
+  defp transform_offers_to_list(form_params) do
+    offers = for {"offers" <> _, offer_id} <- form_params, do: offer_id |> String.to_integer()
+    Map.put(form_params, "offers", offers)
   end
 
   @spec insert_dataset(Ecto.Changeset.t()) :: {:ok, Dataset.t()} | {:error, binary}


### PR DESCRIPTION
Fixes #4950

Transforme les arrays `offers[0]`, `offers[1]` etc. en `offers: […, …]`.
