### PR TITLE
API : ajout custom_tags

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -193,7 +193,8 @@ defmodule TransportWeb.API.DatasetController do
       "legal_owners" => legal_owners(dataset),
       "type" => dataset.type,
       "licence" => dataset.licence,
-      "publisher" => get_publisher(dataset)
+      "publisher" => get_publisher(dataset),
+      "tags" => dataset.custom_tags
     }
 
   @spec get_publisher(Dataset.t()) :: map()

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -703,7 +703,12 @@ defmodule TransportWeb.API.Schemas do
           items: CommunityResource
         },
         covered_area: CoveredArea.schema(),
-        legal_owners: LegalOwners.schema()
+        legal_owners: LegalOwners.schema(),
+        tags: %Schema{
+          type: :array,
+          description: "Tags associated to the dataset, as set by the NAP team",
+          items: %Schema{type: :string}
+        }
       }
 
       if details do

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -137,7 +137,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
         organization_id: "org_id",
         declarative_spatial_areas: [
           build(:administrative_division, nom: "Angers Métropole", insee: "123456", type: :epci)
-        ]
+        ],
+        custom_tags: ["foo", "bar"]
       )
 
     resource_1 =
@@ -261,7 +262,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
         [resource_1, gbfs_resource, resource_2]
         |> Enum.map(& &1.last_update)
         |> Enum.max(DateTime)
-        |> DateTime.to_iso8601()
+        |> DateTime.to_iso8601(),
+      "tags" => ["foo", "bar"]
     }
 
     assert json = conn |> get(path) |> json_response(200)
@@ -338,7 +340,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
                "slug" => "slug-1",
                "title" => "title",
                "type" => "public-transit",
-               "updated" => resource.last_update |> DateTime.to_iso8601()
+               "updated" => resource.last_update |> DateTime.to_iso8601(),
+               "tags" => []
              }
            ] == json
 
@@ -491,7 +494,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "title" => "title",
              "type" => "public-transit",
              "licence" => "lov2",
-             "updated" => [last_update_gtfs, last_update_geojson] |> Enum.max(DateTime) |> DateTime.to_iso8601()
+             "updated" => [last_update_gtfs, last_update_geojson] |> Enum.max(DateTime) |> DateTime.to_iso8601(),
+             "tags" => []
            } == json
 
     assert_schema(json, "DatasetDetails", TransportWeb.API.Spec.spec())
@@ -619,7 +623,8 @@ defmodule TransportWeb.API.DatasetControllerTest do
              "title" => "title",
              "type" => "public-transit",
              "updated" =>
-               [resource, gbfs_resource] |> Enum.map(& &1.last_update) |> Enum.max(DateTime) |> DateTime.to_iso8601()
+               [resource, gbfs_resource] |> Enum.map(& &1.last_update) |> Enum.max(DateTime) |> DateTime.to_iso8601(),
+             "tags" => []
            } == json
 
     assert_schema(json, "DatasetDetails", TransportWeb.API.Spec.spec())


### PR DESCRIPTION
Fixes #4959

Ajoute les `custom_tags` dans notre API. Ces tags, éditorialisés par notre équipe sont parfois utiles pour les réutilisateurs. L'ART et MobilityData ont demandé d'avoir accès à ceci récemment.
