### PR TITLE
Espace producteur : validation d'un GTFS lors de la mise à jour

### DIFF
--- a/apps/transport/lib/db/user_feedback.ex
+++ b/apps/transport/lib/db/user_feedback.ex
@@ -10,7 +10,8 @@ defmodule DB.UserFeedback do
     :gtfs_stops,
     :on_demand_validation,
     :gbfs_validation,
-    :reuser_space
+    :reuser_space,
+    :producer_space
   ]
 
   @ratings [:like, :neutral, :dislike]

--- a/apps/transport/lib/transport_web/live/validate_resource_live.ex
+++ b/apps/transport/lib/transport_web/live/validate_resource_live.ex
@@ -1,0 +1,251 @@
+defmodule TransportWeb.Live.ValidateResourceLive do
+  @moduledoc """
+  A LiveView component for on-demand validation of GTFS files.
+
+  This module provides an interactive interface for users to upload a `.zip` file,
+  monitor its upload progress, and receive real-time feedback on its validity
+  based on transit industry standards.
+
+  ## Features
+
+  * **Drag-and-Drop Upload**: Supports file selection via a styled drop zone using `Phoenix.LiveView.allow_upload/3`.
+  * **Async Processing**: Upon successful upload, files are streamed to S3 and a background validation job (via Oban) is dispatched.
+  * **Real-time Status Polling**: Uses `handle_info/2` to poll the database for updates on the `MultiValidation` state, switching from a loading spinner to a result report once completed.
+  * **Validation Reporting**: Displays high-level status (Success/Error) and provides a link to a detailed validation report, including metadata like feed validity periods.
+
+  ## Workflow
+
+  1.  **Mount**: Initializes the upload configuration and resets the state.
+  2.  **Upload**: User drops a file. `handle_progress/3` triggers once the upload is `done?`.
+  3.  **Job Dispatch**: The file is stored on S3, a `DB.MultiValidation` record is created with a `waiting` state, and an `OnDemandValidationJob` is queued.
+  4.  **Polling**: The view enters a polling loop (every 1 second) until the background job updates the state to `completed`.
+  5.  **Result**: The UI displays the validation outcome. Users can click "Start again" to reset the process.
+
+  ## Internal State
+
+  * `@show_upload`: Boolean. Toggles between the upload form and the validation result/loader.
+  * `@multi_validation`: The `%DB.MultiValidation{}` struct tracking the job status and errors.
+  * `@uploaded_filename`: The original name of the client-side file.
+  * `@uploaded_path`: The temporary path of the file on the server.
+  """
+  use Phoenix.LiveView
+  use Gettext, backend: TransportWeb.Gettext
+  import TransportWeb.Router.Helpers
+  import TransportWeb.DatasetView, only: [outdated_class: 1, empty_to_nil: 1]
+
+  def render(assigns) do
+    ~H"""
+    <div :if={@show_upload}>
+      <div id="gtfs-diff-input" phx-drop-target={@uploads.gtfs.ref}>
+        <form id="upload-form" class="pb-12" phx-change="validate">
+          <.upload_drop_zone uploads={@uploads} />
+        </form>
+      </div>
+
+      <section phx-drop-target={@uploads.gtfs.ref}>
+        <article :for={entry <- @uploads.gtfs.entries} class="upload-entry">
+          <div class="entry-name">
+            <.icon :if={entry.valid?} class="fa fa-square-check" title={dgettext("gtfs-diff", "Valid file")} />
+            <.icon :if={not entry.valid?} class="fa fa-square-xmark" title={dgettext("gtfs-diff", "Invalid file")} />
+            <%= entry.client_name %>
+          </div>
+          <div class="progress-bar">
+            <progress value={entry.progress} max="100"><%= entry.progress %>%</progress>
+            <button
+              type="button"
+              phx-click="cancel-upload"
+              phx-value-ref={entry.ref}
+              title={dgettext("gtfs-diff", "Cancel upload or remove file")}
+              aria-label={dgettext("gtfs-diff", "Cancel upload or remove file")}
+            >
+              <i class="fa fa-xmark"></i>
+            </button>
+          </div>
+        </article>
+      </section>
+    </div>
+    <div :if={@multi_validation}>
+      <p>
+        <%= Phoenix.HTML.raw(dgettext("espace-producteurs", "File: <strong>%{name}</strong>", name: @uploaded_filename)) %>
+      </p>
+      <.validation_status multi_validation={@multi_validation} locale={@locale} />
+      <a
+        class="button-outline primary small"
+        target="_blank"
+        href={validation_path(@socket, :show, @multi_validation.id, token: @multi_validation.oban_args["secret_url_token"])}
+      >
+        <i class="icon fa fa-pen-to-square"></i><%= dgettext("espace-producteurs", "See the validation report") %>
+      </a>
+    </div>
+    <input type="hidden" name="resource_file[filename]" value={@uploaded_filename} />
+    <input type="hidden" name="resource_file[path]" value={@uploaded_path} />
+    """
+  end
+
+  defp upload_drop_zone(%{uploads: _} = assigns) do
+    ~H"""
+    <div class="drop-zone section-grey">
+      <label for={@uploads.gtfs.ref}>
+        <i class="fa fa-upload" aria-hidden="true"></i>
+        <span>
+          <%= dgettext("espace-producteurs", "Drop your GTFS file here or click to browse your local drive") %>
+        </span>
+      </label>
+      <.live_file_input upload={@uploads.gtfs} />
+    </div>
+    """
+  end
+
+  defp icon(%{title: _, class: _} = assigns) do
+    ~H"""
+    <i class={@class} title={@title} aria-label={@title}></i>
+    """
+  end
+
+  defp validation_status(
+         %{multi_validation: %DB.MultiValidation{oban_args: %{"state" => "completed"}, max_error: max_error}} = assigns
+       )
+       when max_error in ["Warning", "Information", "NoError"] do
+    ~H"""
+    <p class="notification success">
+      <%= dgettext("espace-producteurs", "No errors") %>
+      <% start_date = @multi_validation |> DB.MultiValidation.get_metadata_info("start_date") |> empty_to_nil() %>
+      <% end_date = @multi_validation |> DB.MultiValidation.get_metadata_info("end_date") |> empty_to_nil() %>
+      <% gtfs_outdated? = Transport.Validators.GTFSTransport.gtfs_outdated?(@multi_validation) %>
+      <%= if start_date && end_date do %>
+        <div title={dgettext("page-dataset-details", "Validity period")}>
+          <i class="icon icon--calendar-alt" aria-hidden="true"></i>
+          <span><%= start_date |> Shared.DateTimeDisplay.format_date(@locale) %></span>
+          <i class="icon icon--right-arrow ml-05-em" aria-hidden="true"></i>
+          <span class={outdated_class(gtfs_outdated?)}><%= end_date |> Shared.DateTimeDisplay.format_date(@locale) %></span>
+        </div>
+      <% end %>
+    </p>
+    """
+  end
+
+  defp validation_status(
+         %{multi_validation: %DB.MultiValidation{oban_args: %{"state" => "completed"}, max_error: max_error}} = assigns
+       )
+       when max_error in ["Fatal", "Error"] do
+    ~H"""
+    <p class="notification error">
+      <%= dgettext("espace-producteurs", "Invalid file") %>
+    </p>
+    <a phx-click="start_again" class="button-outline warning small mr-24">
+      <i class="icon fa fa-rotate"></i>
+      <%= dgettext("espace-producteurs", "Start again") %>
+    </a>
+    """
+  end
+
+  defp validation_status(%{} = assigns) do
+    ~H"""
+    <div class="loader_container">
+      <div class="loader"></div>
+    </div>
+    """
+  end
+
+  def mount(_params, %{"locale" => locale}, socket) do
+    {:ok,
+     socket
+     |> assign(:locale, locale)
+     |> reset_state()
+     |> allow_upload(:gtfs, accept: ~w(.zip), max_entries: 1, auto_upload: true, progress: &handle_progress/3)}
+  end
+
+  defp reset_state(socket) do
+    socket
+    |> assign(:show_upload, true)
+    |> assign(:multi_validation, nil)
+    |> assign(:uploaded_filename, nil)
+    |> assign(:uploaded_path, nil)
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("start_again", _params, socket) do
+    {:noreply, socket |> reset_state()}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :gtfs, ref)}
+  end
+
+  defp handle_progress(:gtfs, entry, socket) do
+    if entry.done? do
+      [{multi_validation, path, client_name}] =
+        consume_uploaded_entries(socket, :gtfs, fn %{path: path},
+                                                   %Phoenix.LiveView.UploadEntry{client_name: client_name} ->
+          filename = Ecto.UUID.generate()
+          stream_to_s3(path, filename)
+
+          multi_validation = create_multi_validation(filename)
+
+          dispatch_validation_job(multi_validation)
+
+          destination = System.tmp_dir!() <> filename
+          File.cp!(path, destination)
+
+          {:ok, {multi_validation, destination, client_name}}
+        end)
+
+      schedule_next_update()
+
+      {:noreply,
+       assign(socket, %{
+         multi_validation: multi_validation,
+         uploaded_path: path,
+         uploaded_filename: client_name,
+         show_upload: false
+       })}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(:update_data, socket) do
+    multi_validation = DB.Repo.reload!(socket.assigns.multi_validation) |> DB.Repo.preload(:metadata)
+
+    if multi_validation.oban_args["state"] == "waiting" do
+      schedule_next_update()
+    end
+
+    {:noreply, assign(socket, multi_validation: multi_validation)}
+  end
+
+  defp schedule_next_update do
+    Process.send_after(self(), :update_data, 1_000)
+  end
+
+  defp create_multi_validation(filename) do
+    %DB.MultiValidation{
+      validator: "on demand validation requested",
+      validation_timestamp: DateTime.utc_now(),
+      oban_args: %{
+        "type" => "gtfs",
+        "state" => "waiting",
+        "filename" => filename,
+        "permanent_url" => Transport.S3.permanent_url(:on_demand_validation, filename),
+        "secret_url_token" => Ecto.UUID.generate()
+      },
+      validated_data_name: filename
+    }
+    |> DB.Repo.insert!()
+  end
+
+  defp dispatch_validation_job(%DB.MultiValidation{id: id, oban_args: oban_args}) do
+    oban_args |> Map.merge(%{"id" => id}) |> Transport.Jobs.OnDemandValidationJob.new() |> Oban.insert!()
+  end
+
+  defp stream_to_s3(local_filepath, path) do
+    Transport.S3.stream_to_s3!(:on_demand_validation, local_filepath, path, acl: :public_read)
+  end
+end

