### PR TITLE
Validation à la demande : affichage rétention

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_live.html.heex
@@ -7,7 +7,8 @@
       <h2><%= dgettext("validations", "Validation results") %></h2>
       <p>
         <%= dgettext("validations", "This report can be shared with") %>
-        <%= link(dgettext("validations", "this permanent link"), to: @current_url) %>.
+        <%= link(dgettext("validations", "this permanent link"), to: @current_url) %>
+        <%= dgettext("validations", "during 30 days") %>.
       </p>
       <%= if is_final_state do %>
         <p class="small">

--- a/apps/transport/lib/transport_web/templates/validation/show_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_gtfs.html.heex
@@ -7,7 +7,8 @@
       </p>
       <p>
         <%= dgettext("validations", "This report can be shared with") %>
-        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>.
+        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>
+        <%= dgettext("validations", "during 30 days") %>.
       </p>
     </div>
   </div>

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_1_0.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_1_0.html.heex
@@ -7,7 +7,8 @@
       </p>
       <p>
         <%= dgettext("validations", "This report can be shared with") %>
-        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>.
+        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>
+        <%= dgettext("validations", "during 30 days") %>.
       </p>
     </div>
 

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
@@ -7,7 +7,8 @@
       </p>
       <p>
         <%= dgettext("validations", "This report can be shared with") %>
-        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>.
+        <%= link(dgettext("validations", "this permanent link"), to: current_url(@conn)) %>
+        <%= dgettext("validations", "during 30 days") %>.
       </p>
     </div>
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -401,3 +401,7 @@ msgstr "Set of rules of the <a href=\"https://normes.transport.data.gouv.fr\" ta
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "during 30 days"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -401,3 +401,7 @@ msgstr "Ensemble de règles spécifiques au <a href=\"https://normes.transport.d
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
 msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment. Vous pouvez le valider avec le <a href=\"%{url}\" target=\"_blank\">validateur GTFS canonique de MobilityData</a>."
+
+#, elixir-autogen, elixir-format
+msgid "during 30 days"
+msgstr "pendant 30 jours"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -399,3 +399,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "during 30 days"
+msgstr ""


### PR DESCRIPTION
Affiche la durée de rétention d'un rapport de validation à la demande.

#4955 est le job en charge de l'archivage des données
