### PR TITLE
AdminNotifier : mise en place de templates

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/bnlc_consolidation_report.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/bnlc_consolidation_report.html.heex
@@ -1,0 +1,2 @@
+<%= raw(@body) %>
+<br /><br /> 🔗 <a href={@file_url}>Fichier consolidé</a>

--- a/apps/transport/lib/transport_web/templates/email/contact.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/contact.html.heex
@@ -1,0 +1,9 @@
+<ul>
+  <li>User type: <%= @user_type %></li>
+  <li>Question type: <%= @question_type %></li>
+</ul>
+
+<b>Question:</b>
+<p>
+  <%= @question %>
+</p>

--- a/apps/transport/lib/transport_web/templates/email/datasets_without_gtfs_rt_related_resources.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/datasets_without_gtfs_rt_related_resources.html.heex
@@ -1,0 +1,11 @@
+<p>Bonjour,</p>
+
+<p>
+  Les jeux de données suivants contiennent plusieurs GTFS et des liens entre les ressources GTFS-RT et GTFS sont manquants :
+</p>
+
+<ul>
+  <%= raw(@list) %>
+</ul>
+
+<p>L’équipe transport.data.gouv.fr</p>

--- a/apps/transport/lib/transport_web/templates/email/expiration.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/expiration.html.heex
@@ -1,0 +1,5 @@
+<p>Bonjour,</p>
+
+<p>Voici un résumé des jeux de données arrivant à expiration</p>
+
+<%= raw(@expiration) %>

--- a/apps/transport/lib/transport_web/templates/email/feedback.html.md
+++ b/apps/transport/lib/transport_web/templates/email/feedback.html.md
@@ -1,0 +1,8 @@
+Vous avez un nouvel avis sur le PAN.
+
+- Fonctionnalité : <%= @feature %>
+- Notation : <%= @rating %>
+- Adresse e-mail : <%= @email_address %>
+
+Explication :
+<%= @explanation %>

--- a/apps/transport/lib/transport_web/templates/email/inactive_datasets.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/inactive_datasets.html.heex
@@ -1,0 +1,7 @@
+<p>Bonjour,</p>
+
+<%= raw(@inactive_datasets_str) %>
+<%= raw(@reactivated_datasets_str) %>
+<%= raw(@archived_datasets_str) %>
+
+<p>Il faut peut être creuser pour savoir si c'est normal.</p>

--- a/apps/transport/lib/transport_web/templates/email/new_datagouv_datasets.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/new_datagouv_datasets.html.heex
@@ -1,0 +1,14 @@
+<p>Bonjour,</p>
+
+<p>
+  Les jeux de données suivants ont été ajoutés sur data.gouv.fr dans les dernières <%= @duration %>h et sont susceptibles d'avoir leur place sur le PAN :
+</p>
+<ul>
+  <%= raw(@list) %>
+</ul>
+<br />
+<hr />
+<%= @rule_explanation %>
+<p>
+  Vous pouvez modifier <a href="https://github.com/etalab/transport-site/blob/master/apps/transport/lib/jobs/new_datagouv_datasets_job.ex">les règles de cette tâche</a>.
+</p>

--- a/apps/transport/lib/transport_web/templates/email/oban_failure.html.md
+++ b/apps/transport/lib/transport_web/templates/email/oban_failure.html.md
@@ -1,0 +1,1 @@
+Un job Oban <%= @worker %> vient d'échouer, il serait bien d'investiguer.

--- a/apps/transport/lib/transport_web/templates/email/unknown_gbfs_operator_feeds.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/unknown_gbfs_operator_feeds.html.heex
@@ -1,0 +1,13 @@
+<p>Bonjour,</p>
+
+<p>Il n'est pas possible de détecter automatiquement les opérateurs des flux GBFS suivants :</p>
+
+<ul>
+  <%= raw(@list) %>
+</ul>
+
+<p>
+  La configuration peut être modifiée <a href="https://github.com/etalab/transport-site/blob/master/apps/transport/priv/gbfs_operators.csv">sur GitHub</a>.
+</p>
+
+<p>L’équipe transport.data.gouv.fr</p>

--- a/apps/transport/test/transport/jobs/oban_logger_test.exs
+++ b/apps/transport/test/transport/jobs/oban_logger_test.exs
@@ -41,13 +41,15 @@ defmodule Transport.Test.Transport.Jobs.ObanLoggerTest do
                max_attempts: 2
              )
 
-    assert_email_sent(
-      from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
-      to: "tech@transport.data.gouv.fr",
-      subject: "Échec de job Oban : Transport.Test.Transport.Jobs.ObanLoggerJobTag",
-      text_body:
-        "Un job Oban Transport.Test.Transport.Jobs.ObanLoggerJobTag vient d'échouer, il serait bien d'investiguer."
-    )
+    assert_email_sent(fn %Swoosh.Email{
+                           from: {"transport.data.gouv.fr", "contact@transport.data.gouv.fr"},
+                           to: [{"", "tech@transport.data.gouv.fr"}],
+                           subject: "Échec de job Oban : Transport.Test.Transport.Jobs.ObanLoggerJobTag",
+                           html_body: html
+                         } ->
+      assert html =~
+               "Un job Oban Transport.Test.Transport.Jobs.ObanLoggerJobTag vient d’échouer, il serait bien d’investiguer."
+    end)
   end
 
   test "oban default logger is set up for important components" do

--- a/apps/transport/test/transport_web/controllers/contact_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/contact_controller_test.exs
@@ -29,13 +29,15 @@ defmodule TransportWeb.ContactControllerTest do
 
     refute Phoenix.Flash.get(conn.assigns.flash, :info) =~ "🦊"
 
-    assert_email_sent(
-      from: {"PAN, Formulaire Contact", "contact@transport.data.gouv.fr"},
-      to: "contact@transport.data.gouv.fr",
-      subject: "dataset",
-      text_body: "User type: data-reuser\nQuestion type: other\n\nQuestion: where is my dataset?\n",
-      html_body: nil,
-      reply_to: "human@user.fr"
-    )
+    assert_email_sent(fn %Swoosh.Email{
+                           from: {"PAN, Formulaire Contact", "contact@transport.data.gouv.fr"},
+                           to: [{"", "contact@transport.data.gouv.fr"}],
+                           subject: "dataset",
+                           text_body: nil,
+                           html_body: html,
+                           reply_to: {"", "human@user.fr"}
+                         } ->
+      assert html =~ "where is my dataset?"
+    end)
   end
 end


### PR DESCRIPTION
Fixes #3951

Traite le second point de la liste.

> Bouger les mails texte dans des templates (.text.eex), et les fonctions helpers dans email_view.ex

Les e-mails admin sont désormais tous en HTML, il n'y a plus de contenu dans `AdminNotifier`.
