### PR TITLE
clear_proxy_config : désactive la CSP

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -81,6 +81,14 @@ defmodule TransportWeb.Router do
   end
 
   scope "/", TransportWeb do
+    scope "/backoffice", Backoffice, as: :backoffice do
+      pipe_through([:backoffice_clear_proxy_config])
+
+      post("/clear_proxy_config", PageController, :clear_proxy_config)
+    end
+  end
+
+  scope "/", TransportWeb do
     pipe_through(:browser)
     get("/", PageController, :index)
     get("/missions", PageController, :missions)
@@ -251,11 +259,6 @@ defmodule TransportWeb.Router do
     scope "/backoffice", Backoffice, as: :backoffice do
       pipe_through([:backoffice_csv_export])
       get("/download_resources_csv", PageController, :download_resources_csv)
-    end
-
-    scope "/backoffice", Backoffice, as: :backoffice do
-      pipe_through([:backoffice_clear_proxy_config])
-      post("/clear_proxy_config", PageController, :clear_proxy_config)
     end
 
     # Authentication
@@ -432,10 +435,7 @@ defmodule TransportWeb.Router do
     if Plug.Crypto.secure_compare(key_value, expected_value) do
       conn
     else
-      conn
-      |> put_flash(:error, dgettext("alert", "You need to be a member of the transport.data.gouv.fr team."))
-      |> redirect(to: Helpers.page_path(conn, :login, redirect_path: current_path(conn)))
-      |> halt()
+      conn |> put_status(401) |> text("Unauthorized") |> halt()
     end
   end
 

--- a/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/page_controller_test.exs
@@ -298,11 +298,9 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
 
   describe "clear_proxy_config" do
     test "requires auth", %{conn: conn} do
-      assert %URI{path: "/login/explanation"} =
-               conn
-               |> post(Routes.backoffice_page_path(conn, :clear_proxy_config))
-               |> redirected_to(302)
-               |> URI.parse()
+      assert conn
+             |> post(Routes.backoffice_page_path(conn, :clear_proxy_config))
+             |> text_response(401) == "Unauthorized"
     end
 
     test "success case", %{conn: conn} do
@@ -313,6 +311,7 @@ defmodule TransportWeb.Backoffice.PageControllerTest do
 
       assert conn
              |> put_req_header("x-key", "fake_proxy_config_secret_key")
+             |> put_private(:plug_skip_csrf_protection, false)
              |> post(Routes.backoffice_page_path(conn, :clear_proxy_config))
              |> text_response(200) == "OK"
     end


### PR DESCRIPTION
Retravaille #5087

En étant au milieu des autres routes, cette route était protégée par le plug CSRF.

Il n'est pas possible de passer un header CSRF dans la requête, il faut donc désactiver la protection CSRF pour cet endpoint.

Pas vu avant car la protection CSRF est désactivée dans les tests… https://github.com/phoenixframework/phoenix/blob/07fc5ac215b61849ba54c4cc506dbb1b5248d6d3/lib/phoenix/test/conn_test.ex#L153

[Voir sur Sentry](https://transport-data-gouv-fr.sentry.io/issues/4879736144/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream)
