### PR TITLE
Espace producteur : logs de l'usage et compteur

### DIFF
--- a/apps/transport/lib/db/feature_usage.ex
+++ b/apps/transport/lib/db/feature_usage.ex
@@ -17,7 +17,10 @@ defmodule DB.FeatureUsage do
         :post_discussion,
         :post_comment,
         :gtfs_diff,
-        :autocomplete
+        :autocomplete,
+        :upload_file,
+        :delete_resource,
+        :upload_logo
       ]
     )
 


### PR DESCRIPTION
Enregistre des événements liés à l'utilisation de l'Espace Producteur.

- des compteurs AppSignal pour compter les succès et échecs d'opérations
- des événements `DB.FeatureUsage` concernant les logos, l'upload de fichiers, la suppression d'une ressource
