### PR TITLE
Notification en cas d'erreurs d'un GTFS-RT avec seuil

### DIFF
--- a/apps/transport/lib/validators/validator_selection.ex
+++ b/apps/transport/lib/validators/validator_selection.ex
@@ -90,7 +90,8 @@ defmodule Transport.ValidatorsSelection.Impl do
 
   def validators_for_feature(:multi_validation_with_error_realtime_validators),
     do: [
-      Transport.Validators.GBFSValidator
+      Transport.Validators.GBFSValidator,
+      Transport.Validators.GTFSRT
     ]
 
   def validators_for_feature(:stats_compute_aom_gtfs_max_severity), do: [Transport.Validators.GTFSTransport]


### PR DESCRIPTION
On enverra une notification en cas d'erreur pour un GTFS-RT. Un flux remontera si des entités sont manquantes par rapport au GTFS (stops, route, trip ou agency) et qu'il y a au moins 50 erreurs des codes E003, E004, E011 ou E034.

Les notifications seront envoyées tous les 30 jours.
