### PR TITLE
VACUUM FULL toutes les nuits (plutôt que juste le dimanche)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -122,7 +122,7 @@ oban_prod_crontab = [
   {"30 */6 * * *", Transport.Jobs.LowEmissionZonesToGeoData},
   {"30 */6 * * *", Transport.Jobs.IRVEToGeoData},
   {"30 6 * * *", Transport.Jobs.GBFSStationsToGeoData},
-  {"15 1 * * 0", Transport.Jobs.DatabaseVacuumJob},
+  {"15 1 * * *", Transport.Jobs.DatabaseVacuumJob},
   {"15 10 * * *", Transport.Jobs.DatabaseBackupReplicationJob},
   {"0 7 * * *", Transport.Jobs.GTFSRTMultiValidationDispatcherJob},
   {"30 7 * * *", Transport.Jobs.GBFSMultiValidationDispatcherJob},


### PR DESCRIPTION
### Explication

Après avoir mis en place ce suivi hier:

https://metabase.transport.data.gouv.fr/question/140-taille-octets-de-chaque-table-de-la-db

Je voulais voir si le premier nettoyage (merci @AntoineAugusti) sur les on-demand validations (https://github.com/etalab/transport-site/pull/4955, https://github.com/etalab/transport-site/pull/4963) avait impacté quelque chose.

Mais ça n'avait pas bougé par rapport à la veille (à peu de choses près):

<img width="431" height="466" alt="Screenshot 2025-11-27 at 10 00 55" src="https://github.com/user-attachments/assets/5aaf8c8e-ece8-4423-9933-92d8ccbd1406" />

Je me suis alors rappelé que le `VACUUM FULL` était nécessaire dans ce cas pour nettoyer les tuples, et qu'il ne tournait que le dimanche soir.

J'ai fait un `VACUUM FULL multi_validation` et j'ai obtenu en 85 secondes ce résultat:

<img width="821" height="518" alt="Screenshot 2025-11-27 at 10 02 34" src="https://github.com/user-attachments/assets/48b1cf6c-d57d-4e2d-87c9-184b6b178e7f" />

Du coup la présente PR bascule le job à "tous les soirs" plutôt que "juste le dimanche" pour le moment, vu qu'on va faire beaucoup d'autres nettoyages, pour qu'on puisse en profiter et surtout vérifier l'impact quotidiennement.