### PR TITLE
Supprime avertisement relatif au GTFS-Flex

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -1,5 +1,4 @@
-<% is_gtfs_flex = not is_nil(@resource_history) and DB.ResourceHistory.gtfs_flex?(@resource_history)
-associated_geojson = get_associated_geojson(@related_files)
+<% associated_geojson = get_associated_geojson(@related_files)
 locale = get_session(@conn, :locale) %>
 <section>
   <div class="grey-background">
@@ -73,16 +72,7 @@ locale = get_session(@conn, :locale) %>
       <% end %>
       <h2 id="validation-report" class="mt-48"><%= dgettext("validations", "Validation report") %></h2>
       <div class="panel" id="issues">
-        <p :if={is_gtfs_flex} class="notification">
-          <%= raw(
-            dgettext(
-              "validations",
-              ~s|This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href="%{url}" target="_blank">Canonical GTFS Schedule Validator from MobilityData</a>.|,
-              url: "https://gtfs-validator.mobilitydata.org"
-            )
-          ) %>
-        </p>
-        <%= if not is_gtfs_flex and is_nil(@validation_summary) do %>
+        <%= if is_nil(@validation_summary) do %>
           <%= dgettext("validations", "No validation available") %>
         <% end %>
         <%= unless is_nil(@validation_summary) do %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -398,10 +398,6 @@ msgstr ""
 msgid "french-profile-description"
 msgstr "Set of rules of the <a href=\"https://normes.transport.data.gouv.fr\" target=\"_blank\">French profile</a>."
 
-#, elixir-autogen, elixir-format, fuzzy
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
-msgstr ""
-
 #, elixir-autogen, elixir-format
 msgid "during %{retention_days} days"
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -398,10 +398,6 @@ msgstr "Profil France"
 msgid "french-profile-description"
 msgstr "Ensemble de règles spécifiques au <a href=\"https://normes.transport.data.gouv.fr\" target=\"_blank\">profil France</a>."
 
-#, elixir-autogen, elixir-format, fuzzy
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
-msgstr "Ce fichier contient l'extension GTFS-Flex. Nous ne sommes pas en mesure de le valider pour le moment. Vous pouvez le valider avec le <a href=\"%{url}\" target=\"_blank\">validateur GTFS canonique de MobilityData</a>."
-
 #, elixir-autogen, elixir-format
 msgid "during %{retention_days} days"
 msgstr "pendant %{retention_days} jours"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -397,10 +397,6 @@ msgid "french-profile-description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "This file contains the GTFS-Flex extension. We are not able to validate it for now. You can validate it using the <a href=\"%{url}\" target=\"_blank\">Canonical GTFS Schedule Validator from MobilityData</a>."
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "during %{retention_days} days"
 msgstr ""
 


### PR DESCRIPTION
Supprime l'avertissement indiquant qu'on ne valide pas un GTFS-Flex car dorénavant ceci est fait.
