### PR TITLE
MobilityDataGTFSValidator : version du validateur depuis GitHub

### DIFF
--- a/apps/transport/test/transport/validators/mobilitydata_gtfs_transport_validator_test.exs
+++ b/apps/transport/test/transport/validators/mobilitydata_gtfs_transport_validator_test.exs
@@ -64,4 +64,45 @@ defmodule Transport.Validators.MobilityDataGTFSValidatorTest do
              }
            ] = DB.MultiValidation.with_result() |> DB.Repo.all()
   end
+
+  test "uses the GitHub validator version if the version is missing from the summary" do
+    gtfs_url = "https://example.com/gtfs"
+    job_id = Ecto.UUID.generate()
+    report_html_url = "https://example.com/#{job_id}/report.html"
+    version = "4.2.0"
+    %{id: rh_id} = rh = insert(:resource_history, payload: %{"permanent_url" => gtfs_url})
+
+    expect(Transport.Validators.MobilityDataGTFSValidatorClient.Mock, :create_a_validation, fn ^gtfs_url ->
+      job_id
+    end)
+
+    expect(Transport.Validators.MobilityDataGTFSValidatorClient.Mock, :get_a_validation, fn ^job_id ->
+      notices = [
+        %{"code" => "unusable_trip", "severity" => "WARNING", "totalNotices" => 2, "sampleNotices" => ["foo", "bar"]}
+      ]
+
+      {:successful, %{"summary" => %{}, "notices" => notices}}
+    end)
+
+    expect(Transport.Validators.MobilityDataGTFSValidatorClient.Mock, :report_html_url, fn ^job_id ->
+      report_html_url
+    end)
+
+    # Call to GitHub to get the version
+    expect(Transport.HTTPoison.Mock, :get!, fn url ->
+      assert url == "https://api.github.com/repos/MobilityData/gtfs-validator/releases/latest"
+      %HTTPoison.Response{status_code: 200, body: %{tag_name: "v" <> version} |> Jason.encode!()}
+    end)
+
+    assert :ok == MobilityDataGTFSValidator.validate_and_save(rh)
+
+    assert [
+             %DB.MultiValidation{
+               resource_history_id: ^rh_id,
+               validator: "MobilityData GTFS Validator",
+               validator_version: ^version,
+               command: ^report_html_url
+             }
+           ] = DB.MultiValidation.with_result() |> DB.Repo.all()
+  end
 end


### PR DESCRIPTION
See https://github.com/MobilityData/gtfs-validator/issues/2021

La version du validateur peut être manquante des rapports de validation. Dans ce cas on utilise le dernier tag sur GitHub pour connaitre la version du validateur.
