### PR TITLE
Contact : sauvegarde la locale en BDD

### DIFF
--- a/apps/transport/lib/db/contact.ex
+++ b/apps/transport/lib/db/contact.ex
@@ -29,6 +29,7 @@ defmodule DB.Contact do
     field(:phone_number, DB.Encrypted.Binary)
     field(:secondary_phone_number, DB.Encrypted.Binary)
     field(:last_login_at, :utc_datetime_usec)
+    field(:locale, :string)
 
     field(:creation_source, Ecto.Enum,
       values: [

--- a/apps/transport/priv/repo/migrations/20251220162908_contact_add_locale.exs
+++ b/apps/transport/priv/repo/migrations/20251220162908_contact_add_locale.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ContactAddLocale do
+  use Ecto.Migration
+
+  def change do
+    alter table(:contact) do
+      add(:locale, :string, default: "fr")
+    end
+  end
+end

--- a/apps/transport/test/transport_web/live_views/notifications_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/notifications_live_test.exs
@@ -210,10 +210,12 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
   test "displays an error message if we can’t retrieve user orgs (and thus datasets) through data.gouv.fr", %{
     conn: conn
   } do
+    contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
     Datagouvfr.Client.User.Mock
     |> expect(:me, fn _ -> {:error, %HTTPoison.Error{reason: :nxdomain, id: nil}} end)
 
-    conn = conn |> init_test_session(%{current_user: %{"id" => Ecto.UUID.generate()}, datagouv_token: %{}})
+    conn = conn |> init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}, datagouv_token: %{}})
     content = conn |> get(@producer_url) |> html_response(200)
     assert content =~ "Une erreur a eu lieu lors de la récupération de vos ressources"
   end


### PR DESCRIPTION
Enregistre la langue d'utilisation du PAN en BDD pour les personnes connectées dans `contact.locale`.

Ceci pourrait être utile pour envoyer des e-mails en FR et EN.
