### PR TITLE
Affichage du nombre d'erreurs proprement

### DIFF
--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -90,14 +90,25 @@ defmodule Transport.Validators.GTFSTransport do
   "1 échec irrécupérable"
   iex> format_severity("Fatal", 2)
   "2 échecs irrécupérables"
+  iex> format_severity("Fatal", 2_000)
+  "2 000 échecs irrécupérables"
   """
   @spec format_severity(binary(), non_neg_integer()) :: binary()
   def format_severity(key, count) do
     case key do
-      "Fatal" -> dngettext("gtfs-transport-validator", "Fatal failure", "Fatal failures", count)
-      "Error" -> dngettext("gtfs-transport-validator", "Error", "Errors", count)
-      "Warning" -> dngettext("gtfs-transport-validator", "Warning", "Warnings", count)
-      "Information" -> dngettext("gtfs-transport-validator", "Information", "Informations", count)
+      "Fatal" ->
+        dngettext("gtfs-transport-validator", "Fatal failure", "Fatal failures", count,
+          value: Helpers.format_number(count)
+        )
+
+      "Error" ->
+        dngettext("gtfs-transport-validator", "Error", "Errors", count, value: Helpers.format_number(count))
+
+      "Warning" ->
+        dngettext("gtfs-transport-validator", "Warning", "Warnings", count, value: Helpers.format_number(count))
+
+      "Information" ->
+        dngettext("gtfs-transport-validator", "Information", "Informations", count, value: Helpers.format_number(count))
     end
   end
 

--- a/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
+++ b/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
@@ -233,16 +233,21 @@ defmodule Transport.Validators.MobilityDataGTFSValidator do
   iex> Gettext.put_locale("fr")
   iex> format_severity("ERROR", 1)
   "1 erreur"
-  iex> format_severity("ERROR", 2)
-  "2 erreurs"
+  iex> format_severity("ERROR", 2_000)
+  "2 000 erreurs"
   iex> assert_raise CaseClauseError, fn -> format_severity("NOPE", 42) end
   """
   @spec format_severity(binary(), non_neg_integer()) :: binary()
   def format_severity(key, count) do
     case key do
-      "ERROR" -> dngettext("gtfs-transport-validator", "Error", "Errors", count)
-      "WARNING" -> dngettext("gtfs-transport-validator", "Warning", "Warnings", count)
-      "INFO" -> dngettext("gtfs-transport-validator", "Information", "Informations", count)
+      "ERROR" ->
+        dngettext("gtfs-transport-validator", "Error", "Errors", count, value: Helpers.format_number(count))
+
+      "WARNING" ->
+        dngettext("gtfs-transport-validator", "Warning", "Warnings", count, value: Helpers.format_number(count))
+
+      "INFO" ->
+        dngettext("gtfs-transport-validator", "Information", "Informations", count, value: Helpers.format_number(count))
     end
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/gtfs-transport-validator.po
@@ -166,26 +166,26 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error"
 msgid_plural "Errors"
-msgstr[0] "%{count} error"
-msgstr[1] "%{count} errors"
+msgstr[0] "%{value} error"
+msgstr[1] "%{value} errors"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fatal failure"
 msgid_plural "Fatal failures"
-msgstr[0] "%{count} fatal failure"
-msgstr[1] "%{count} fatal failures"
+msgstr[0] "%{value} fatal failure"
+msgstr[1] "%{value} fatal failures"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Information"
 msgid_plural "Informations"
-msgstr[0] "%{count} information"
-msgstr[1] "%{count} informations"
+msgstr[0] "%{value} information"
+msgstr[1] "%{value} informations"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Warning"
 msgid_plural "Warnings"
-msgstr[0] "%{count} warning"
-msgstr[1] "%{count} warnings"
+msgstr[0] "%{value} warning"
+msgstr[1] "%{value} warnings"
 
 #, elixir-autogen, elixir-format
 msgid "Calendar files are empty. The service is never running."

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/gtfs-transport-validator.po
@@ -166,26 +166,26 @@ msgstr "Trajet non utilisable"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error"
 msgid_plural "Errors"
-msgstr[0] "%{count} erreur"
-msgstr[1] "%{count} erreurs"
+msgstr[0] "%{value} erreur"
+msgstr[1] "%{value} erreurs"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fatal failure"
 msgid_plural "Fatal failures"
-msgstr[0] "%{count} échec irrécupérable"
-msgstr[1] "%{count} échecs irrécupérables"
+msgstr[0] "%{value} échec irrécupérable"
+msgstr[1] "%{value} échecs irrécupérables"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Information"
 msgid_plural "Informations"
-msgstr[0] "%{count} information"
-msgstr[1] "%{count} informations"
+msgstr[0] "%{value} information"
+msgstr[1] "%{value} informations"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Warning"
 msgid_plural "Warnings"
-msgstr[0] "%{count} avertissement"
-msgstr[1] "%{count} avertissements"
+msgstr[0] "%{value} avertissement"
+msgstr[1] "%{value} avertissements"
 
 #, elixir-autogen, elixir-format
 msgid "Calendar files are empty. The service is never running."


### PR DESCRIPTION
## Problème
<img width="445" height="415" alt="Screenshot 2025-12-04 at 13 44 10" src="https://github.com/user-attachments/assets/10778b71-478f-4bc1-b5b0-a91541016c0e" />

## Solution

Ajoute des espaces ou virgules pour le nombre d'erreurs.