### PR TITLE
GBFSValidator : correction du calcul du digest

### DIFF
--- a/apps/transport/lib/validators/gbfs_validator.ex
+++ b/apps/transport/lib/validators/gbfs_validator.ex
@@ -17,7 +17,7 @@ defmodule Transport.Validators.GBFSValidator do
       validated_data_name: url,
       validator: validator_name(),
       result: Map.from_struct(validation_result),
-      digest: Map.from_struct(validation_result) |> digest(),
+      digest: Map.from_struct(validation_result) |> Map.new(fn {k, v} -> {to_string(k), v} end) |> digest(),
       metadata: %DB.ResourceMetadata{
         metadata: Map.reject(result, fn {key, _val} -> key == :validation end),
         resource_id: resource_id

--- a/apps/transport/test/transport/validators/gbfs_validator_test.exs
+++ b/apps/transport/test/transport/validators/gbfs_validator_test.exs
@@ -65,6 +65,7 @@ defmodule Transport.Validators.GBFSValidatorTest do
                  "version_validated" => "1.1"
                },
              validated_data_name: ^url,
+             digest: %{"errors_count" => 0},
              command: "https://gbfs-validator.netlify.app/.netlify/functions/validator",
              validator: "MobilityData/gbfs-validator",
              validator_version: "31c5325"

--- a/scripts/backfill_multi_validation_digest.exs
+++ b/scripts/backfill_multi_validation_digest.exs
@@ -56,7 +56,7 @@ defmodule Script do
         Transport.Validators.JSONSchema.digest(mv.result)
 
       "MobilityData GTFS Validator" ->
-        Transport.Validators.MobilityDataGTFSValidator.digest(mv.result)
+        Transport.Validators.MobilityDataGTFSValidator.digest(Map.get(mv.result, "notices", []))
 
       unsupported ->
         Logger.warning("multi_validation ##{mv.id}: unsupported validator #{unsupported}")


### PR DESCRIPTION
cc @ptitfred, les clés étaient des atoms ce qui faisait que le `digest` était toujours vide.