### PR TITLE
SafeSVGTest : make sure SVG don't embed script

### DIFF
--- a/apps/transport/test/safe_svg_test.exs
+++ b/apps/transport/test/safe_svg_test.exs
@@ -4,17 +4,22 @@ defmodule SafeSVGTest do
   """
   use ExUnit.Case, async: true
 
-  @false_positives ["apps/transport/client/node_modules/template.data.gouv.fr/dist/images/logo-marianne-brassard.svg"]
+  @false_positives [
+    "../../apps/transport/client/node_modules/template.data.gouv.fr/dist/images/logo-marianne-brassard.svg"
+  ]
 
   test "SVGs don't have a script tag" do
-    files =
-      "../../apps/transport/**/*.svg"
-      |> Path.wildcard()
+    candidates = "../../apps/transport/**/*.svg" |> Path.wildcard()
+
+    refute Enum.empty?(candidates)
+
+    dangerous_files =
+      candidates
       |> Enum.reject(&(&1 in @false_positives))
       |> Enum.filter(&potential_issue_detected?/1)
       |> Enum.map(&Path.relative_to(&1, "../.."))
 
-    assert files == []
+    assert Enum.empty?(dangerous_files)
   end
 
   def potential_issue_detected?(file) do


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/2265

Vérifie que les SVG n'ont pas de tag `script`, voir https://code-garage.com/blog/pourquoi-les-svg-peuvent-etre-dangereux/
