### PR TITLE
MobilityDataGTFSValidator : digest quand pas d'erreurs

### DIFF
--- a/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
+++ b/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
@@ -125,12 +125,10 @@ defmodule Transport.Validators.MobilityDataGTFSValidator do
     "stats" => %{"WARNING" => 2},
     "summary" => [%{"code" => "unusable_trip", "severity" => "WARNING", "totalNotices" => 2}]
   }
+  iex> digest([])
+  %{"max_severity" => %{"max_level" => "NoError", "worst_occurrences" => 0}, "stats" => %{}, "summary" => []}
   """
   @spec digest([map()]) :: map()
-  def digest([]) do
-    %{"stats" => nil, "max_severity" => nil, "summary" => nil}
-  end
-
   def digest(validation_result) do
     %{
       "stats" => count_by_severity(validation_result),

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -380,6 +380,27 @@ defmodule TransportWeb.DatasetControllerTest do
     assert conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
   end
 
+  test "displays no error when validated with the MobilityData validator", %{conn: conn} do
+    dataset = insert(:dataset)
+    resource = insert(:resource, dataset: dataset, format: "GTFS")
+    resource_history = insert(:resource_history, resource_id: resource.id)
+
+    result = %{"notices" => []}
+
+    insert(:multi_validation,
+      resource_history: resource_history,
+      validator: Transport.Validators.MobilityDataGTFSValidator.validator_name(),
+      result: result,
+      digest: Transport.Validators.MobilityDataGTFSValidator.digest(result["notices"])
+    )
+
+    mock_empty_history_resources()
+
+    conn = conn |> get(dataset_path(conn, :details, dataset.slug))
+
+    assert conn |> html_response(200) |> extract_resource_details() =~ "Pas d'erreur"
+  end
+
   test "displays MobilityData if validated by both GTFS validators", %{conn: conn} do
     dataset = insert(:dataset)
     resource = insert(:resource, dataset: dataset, format: "GTFS")


### PR DESCRIPTION
Retravaille le `digest` du validateur GTFS MobilityData lorsqu'il n'y a pas d'erreur.

Corrige [une erreur Sentry](https://transport-data-gouv-fr.sentry.io/issues/7074415196/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream).