--- a/apps/transport/lib/transport_web/templates/espace_producteur/delete_resource_confirmation.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/delete_resource_confirmation.html.heex
@@ -30,3 +30,9 @@
     <% end %>
   </div>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/download_statistics.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/download_statistics.html.heex
@@ -45,3 +45,9 @@
     </div>
   </div>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
@@ -126,3 +126,9 @@
     </div>
   </div>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/proxy_statistics.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/proxy_statistics.html.heex
@@ -41,3 +41,9 @@
     </div>
   </div>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/resource_form.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/resource_form.html.heex
@@ -1,4 +1,8 @@
 <% new_resource = is_nil(@datagouv_resource) %>
+<% resource =
+  Enum.find_value(@dataset.resources, fn resource ->
+    if resource.datagouv_id == @datagouv_resource["id"], do: resource
+  end) %>
 <div class="add-update-resource">
   <section class="container pt-48 pb-24">
     <%= if new_resource do %>
@@ -61,7 +65,7 @@
                 label: dgettext("espace-producteurs", "Format"),
                 value: @datagouv_resource["format"]
               ) %>
-              <div class="pt-48">
+              <div class="pt-24">
                 <%= if new_resource do %>
                   <%= render("_upload_file.html", datagouv_resource: @datagouv_resource, f: f, conn: @conn) %>
                   <div class="choose-or">
