### PR TITLE
Ajout plug pour données d'un producteur

### DIFF
--- a/apps/transport/lib/transport_web/plugs/producer_data.ex
+++ b/apps/transport/lib/transport_web/plugs/producer_data.ex
@@ -1,0 +1,65 @@
+defmodule TransportWeb.Plugs.ProducerData do
+  @moduledoc """
+  A Plug to fetch and assign dataset information and validation checks for authenticated producers.
+
+  This plug intercepts the connection and checks if the current user has "producer"
+  privileges. If they do, it retrieves the user's datasets and performs a series
+  of data integrity checks, caching the results during 30 minutes to optimize
+  performance.
+
+  ## Assignments
+
+  This plug adds the following keys to `conn.assigns`:
+
+  * `:datasets_for_user` - A list of dataset records associated with the current user.
+  * `:datasets_checks` - The results of validation logic run against those datasets.
+  """
+  import Plug.Conn
+
+  @cache_delay :timer.minutes(30)
+  @cache_name Transport.Cache.Cachex.cache_name()
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{} = conn, _opts) do
+    if TransportWeb.Session.producer?(conn) do
+      conn |> datasets_for_user() |> datasets_checks()
+    else
+      conn
+    end
+  end
+
+  defp datasets_for_user(%Plug.Conn{assigns: %{current_user: %{"id" => user_id}}} = conn) do
+    cache_key = "datasets_for_user::#{user_id}"
+
+    datasets =
+      Transport.Cache.fetch(cache_key, fn -> DB.Dataset.datasets_for_user(conn) end, @cache_delay)
+      |> maybe_delete(cache_key)
+
+    assign(conn, :datasets_for_user, datasets)
+  end
+
+  defp maybe_delete({:error, _} = value, cache_key) do
+    Cachex.del(@cache_name, cache_key)
+    value
+  end
+
+  defp maybe_delete(value, _cache_key), do: value
+
+  defp datasets_checks(%Plug.Conn{assigns: %{datasets_for_user: datasets, current_user: %{"id" => user_id}}} = conn) do
+    checks =
+      case datasets do
+        [%DB.Dataset{} | _] = datasets ->
+          Transport.Cache.fetch(
+            "datasets_checks::#{user_id}",
+            fn -> Enum.map(datasets, &Transport.DatasetChecks.check/1) end,
+            @cache_delay
+          )
+
+        _ ->
+          []
+      end
+
+    assign(conn, :datasets_checks, checks)
+  end
+end

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -19,7 +19,7 @@ defmodule TransportWeb.Router do
     plug(TransportWeb.Plugs.PutLocale)
     plug(:assign_current_user)
     plug(:assign_datagouv_token)
-    plug(:assign_datasets_for_user)
+    plug(TransportWeb.Plugs.ProducerData)
     plug(:maybe_login_again)
     plug(:assign_mix_env)
     plug(Sentry.PlugContext)
@@ -368,22 +368,6 @@ defmodule TransportWeb.Router do
   defp assign_current_user(conn, _) do
     # `current_user` is set by TransportWeb.SessionController.user_params_for_session/1
     assign(conn, :current_user, get_session(conn, :current_user))
-  end
-
-  defp assign_datasets_for_user(conn, _) do
-    if TransportWeb.Session.producer?(conn) do
-      conn
-      |> assign(
-        :datasets_for_user,
-        Transport.Cache.fetch(
-          ~s|datasets_for_user::#{conn.assigns.current_user["id"]}|,
-          fn -> DB.Dataset.datasets_for_user(conn) end,
-          :timer.minutes(30)
-        )
-      )
-    else
-      conn
-    end
   end
 
   defp assign_datagouv_token(conn, _) do

--- a/apps/transport/lib/transport_web/views/layout_view.ex
+++ b/apps/transport/lib/transport_web/views/layout_view.ex
@@ -35,9 +35,9 @@ defmodule TransportWeb.LayoutView do
 
   def notifications_count(%Plug.Conn{} = conn) do
     if TransportWeb.Session.producer?(conn) do
-      conn.assigns.datasets_for_user
-      |> Enum.map(&Transport.DatasetChecks.check/1)
-      |> Enum.reduce(0, fn x, acc -> Transport.DatasetChecks.count_issues(x) + acc end)
+      Enum.reduce(conn.assigns.datasets_checks, 0, fn check, acc ->
+        Transport.DatasetChecks.count_issues(check) + acc
+      end)
     else
       0
     end

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -44,7 +44,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :espace_producteur))
 
       # `is_producer` attribute has been set for the current user
