### PR TITLE
API datasets : valeur de retour pour legal owners

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/datasets_controller.ex
@@ -334,21 +334,24 @@ defmodule TransportWeb.API.DatasetController do
   end
 
   defp legal_owners(dataset) do
-    %{
-      "aoms" => legal_owners_aom(dataset.legal_owners_aom),
-      "regions" => legal_owners_region(dataset.legal_owners_region),
-      "company" => dataset.legal_owner_company_siren
-    }
+    legal_owners_aom(dataset.legal_owners_aom) ++
+      legal_owners_region(dataset.legal_owners_region) ++ legal_owners_company(dataset)
   end
 
   defp legal_owners_aom(aoms) do
-    aoms
-    |> Enum.map(fn aom -> %{"name" => aom.nom, "siren" => aom.siren} end)
+    Enum.map(aoms, fn aom -> %{"name" => aom.nom, "siren" => aom.siren, "type" => "aom"} end)
   end
 
   defp legal_owners_region(regions) do
-    regions
-    |> Enum.map(fn region -> %{"name" => region.nom, "insee" => region.insee} end)
+    Enum.map(regions, fn region -> %{"name" => region.nom, "insee" => region.insee, "type" => "region"} end)
+  end
+
+  def legal_owners_company(%{legal_owner_company_siren: nil}), do: []
+
+  def legal_owners_company(%{legal_owner_company_siren: legal_owner_company_siren}) do
+    [
+      %{"id" => nil, "siren" => legal_owner_company_siren, "type" => "company"}
+    ]
   end
 
   def offers(%DB.Dataset{} = dataset) do

--- a/apps/transport/lib/transport_web/api/schemas.ex
+++ b/apps/transport/lib/transport_web/api/schemas.ex
@@ -299,10 +299,11 @@ defmodule TransportWeb.API.Schemas do
       title: "AOM",
       description: "AOM object, as used in covered area and legal owners",
       type: :object,
-      required: [:name, :siren],
+      required: [:name, :siren, :type],
       properties: %{
         name: %Schema{type: :string},
-        siren: %Schema{type: :string}
+        siren: %Schema{type: :string},
+        type: %Schema{type: :string, enum: ["aom"]}
       },
       additionalProperties: false
     })
@@ -316,10 +317,28 @@ defmodule TransportWeb.API.Schemas do
       title: "Region",
       description: "Region object",
       type: :object,
-      required: [:name, :insee],
+      required: [:name, :insee, :type],
       properties: %{
         name: %Schema{type: :string},
-        insee: %Schema{type: :string}
+        insee: %Schema{type: :string},
+        type: %Schema{type: :string, enum: ["region"]}
+      },
+      additionalProperties: false
+    })
+  end
+
+  defmodule Company do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Company",
+      description: "Company object",
+      type: :object,
+      required: [:siren, :type],
+      properties: %{
+        siren: %Schema{type: :string},
+        type: %Schema{type: :string, enum: ["company"]}
       },
       additionalProperties: false
     })
@@ -385,17 +404,13 @@ defmodule TransportWeb.API.Schemas do
 
     OpenApiSpex.schema(%{
       title: "LegalOwners",
-      type: :object,
-      properties: %{
-        aoms: %Schema{
-          type: :array,
-          items: AOM.schema()
-        },
-        regions: %Schema{
-          type: :array,
-          items: Region.schema()
-        },
-        company: %Schema{type: :string, nullable: true}
+      type: :array,
+      items: %Schema{
+        anyOf: [
+          AOM.schema(),
+          Region.schema(),
+          Company.schema()
+        ]
       },
       additionalProperties: false
     })

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -210,7 +210,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     dataset_res = %{
       "community_resources" => [],
       "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
-      "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
+      "legal_owners" => [],
       "created_at" => "2021-12-23",
       "datagouv_id" => "datagouv",
       "id" => "datagouv",
@@ -332,7 +332,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
              %{
                "community_resources" => [],
                "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
-               "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
+               "legal_owners" => [],
                "created_at" => "2021-12-23",
                "datagouv_id" => "datagouv",
                "id" => "datagouv",
@@ -464,13 +464,10 @@ defmodule TransportWeb.API.DatasetControllerTest do
     assert %{
              "community_resources" => [],
              "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
-             "legal_owners" => %{
-               "aoms" => [
-                 %{"name" => "Angers Métropole", "siren" => "siren"}
-               ],
-               "company" => nil,
-               "regions" => [%{"name" => "Pays de la Loire", "insee" => "52"}]
-             },
+             "legal_owners" => [
+               %{"name" => "Angers Métropole", "siren" => "siren", "type" => "aom"},
+               %{"insee" => "52", "name" => "Pays de la Loire", "type" => "region"}
+             ],
              "created_at" => "2021-12-23",
              "datagouv_id" => "datagouv",
              "history" => [],
@@ -591,7 +588,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
     assert %{
              "community_resources" => [],
              "covered_area" => [%{"insee" => "123456", "nom" => "Angers Métropole", "type" => "epci"}],
-             "legal_owners" => %{"aoms" => [], "company" => nil, "regions" => []},
+             "legal_owners" => [],
              "created_at" => "2021-12-23",
              "datagouv_id" => "datagouv",
              "history" => [],


### PR DESCRIPTION
Fixes #4276

Transforme les responsables légaux dans un tableau plat.

```json
  "legal_owners": [
      {
        "id": 53,
        "type": "aom"
        "name": "CA du Bocage Bressuirais",
        "siren": "200040244"
      },
      {
        "id": 54,
        "type": "aom",
        "name": "CA du Grand Guéret",
        "siren": "200034825"
      },
      {
        "id":null,
        "type": "company",
        "siren": "123456789",
      },
      {
        "id":9,
        "type":"region",
        "insee": "75",
        "name": "Nouvelle-Aquitaine"
      }
    ]
```
