### PR TITLE
Espace producteur : affichage de la validité

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -43,3 +43,7 @@
     padding-right: 12px;
   }
 }
+
+.no-underline a {
+  text-decoration: none;
+}

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -102,18 +102,12 @@
   <% end %>
 
   <%= unless Resource.gtfs?(@resource) or Resource.netex?(@resource) do %>
-    <%= if multi_validation_performed?(validation) do %>
-      <% nb_warnings = warnings_count(validation) %>
-      <% nb_errors = errors_count(validation) %>
-      <%= render(TransportWeb.DatasetView, "_resource_validation_summary.html",
-        conn: @conn,
-        resource: @resource,
-        validation: validation,
-        nb_warnings: nb_warnings,
-        nb_errors: nb_errors,
-        locale: @locale
-      ) %>
-    <% end %>
+    <%= render(TransportWeb.DatasetView, "_resource_validation_summary.html",
+      conn: @conn,
+      resource: @resource,
+      validation: validation,
+      locale: @locale
+    ) %>
   <% end %>
 
   <div class="resource-panel-bottom">

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary.html.heex
@@ -1,19 +1,23 @@
-<%= unless is_nil(@nb_errors) and is_nil(@nb_warnings) do %>
-  <div class="pb-24">
-    <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
-    <a href={link} target="_blank">
-      <span class={summary_class(@validation)}>
-        <%= if @nb_errors + (@nb_warnings || 0) == 0 do %>
-          <%= dgettext("page-dataset-details", "No error detected") %>
-        <% end %>
-        <%= if @nb_errors == 0 and is_integer(@nb_warnings) and @nb_warnings > 0 do %>
-          <%= "#{format_number(@nb_warnings, locale: @locale)} #{dpngettext("validations", "warnings", "warning", "warnings", @nb_warnings)}" %>
-        <% end %>
-        <%= if @nb_errors > 0 do %>
-          <%= "#{format_number(@nb_errors, locale: @locale)} #{dpngettext("validations", "errors", "error", "errors", @nb_errors)}" %>
-        <% end %>
-      </span>
-    </a>
-    <span><%= dgettext("page-dataset-details", "during validation") %></span>
-  </div>
+<%= if multi_validation_performed?(@validation) do %>
+  <% nb_warnings = warnings_count(@validation) %>
+  <% nb_errors = errors_count(@validation) %>
+  <%= unless is_nil(nb_errors) and is_nil(nb_warnings) do %>
+    <div class="pb-24">
+      <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
+      <a href={link}>
+        <span class={summary_class(@validation)}>
+          <%= if nb_errors + (nb_warnings || 0) == 0 do %>
+            <%= dgettext("page-dataset-details", "No error detected") %>
+          <% end %>
+          <%= if nb_errors == 0 and is_integer(nb_warnings) and nb_warnings > 0 do %>
+            <%= "#{format_number(nb_warnings, locale: @locale)} #{dpngettext("validations", "warnings", "warning", "warnings", nb_warnings)}" %>
+          <% end %>
+          <%= if nb_errors > 0 do %>
+            <%= "#{format_number(nb_errors, locale: @locale)} #{dpngettext("validations", "errors", "error", "errors", nb_errors)}" %>
+          <% end %>
+        </span>
+      </a>
+      <span><%= dgettext("page-dataset-details", "during validation") %></span>
+    </div>
+  <% end %>
 <% end %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_gtfs.html.heex
@@ -9,7 +9,7 @@
     <% link = resource_path(@conn, :details, @resource.id) <> "#validation-report" %>
     <% %{"max_level" => severity, "worst_occurrences" => count} = @validation.digest["max_severity"] %>
     <a href={link}>
-      <span class={summary_class(%{severity: severity, count_errors: count})}>
+      <span class={summary_class(@validation)}>
         <%= if validator.no_error?(severity) do %>
           <%= dgettext("page-dataset-details", "No error detected") %>
         <% else %>

--- a/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource_validation_summary_netex.html.heex
@@ -4,7 +4,7 @@
     <% results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(@validation.validator_version) %>
     <% %{"max_level" => severity, "worst_occurrences" => count} = @validation.digest["max_severity"] %>
     <a href={link}>
