### PR TITLE
EmailPreview : pouvoir envoyer depuis prévisualisation

### DIFF
--- a/apps/transport/lib/transport_web/live/backoffice/email_preview_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/email_preview_live.ex
@@ -112,12 +112,22 @@ defmodule TransportWeb.Backoffice.EmailPreviewLive do
   end
 
   @impl true
-  def handle_event("change", %{"search" => search} = params, %Phoenix.LiveView.Socket{} = socket) do
+  def handle_event(
+        "receive_selected_email",
+        _params,
+        %Phoenix.LiveView.Socket{assigns: %{selected_email: %Swoosh.Email{} = selected_email}} = socket
+      ) do
+    selected_email |> Transport.Mailer.deliver()
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("change", %{"search" => search}, %Phoenix.LiveView.Socket{} = socket) do
     {:noreply, socket |> push_patch(to: backoffice_live_path(socket, __MODULE__, search: search))}
   end
 
   @impl true
-  def handle_params(%{"search" => search} = params, _uri, socket) do
+  def handle_params(%{"search" => _} = params, _uri, socket) do
     {:noreply, socket |> filter_config(params)}
   end
 

--- a/apps/transport/lib/transport_web/live/backoffice/email_preview_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/email_preview_live.html.heex
@@ -27,7 +27,7 @@
             <a href="#preview" class="button-outline primary small" phx-click="see_email" phx-value-key_name={id}>
               <i class="fa-solid fa-magnifying-glass"></i> Voir
             </a>
-            <a href="#" class="button-outline primary small" phx-click="receive_email" phx-value-key_name={id}>
+            <a href="#" class="button-outline secondary small" phx-click="receive_email" phx-value-key_name={id}>
               <i class="fa-solid fa-envelope"></i> Recevoir
             </a>
           </td>
@@ -43,6 +43,9 @@
       <div class="">
         <h4><%= @selected_email.subject %></h4>
         <iframe id="iframe" srcdoc={@selected_email.html_body}></iframe>
+        <a href="#" class="mt-24 button-outline primary small" phx-click="receive_selected_email">
+          <i class="fa-solid fa-envelope"></i> Recevoir
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Ajoute un bouton depuis l'espace de prévisualisation pour envoyer l'e-mail
