### PR TITLE
Upgrade Postgres 14->18, TimescaleDB -> 2.23 pour le CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: timescale/timescaledb-ha:pg18.1-ts2.24.0
+        image: timescale/timescaledb-ha:pg18.0-ts2.23.0
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: transport_test


### PR DESCRIPTION
Voir:
- #5007
- #2145 