### PR TITLE
Espace producteur : téléchargement des statistiques de ressources

### DIFF
--- a/apps/transport/lib/db/resource_monthly_metric.ex
+++ b/apps/transport/lib/db/resource_monthly_metric.ex
@@ -7,6 +7,7 @@ defmodule DB.ResourceMonthlyMetric do
   use Ecto.Schema
   use TypedEctoSchema
   import Ecto.Changeset
+  import Ecto.Query
 
   typed_schema "resource_monthly_metrics" do
     belongs_to(:resource, DB.Resource, foreign_key: :resource_datagouv_id, references: :datagouv_id, type: :string)
@@ -23,5 +24,28 @@ defmodule DB.ResourceMonthlyMetric do
     |> validate_required([:resource_datagouv_id, :year_month, :metric_name, :count])
     |> validate_format(:year_month, ~r/\A2\d{3}-(0[1-9]|1[012])\z/)
     |> validate_number(:count, greater_than_or_equal_to: 0)
+  end
+
+  def download_statistics(datasets) do
+    datagouv_ids =
+      datasets
+      |> Enum.flat_map(& &1.resources)
+      |> Enum.filter(&DB.Resource.hosted_on_datagouv?/1)
+      |> Enum.map(& &1.datagouv_id)
+
+    DB.Dataset.base_query()
+    |> DB.Resource.join_dataset_with_resource()
+    |> join(:inner, [resource: r], rmm in __MODULE__, on: rmm.resource_datagouv_id == r.datagouv_id, as: :rmm)
+    |> where([resource: r, rmm: rmm], r.datagouv_id in ^datagouv_ids and rmm.metric_name == :downloads)
+    |> select([dataset: d, resource: r, rmm: rmm], %{
+      year_month: rmm.year_month,
+      count: rmm.count,
+      dataset_title: d.custom_title,
+      resource_title: r.title,
+      dataset_datagouv_id: rmm.dataset_datagouv_id,
+      resource_datagouv_id: rmm.resource_datagouv_id
+    })
+    |> order_by([_, _, rmm], [rmm.year_month, rmm.resource_datagouv_id])
+    |> DB.Repo.all()
   end
 end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -105,6 +105,7 @@ defmodule TransportWeb.Router do
       pipe_through([:producer_space])
       get("/", PageController, :espace_producteur)
       get("/proxy_statistics", EspaceProducteurController, :proxy_statistics)
+      get("/download_statistics_csv", EspaceProducteurController, :download_statistics_csv)
 
       scope "/datasets" do
         get("/:dataset_id/edit", EspaceProducteurController, :edit_dataset)

--- a/apps/transport/test/db/resource_monthly_metric_test.exs
+++ b/apps/transport/test/db/resource_monthly_metric_test.exs
@@ -38,5 +38,80 @@ defmodule DB.ResourceMonthlyMetricTest do
                  year_month: "bar"
                })
     end
+
+    test "download_statistics" do
+      dataset = insert(:dataset, custom_title: "Title")
+
+      resource =
+        insert(:resource,
+          title: "GTFS",
+          url: "https://static.data.gouv.fr/url",
+          dataset: dataset,
+          datagouv_id: "a" <> Ecto.UUID.generate()
+        )
+
+      assert resource |> DB.Resource.hosted_on_datagouv?()
+
+      other_resource =
+        insert(:resource,
+          title: "GTFS 2",
+          url: "https://static.data.gouv.fr/url2",
+          dataset: dataset,
+          datagouv_id: "b" <> Ecto.UUID.generate()
+        )
+
+      assert other_resource |> DB.Resource.hosted_on_datagouv?()
+
+      insert(:resource_monthly_metric,
+        metric_name: :downloads,
+        dataset_datagouv_id: dataset.datagouv_id,
+        resource_datagouv_id: resource.datagouv_id,
+        count: 2,
+        year_month: "2025-12"
+      )
+
+      insert(:resource_monthly_metric,
+        metric_name: :downloads,
+        dataset_datagouv_id: dataset.datagouv_id,
+        resource_datagouv_id: resource.datagouv_id,
+        count: 3,
+        year_month: "2025-11"
+      )
+
+      insert(:resource_monthly_metric,
+        metric_name: :downloads,
+        dataset_datagouv_id: dataset.datagouv_id,
+        resource_datagouv_id: other_resource.datagouv_id,
+        count: 4,
+        year_month: "2025-11"
+      )
+
+      assert [dataset |> DB.Repo.preload(:resources)] |> DB.ResourceMonthlyMetric.download_statistics() == [
+               %{
+                 count: 3,
+                 dataset_title: "Title",
+                 resource_title: "GTFS",
+                 year_month: "2025-11",
+                 resource_datagouv_id: resource.datagouv_id,
+                 dataset_datagouv_id: dataset.datagouv_id
+               },
+               %{
+                 count: 4,
+                 dataset_title: "Title",
+                 resource_title: "GTFS 2",
+                 year_month: "2025-11",
+                 resource_datagouv_id: other_resource.datagouv_id,
+                 dataset_datagouv_id: dataset.datagouv_id
+               },
+               %{
+                 count: 2,
+                 dataset_title: "Title",
+                 resource_title: "GTFS",
+                 year_month: "2025-12",
+                 resource_datagouv_id: resource.datagouv_id,
+                 dataset_datagouv_id: dataset.datagouv_id
+               }
+             ]
+    end
   end
 end

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -292,6 +292,77 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
   end
 
