### PR TITLE
Upload de fichiers : supprime espaces

### DIFF
--- a/apps/datagouvfr/lib/datagouvfr/client/resources.ex
+++ b/apps/datagouvfr/lib/datagouvfr/client/resources.ex
@@ -187,10 +187,10 @@ defmodule Datagouvfr.Client.Resources.External do
   "cedille"
   iex> remove_accents_and_spaces("Hello")
   "Hello"
-  iex> remove_accents_and_spaces("Hello world")
+  iex> remove_accents_and_spaces("Hello world\t")
   "Helloworld"
   """
   def remove_accents_and_spaces(value) do
-    value |> String.normalize(:nfd) |> String.replace(~r/\p{M}/u, "") |> String.replace(" ", "")
+    value |> String.normalize(:nfd) |> String.replace(~r/\p{M}/u, "") |> String.replace(~r/\s/, "")
   end
 end


### PR DESCRIPTION
Retour de #5077

Il semblerait que la présence d'espace (ou d'accents) pose problème lors de l'upload de fichiers.
