### PR TITLE
ResourceUnavailableNotificationJob : rappel toutes les 24h lors d'indisponibilités

### DIFF
--- a/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_notification_job.ex
@@ -1,20 +1,93 @@
 defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
   @moduledoc """
-  Job in charge of sending notifications when a dataset has at least a resource
-  currently unavailable for at least 6 hours.
+  An Oban worker responsible for notifying contacts when dataset resources
+  experience prolonged downtime.
 
-  Notifications are sent at the dataset level and are sent again no sooner than
-  7 days apart (to avoid potential spamming).
+  ## Overview
+  This job monitors resource availability and sends email notifications to both
+  **producers** and **reusers** when a resource has been unavailable for a
+  significant period.
 
-  This job should be scheduled every 30 minutes because it looks at unavailabilities
-  that are ongoing since [6h00 ; 6h30].
+  ## Notification Logic
+  Notifications are triggered based on two main scenarios:
+  1.  **Initial Detection:** Triggered when a resource has been unavailable
+      for at least 6 hours.
+  2.  **Recurring Reminder:** If the resource remains unavailable, a follow-up
+      notification is sent every 24 hours.
+
+  ## Operational Details
+  * **Frequency:** This job should be scheduled to run every **30 minutes**.
+      It specifically looks for unavailabilities that started between `6h00`
+      and `6h30` ago to ensure no downtime window is missed.
+  * **Aggregation:** Notifications are grouped at the **Dataset** level.
+      If multiple resources in the same dataset are down, a single email listing
+      all affected resources is sent to each subscriber.
+  * **Retry Policy:** Performs up to 3 attempts in case of failure.
+  * **Smart Detection:** For producers, the job attempts to detect "delete and
+      recreate" patterns on `data.gouv.fr` to provide helpful feedback on
+      maintenance best practices.
+
+  ## Job Arguments
+  The job handles two types of execution based on the arguments provided:
+
+  ### 1. The Standard Scan (No Args)
+  When triggered without specific arguments (the default scheduled state),
+  it queries the database for `ResourceUnavailability` records that have
+  reached the 6-hour threshold.
+
+  ### 2. The Recurring Reminder (With Args)
+  When the job finishes an initial notification, it enqueues a *future* version
+  of itself containing:
+  * `dataset_id`: The ID of the affected dataset.
+  * `resource_ids`: List of IDs that were down.
+  * `hours_consecutive_downtime`: The cumulative downtime count (increments by 24).
   """
   use Oban.Worker, max_attempts: 3, tags: ["notifications"]
   import Ecto.Query
 
   @hours_consecutive_downtime 6
-  @nb_days_before_sending_notification_again 7
+  @nb_hours_before_sending_notification_again 24
   @notification_reason Transport.NotificationReason.reason(:resource_unavailable)
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        id: job_id,
+        args: %{
+          "dataset_id" => dataset_id,
+          "resource_ids" => resource_ids,
+          "hours_consecutive_downtime" => hours_consecutive_downtime
+        }
+      }) do
+    dataset = DB.Repo.get!(DB.Dataset, dataset_id) |> DB.Repo.preload(:resources)
+
+    dataset.resources
+    |> Enum.filter(fn %DB.Resource{id: resource_id, is_available: is_available} ->
+      not is_available and resource_id in resource_ids
+    end)
+    |> case do
+      [] ->
+        :ok
+
+      resources ->
+        producer_subscriptions = subscriptions(dataset, :producer)
+
+        send_to_producers(producer_subscriptions, dataset, resources,
+          job_id: job_id,
+          hours_consecutive_downtime: hours_consecutive_downtime
+        )
+
+        dataset
+        |> subscriptions(:reuser)
+        |> send_to_reusers(dataset, resources,
+          producer_warned: not Enum.empty?(producer_subscriptions),
+          job_id: job_id,
+          hours_consecutive_downtime: hours_consecutive_downtime
+        )
+
+        enqueue_next_job(dataset, resources, hours_consecutive_downtime + @nb_hours_before_sending_notification_again)
+        :ok
+    end
+  end
 
   @impl Oban.Worker
   def perform(%Oban.Job{id: job_id, inserted_at: %DateTime{} = inserted_at}) do
@@ -22,25 +95,45 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     |> relevant_unavailabilities()
     |> Enum.each(fn {%DB.Dataset{} = dataset, unavailabilities} ->
       producer_subscriptions = subscriptions(dataset, :producer)
-      send_to_producers(producer_subscriptions, dataset, unavailabilities, job_id: job_id)
+
+      send_to_producers(producer_subscriptions, dataset, unavailabilities,
+        job_id: job_id,
+        hours_consecutive_downtime: @hours_consecutive_downtime
+      )
+
+      enqueue_next_job(
+        dataset,
+        Enum.map(unavailabilities, & &1.resource),
+        @hours_consecutive_downtime + @nb_hours_before_sending_notification_again
+      )
 
       dataset
       |> subscriptions(:reuser)
       |> send_to_reusers(dataset, unavailabilities,
         producer_warned: not Enum.empty?(producer_subscriptions),
-        job_id: job_id
+        job_id: job_id,
+        hours_consecutive_downtime: @hours_consecutive_downtime
       )
     end)
   end
 
