### PR TITLE
Config proxy : gère affichage de flux GBFS

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -71,7 +71,8 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
       unique_slug: resource.identifier,
       proxy_url: Transport.Proxy.resource_url(proxy_base_url, resource.identifier),
       original_url: resource.target_url,
-      ttl: resource.ttl
+      ttl: resource.ttl,
+      type: "HTTP"
     }
   end
 
@@ -80,7 +81,8 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
       unique_slug: resource.identifier,
       proxy_url: Transport.Proxy.resource_url(proxy_base_url, resource.identifier),
       original_url: resource.target_url,
-      ttl: nil
+      ttl: nil,
+      type: "SIRI"
     }
   end
 
@@ -92,7 +94,8 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
       # At time of writing, the global feed is not cached
       ttl: "N/A",
       # We do not display the internal count for aggregate item at the moment
-      internal_count_default_value: nil
+      internal_count_default_value: nil,
+      type: "Aggregate"
     }
   end
 
@@ -102,7 +105,18 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
       proxy_url: Transport.Proxy.resource_url(proxy_base_url, resource.identifier),
       # TODO: display original bucket & path name
       original_url: nil,
-      ttl: resource.ttl
+      ttl: resource.ttl,
+      type: "S3"
+    }
+  end
+
+  defp extract_config(proxy_base_url, %Unlock.Config.Item.GBFS{} = resource) do
+    %{
+      unique_slug: resource.identifier,
+      proxy_url: Transport.Proxy.resource_url(proxy_base_url, resource.identifier) <> "/gbfs.json",
+      original_url: resource.base_url,
+      ttl: resource.ttl,
+      type: "GBFS"
     }
   end
 

--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.html.heex
@@ -12,6 +12,7 @@
   <table class="table mt-48">
     <thead>
       <tr>
+        <th>Type</th>
         <th>Identifiant</th>
         <th>URL proxy</th>
         <th>Donnée cible</th>
@@ -30,6 +31,7 @@
     <tbody>
       <%= for resource <- @proxy_configuration do %>
         <tr>
+          <td><span class="label"><%= resource.type %></span></td>
           <td><%= resource.unique_slug %></td>
           <% # TODO: use regular link helper %>
           <td><a href={resource.proxy_url}>lien</a></td>

--- a/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/proxy_config_live_test.exs
@@ -78,16 +78,19 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
     # NOTE: alphabetical slug order
     assert [
              %{
+               "Type" => "Aggregate",
                "Identifiant" => "aggregate-slug",
                "Req ext 7j" => "0",
                "Req int 7j" => "N/C"
              },
              %{
+               "Type" => "HTTP",
                "Identifiant" => "gtfs-rt-slug",
                "Req ext 7j" => "2",
                "Req int 7j" => "1"
              },
              %{
+               "Type" => "S3",
                "Identifiant" => "s3-slug",
                "Req ext 7j" => "0",
                "Req int 7j" => "0"
@@ -108,6 +111,7 @@ defmodule TransportWeb.Backoffice.ProxyConfigLiveTest do
     assert [
              _aggregate_item,
              %{
+               "Type" => "HTTP",
                "Identifiant" => "gtfs-rt-slug",
                "Req ext 7j" => "4",
                "Req int 7j" => "2"


### PR DESCRIPTION
Suite à #5086, il est nécessaire d'adapter la configuration dans le BO pour afficher les flux GBFS.

<img width="1201" height="509" alt="Screenshot 2025-12-17 at 12 04 01" src="https://github.com/user-attachments/assets/eee04b85-4bde-47e6-a12b-536c1a4d777e" />