@@ -61,7 +61,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     test "action items", %{conn: conn} do
       menu_items = fn %Plug.Conn{} = conn ->
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :espace_producteur))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -109,7 +109,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :espace_producteur))
 
       {:ok, doc} = conn |> html_response(200) |> Floki.parse_document()
@@ -128,7 +128,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       doc =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :espace_producteur))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -207,7 +207,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -235,7 +235,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       doc =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -249,7 +249,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       doc =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset.id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -272,7 +272,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       content =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset_id))
         |> html_response(200)
 
@@ -301,7 +301,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       doc =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset_id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -365,7 +365,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       doc =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_dataset, dataset_id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -403,7 +403,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> post(espace_producteur_path(conn, :upload_logo, dataset.id), %{"upload" => %{"file" => %Plug.Upload{}}})
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -478,7 +478,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> delete(espace_producteur_path(conn, :remove_custom_logo, dataset.id))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -506,7 +506,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> delete(espace_producteur_path(conn, :remove_custom_logo, dataset.id))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -530,7 +530,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :proxy_statistics))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -574,7 +574,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       html =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :proxy_statistics))
         |> html_response(200)
 
@@ -594,10 +594,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     test "redirects when there is an error when fetching datasets", %{conn: conn} do
       Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> {:error, nil} end)
 
-      conn =
-        conn
-        |> init_test_session(current_user: %{"is_producer" => true})
-        |> get(espace_producteur_path(conn, :download_statistics_csv))
+      conn = conn |> init_session_for_producer() |> get(espace_producteur_path(conn, :download_statistics_csv))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
 
@@ -635,7 +632,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       response =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :download_statistics_csv))
 
       assert response_content_type(response, :csv) == "text/csv; charset=utf-8"
@@ -667,7 +664,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :proxy_statistics_csv))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -711,7 +708,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       response =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :proxy_statistics_csv))
 
       assert response_content_type(response, :csv) == "text/csv; charset=utf-8"
@@ -739,7 +736,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   describe "resource_actions" do
     test "we can show the form of an existing remote resource", %{conn: conn} do
-      conn = conn |> init_test_session(current_user: %{"is_producer" => true})
+      conn = conn |> init_session_for_producer()
       resource_datagouv_id = "resource_dataset_id"
 
       %DB.Dataset{id: dataset_id, datagouv_id: dataset_datagouv_id, organization_id: organization_id} =
@@ -782,7 +779,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       html =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :edit_resource, dataset_id, resource_datagouv_id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -791,7 +788,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
 
     test "we can show the form for a new resource", %{conn: conn} do
-      conn = conn |> init_test_session(current_user: %{"is_producer" => true})
+      conn = conn |> init_session_for_producer()
 
       %DB.Dataset{id: dataset_id, datagouv_id: dataset_datagouv_id, organization_id: organization_id} =
         insert(:dataset, custom_title: custom_title = "Base Nationale des Lieux de Covoiturage")
@@ -814,7 +811,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
 
     test "we can add a new resource with a URL", %{conn: conn} do
-      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> :ok end)
+      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> [] end)
       %DB.Dataset{datagouv_id: dataset_datagouv_id} = insert(:dataset)
       %DB.Contact{id: contact_id} = contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
       conn = conn |> init_test_session(%{current_user: %{"id" => contact.datagouv_user_id, "is_producer" => true}})
@@ -866,7 +863,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
 
     test "post_file with a file with hidden fields", %{conn: conn} do
-      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> :ok end)
+      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> [] end)
       %DB.Dataset{datagouv_id: dataset_datagouv_id} = insert(:dataset)
       %DB.Contact{id: contact_id} = contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
       conn = conn |> init_test_session(%{current_user: %{"id" => contact.datagouv_user_id, "is_producer" => true}})
@@ -915,7 +912,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
 
     test "we can show the delete confirmation page", %{conn: conn} do
-      conn = conn |> init_test_session(current_user: %{"is_producer" => true})
+      conn = conn |> init_session_for_producer()
       resource_datagouv_id = "resource_dataset_id"
 
       %DB.Dataset{id: dataset_id, datagouv_id: dataset_datagouv_id, organization_id: organization_id} =
@@ -941,7 +938,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
     end
 
     test "we can delete a resource", %{conn: conn} do
-      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> :ok end)
+      Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> [] end)
 
       %DB.Dataset{datagouv_id: dataset_datagouv_id, resources: [%DB.Resource{datagouv_id: resource_datagouv_id}]} =
         insert(:dataset, resources: [insert(:resource)])
@@ -993,7 +990,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :reuser_improved_data, 42, 1337))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -1016,7 +1013,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       html =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :reuser_improved_data, dataset.id, resource.id))
         |> html_response(200)
         |> Floki.parse_document!()
