### PR TITLE
Métadonnées pour validateur MobilityData

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_mobilitydata_metadata.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_mobilitydata_metadata.html.heex
@@ -1,0 +1,21 @@
+<div :if={not is_nil(@validation.metadata)} %>
+  <% %DB.ResourceMetadata{metadata: metadata, features: features} = @validation.metadata
+  locale = get_session(@conn, :locale) %>
+  <%= if metadata["start_date"] != nil and metadata["end_date"] != nil do %>
+    <p>
+      <%= dgettext("validations", "It is valid from") %>
+      <strong><%= DateTimeDisplay.format_date(metadata["start_date"], locale) %></strong> <%= dgettext(
+        "validations",
+        "to"
+      ) %> <strong><%= DateTimeDisplay.format_date(metadata["end_date"], locale) %></strong>.
+    </p>
+  <% end %>
+  <div :if={not is_nil(metadata["counts"])}>
+    <ul>
+      <li :for={{value, count} <- metadata["counts"]}><%= value %> : <%= format_number(count, locale: locale) %></li>
+    </ul>
+  </div>
+  <div :if={Enum.count(features) > 0} lang="en">
+    <span :for={feature <- Enum.sort(features)} class="label"><%= feature %></span>
+  </div>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/details.html.heex
@@ -6,6 +6,9 @@
       </h2>
       <div class="panel">
         <%= render("_resource_description.html", conn: @conn, resource: @resource, resource_history: @resource_history) %>
+        <%= if Transport.Validators.MobilityDataGTFSValidator.mine?(@validation) do %>
+          <%= render("_mobilitydata_metadata.html", conn: @conn, validation: @validation) %>
+        <% end %>
       </div>
 
       <%= unless Enum.empty?(@resource.resources_related) do %>

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -904,6 +904,10 @@ defmodule TransportWeb.ResourceControllerTest do
     insert(:multi_validation, %{
       resource_history: rh,
       validator: Transport.Validators.MobilityDataGTFSValidator.validator_name(),
+      metadata: %DB.ResourceMetadata{
+        metadata: %{"start_date" => "2025-12-01", "end_date" => "2025-12-31"},
+        features: ["Bike Allowed"]
+      },
       result: %{
         "notices" => [
           %{
@@ -925,6 +929,12 @@ defmodule TransportWeb.ResourceControllerTest do
 
     response = conn |> get(resource_path(conn, :details, resource.id))
 
+    # Resource metadata
+    assert response |> html_response(200) =~ "01/12/2025"
+    assert response |> html_response(200) =~ "31/12/2025"
+    assert response |> html_response(200) =~ "Bike Allowed"
+
+    # Validation
     assert response |> html_response(200) =~ "Rapport de validation"
     assert response |> html_response(200) =~ "1 avertissement"
     assert response |> html_response(200) =~ "unusable_trip"


### PR DESCRIPTION
Affiche des métadonnées comme les dates de validité, le nombre d'entités présentes et les fonctionnalités présentes pour un GTFS validé avec le validateur MobilityData.

<img width="1231" height="687" alt="Screenshot 2025-12-08 at 22 23 02" src="https://github.com/user-attachments/assets/229176a4-522b-4bb8-bc8d-42197ee5e725" />
