### PR TITLE
Optimisation de `/datasets` (ne plus charger les `geom` des `AdministrativeDivision`s

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -258,13 +258,14 @@ defmodule TransportWeb.DatasetController do
     |> Repo.paginate(page: config.page_number)
   end
 
-  # ?before_optim=1 loads the full group of ":geom"s which can be several MB total
+  # pre-optimisation version kept, in order to allow side-by-side prod benchmark
   defp preload_spatial_areas(query, %{"before_optim" => "1"}) do
     query |> preload([:declarative_spatial_areas])
   end
 
   defp preload_spatial_areas(query, _params) do
     DB.AdministrativeDivision
+    # avoid loading `:geom` (total for `/datasets` can be several MB)
     |> select([a], struct(a, [:type, :nom]))
     |> then(&preload(query, declarative_spatial_areas: ^&1))
   end


### PR DESCRIPTION
~~(ne pas déployer ce week-end!!!)~~ EDIT: on s'est entendu avec @AntoineAugusti, on va déployer.

### TL;DR 

Cette PR modifie le chargement des données dans `/datasets` et similaires, pour éviter en particulier de charger les `geom` des `DB.AdministrativeDivision`, car si j'ai compris, elles ne servent pas.

Or elles sont imposantes (sur `/datasets`, sauf erreur on tourne à un total de près de 3MB, pour générer une page web qui fait 60kb ; un peu moins sur la page 2 etc ; pour les communes ça dépend des cas).

Donc je supprime ce chargement ; je garde l'ancienne version si on veut comparer (ce que j'ai fait en local, voir plus bas).

**Gains**:
- en local on gagne près de 80% (voir plus bas pour le benchmark détaillé)
- sur staging c'est beaucoup plus faible (du fait de la latence réseau), mais le gain côté CPU et mémoire sera tout aussi important (je m'attends davantage à voir le résultat potentiel sur l'uptime que sur le benchmark, mais à suivre), et je pense que la stabilité générale sera améliorée sur cette partie

Si il est confirmé que mon code est correct, ça ne fera pas de mal, et ça allège le traitement!

### Point de départ de l'optimisation

On est plusieurs à avoir remarqué (cf #4967 par @vdegove) que la page `/datasets` fait de grosses requêtes.

Avant de chercher à optimiser j'ai été vérifier l'usage actuel dans AppSignal, section Performance / Actions, et j'ai trié par "throughput décroissant":

<img width="919" height="417" alt="Screenshot 2025-11-29 at 10 37 55" src="https://github.com/user-attachments/assets/f8120f86-56b1-4520-89a7-a7fef054e86f" />

Ça m'a orienté pour aller chercher de plus près (recherche perso mixée à analyse IA pour gagner du temps).

J'ai fini par remarquer qu'on charge, si j'ai compris, les `DB.AdministrativeDivision` associées depuis début septembre (https://github.com/etalab/transport-site/pull/4791) quand on fait une requête à `/datasets`, et que le gros des problèmes de perf récents collent au niveau date:

<img width="503" height="196" alt="Screenshot 2025-11-29 at 10 42 26" src="https://github.com/user-attachments/assets/03c7797c-3381-46ca-964b-6f3d0e50aa67" />

En partant de là, j'ai fini par remarquer qu'on charge tout `DB.AdministrativeDivision` pour chaque `DB.Dataset` de la page, et qu'en particulier, ça inclut `geom`, champ qu'on n'utilise en fait (sauf erreur, à vérifier poke @AntoineAugusti qui sera + au courant) pas dans la requête.

Or, cette data est grosse. J'ai calculé qu'on a:
- environ 3MB de `geom` totales sur la première page de `/datasets`
- 2.5MB sur la deuxième (après ça décroît mais ça se compte en centaines de ko quand même) 
- c'est gros aussi sur certaines communes (Lyon il me semble)

Donc on consomme de l'IO, on monopolise aussi les connections plus longtemps (car il faut transférer cette data entre la base et le process Elixir), et on prend du CPU à traiter tout ça.

### Résultats en local (5000 requêtes, 100 concurrence)

Je requête avec `hey -n 5000 -c 100 http://localhost:5000/datasets`

Tableau synthétique fait à l'IA:

  | Métrique    | Before Optim | Optimisé | Gain  |
  |-------------|--------------|----------|-------|
  | Total       | 42.9s        | 7.9s     | -82%  |
  | Req/sec     | 116          | 635      | +447% |
  | Latence moy | 858ms        | 156ms    | -82%  |
  | P50         | 858ms        | 146ms    | -83%  |
  | P99         | 911ms        | 203ms    | -78%  |

J'ai testé également sur `prochainement`, avec des écarts beaucoup plus faibles (mais principalement liés à la latence je pense).

Points d'alertes:
- J'ai travaillé avec Postgres 18 (pour des raisons pratiques)
- J'ai observé un effet de warm-up important sur les tests (pour autant ça restera intéressant)