### PR TITLE
Ajout colonne iso3166 pour departement

### DIFF
--- a/apps/transport/priv/repo/migrations/20251209110327_departement_iso3166.exs
+++ b/apps/transport/priv/repo/migrations/20251209110327_departement_iso3166.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.DepartementIso3166 do
+  use Ecto.Migration
+
+  def change do
+    alter table(:departement) do
+      add(:iso3166, :string)
+    end
+
+    execute("""
+    UPDATE departement SET iso3166 = 'FR-' || insee;
+    """)
+  end
+end


### PR DESCRIPTION
Fixes #4029

#4949 avait ajouté le code ISO 3166 pour les régions, cette PR le fait pour les départements.
