### PR TITLE
DeclarativeSpatialAreasLive : améliorations UX

### DIFF
--- a/apps/transport/client/stylesheets/components/_autocomplete.scss
+++ b/apps/transport/client/stylesheets/components/_autocomplete.scss
@@ -9,6 +9,10 @@
   position: absolute;
   text-align: left;
   z-index: 1;
+
+  &.hidden {
+    display: none;
+  }
 }
 
 #magnifier {

--- a/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/declarative_spatial_areas_live.ex
@@ -14,7 +14,7 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
         @form,
         :spatial_areas_search_input,
         placeholder: "Recherchez votre territoire…",
-        phx_keydown: "search_division",
+        phx_change: "change",
         phx_target: @myself,
         id: "spatial_areas_search_input",
         required: @required
@@ -65,6 +65,12 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
               item.classList.add("autoComplete_selected");
             }
           });
+        }
+
+        window.onclick = function(event) {
+          if (!event.target.matches('#autoCompleteResults')) {
+            document.getElementById("autoCompleteResults").classList.add('hidden');
+          }
         }
 
         searchInput.addEventListener('keydown', (event) => {
@@ -118,15 +124,11 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
     {:ok, socket |> assign(assigns) |> assign(:required, assigns.declarative_spatial_areas |> Enum.empty?())}
   end
 
-  def handle_event("search_division", %{"key" => "Escape"}, socket) do
-    {:noreply, assign(socket, administrative_division_search_matches: [])}
+  def handle_event("change", %{"form" => %{"spatial_areas_search_input" => ""}}, socket) do
+    {:noreply, assign(socket, matches: [], administrative_division_search_matches: [])}
   end
 
-  def handle_event("search_division", %{"value" => ""}, socket) do
-    {:noreply, assign(socket, matches: [])}
-  end
-
-  def handle_event("search_division", %{"value" => query}, socket) when byte_size(query) <= 100 do
+  def handle_event("change", %{"form" => %{"spatial_areas_search_input" => query}}, socket) do
     existing_ids = Enum.map(socket.assigns.declarative_spatial_areas, & &1.id)
 
     matches =
@@ -137,10 +139,6 @@ defmodule TransportWeb.DeclarativeSpatialAreasLive do
       |> Enum.take(5)
 
     {:noreply, assign(socket, administrative_division_search_matches: matches)}
-  end
-
-  def handle_event("search_division", _, socket) do
-    {:noreply, socket}
   end
 
   def handle_event("select_division", %{"id" => id}, socket) do


### PR DESCRIPTION
Fixes #4794
Fixes #4731

- Prend en compte la dernière lettre quand on tape dans l'input
- Masque l'autocomplete quand on clique en dehors
