### PR TITLE
Autocomplete : désactive submit

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -69,7 +69,7 @@ const autoCompletejs = new AutoComplete({
             return match.join('')
         }
     },
-    submit: true,
+    submit: false,
     resultsList: {
         maxResults: 7,
         id: 'autoComplete_list',

--- a/apps/transport/client/javascripts/autocomplete_address.js
+++ b/apps/transport/client/javascripts/autocomplete_address.js
@@ -17,7 +17,7 @@ new AutoComplete({
     threshold: 3,
     debounce: 200,
     highlight: true,
-    submit: true,
+    submit: false,
     resultsList: {
         maxResults: 5,
         id: 'autoComplete_list',


### PR DESCRIPTION
Revient sur https://github.com/etalab/transport-site/pull/5090

Le fonctionnement n'est pas bon, "Entrée" sélectionne toujours le 1er résultat.

En désactivant le submit on force à sélectionner un résultat, mais la touche continue de fonctionner.