+  describe "download_statistics_csv" do
+    test "requires authentication", %{conn: conn} do
+      conn |> get(espace_producteur_path(conn, :download_statistics_csv)) |> assert_redirects_to_info_page()
+    end
+
+    test "redirects when there is an error when fetching datasets", %{conn: conn} do
+      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> {:error, nil} end)
+
+      conn =
+        conn
+        |> init_test_session(%{current_user: %{}})
+        |> get(espace_producteur_path(conn, :download_statistics_csv))
+
+      assert redirected_to(conn, 302) == page_path(conn, :espace_producteur)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "Une erreur a eu lieu lors de la récupération de vos ressources"
+    end
+
+    test "renders successfully with a datagouv resource", %{conn: conn} do
+      dataset = insert(:dataset)
+      resource = insert(:resource, dataset: dataset, url: "https://static.data.gouv.fr/url", title: "GTFS.zip")
+
+      assert DB.Resource.hosted_on_datagouv?(resource)
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn _conn -> {:ok, %{"organizations" => [%{"id" => dataset.organization_id}]}} end)
+
+      insert(:resource_monthly_metric,
+        metric_name: :downloads,
+        dataset_datagouv_id: dataset.datagouv_id,
+        resource_datagouv_id: resource.datagouv_id,
+        count: 2,
+        year_month: "2025-12"
+      )
+
+      assert [dataset |> DB.Repo.preload(:resources)] |> DB.ResourceMonthlyMetric.download_statistics() == [
+               %{
+                 count: 2,
+                 dataset_title: dataset.custom_title,
+                 resource_title: resource.title,
+                 year_month: "2025-12",
+                 dataset_datagouv_id: dataset.datagouv_id,
+                 resource_datagouv_id: resource.datagouv_id
+               }
+             ]
+
+      response =
+        conn
+        |> init_test_session(%{current_user: %{}})
+        |> get(espace_producteur_path(conn, :download_statistics_csv))
+
+      assert response_content_type(response, :csv) == "text/csv; charset=utf-8"
+
+      assert Plug.Conn.get_resp_header(response, "content-disposition") == [
+               ~s(attachment; filename="download_statistics-#{Date.utc_today() |> Date.to_iso8601()}.csv")
+             ]
+
+      assert [response(response, 200)] |> CSV.decode!(headers: true) |> Enum.to_list() == [
+               %{
+                 "count" => "2",
+                 "dataset_datagouv_id" => dataset.datagouv_id,
+                 "dataset_title" => dataset.custom_title,
+                 "resource_datagouv_id" => resource.datagouv_id,
+                 "resource_title" => "GTFS.zip",
+                 "year_month" => "2025-12"
+               }
+             ]
+    end
+  end
+
   describe "resource_actions" do
     test "we can show the form of an existing resource", %{conn: conn} do
       conn = conn |> init_test_session(%{current_user: %{}})


### PR DESCRIPTION
Comme #5120, propose de télécharger des statistiques de téléchargements dans l'Espace Producteur pour les ressources hébergées sur data.gouv.fr.

Les statistiques sont affichées pour l'année en cours sur une page, dans #5131.

> [!NOTE]
> Un bouton de téléchargement sera ajouté à l'UI une fois que #5131 sera mergé.
