### PR TITLE
Renomme places en autocomplete

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -25,7 +25,7 @@ const autoCompletejs = new AutoComplete({
     data: {
         src: async () => {
             const query = document.querySelector('#autoComplete').value
-            const source = await fetch(`/api/places?q=${query}`)
+            const source = await fetch(`/api/autocomplete?q=${query}`)
             let data = await source.json()
             data = [
                 {

--- a/apps/transport/lib/db/autocomplete.ex
+++ b/apps/transport/lib/db/autocomplete.ex
@@ -1,12 +1,12 @@
-defmodule DB.Place do
+defmodule DB.Autocomplete do
   @moduledoc """
-  Commune schema
+  Autocomplete schema
   """
   use Ecto.Schema
   use TypedEctoSchema
 
   @primary_key false
-  typed_schema "places" do
+  typed_schema "autocomplete" do
     field(:nom, :string)
     field(:type, :string)
     field(:place_id, :string)

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -45,10 +45,10 @@ defmodule Transport.ImportData do
     # validation is now gone, replaced by DB.MultiValidation
   end
 
-  def refresh_places do
+  def refresh_autocomplete do
     Logger.info("Refreshing places...")
-    # NOTE: I could not find a way to call "refresh_places()" directly
-    {:ok, _result} = Repo.query("REFRESH MATERIALIZED VIEW places;")
+    # NOTE: I could not find a way to call "refresh_autocomplete()" directly
+    {:ok, _result} = Repo.query("REFRESH MATERIALIZED VIEW autocomplete;")
   end
 
   def generate_import_logs!(
@@ -105,7 +105,7 @@ defmodule Transport.ImportData do
     {:ok, changeset} = Dataset.changeset(dataset_map_from_data_gouv)
     result = Repo.update!(changeset)
 
-    refresh_places()
+    refresh_autocomplete()
     result
   end
 

--- a/apps/transport/lib/transport_web/api/router.ex
+++ b/apps/transport/lib/transport_web/api/router.ex
@@ -46,10 +46,10 @@ defmodule TransportWeb.API.Router do
 
     get("/openapi", OpenApiSpex.Plug.RenderSpec, :show)
 
-    scope "/places" do
+    scope "/autocomplete" do
       pipe_through(:public_cache)
 
-      get("/", TransportWeb.API.PlacesController, :autocomplete)
+      get("/", TransportWeb.API.AutocompleteController, :autocomplete)
     end
 
     scope "/datasets" do

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -792,9 +792,21 @@ defmodule TransportWeb.API.Schemas do
     require OpenApiSpex
 
     @properties %{
-      url: %Schema{type: :string, description: "URL of the Resource"},
-      type: %Schema{type: :string, description: "type of the resource (commune, region, aom)"},
-      name: %Schema{type: :string, description: "name of the resource"}
+      url: %Schema{type: :string, description: "URL of the resource"},
+      type: %Schema{
+        type: :string,
+        description: "Type of the resource",
+        enum: [
+          "region",
+          "departement",
+          "epci",
+          "commune",
+          "feature",
+          "mode",
+          "offer"
+        ]
+      },
+      name: %Schema{type: :string, description: "Name of the resource"}
     }
 
     OpenApiSpex.schema(%{

--- a/apps/transport/lib/transport_web/api/views/autocomplete_view.ex
+++ b/apps/transport/lib/transport_web/api/views/autocomplete_view.ex
@@ -1,4 +1,4 @@
-defmodule TransportWeb.API.PlacesView do
+defmodule TransportWeb.API.AutocompleteView do
   alias TransportWeb.API.JSONView
 
   def render(conn, data) do

--- a/apps/transport/priv/repo/migrations/20251208124339_places_rename_autocomplete.exs
+++ b/apps/transport/priv/repo/migrations/20251208124339_places_rename_autocomplete.exs
@@ -1,0 +1,12 @@
+defmodule DB.Repo.Migrations.PlacesRenameAutocomplete do
+  use Ecto.Migration
+
+  def up do
+    (Application.app_dir(:transport, "priv") <> "/repo/migrations/sql/places_rename_autocomplete.sql")
+    |> File.read!()
+    |> String.split("|")
+    |> Enum.each(fn q -> DB.Repo |> Ecto.Adapters.SQL.query!(q) end)
+  end
+
+  def down, do: IO.puts("No going back")
+end

--- a/apps/transport/priv/repo/migrations/sql/places_rename_autocomplete.sql
+++ b/apps/transport/priv/repo/migrations/sql/places_rename_autocomplete.sql
@@ -1,0 +1,29 @@
+ALTER MATERIALIZED VIEW places RENAME TO autocomplete|
+
+DROP TRIGGER IF EXISTS refresh_places_trigger ON administrative_division|
+DROP TRIGGER IF EXISTS refresh_places_trigger ON offer|
+
+DROP FUNCTION refresh_places|
+
+
+CREATE OR REPLACE FUNCTION refresh_autocomplete()
+RETURNS trigger AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW autocomplete;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql|
+
+
+CREATE TRIGGER refresh_autocomplete_trigger
+AFTER INSERT OR UPDATE OR DELETE
+ON administrative_division
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_autocomplete()|
+
+
+CREATE TRIGGER refresh_autocomplete_trigger
+AFTER INSERT OR UPDATE OR DELETE
+ON offer
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_autocomplete()|

--- a/apps/transport/test/transport_web/controllers/api/autocomplete_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/autocomplete_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule TransportWeb.API.PlacesControllerTest do
+defmodule TransportWeb.API.AutocompleteControllerTest do
   use TransportWeb.ConnCase, async: true
   alias TransportWeb.API.Router.Helpers
   import OpenApiSpex.TestAssertions
@@ -24,7 +24,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
     do: Enum.map(res, &Map.update!(&1, "url", fn v -> cleanup(v) end))
 
   test "Search a place", %{conn: conn} do
-    path = Helpers.places_path(conn, :autocomplete, q: "chat")
+    path = Helpers.autocomplete_path(conn, :autocomplete, q: "chat")
     conn = conn |> get(path)
     r = conn |> json_response(200)
 
@@ -56,7 +56,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search a place with accent", %{conn: conn} do
     json =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "cha"))
+      |> get(Helpers.autocomplete_path(conn, :autocomplete, q: "cha"))
       |> json_response(200)
 
     assert clean_urls(json) ==
@@ -84,7 +84,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search a place with multiple words", %{conn: conn} do
     json =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "ile de fr"))
+      |> get(Helpers.autocomplete_path(conn, :autocomplete, q: "ile de fr"))
       |> json_response(200)
 
     assert clean_urls(json) ==
@@ -107,7 +107,7 @@ defmodule TransportWeb.API.PlacesControllerTest do
   test "Search an unknown place", %{conn: conn} do
     json =
       conn
-      |> get(Helpers.places_path(conn, :autocomplete, q: "pouet"))
+      |> get(Helpers.autocomplete_path(conn, :autocomplete, q: "pouet"))
       |> json_response(200)
 
     assert clean_urls(json) == []


### PR DESCRIPTION
Fixes https://github.com/etalab/transport-site/issues/5040

Renomme la vue `places` en `autocomplete`. Renomme le code et les tests associés.
