### PR TITLE
DatasetController : gère nil versions pour GBFS

### DIFF
--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -138,7 +138,7 @@
         </div>
       <% end %>
       <%= if Resource.gbfs?(@resource) do %>
-        <%= for version <- validation |> get_metadata_info("versions", []) do %>
+        <%= for version <- validation |> get_metadata_info("versions", []) || [] do %>
           <a href={gbfs_documentation_link(version)} target="_blank">
             <span class="label version">
               <%= dgettext("page-dataset-details", "Version %{version}", version: version) %>

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -341,14 +341,15 @@ defmodule TransportWeb.DatasetControllerTest do
       validator: Transport.Validators.GBFSValidator.validator_name(),
       result: result,
       digest: digest,
-      metadata: %{metadata: %{}}
+      metadata: %DB.ResourceMetadata{metadata: %{"versions" => nil, "ttl" => 60}}
     )
 
     mock_empty_history_resources()
 
-    conn = conn |> get(dataset_path(conn, :details, dataset.slug))
+    content = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
 
-    assert conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
+    assert content |> extract_resource_details() =~ "1 erreur"
+    assert content |> extract_resource_details() =~ "60s"
   end
 
   test "show number of errors when validated with the MobilityData validator", %{conn: conn} do


### PR DESCRIPTION
Corrige une erreur 500 sur la page d'un jeu de données.

[Voir Sentry](https://transport-data-gouv-fr.sentry.io/issues/6754635147/)
