### PR TITLE
subscriptions_for_reason_dataset_and_role: tri ascendant

### DIFF
--- a/apps/transport/lib/db/notification_subscription.ex
+++ b/apps/transport/lib/db/notification_subscription.ex
@@ -77,6 +77,7 @@ defmodule DB.NotificationSubscription do
       [notification_subscription: ns],
       ns.reason == ^reason and ns.dataset_id == ^dataset_id and ns.role == ^role
     )
+    |> order_by([ns], {:asc, ns.id})
     |> DB.Repo.all()
   end
 


### PR DESCRIPTION
Fixes #4975
Fixes #4979

Tri les abonnements aux notifications dans l'ordre de création pour assurer une stabilité des tests, qui se reposent sur l'ordre.