@@ -1065,7 +1062,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :download_statistics))
 
       assert redirected_to(conn, 302) == espace_producteur_path(conn, :espace_producteur)
@@ -1099,7 +1096,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
       html =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_session_for_producer()
         |> get(espace_producteur_path(conn, :download_statistics))
         |> html_response(200)
 
@@ -1206,5 +1203,10 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
 
   defp assert_breadcrumb_content(doc, expected) do
     assert doc |> Floki.find(".breadcrumbs-element") |> Enum.map(&Floki.text/1) == expected
+  end
+
+  defp init_session_for_producer(%Plug.Conn{} = conn) do
+    contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+    conn |> init_test_session(current_user: %{"is_producer" => true, "id" => contact.datagouv_user_id})
   end
 end

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -80,11 +80,12 @@ defmodule TransportWeb.PageControllerTest do
     end
 
     test "for logged-in users", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
       Datagouvfr.Client.User.Mock |> expect(:me, fn _conn -> [] end)
 
       conn =
         conn
-        |> init_test_session(current_user: %{"is_producer" => true})
+        |> init_test_session(current_user: %{"is_producer" => true, "id" => contact.datagouv_user_id})
         |> get(page_path(conn, :infos_producteurs))
 
       body = html_response(conn, 200)

--- a/apps/transport/test/transport_web/plugs/producer_data_test.exs
+++ b/apps/transport/test/transport_web/plugs/producer_data_test.exs
@@ -1,0 +1,85 @@
+defmodule TransportWeb.Plugs.ProducerDataTest do
+  use TransportWeb.ConnCase, async: false
+  alias TransportWeb.Plugs.ProducerData
+  import DB.Factory
+  import Mox
+
+  setup :verify_on_exit!
+
+  @cache_name Transport.Cache.Cachex.cache_name()
+
+  setup do
+    Mox.stub_with(Transport.ValidatorsSelection.Mock, Transport.ValidatorsSelection.Impl)
+
+    # Use a real in-memory cache for these tests to test the caching mecanism
+    old_value = Application.fetch_env!(:transport, :cache_impl)
+    Application.put_env(:transport, :cache_impl, Transport.Cache.Cachex)
+
+    on_exit(fn ->
+      Application.put_env(:transport, :cache_impl, old_value)
+      Cachex.reset(@cache_name)
+    end)
+
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  describe "call" do
+    test "when user is a producer", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+      %DB.Dataset{id: dataset_id} = dataset = insert(:dataset)
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:ok, %{"organizations" => [%{"id" => dataset.organization_id}]}} end)
+
+      current_user = %{"is_producer" => true, "id" => contact.datagouv_user_id}
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{current_user: current_user})
+        |> assign(:current_user, current_user)
+        |> ProducerData.call([])
+
+      # Assigns have been saved
+      assert %{
+               datasets_checks: [%{expiring_resource: [], invalid_resource: [], unavailable_resource: []}],
+               datasets_for_user: [%DB.Dataset{id: ^dataset_id}]
+             } = conn.assigns
+
+      # Cache has been set
+      assert ["datasets_checks::#{contact.datagouv_user_id}", "datasets_for_user::#{contact.datagouv_user_id}"] ==
+               Cachex.keys!(@cache_name) |> Enum.sort()
+
+      # With the appropriate TTL
+      assert_in_delta Cachex.ttl!(@cache_name, "datasets_checks::#{contact.datagouv_user_id}"), :timer.minutes(30), 50
+      assert_in_delta Cachex.ttl!(@cache_name, "datasets_for_user::#{contact.datagouv_user_id}"), :timer.minutes(30), 50
+    end
+
+    test "when user is a producer and there is an OAuth 2 error", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+      Datagouvfr.Client.User.Mock
+      |> expect(:me, fn %Plug.Conn{} -> {:error, "An error occured"} end)
+
+      current_user = %{"is_producer" => true, "id" => contact.datagouv_user_id}
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{current_user: current_user})
+        |> assign(:current_user, current_user)
+        |> ProducerData.call([])
+
+      # Assigns have been saved
+      assert %{
+               datasets_checks: [],
+               datasets_for_user: {:error, "An error occured"}
+             } = conn.assigns
+
+      # Cache has not set
+      assert [] == Cachex.keys!(@cache_name)
+    end
+
+    test "when user is not a producer", %{conn: conn} do
+      assert %Plug.Conn{} = conn |> Phoenix.ConnTest.init_test_session(%{}) |> ProducerData.call([])
+    end
+  end
+end


### PR DESCRIPTION
Ajoute un plug en charge de créer les données utiles pour un producteur et de les mettre en cache.

Voir https://github.com/etalab/transport-site/pull/5167