@@ -75,7 +79,11 @@
                   <%= if remote?(@datagouv_resource) do %>
                     <%= render("_specify_url.html", datagouv_resource: @datagouv_resource, f: f, conn: @conn) %>
                   <% else %>
-                    <%= render("_upload_file.html", datagouv_resource: @datagouv_resource, f: f, conn: @conn) %>
+                    <%= if DB.Resource.gtfs?(resource) do %>
+                      <%= live_render(@conn, TransportWeb.Live.ValidateResourceLive, session: %{}) %>
+                    <% else %>
+                      <%= render("_upload_file.html", datagouv_resource: @datagouv_resource, f: f, conn: @conn) %>
+                    <% end %>
                   <% end %>
                   <div class="choose-submit pt-24">
                     <%= submit(dgettext("espace-producteurs", "Update the resource"), class: "button primary") %>
@@ -134,3 +142,9 @@
     </div>
   </section>
 </div>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/reuser_improved_data.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/reuser_improved_data.html.heex
@@ -52,3 +52,9 @@
     </table>
   </div>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
+++ b/apps/transport/lib/transport_web/templates/page/espace_producteur.html.heex
@@ -144,3 +144,9 @@
     </div>
   </section>
 </section>
+<section class="section section-white">
+  <%= live_render(@conn, TransportWeb.Live.FeedbackLive,
+    id: "feedback-form",
+    session: %{"feature" => "producer_space"}
+  ) %>
+</section>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -346,3 +346,27 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Download download statistics"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "File: <strong>%{name}</strong>"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid file"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No errors"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See the validation report"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Drop your GTFS file here or click to browse your local drive"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Start again"
+msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -345,3 +345,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Download download statistics"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "File: <strong>%{name}</strong>"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Invalid file"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No errors"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "See the validation report"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Drop your GTFS file here or click to browse your local drive"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Start again"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -346,3 +346,27 @@ msgstr "Vous trouverez ci-dessous les statistiques du proxy pour vos ressources.
 #, elixir-autogen, elixir-format
 msgid "Download download statistics"
 msgstr "Télécharger les statistiques de téléchargements"
