### PR TITLE
AdministrativeDivision : ne pas charger geom par défaut

### DIFF
--- a/apps/transport/lib/db/administrative_division.ex
+++ b/apps/transport/lib/db/administrative_division.ex
@@ -38,7 +38,7 @@ defmodule DB.AdministrativeDivision do
     )
 
     field(:nom, :string)
-    field(:geom, Geo.PostGIS.Geometry) :: Geo.MultiPolygon.t()
+    field(:geom, Geo.PostGIS.Geometry, load_in_query: false) :: Geo.MultiPolygon.t()
     field(:population, :integer)
   end
 

--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -127,7 +127,7 @@ defmodule TransportWeb.API.DatasetController do
     Dataset
     |> Dataset.reject_experimental_datasets()
     |> Repo.get_by(datagouv_id: id)
-    |> Repo.preload([:declarative_spatial_areas])
+    |> Repo.preload(declarative_spatial_areas: from(p in DB.AdministrativeDivision, select: [:nom, :type, :geom]))
     |> case do
       %Dataset{} = dataset ->
         data =


### PR DESCRIPTION
En lien avec #4991

Ne pas charger `geom` par défaut pour `administrative_division`.

Seul un endroit était nécessaire à adapter.
