### PR TITLE
Dataset : ignore JDDs archivés pour counts

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -107,6 +107,7 @@ defmodule DB.Dataset do
   def hidden, do: from(d in DB.Dataset, as: :dataset, where: d.is_active and d.is_hidden)
   def include_hidden_datasets(%Ecto.Query{} = query), do: or_where(query, [dataset: d], d.is_hidden)
   def base_with_hidden_datasets, do: base_query() |> include_hidden_datasets()
+  def reject_archived_datasets(%Ecto.Query{} = query), do: where(query, [dataset: d], is_nil(d.archived_at))
 
   @spec archived?(__MODULE__.t()) :: boolean()
   def archived?(%__MODULE__{archived_at: nil}), do: false
@@ -528,8 +529,8 @@ defmodule DB.Dataset do
       |> filter_by_resource_format(params)
       |> filter_by_fulltext(params)
       |> filter_by_offer(params)
+      |> reject_archived_datasets()
       |> select([dataset: d], d.id)
-      |> where([dataset: d], is_nil(d.archived_at))
 
     base_query()
     |> where([dataset: d], d.id in subquery(q))
@@ -804,6 +805,7 @@ defmodule DB.Dataset do
 
   defp count_by_mode_query(mode) do
     base_query()
+    |> reject_archived_datasets()
     |> join(:inner, [dataset: d], r in assoc(d, :resources), as: :resource)
     |> where([resource: r], fragment("?->'gtfs_modes' @> ?", r.counter_cache, ^mode))
   end
@@ -811,6 +813,7 @@ defmodule DB.Dataset do
   @spec count_by_type(binary()) :: any()
   def count_by_type(type) do
     base_query()
+    |> reject_archived_datasets()
     |> where([d], d.type == ^type)
     |> Repo.aggregate(:count, :id)
   end
@@ -821,13 +824,14 @@ defmodule DB.Dataset do
   @spec count_public_transport_has_realtime :: number()
   def count_public_transport_has_realtime do
     base_query()
+    |> reject_archived_datasets()
     |> where([d], d.has_realtime and d.type == "public-transit")
     |> Repo.aggregate(:count, :id)
   end
 
   @spec count_by_custom_tag(binary()) :: non_neg_integer()
   def count_by_custom_tag(custom_tag) do
-    base_query() |> filter_by_custom_tag(custom_tag) |> Repo.aggregate(:count, :id)
+    base_query() |> reject_archived_datasets() |> filter_by_custom_tag(custom_tag) |> Repo.aggregate(:count, :id)
   end
 
   @spec get_by_slug(binary) :: {:ok, __MODULE__.t()} | {:error, binary()}

--- a/apps/transport/test/db/dataset_test.exs
+++ b/apps/transport/test/db/dataset_test.exs
@@ -544,6 +544,7 @@ defmodule DB.DatasetDBTest do
     france = insert(:administrative_division, type: :pays, insee: "FR", nom: "France")
     dataset = insert(:dataset)
     dataset_2 = insert(:dataset, declarative_spatial_areas: [france])
+    archived_dataset = insert(:dataset, archived_at: DateTime.utc_now())
 
     # As filled by `Transport.CounterCache`
     insert(:resource, counter_cache: %{gtfs_modes: ["bus"]}, dataset: dataset)
@@ -552,6 +553,8 @@ defmodule DB.DatasetDBTest do
     insert(:resource, counter_cache: %{gtfs_modes: ["bus"]}, dataset: dataset_2)
     insert(:resource, counter_cache: %{gtfs_modes: ["ski"]}, dataset: dataset_2)
 
+    insert(:resource, counter_cache: %{gtfs_modes: ["ski"]}, dataset: archived_dataset)
+
     assert DB.Dataset.count_by_mode("bus") == 2
     assert DB.Dataset.count_by_mode("ski") == 2
     # this counts datasets covering France with bus resources
@@ -559,9 +562,44 @@ defmodule DB.DatasetDBTest do
   end
 
   test "count_by_custom_tag" do
+    insert(:dataset, archived_at: DateTime.utc_now(), custom_tags: ["foo"])
+
     assert 0 == DB.Dataset.count_by_custom_tag("foo")
+
     insert(:dataset, type: "public-transit", is_active: true, custom_tags: ["bar", "foo"])
+
     assert 1 == DB.Dataset.count_by_custom_tag("foo")
+  end
+
+  test "count_by_type" do
+    insert(:dataset, type: "public-transit")
+    insert(:dataset, type: "public-transit")
+
+    insert(:dataset, type: "road-data")
+    insert(:dataset, type: "road-data", archived_at: DateTime.utc_now())
+
+    assert %{
+             "bike-data" => 0,
+             "carpooling-areas" => 0,
+             "carpooling-lines" => 0,
+             "carpooling-offers" => 0,
+             "charging-stations" => 0,
+             "informations" => 0,
+             "pedestrian-path" => 0,
+             "public-transit" => 2,
+             "road-data" => 1,
+             "vehicles-sharing" => 0
+           } == DB.Dataset.count_by_type()
+  end
+
+  test "count_public_transport_has_realtime" do
+    assert 0 == DB.Dataset.count_public_transport_has_realtime()
+
+    insert(:dataset, type: "public-transit", has_realtime: true)
+    insert(:dataset, type: "public-transit", has_realtime: false)
+    insert(:dataset, type: "public-transit", has_realtime: true, archived_at: DateTime.utc_now())
+
+    assert 1 == DB.Dataset.count_public_transport_has_realtime()
   end
 
   test "correct organization type" do


### PR DESCRIPTION
Ignore les JDDs qui sont archivés lorsque l'on compte le total de jeux de données, comme par exemple sur l'accueil.
