### PR TITLE
Fix resource#details pour NeTEx sans erreurs

### DIFF
--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -109,10 +109,14 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
   defp drop_empty_values(map), do: Map.filter(map, fn {_key, value} -> value != %{} and not is_nil(value) end)
 
   def get_values(%Explorer.DataFrame{} = df, column) do
-    df
-    |> DF.distinct([column])
-    |> DF.to_rows()
-    |> Enum.map(& &1[column])
+    if has_column?(df, column) do
+      df
+      |> DF.distinct([column])
+      |> DF.to_rows()
+      |> Enum.map(& &1[column])
+    else
+      []
+    end
   end
 
   def count_and_slice(%Explorer.DataFrame{} = df, pagination_config) do
@@ -124,5 +128,11 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
       |> to_issues()
 
     {total_count, issues}
+  end
+
+  def has_column?(df, column_name) do
+    df
+    |> DF.names()
+    |> Enum.member?(column_name)
   end
 end

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
@@ -121,11 +121,17 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
         %{"issues_category" => issues_category} = filter,
         %Scrivener.Config{} = pagination_config
       ) do
-    {filter,
-     df
-     |> DF.filter(category == ^issues_category)
-     |> order_issues_by_location()
-     |> Commons.count_and_slice(pagination_config)}
+    results =
+      if Commons.has_column?(df, "category") do
+        df
+        |> DF.filter(category == ^issues_category)
+        |> order_issues_by_location()
+        |> Commons.count_and_slice(pagination_config)
+      else
+        {0, []}
+      end
+
+    {filter, results}
   end
 
   def get_issues(%Explorer.DataFrame{} = df, %{}, %Scrivener.Config{} = pagination_config) do

--- a/apps/transport/test/transport/validators/netex/results_adapters/v0_1_0_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/v0_1_0_test.exs
@@ -15,7 +15,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0Test do
     "criticity" => "error"
   }
 
-  test "get_issues from binary" do
+  test "get_issues from binary, with errors" do
     pagination_config = make_pagination_config(%{})
 
     binary_result =
@@ -40,6 +40,34 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0Test do
              V0_1_0.get_issues(binary_result, %{"issue_type" => "xsd-123"}, pagination_config)
 
     assert {%{"issue_type" => "valid-day-bits"}, {41, repeated(@rule, 1)}} ==
+             V0_1_0.get_issues(binary_result, %{"issue_type" => "valid-day-bits"}, pagination_config)
+  end
+
+  test "get_issues from binary, no error" do
+    pagination_config = make_pagination_config(%{})
+
+    binary_result =
+      result_factory("xsd-123": 0, "valid-day-bits": 0)
+      |> V0_1_0.to_binary_result()
+
+    assert {%{"issue_type" => ""}, {0, repeated(@rule, 0)}} ==
+             V0_1_0.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issue_type" => "xsd-123"}, {0, repeated(@xsd, 0)}} ==
+             V0_1_0.get_issues(binary_result, %{"issue_type" => "xsd-123"}, pagination_config)
+
+    assert {%{"issue_type" => "valid-day-bits"}, {0, repeated(@rule, 0)}} ==
+             V0_1_0.get_issues(binary_result, %{"issue_type" => "valid-day-bits"}, pagination_config)
+
+    pagination_config = make_pagination_config(%{"page" => "3"})
+
+    assert {%{"issue_type" => ""}, {0, repeated(@rule, 0)}} ==
+             V0_1_0.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issue_type" => "xsd-123"}, {0, repeated(@xsd, 0)}} ==
+             V0_1_0.get_issues(binary_result, %{"issue_type" => "xsd-123"}, pagination_config)
+
+    assert {%{"issue_type" => "valid-day-bits"}, {0, repeated(@rule, 0)}} ==
              V0_1_0.get_issues(binary_result, %{"issue_type" => "valid-day-bits"}, pagination_config)
   end
 

--- a/apps/transport/test/transport/validators/netex/results_adapters/v0_2_0_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/v0_2_0_test.exs
@@ -15,7 +15,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0Test do
     "criticity" => "error"
   }
 
-  test "get_issues from binary" do
+  test "get_issues from binary, with errors" do
     pagination_config = make_pagination_config(%{})
 
     binary_result =
@@ -40,6 +40,34 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0Test do
              V0_2_0.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
 
     assert {%{"issues_category" => "base-rules"}, {41, repeated(@rule, 1)}} ==
+             V0_2_0.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
+  end
+
+  test "get_issues from binary, no error" do
+    pagination_config = make_pagination_config(%{})
+
+    binary_result =
+      result_factory("base-rules": 0, "xsd-schema": 0)
+      |> V0_2_0.to_binary_result()
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_0.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_0.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
+
+    assert {%{"issues_category" => "base-rules"}, {0, repeated(@rule, 0)}} ==
+             V0_2_0.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
+
+    pagination_config = make_pagination_config(%{"page" => "3"})
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_0.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_0.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
+
+    assert {%{"issues_category" => "base-rules"}, {0, repeated(@rule, 0)}} ==
              V0_2_0.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
   end
 

--- a/apps/transport/test/transport/validators/netex/results_adapters/v0_2_1_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/v0_2_1_test.exs
@@ -15,7 +15,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1Test do
     "criticity" => "error"
   }
 
-  test "get_issues from binary" do
+  test "get_issues from binary, with errors" do
     pagination_config = make_pagination_config(%{})
 
     binary_result =
@@ -40,6 +40,34 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1Test do
              V0_2_1.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
 
     assert {%{"issues_category" => "base-rules"}, {41, repeated(@rule, 1)}} ==
+             V0_2_1.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
+  end
+
+  test "get_issues from binary, no error" do
+    pagination_config = make_pagination_config(%{})
+
+    binary_result =
+      result_factory("base-rules": 0, "xsd-schema": 0)
+      |> V0_2_1.to_binary_result()
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_1.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_1.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
+
+    assert {%{"issues_category" => "base-rules"}, {0, repeated(@rule, 0)}} ==
+             V0_2_1.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
+
+    pagination_config = make_pagination_config(%{"page" => "3"})
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_1.get_issues(binary_result, %{}, pagination_config)
+
+    assert {%{"issues_category" => "xsd-schema"}, {0, repeated(@xsd, 0)}} ==
+             V0_2_1.get_issues(binary_result, %{"issues_category" => "xsd-schema"}, pagination_config)
+
+    assert {%{"issues_category" => "base-rules"}, {0, repeated(@rule, 0)}} ==
              V0_2_1.get_issues(binary_result, %{"issues_category" => "base-rules"}, pagination_config)
   end
 


### PR DESCRIPTION
En l'absence d'erreurs, le dataframe est vide, et n'a pas non plus de colonne. Le code plante avec comme erreur :

```
** (ArgumentError) could not find column name "category". The available columns are: [].
```