### PR TITLE
Ajout classe .producer-actions

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -14,6 +14,12 @@
   }
 }
 
+.producer-actions {
+  background-color: var(--theme-background-grey);
+  padding-top: 24px;
+  padding-bottom: 48px;
+}
+
 .producer-space {
   background-color: var(--theme-background-grey);
   min-height: 80vh;


### PR DESCRIPTION
J'ai eu la main lourde dans https://github.com/etalab/transport-site/pull/5065, cette classe CSS est encore utilisée.
