### PR TITLE
Espace Producteur : ajout classe filler

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -43,3 +43,12 @@
     padding-right: 12px;
   }
 }
+
+a.filler {
+  margin-right: .3em;
+  text-decoration: none;
+  color: var(--theme-dark-text);
+  &:first-child {
+    margin-left: .5em;
+  }
+}

--- a/apps/transport/lib/transport_web/templates/espace_producteur/resource_form.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/resource_form.html.heex
@@ -64,9 +64,9 @@
                   label f, :format do
                     [
                       dgettext("espace-producteurs", "Format"),
-                      content_tag(:a, "GTFS", class: "filler", onclick: "fill(this);"),
-                      content_tag(:a, "NeTEx", class: "filler", onclick: "fill(this);"),
-                      content_tag(:a, "gtfs-rt", class: "filler", onclick: "fill(this);")
+                      content_tag(:a, "GTFS", class: "filler label", onclick: "fill(this);"),
+                      content_tag(:a, "NeTEx", class: "filler label", onclick: "fill(this);"),
+                      content_tag(:a, "gtfs-rt", class: "filler label", onclick: "fill(this);")
                     ]
                   end,
                 placeholder: "GTFS, NeTEx, …",


### PR DESCRIPTION
Corrige l'interface qui permet de choisir un format de données dans l'espace producteur.

## Avant
<img width="849" height="334" alt="Screenshot 2025-12-18 at 11 54 35" src="https://github.com/user-attachments/assets/41b03be0-2340-4a33-b438-5f589d99a45b" />


## Après

<img width="837" height="340" alt="Screenshot 2025-12-18 at 11 53 08" src="https://github.com/user-attachments/assets/351d3c4a-5d08-4428-a723-402eb0fa2df6" />