-      <span class={summary_class(%{severity: String.capitalize(severity), count_errors: count})}>
+      <span class={summary_class(@validation)}>
         <%= if results_adapter.no_error?(severity) do %>
           <%= dgettext("page-dataset-details", "No error detected") %>
         <% else %>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/edit_dataset.html.heex
@@ -44,7 +44,13 @@
                 fn %DB.Resource{datagouv_id: resource_datagouv_id} = db_resource ->
                   if resource["id"] == resource_datagouv_id, do: db_resource
                 end
-              ) %>
+              )
+
+            validation =
+              case db_resource do
+                %DB.Resource{} -> @latest_validation[db_resource.id] |> hd()
+                _ -> nil
+              end %>
             <tr>
               <td>
                 <%= resource["title"] %> <span :if={db_resource} class="label"><%= db_resource.format %></span>
@@ -52,9 +58,35 @@
               <td data-name="validity-dates">
                 <TransportWeb.DatasetView.validity_dates
                   :if={db_resource}
-                  multi_validation={@latest_validation[db_resource.id] |> hd()}
+                  multi_validation={validation}
                   locale={get_session(@conn, :locale)}
                 />
+              </td>
+              <td data-name="validity" class="no-underline">
+                <%= if DB.Resource.gtfs?(db_resource) do %>
+                  <%= render(TransportWeb.DatasetView, "_resource_validation_summary_gtfs.html",
+                    conn: @conn,
+                    resource: db_resource,
+                    validation: validation
+                  ) %>
+                <% end %>
+
+                <%= if DB.Resource.netex?(db_resource) do %>
+                  <%= render(TransportWeb.DatasetView, "_resource_validation_summary_netex.html",
+                    conn: @conn,
+                    resource: db_resource,
+                    validation: validation
+                  ) %>
+                <% end %>
+
+                <%= unless DB.Resource.gtfs?(db_resource) or DB.Resource.netex?(db_resource) do %>
+                  <%= render(TransportWeb.DatasetView, "_resource_validation_summary.html",
+                    conn: @conn,
+                    resource: db_resource,
+                    validation: validation,
+                    locale: get_session(@conn, :locale)
+                  ) %>
+                <% end %>
               </td>
               <td class="align-right">
                 <a

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -242,6 +242,10 @@ defmodule TransportWeb.DatasetView do
   iex> summary_class(%{severity: "ERROR"})
   "resource__summary--Error"
   """
+  def summary_class(%{digest: %{"max_severity" => %{"max_level" => severity, "worst_occurrences" => count_errors}}}) do
+    summary_class(%{count_errors: count_errors, severity: severity})
+  end
+
   def summary_class(%{count_errors: 0}), do: "resource__summary--Success"
   def summary_class(%{severity: severity}), do: "resource__summary--#{String.capitalize(severity)}"
 

--- a/apps/transport/test/support/factory.ex
+++ b/apps/transport/test/support/factory.ex
@@ -274,7 +274,10 @@ defmodule DB.Factory do
       insert(:multi_validation,
         validator: Transport.Validators.GTFSTransport.validator_name(),
         resource_history_id: resource_history.id,
-        max_error: Keyword.get(opts, :max_error)
+        max_error: Keyword.get(opts, :max_error, "NoError"),
+        digest: %{
+          "max_severity" => %{"max_level" => Keyword.get(opts, :max_error, "NoError"), "worst_occurrences" => 0}
+        }
       )
 
     resource_metadata =

--- a/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
+++ b/apps/transport/test/transport/jobs/dataset_quality_score_test.exs
@@ -978,7 +978,7 @@ defmodule Transport.Test.Transport.Jobs.DatasetQualityScoreTest do
                    "previous_score" => nil,
                    "today_score" => 1.0,
                    "resources" => [
-                     %{"compliance" => 1.0, "raw_measure" => %{"max_error" => nil}, "resource_id" => ^resource_id}
+                     %{"compliance" => 1.0, "raw_measure" => %{"max_error" => "NoError"}, "resource_id" => ^resource_id}
                    ]
                  }
                }


### PR DESCRIPTION
Suite de #5160, après l'ajout des dates de validité, affichage du statut de validité et d'un lien vers le rapport de validation.

<img width="1234" height="748" alt="Screenshot 2025-12-26 at 14 08 33" src="https://github.com/user-attachments/assets/5871c0f0-480e-446a-82ab-b91e880b2383" />