+  defp enqueue_next_job(%DB.Dataset{id: dataset_id}, resources, hours_consecutive_downtime) do
+    resource_ids = Enum.map(resources, & &1.id)
+
+    %{dataset_id: dataset_id, resource_ids: resource_ids, hours_consecutive_downtime: hours_consecutive_downtime}
+    |> new(schedule_in: @nb_hours_before_sending_notification_again * 60 * 60)
+    |> Oban.insert!()
+  end
+
   defp send_to_reusers(subscriptions, %DB.Dataset{} = dataset, unavailabilities,
          producer_warned: producer_warned,
-         job_id: job_id
+         job_id: job_id,
+         hours_consecutive_downtime: hours_consecutive_downtime
        ) do
-    Enum.each(subscriptions, fn subscription ->
+    Enum.each(subscriptions, fn %DB.NotificationSubscription{} = subscription ->
       send_mail(subscription,
         dataset: dataset,
-        hours_consecutive_downtime: @hours_consecutive_downtime,
+        hours_consecutive_downtime: hours_consecutive_downtime,
         producer_warned: producer_warned,
         resource_titles: Enum.map_join(unavailabilities, ", ", &resource_title/1),
         unavailabilities: unavailabilities,
@@ -49,11 +142,14 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     end)
   end
 
-  defp send_to_producers(subscriptions, %DB.Dataset{} = dataset, unavailabilities, job_id: job_id) do
-    Enum.each(subscriptions, fn subscription ->
+  defp send_to_producers(subscriptions, %DB.Dataset{} = dataset, unavailabilities,
+         job_id: job_id,
+         hours_consecutive_downtime: hours_consecutive_downtime
+       ) do
+    Enum.each(subscriptions, fn %DB.NotificationSubscription{} = subscription ->
       send_mail(subscription,
         dataset: dataset,
-        hours_consecutive_downtime: @hours_consecutive_downtime,
+        hours_consecutive_downtime: hours_consecutive_downtime,
         deleted_recreated_on_datagouv: deleted_and_recreated_resource_hosted_on_datagouv(dataset, unavailabilities),
         resource_titles: Enum.map_join(unavailabilities, ", ", &resource_title/1),
         unavailabilities: unavailabilities,
@@ -75,10 +171,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     unavailabilities = Keyword.fetch!(args, :unavailabilities)
 
     DB.Notification.insert!(dataset, subscription, %{
-      resource_ids:
-        Enum.map(unavailabilities, fn %DB.ResourceUnavailability{resource: %DB.Resource{id: resource_id}} ->
-          resource_id
-        end),
+      resource_ids: Enum.map(unavailabilities, &resource_id/1),
       producer_warned: Keyword.fetch!(args, :producer_warned),
       hours_consecutive_downtime: Keyword.fetch!(args, :hours_consecutive_downtime),
       job_id: Keyword.fetch!(args, :job_id)
@@ -90,10 +183,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     unavailabilities = Keyword.fetch!(args, :unavailabilities)
 
     DB.Notification.insert!(dataset, subscription, %{
-      resource_ids:
-        Enum.map(unavailabilities, fn %DB.ResourceUnavailability{resource: %DB.Resource{id: resource_id}} ->
-          resource_id
-        end),
+      resource_ids: Enum.map(unavailabilities, &resource_id/1),
       deleted_recreated_on_datagouv: Keyword.fetch!(args, :deleted_recreated_on_datagouv),
       hours_consecutive_downtime: Keyword.fetch!(args, :hours_consecutive_downtime),
       job_id: Keyword.fetch!(args, :job_id)
@@ -108,6 +198,8 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
   - a resource hosted on datagouv is unavailable (ie it was deleted)
   - call the API now and see that a resource hosted on datagouv has been created recently
   """
+  def deleted_and_recreated_resource_hosted_on_datagouv(%DB.Dataset{} = dataset, [%DB.Resource{} | _]), do: false
+
   def deleted_and_recreated_resource_hosted_on_datagouv(%DB.Dataset{} = dataset, unavailabilities) do
     hosted_on_datagouv = Enum.any?(unavailabilities, &DB.Resource.hosted_on_datagouv?(&1.resource))
     hosted_on_datagouv and created_resource_hosted_on_datagouv_recently?(dataset)
@@ -160,7 +252,7 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
   end
 
   def email_addresses_already_sent(%DB.Dataset{id: dataset_id}) do
-    datetime_limit = DateTime.utc_now() |> DateTime.add(-@nb_days_before_sending_notification_again, :day)
+    datetime_limit = DateTime.utc_now() |> DateTime.add(-@nb_hours_before_sending_notification_again, :hour)
 
     DB.Notification
     |> where([n], n.inserted_at >= ^datetime_limit and n.dataset_id == ^dataset_id and n.reason == @notification_reason)
@@ -169,7 +261,9 @@ defmodule Transport.Jobs.ResourceUnavailableNotificationJob do
     |> DB.Repo.all()
   end
 
-  defp resource_title(%DB.ResourceUnavailability{resource: %DB.Resource{title: title}}) do
-    title
-  end
+  defp resource_id(%DB.Resource{id: id}), do: id
+  defp resource_id(%DB.ResourceUnavailability{resource: %DB.Resource{id: id}}), do: id
+
+  defp resource_title(%DB.Resource{title: title}), do: title
+  defp resource_title(%DB.ResourceUnavailability{resource: %DB.Resource{title: title}}), do: title
 end


### PR DESCRIPTION
Modifie `ResourceUnavailableNotificationJob` pour envoyer des rappels de notification toutes les 24 heures, si au moins une ressource reste indisponible.

On continue de prévenir les producteurs et les réutilisateurs.