### PR TITLE
ProxyConfigLive : corrige choix dans select

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/proxy_config_live.ex
@@ -39,7 +39,7 @@ defmodule TransportWeb.Backoffice.ProxyConfigLive do
       last_updated_at: (Time.utc_now() |> Time.truncate(:second) |> to_string()) <> " UTC",
       stats_days: @stats_days,
       proxy_configuration: config,
-      select_options: Enum.map(config, &{&1.type, &1.type})
+      select_options: Enum.map(config, &{&1.type, &1.type}) |> Enum.uniq() |> Enum.sort()
     )
     |> filter_config()
   end


### PR DESCRIPTION
Suite de #5095

Les choix proposés dans le `select` doivent être uniques…

## Bug visible
<img width="909" height="529" alt="Screenshot 2025-12-18 at 10 36 47" src="https://github.com/user-attachments/assets/8b39b965-0be8-40c5-bc4a-f9fa08c14052" />

