### PR TITLE
MultiValidationWithErrorNotificationJob : ajout MobilityData

### DIFF
--- a/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
+++ b/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
@@ -16,7 +16,8 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   @static_data_validators [
     Transport.Validators.GTFSTransport,
     Transport.Validators.TableSchema,
-    Transport.Validators.EXJSONSchema
+    Transport.Validators.EXJSONSchema,
+    Transport.Validators.MobilityDataGTFSValidator
   ]
   @realtime_data_validators [
     Transport.Validators.GBFSValidator
@@ -134,7 +135,7 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     DB.MultiValidation.base_query()
     |> where(
       [multi_validation: mv],
-      mv.max_error in ["Error", "Fatal"] or fragment("?->>'has_errors' = 'true'", mv.result)
+      mv.max_error in ["Error", "Fatal", "ERROR"] or fragment("?->>'has_errors' = 'true'", mv.result)
     )
     |> where(
       [multi_validation: mv],
@@ -187,6 +188,7 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
       Transport.Validators.GTFSTransport => {7, :day},
       Transport.Validators.TableSchema => {7, :day},
       Transport.Validators.EXJSONSchema => {7, :day},
+      Transport.Validators.MobilityDataGTFSValidator => {7, :day},
       Transport.Validators.GBFSValidator => {30, :day}
     }
     |> Map.new(fn {validator, delay} -> {validator.validator_name(), delay} end)


### PR DESCRIPTION
Modifie le job en charge d'envoyer des notifications en cas d'erreurs pour gérer le validateur GTFS de MobilityData.
