### PR TITLE
Optimisation : évite l'accumulation mémoire d'un prepared statement volumineux (`/resource/:xyz`)

### DIFF
--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -111,7 +111,7 @@ defmodule DB.MultiValidation do
     |> order_by([mv, rh, r], desc: rh.inserted_at, desc: r.id, desc: mv.validation_timestamp)
     |> preload([:metadata, :resource_history])
     |> limit(1)
-    # NOTE: do not use prepared statement here, since it is big & not unallocated, apparently
+    # NOTE: do not use named prepared statement here, since it is big & not unallocated, apparently
     |> DB.Repo.one(prepare: :unnamed)
   end
 


### PR DESCRIPTION
J'expliquerai lundi plus en détail comment j'en suis arrivé là (long story - on a bien un leak).

Cette PR bascule une requête spécifique vers prepare: :unnamed.

Contexte : les prepared statements nommés (défaut Ecto) gardent leur plan d'exécution en mémoire côté PostgreSQL. Pour des requêtes complexes avec plusieurs JOINs, ce plan peut atteindre ~30 MB et s'accumule tant que la connexion vit.

Impact attendu : réduction significative du leak mémoire observé sur Grafana (mémoire disponible), qui ne provient que de `prod-site` (pas de `prod-worker`, ou pas dans les mêmes proportions en tout cas) — confirmé en test local.

En théorie, ça devrait réduire la pente de descente (atténuer le leak, pas le supprimer totalement).

Prudence : je fais un test isolé sur ce qui me paraît le plus coûteux. Si ça fonctionne, il faudra être prudent avant de généraliser — les named statements ont leur intérêt (performance) pour les requêtes simples et fréquentes. Ici, la requête est juste trop grosse.

Nb: comme sur mon optimisation précédente https://github.com/etalab/transport-site/pull/4987, si ça fonctionne bien on pourra la décliner, ça va se trouver à plusieurs endroits.