### PR TITLE
EditDatasetLive : gère aom_id nil

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -162,9 +162,12 @@ defmodule TransportWeb.EditDatasetLive do
   end
 
   def handle_info({:updated_offers, offers}, socket) do
-    legal_owners =
-      (socket.assigns.legal_owners ++ Enum.map(offers, &%{id: &1.aom_id, type: "aom", label: &1.nom_aom}))
-      |> Enum.uniq()
+    new_aoms =
+      offers
+      |> Enum.reject(&is_nil(&1.aom_id))
+      |> Enum.map(&%{id: &1.aom_id, type: "aom", label: &1.nom_aom})
+
+    legal_owners = (socket.assigns.legal_owners ++ new_aoms) |> Enum.uniq()
 
     {:noreply, socket |> assign(:offers, offers) |> assign(:legal_owners, legal_owners)}
   end


### PR DESCRIPTION
Fixes #4962


Gère le cas où l'AOM n'est pas connue pour l'offre.

Stacktrace 

```
** (FunctionClauseError) no function clause matching in TransportWeb.LegalOwnerSelectLive.owner_label/1
    (transport 0.0.1) lib/transport_web/live/backoffice/legal_owner_select_live.ex:90: TransportWeb.LegalOwnerSelectLive.owner_label(nil)
    (transport 0.0.1) lib/transport_web/live/backoffice/legal_owner_select_live.ex:26: anonymous fn/3 in TransportWeb.LegalOwnerSelectLive.render/1
    (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (transport 0.0.1) lib/transport_web/live/backoffice/legal_owner_select_live.ex:24: anonymous fn/2 in TransportWeb.LegalOwnerSelectLive.render/1
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:368: Phoenix.LiveView.Diff.traverse/7
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:759: Phoenix.LiveView.Diff.render_component/8
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:697: Phoenix.LiveView.Diff.zip_components/5
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:680: anonymous fn/4 in Phoenix.LiveView.Diff.render_pending_components/6
    (stdlib 6.2.2.1) maps.erl:860: :maps.fold_1/4
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:625: Phoenix.LiveView.Diff.render_pending_components/6
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:143: Phoenix.LiveView.Diff.render/3
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/channel.ex:963: anonymous fn/4 in Phoenix.LiveView.Channel.render_diff/3
    (telemetry 1.3.0) /Users/antoineaugusti/Documents/transport-site/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/channel.ex:958: Phoenix.LiveView.Channel.render_diff/3
    (phoenix_live_view 0.20.17) lib/phoenix_live_view/channel.ex:805: Phoenix.LiveView.Channel.handle_changed/4
    (stdlib 6.2.2.1) gen_server.erl:2345: :gen_server.try_handle_info/3
    (stdlib 6.2.2.1) gen_server.erl:2433: :gen_server.handle_msg/6
    (stdlib 6.2.2.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Last message: {:updated_offers, [%{id: 166, label: "Sylvia", aom_id: 155, nom_aom: "CA de Saint-Dié-des-Vosges"}, %{id: 418, label: "Nomad", aom_id: nil, nom_aom: "Conseil régional de Normandie"}]}
```
