### PR TITLE
AutocompleteController : évite erreur 500

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/autocomplete_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/autocomplete_controller.ex
@@ -2,7 +2,7 @@ defmodule TransportWeb.API.AutocompleteController do
   use TransportWeb, :controller
   alias Helpers
   alias OpenApiSpex.Operation
-  import Ecto.{Query}
+  import Ecto.Query
 
   @spec open_api_operation(any) :: Operation.t()
   def open_api_operation(action), do: apply(__MODULE__, :"#{action}_operation", [])
@@ -38,10 +38,10 @@ defmodule TransportWeb.API.AutocompleteController do
     |> DB.Repo.all()
   end
 
-  @spec autocomplete(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def autocomplete(%Plug.Conn{} = conn, %{"q" => query}) do
+  @spec autocomplete(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def autocomplete(%Plug.Conn{} = conn, params) do
     query =
-      query
+      Map.get(params, "q", "")
       # we replace '-' to ' ' because we also did this transformation for indexed_name
       |> String.replace("-", " ")
       # we replace ' ' to '%' to search for composite name to be easily searchable


### PR DESCRIPTION
Visiblement des requêtes sont faites sans passer le paramètre `q`. Considérer que c'est une recherche vide alors.

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/7105976762/?environment=prod&project=6197733&query=is%3Aunresolved&referrer=issue-stream)
