### PR TITLE
Ajout job TableSizeHistoryJob

### DIFF
--- a/apps/transport/lib/db/table_size_history.ex
+++ b/apps/transport/lib/db/table_size_history.ex
@@ -1,0 +1,13 @@
+defmodule DB.TableSizeHistory do
+  @moduledoc """
+  History table holding table size records
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+
+  typed_schema "table_size_history" do
+    field(:table_name, :string)
+    field(:size, :integer)
+    field(:date, :date)
+  end
+end

--- a/apps/transport/lib/jobs/table_size_history_job.ex
+++ b/apps/transport/lib/jobs/table_size_history_job.ex
@@ -1,0 +1,62 @@
+defmodule Transport.Jobs.TableSizeHistoryJob do
+  @moduledoc """
+  Write, for each table, the space taken in the database.
+  """
+  use Oban.Worker, max_attempts: 3
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    query = """
+    WITH RECURSIVE pg_inherit(inhrelid, inhparent) AS
+     (select inhrelid, inhparent
+     FROM pg_inherits
+     UNION
+     SELECT child.inhrelid, parent.inhparent
+     FROM pg_inherit child, pg_inherits parent
+     WHERE child.inhparent = parent.inhrelid),
+    pg_inherit_short AS (SELECT * FROM pg_inherit WHERE inhparent NOT IN (SELECT inhrelid FROM pg_inherit))
+    SELECT
+    	table_name,
+    	total_bytes::bigint AS size,
+    	current_date as date
+    FROM (
+     SELECT *, total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
+     FROM (
+          SELECT c.oid
+               , nspname AS table_schema
+               , relname AS TABLE_NAME
+               , SUM(c.reltuples) OVER (partition BY parent) AS row_estimate
+               , SUM(pg_total_relation_size(c.oid)) OVER (partition BY parent) AS total_bytes
+               , SUM(pg_indexes_size(c.oid)) OVER (partition BY parent) AS index_bytes
+               , SUM(pg_total_relation_size(reltoastrelid)) OVER (partition BY parent) AS toast_bytes
+               , parent
+           FROM (
+                 SELECT pg_class.oid
+                     , reltuples
+                     , relname
+                     , relnamespace
+                     , pg_class.reltoastrelid
+                     , COALESCE(inhparent, pg_class.oid) parent
+                 FROM pg_class
+                     LEFT JOIN pg_inherit_short ON inhrelid = oid
+                 WHERE relkind IN ('r', 'p')
+              ) c
+              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE nspname = 'public'
+    ) a
+    WHERE oid = parent
+    ) a
+    ORDER BY total_bytes DESC
+
+    """
+
+    %{columns: columns, rows: rows} = Ecto.Adapters.SQL.query!(DB.Repo, query)
+
+    columns = Enum.map(columns, &String.to_existing_atom/1)
+    rows = Enum.map(rows, fn row -> columns |> Enum.zip(row) |> Map.new() end)
+
+    DB.Repo.insert_all(DB.TableSizeHistory, rows)
+
+    :ok
+  end
+end

--- a/apps/transport/priv/repo/migrations/20251209123938_add_table_size_history.exs
+++ b/apps/transport/priv/repo/migrations/20251209123938_add_table_size_history.exs
@@ -1,0 +1,14 @@
+defmodule DB.Repo.Migrations.AddTableSizeHistory do
+  use Ecto.Migration
+
+  def change do
+    create table(:table_size_history) do
+      add(:table_name, :string, null: false)
+      add(:size, :bigint, null: false)
+      add(:date, :date, null: false)
+    end
+
+    create(index(:table_size_history, [:table_name]))
+    create(unique_index(:table_size_history, [:table_name, :date]))
+  end
+end

--- a/apps/transport/test/transport/jobs/table_size_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/table_size_history_job_test.exs
@@ -1,0 +1,21 @@
+defmodule Transport.Test.Transport.Jobs.TableSizeHistoryJobTest do
+  use ExUnit.Case, async: true
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.TableSizeHistoryJob
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "perform" do
+    today = Date.utc_today()
+
+    assert :ok == perform_job(TableSizeHistoryJob, %{})
+
+    records = DB.Repo.all(DB.TableSizeHistory)
+
+    assert Enum.count(records) >= 50
+    assert Enum.member?(Enum.map(records, & &1.table_name), "dataset")
+    assert Enum.uniq(Enum.map(records, & &1.date)) == [today]
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -172,7 +172,8 @@ oban_prod_crontab = [
   {"30 2 * * *", Transport.Jobs.IRVEConsolidationJob},
   {"10 * * * *", Transport.Jobs.DefaultTokensJob},
   {"0 2 * * *", Transport.Jobs.CleanOnDemandValidationJob},
-  {"10 2 * * *", Transport.Jobs.CleanMultiValidationJob}
+  {"10 2 * * *", Transport.Jobs.CleanMultiValidationJob},
+  {"20 2 * * *", Transport.Jobs.TableSizeHistoryJob}
 ]
 
 # Make sure that all modules exist


### PR DESCRIPTION
Fixes #5041

Ajoute un job quotidien qui est en charge d'inspecter la taille de chaque table et de l'écrire dans la table `table_size_history`.