### PR TITLE
Edit dataset BO : champs obligatoires

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -16,7 +16,8 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
         placeholder: "Recherchez votre territoire…",
         phx_keydown: "search_division",
         phx_target: @myself,
-        id: "spatial_areas_search_input"
+        id: "spatial_areas_search_input",
+        required: @required
       ) %>
       <div
         :if={@administrative_division_search_matches != []}
@@ -111,6 +112,10 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
       |> assign(:administrative_division_search_matches, [])
 
     {:ok, socket}
+  end
+
+  def update(assigns, socket) do
+    {:ok, socket |> assign(assigns) |> assign(:required, assigns.declarative_spatial_areas |> Enum.empty?())}
   end
 
   def handle_event("search_division", %{"key" => "Escape"}, socket) do

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.ex
@@ -104,8 +104,7 @@ defmodule TransportWeb.EditDatasetLive do
       "Réseau",
       "Opérateur de transport",
       "Partenariat régional",
-      "Fournisseur de système",
-      "Autre"
+      "Fournisseur de système"
     ]
 
   def handle_event(

--- a/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/edit_dataset_live.html.heex
@@ -79,9 +79,8 @@
       selected:
         if not is_nil(@dataset) do
           @dataset.organization_type
-        else
-          ""
         end,
+      required: true,
       prompt: dgettext("backoffice", "Publisher type")
     ) %>
   </div>
@@ -119,7 +118,7 @@
   <div class="panel mt-48">
     <div class="panel__header">
       <h4>
-        <%= dgettext("backoffice", "Spatial area (new)") %>
+        <%= dgettext("backoffice", "Spatial area") %>
       </h4>
     </div>
     <.live_component

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -285,13 +285,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-autogen, elixir-format
-msgid "Spatial area (new)"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Offers"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area"
 msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -285,13 +285,13 @@ msgstr[0] "%{reusers_count} reuser."
 msgstr[1] "%{reusers_count} reusers."
 
 #, elixir-autogen, elixir-format
-msgid "Spatial area (new)"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr "Choose one or many municipalities, EPCIs, departments, regions or country. This is not displayed to users (website, API) for now."
 
 #, elixir-autogen, elixir-format
 msgid "Offers"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Spatial area"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -285,13 +285,13 @@ msgstr[0] "%{reusers_count} réutilisateur."
 msgstr[1] "%{reusers_count} réutilisateurs."
 
 #, elixir-autogen, elixir-format
-msgid "Spatial area (new)"
-msgstr "Territoire couvert déclaré (nouvelle version)"
-
-#, elixir-autogen, elixir-format
 msgid "spatial areas label"
 msgstr "Choisissez un ou plusieurs communes, EPCI, départements, régions ou pays. Ceci n’est pas affiché publiquement (site, API) pour l’instant."
 
 #, elixir-autogen, elixir-format
 msgid "Offers"
 msgstr "Offres"
+
+#, elixir-autogen, elixir-format
+msgid "Spatial area"
+msgstr "Territoire couvert déclaré"


### PR DESCRIPTION
Fixes #4821

Rendre obligatoire la saisie du territoire couvert déclaré et du type de publicateur.