+
+#, elixir-autogen, elixir-format
+msgid "File: <strong>%{name}</strong>"
+msgstr "Fichier : <strong>%{name}</strong>"
+
+#, elixir-autogen, elixir-format
+msgid "Invalid file"
+msgstr "Fichier invalide"
+
+#, elixir-autogen, elixir-format
+msgid "No errors"
+msgstr "Pas d'erreurs"
+
+#, elixir-autogen, elixir-format
+msgid "See the validation report"
+msgstr "Voir le rapport de validation"
+
+#, elixir-autogen, elixir-format
+msgid "Drop your GTFS file here or click to browse your local drive"
+msgstr "Glissez un fichier GTFS ici ou cliquez pour parcourir vos répertoires locaux"
+
+#, elixir-autogen, elixir-format
+msgid "Start again"
+msgstr "Essayer à nouveau"

--- a/apps/transport/test/transport_web/live_views/validate_resource_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/validate_resource_live_test.exs
@@ -1,0 +1,221 @@
+defmodule Transport.TransportWeb.Live.ValidateResourceLiveTest do
+  use TransportWeb.ConnCase, async: true
+  use Oban.Testing, repo: DB.Repo
+  import Phoenix.LiveViewTest
+
+  @gtfs_path "#{__DIR__}/../../fixture/files/gtfs.zip"
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  test "success case for a GTFS", %{conn: conn} do
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.Live.ValidateResourceLive, session: %{"locale" => "fr"})
+
+    assert [
+             {"input",
+              [
+                {"id", _},
+                {"type", "file"},
+                {"name", "gtfs"},
+                {"accept", ".zip"},
+                {"data-phx-hook", "Phoenix.LiveFileUpload"},
+                {"data-phx-update", "ignore"},
+                {"data-phx-upload-ref", _},
+                {"data-phx-active-refs", ""},
+                {"data-phx-done-refs", ""},
+                {"data-phx-preflighted-refs", ""},
+                {"data-phx-auto-upload", "data-phx-auto-upload"}
+              ], []}
+           ] = render(view) |> Floki.parse_document!() |> Floki.find(~s|input[type="file"]|)
+
+    Transport.Test.S3TestUtils.s3_mock_stream_file(
+      start_path: "",
+      bucket: "transport-data-gouv-fr-on-demand-validation-test"
+    )
+
+    content = upload_file(view)
+
+    # Loading state
+    assert_loading_state(content)
+
+    # Validation has been created
+    assert [
+             %DB.MultiValidation{
+               oban_args: %{
+                 "filename" => filename,
+                 "permanent_url" => permanent_url,
+                 "secret_url_token" => _,
+                 "state" => "waiting",
+                 "type" => "gtfs"
+               }
+             } = multi_validation
+           ] = DB.Repo.all(DB.MultiValidation)
+
+    assert permanent_url == Transport.S3.permanent_url(:on_demand_validation, filename)
+
+    # Job has been enqueued
+    oban_args = Map.put(multi_validation.oban_args, "id", multi_validation.id)
+
+    assert [
+             %Oban.Job{
+               state: "available",
+               args: ^oban_args,
+               queue: "on_demand_validation",
+               worker: "Transport.Jobs.OnDemandValidationJob"
+             }
+           ] = all_enqueued()
+
+    # Update the validation to mimick success
+    multi_validation
+    |> DB.Repo.preload(:metadata)
+    |> Ecto.Changeset.change(%{
+      oban_args: Map.put(multi_validation.oban_args, "state", "completed"),
+      max_error: "Warning",
+      metadata: %DB.ResourceMetadata{metadata: %{"start_date" => "2025-12-01", "end_date" => "2025-12-31"}}
+    })
+    |> DB.Repo.update!()
+
+    send(view.pid, :update_data)
+    content = render(view) |> Floki.parse_document!()
+
+    # Success is displayed
+    assert [
+             {
+               "p",
+               [{"class", "notification success"}],
+               [
+                 "\n  Pas d'erreurs\n  \n  \n  \n  \n    ",
+                 _
+               ]
+             }
+           ] = content |> Floki.find(".notification")
+
+    # Validity period is displayed
+    assert content |> Floki.find(~s|[title="Période de validité"]|) == [
+             {"div", [{"title", "Période de validité"}],
+              [
+                {"i", [{"class", "icon icon--calendar-alt"}, {"aria-hidden", "true"}], []},
+                {"span", [], ["01/12/2025"]},
+                {"i", [{"class", "icon icon--right-arrow ml-05-em"}, {"aria-hidden", "true"}], []},
+                {"span", [{"class", ""}], ["31/12/2025"]}
+              ]}
+           ]
+
+    # Link to see the validation report
+    assert_validation_report_link(content, multi_validation)
+
+    # Hidden inputs are present
+    assert [
+             {"input", [{"type", "hidden"}, {"name", "resource_file[filename]"}, {"value", "gtfs.zip"}], []},
+             {"input", [{"type", "hidden"}, {"name", "resource_file[path]"}, {"value", _}], []}
+           ] = content |> Floki.find("input")
+  end
+
+  test "error case for a GTFS", %{conn: conn} do
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.Live.ValidateResourceLive, session: %{"locale" => "fr"})
+
+    Transport.Test.S3TestUtils.s3_mock_stream_file(
+      start_path: "",
+      bucket: "transport-data-gouv-fr-on-demand-validation-test"
+    )
+
+    content = upload_file(view)
+
+    # Loading state
+    assert_loading_state(content)
+
+    # Validation has been created
+    assert [
+             %DB.MultiValidation{
+               oban_args: %{
+                 "filename" => filename,
+                 "permanent_url" => permanent_url,
+                 "secret_url_token" => _,
+                 "state" => "waiting",
+                 "type" => "gtfs"
+               }
+             } = multi_validation
+           ] = DB.Repo.all(DB.MultiValidation)
+
+    assert permanent_url == Transport.S3.permanent_url(:on_demand_validation, filename)
+
+    # Job has been enqueued
+    oban_args = Map.put(multi_validation.oban_args, "id", multi_validation.id)
+
+    assert [
+             %Oban.Job{
+               state: "available",
+               args: ^oban_args,
+               queue: "on_demand_validation",
+               worker: "Transport.Jobs.OnDemandValidationJob"
+             }
+           ] = all_enqueued()
+
+    # Update the validation to mimick an error
+    multi_validation
+    |> DB.Repo.preload(:metadata)
+    |> Ecto.Changeset.change(%{
+      oban_args: Map.put(multi_validation.oban_args, "state", "completed"),
+      max_error: "Error",
+      metadata: %DB.ResourceMetadata{metadata: %{"start_date" => "2025-12-01", "end_date" => "2025-12-31"}}
+    })
+    |> DB.Repo.update!()
+
+    send(view.pid, :update_data)
+    content = render(view) |> Floki.parse_document!()
+
+    # Error state is displayed
+    assert [{"p", [{"class", "notification error"}], ["\n  Fichier invalide\n"]}] =
+             content |> Floki.find(".notification")
+
+    # Can start again
+    assert content |> Floki.find(~s|[phx-click="start_again"]|) == [
+             {"a", [{"phx-click", "start_again"}, {"class", "button-outline warning small mr-24"}],
+              [{"i", [{"class", "icon fa fa-rotate"}], []}, "\n  Essayer à nouveau\n"]}
+           ]
+
+    # Link to see the validation report
+    assert_validation_report_link(content, multi_validation)
+
+    # Click on "Start again"
+    view |> element(~s|[phx-click="start_again"]|) |> render_click()
+
+    refute view |> has_element?(".notification")
+    assert view |> has_element?(~s|input[type="file"|)
+  end
+
+  defp assert_validation_report_link(content, %DB.MultiValidation{
+         id: id,
+         oban_args: %{"secret_url_token" => secret_url_token}
+       }) do
+    assert content |> Floki.find(".button-outline.primary") == [
+             {"a",
+              [
+                {"class", "button-outline primary small"},
+                {"target", "_blank"},
+                {"href", validation_path(TransportWeb.Endpoint, :show, id, token: secret_url_token)}
+              ], [{"i", [{"class", "icon fa fa-pen-to-square"}], []}, "Voir le rapport de validation\n  "]}
+           ]
+  end
+
+  defp assert_loading_state(content) do
+    assert content =~ "Fichier : <strong>gtfs.zip</strong>"
+
+    assert content |> Floki.parse_document!() |> Floki.find(".loader_container") == [
+             {"div", [{"class", "loader_container"}], [{"div", [{"class", "loader"}], []}]}
+           ]
+  end
+
+  defp upload_file(%Phoenix.LiveViewTest.View{} = view) do
+    file_input(view, "#upload-form", :gtfs, [
+      %{
+        name: "gtfs.zip",
+        content: File.read!(@gtfs_path)
+      }
+    ])
+    |> render_upload("gtfs.zip")
+  end
+end


### PR DESCRIPTION
Modifie l'espace producteur pour que quand on met à jour une ressource GTFS on propose la validation de celle-ci avant la mise à jour de la ressource.


https://github.com/user-attachments/assets/551507c6-0c98-442e-8523-38617eb0cad3


