### PR TITLE
Autocomplete : raccourci clavier pour focus

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -87,6 +87,16 @@ const autoCompletejs = new AutoComplete({
     }
 })
 
+document.addEventListener('keydown', function (event) {
+    if (event.key === '/' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+        const searchInput = document.getElementById('autoComplete')
+        if (searchInput) {
+            event.preventDefault()
+            searchInput.focus()
+        }
+    }
+})
+
 document.querySelector('#autoComplete').addEventListener('selection', function (event) {
     const selection = event.detail.selection.value
 

--- a/apps/transport/client/javascripts/autocomplete_address.js
+++ b/apps/transport/client/javascripts/autocomplete_address.js
@@ -43,3 +43,13 @@ new AutoComplete({
         selected: 'autoComplete_selected'
     }
 })
+
+document.addEventListener('keydown', function (event) {
+    if (event.key === '/' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+        const searchInput = document.getElementById('autoComplete')
+        if (searchInput) {
+            event.preventDefault()
+            searchInput.focus()
+        }
+    }
+})


### PR DESCRIPTION
Ajoute le raccourci clavier `/` pour focus l'autocomplete sur les pages où il est présent.
