### PR TITLE
Support vieilles ressources sans résultats

### DIFF
--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -85,6 +85,8 @@ defmodule TransportWeb.ResourceView do
     Enum.take(errors, max_display_errors())
   end
 
+  def errors_sample(_), do: []
+
   def max_display_errors, do: 50
 
   def hours_ago(utcdatetime, locale) do


### PR DESCRIPTION
Résultats supprimés pour une vieille ressource, pourtant ouverte par quelqu'un.

Exemple : https://appsignal.com/transport-dot-data-dot-gouv-dot-fr/sites/64a54ec183eb67b60f03fb6e/exceptions/incidents/164/samples/64a54ec183eb67b60f03fb6e-1382315578707215047917647638601