### PR TITLE
Fix cleanup des conversions NeTEx

### DIFF
--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -11,7 +11,7 @@ defmodule DB.DataConversion do
     field(:converter, :string)
     field(:converter_version, :string)
     field(:convert_from, Ecto.Enum, values: [:GTFS])
-    field(:convert_to, Ecto.Enum, values: [:GeoJSON])
+    field(:convert_to, Ecto.Enum, values: [:GeoJSON, :NeTEx])
     field(:resource_history_uuid, Ecto.UUID)
     field(:payload, :map)
 
@@ -21,11 +21,19 @@ defmodule DB.DataConversion do
   def base_query, do: from(dc in DB.DataConversion, as: :data_conversion)
 
   @doc """
+  NeTEx is no longer supported as a target format but it's kept in the schema to support legacy data and the cleanup job.
+  """
+  def available_conversion_formats,
+    do:
+      Ecto.Enum.values(DB.DataConversion, :convert_to)
+      |> Enum.reject(&(&1 == :NeTEx))
+
+  @doc """
   Finds the default converter to use for a target format.
 
   iex> converter_to_use(:GeoJSON)
   "rust-transit/gtfs-to-geojson"
-  iex> Enum.each(Ecto.Enum.values(DB.DataConversion, :convert_to), & converter_to_use/1)
+  iex> available_conversion_formats() |> Enum.each(& converter_to_use/1)
   :ok
   """
   @spec converter_to_use(binary() | atom()) :: binary()

--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -917,7 +917,7 @@ defmodule DB.Dataset do
     target_formats = target_conversion_formats(dataset)
     # The filler's purpose is to make sure we have a {conversion_format, nil} value
     # for every resource, even if we don't have a conversion
-    filler = Enum.into(available_conversion_formats(), %{}, &{&1, nil})
+    filler = Enum.into(DB.DataConversion.available_conversion_formats(), %{}, &{&1, nil})
     resource_ids = Enum.map(resources, & &1.id)
 
     results =
@@ -962,10 +962,8 @@ defmodule DB.Dataset do
   """
   @spec target_conversion_formats(DB.Dataset.t()) :: [atom()]
   def target_conversion_formats(%__MODULE__{}) do
-    available_conversion_formats()
+    DB.DataConversion.available_conversion_formats()
   end
-
-  defp available_conversion_formats, do: Ecto.Enum.values(DB.DataConversion, :convert_to)
 
   defp validate_siren(%Ecto.Changeset{} = changeset) do
     case get_change(changeset, :legal_owner_company_siren) do

--- a/apps/transport/lib/transport/telemetry.ex
+++ b/apps/transport/lib/transport/telemetry.ex
@@ -6,7 +6,7 @@ defmodule Transport.Telemetry do
   defdelegate proxy_request_event_name(request), to: Unlock.Telemetry
 
   def conversions_get_event_names do
-    DB.DataConversion |> Ecto.Enum.values(:convert_to) |> Enum.map(&[:conversions, :get, &1])
+    DB.DataConversion.available_conversion_formats() |> Enum.map(&[:conversions, :get, &1])
   end
 
   @moduledoc """

--- a/apps/transport/lib/transport_web/controllers/conversion_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/conversion_controller.ex
@@ -2,7 +2,9 @@ defmodule TransportWeb.ConversionController do
   use TransportWeb, :controller
 
   def get(%Plug.Conn{} = conn, %{"resource_id" => resource_id, "convert_to" => convert_to}) do
-    if convert_to in Ecto.Enum.dump_values(DB.DataConversion, :convert_to) do
+    acceptable_formats = DB.DataConversion.available_conversion_formats() |> Enum.map(&to_string/1)
+
+    if convert_to in acceptable_formats do
       case DB.Resource.get_related_conversion_info(resource_id, String.to_existing_atom(convert_to)) do
         nil ->
           conn |> conversion_not_found()
@@ -19,7 +21,7 @@ defmodule TransportWeb.ConversionController do
           |> redirect(external: url)
       end
     else
-      conn |> conversion_not_found("`convert_to` is not a possible value.")
+      conn |> conversion_not_found("`#{convert_to}` is not a possible value.")
     end
   end
 

--- a/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TransportWeb.ConversionControllerTest do
 
     test "when the conversion format does not exist", %{conn: conn} do
       assert conn |> get(conversion_path(conn, :get, 42, "foo")) |> text_response(404) ==
-               "Conversion not found. `convert_to` is not a possible value."
+               "Conversion not found. `foo` is not a possible value."
     end
 
     test "when the resource exists but there are no conversions", %{conn: conn} do


### PR DESCRIPTION
Complément de #4593 ; il n'est plus possible de convertir des GTFS en NeTEx, mais il devrait toujours être possible de faire le ménage des anciennes conversions. Cette PR fixe cela.

Closes #4970.