### PR TITLE
JS : mise à jour du package autocomplete

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -2,7 +2,7 @@
 /* global contactId */
 // https://github.com/babel/babel/issues/9849
 require('regenerator-runtime')
-const AutoComplete = require('@tarekraafat/autocomplete.js/dist/js/autoComplete')
+const AutoComplete = require('@tarekraafat/autocomplete.js/dist/autoComplete')
 
 const labels = {
     region: 'région',
@@ -54,6 +54,7 @@ const autoCompletejs = new AutoComplete({
     debounce: 200,
     highlight: true,
     searchEngine: (query, record) => {
+        record = record.name
         // inspired by the 'loose' searchEngine, but that always matches
         query = query.replace(/ /g, '').normalize('NFD').replace(/[\u0300-\u036f]/g, '')
         const recordLowerCase = record.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
@@ -78,40 +79,38 @@ const autoCompletejs = new AutoComplete({
             return match.join('')
         }
     },
-    maxResults: 7,
     resultsList: {
-        render: true,
-        container: source => {
-            source.setAttribute('id', 'autoComplete_list')
-        },
-        destination: document.querySelector('#autoCompleteResults'),
+        maxResults: 7,
+        id: 'autoComplete_list',
+        destination: '#autoCompleteResults',
         position: 'beforeend',
-        element: 'ul'
+        tag: 'ul'
     },
     resultItem: {
-        content: (data, source) => {
+        element: (source, data) => {
             source.innerHTML = `<div><span class="autocomplete_name">${data.match}</span><span class="autocomplete_type">${labels[data.value.type] || ''}</span></div>`
         },
-        element: 'li'
-    },
-    onSelection: feedback => {
-        feedback.event.preventDefault()
-
-        const selection = feedback.selection.value
-
-        // Log the selected value
-        fetch('/api/features/autocomplete', {
-            method: 'POST',
-            headers: {
-                'content-type': 'application/json'
-            },
-            body: JSON.stringify({
-                ...selection,
-                contact_id: contactId
-            })
-        })
-
-        // Redirect to the target URL
-        window.location = selection.url
+        tag: 'li',
+        highlight: 'autoComplete_highlight',
+        selected: 'autoComplete_selected'
     }
+})
+
+document.querySelector('#autoComplete').addEventListener('selection', function (event) {
+    const selection = event.detail.selection.value
+
+    // Log the selected value
+    fetch('/api/features/autocomplete', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            ...selection,
+            contact_id: contactId
+        })
+    })
+
+    // Redirect to the target URL
+    window.location = selection.url
 })

--- a/apps/transport/client/package.json
+++ b/apps/transport/client/package.json
@@ -16,7 +16,7 @@
     "@deck.gl/core": "^8.7.0",
     "@deck.gl/layers": "^8.7.0",
     "@fortawesome/fontawesome-free": "^6.2.0",
-    "@tarekraafat/autocomplete.js": "^7.2.0",
+    "@tarekraafat/autocomplete.js": "^10.2.9",
     "clipboard": "^2.0.10",
     "core-js": "3",
     "deck.gl-leaflet": "^1.2.1",

--- a/apps/transport/client/yarn.lock
+++ b/apps/transport/client/yarn.lock
@@ -1291,10 +1291,10 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@tarekraafat/autocomplete.js@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/@tarekraafat/autocomplete.js/-/autocomplete.js-7.2.0.tgz"
-  integrity sha512-p1aEcKC/WHpVBuFyRhXq/ie+mgO4QqCNEsdVIPUBgmNqmxV4dVfqYEpk///9vvKyranUUvrlVu4e2tdzAaXKIg==
+"@tarekraafat/autocomplete.js@^10.2.9":
+  version "10.2.9"
+  resolved "https://registry.yarnpkg.com/@tarekraafat/autocomplete.js/-/autocomplete.js-10.2.9.tgz#316b2b1f8171f21737fdcbadda74c2cfae00f840"
+  integrity sha512-A7OP3iJDTWeO85M3Vxu391acu9SmDguormHpMZ13khuyM180dKl9O1gAXSDA322XwkYuUU1Ad7WchW1TQNNuDw==
 
 "@trysound/sax@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
Fixes #3391

Met à jour `autocomplete.js` dans sa dernière version. Je repercute les changements majeurs.
