### PR TITLE
DatasetChecks : fonction pour réutilisateurs

### DIFF
--- a/apps/transport/lib/transport_web/plugs/producer_data.ex
+++ b/apps/transport/lib/transport_web/plugs/producer_data.ex
@@ -50,13 +50,19 @@ defmodule TransportWeb.Plugs.ProducerData do
     checks =
       case datasets do
         [%DB.Dataset{} | _] = datasets ->
-          maybe_skip_cache(conn, cache_key, fn -> Enum.map(datasets, &Transport.DatasetChecks.check/1) end)
+          datasets_checks(conn, cache_key, datasets)
 
         _ ->
           []
       end
 
     assign(conn, :datasets_checks, checks)
+  end
+
+  defp datasets_checks(conn, cache_key, datasets) do
+    maybe_skip_cache(conn, cache_key, fn ->
+      Enum.map(datasets, fn %DB.Dataset{} = dataset -> Transport.DatasetChecks.check(dataset, :producer) end)
+    end)
   end
 
   defp maybe_delete_if_error({:error, _} = value, cache_key) do

--- a/apps/transport/lib/transport_web/plugs/reuser_data.ex
+++ b/apps/transport/lib/transport_web/plugs/reuser_data.ex
@@ -41,13 +41,23 @@ defmodule TransportWeb.Plugs.ReuserData do
     checks =
       case datasets do
         [%DB.Dataset{} | _] = datasets ->
-          Transport.Cache.fetch(cache_key, fn -> Enum.map(datasets, &Transport.DatasetChecks.check/1) end, @cache_delay)
+          datasets_checks(datasets, cache_key)
 
         _ ->
           []
       end
 
     assign(conn, :followed_datasets_checks, checks)
+  end
+
+  defp datasets_checks(datasets, cache_key) do
+    Transport.Cache.fetch(
+      cache_key,
+      fn ->
+        Enum.map(datasets, fn %DB.Dataset{} = dataset -> Transport.DatasetChecks.check(dataset, :reuser) end)
+      end,
+      @cache_delay
+    )
   end
 
   defp followed_datasets_checks(%Plug.Conn{} = conn), do: assign(conn, :followed_datasets_checks, [])

--- a/apps/transport/lib/transport_web/templates/espace_producteur/_urgent_issues.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/_urgent_issues.html.heex
@@ -9,7 +9,7 @@
           <th><%= dgettext("espace-producteurs", "Dataset") %></th>
           <th><%= dgettext("espace-producteurs", "Resource") %></th>
           <th><%= dgettext("espace-producteurs", "Issue") %></th>
-          <th :if={@mode == :producer}><%= dgettext("espace-producteurs", "Actions") %></th>
+          <th><%= dgettext("espace-producteurs", "Actions") %></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/transport/lib/transport_web/templates/espace_producteur/discussions.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/discussions.html.heex
@@ -37,7 +37,7 @@
                   <a
                     href={dataset_path(@conn, :details, dataset.slug) <> ~s|#discussion-#{discussion["id"]}|}
                     target="_blank"
-                    class="button-outline primary small-padding"
+                    class="button-outline primary small"
                     data-tracking-category="espace_producteur"
                     data-tracking-action="unanswered_discussion_button"
                   >

--- a/apps/transport/lib/transport_web/views/espace_producteur_view.ex
+++ b/apps/transport/lib/transport_web/views/espace_producteur_view.ex
@@ -94,7 +94,7 @@ defmodule TransportWeb.EspaceProducteurView do
     <td>
       <a
         href={dataset_path(TransportWeb.Endpoint, :details, @dataset.slug) <> ~s|#discussion-#{@issue["id"]}|}
-        class="button-outline primary small-padding"
+        class="button-outline primary small"
         data-tracking-category="espace_producteur"
         data-tracking-action="urgent_issues_see_discussion_button"
       >
@@ -109,7 +109,7 @@ defmodule TransportWeb.EspaceProducteurView do
     <td>
       <a
         href={espace_producteur_path(TransportWeb.Endpoint, :edit_resource, @dataset.id, @issue.datagouv_id)}
-        class="button-outline primary small-padding"
+        class="button-outline primary small"
         data-tracking-category="espace_producteur"
         data-tracking-action="urgent_issues_edit_resource_button"
       >
@@ -124,7 +124,7 @@ defmodule TransportWeb.EspaceProducteurView do
     <td>
       <a
         href={resource_path(TransportWeb.Endpoint, :details, @issue.id)}
-        class="button-outline primary small-padding"
+        class="button-outline primary small"
         target="_blank"
         data-tracking-category="espace_reutilisateur"
         data-tracking-action="urgent_issues_see_resource_button"
@@ -135,12 +135,12 @@ defmodule TransportWeb.EspaceProducteurView do
     """
   end
 
-  defp issue_link(%{mode: :reuser, check_name: :unanswered_discussions} = assigns) do
+  defp issue_link(%{mode: :reuser, check_name: :recent_discussions} = assigns) do
     ~H"""
     <td>
       <a
         href={dataset_path(TransportWeb.Endpoint, :details, @dataset.slug) <> ~s|#discussion-#{@issue["id"]}|}
-        class="button-outline primary small-padding"
+        class="button-outline primary small"
         data-tracking-category="espace_producteur"
         data-tracking-action="urgent_issues_see_discussion_button"
       >

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/espace-producteurs.po
@@ -442,3 +442,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Expired resource"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "recent_discussions"
+msgstr ""

--- a/apps/transport/priv/gettext/espace-producteurs.pot
+++ b/apps/transport/priv/gettext/espace-producteurs.pot
@@ -441,3 +441,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Expired resource"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "recent_discussions"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/espace-producteurs.po
@@ -442,3 +442,7 @@ msgstr "Glissez un fichier ici ou cliquez pour parcourir vos répertoires locaux
 #, elixir-autogen, elixir-format
 msgid "Expired resource"
 msgstr "Ressource expirée"
+
+#, elixir-autogen, elixir-format
+msgid "recent_discussions"
+msgstr "Discussion récente"

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -109,11 +109,6 @@ defmodule TransportWeb.DatasetControllerTest do
       followed_dataset = insert(:dataset, custom_title: "B")
       insert(:dataset_follower, contact_id: contact.id, dataset_id: followed_dataset.id)
 
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
-
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
       document =
@@ -144,11 +139,6 @@ defmodule TransportWeb.DatasetControllerTest do
       followed_dataset = insert(:dataset, custom_title: "B")
       insert(:dataset_follower, contact_id: contact.id, dataset_id: followed_dataset.id)
       insert(:dataset, custom_title: "C")
-
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
 
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
@@ -216,11 +206,6 @@ defmodule TransportWeb.DatasetControllerTest do
       contact = insert_contact(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()})
       dataset = insert(:dataset)
       insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset.id, source: :follow_button)
-
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
 
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -195,7 +195,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
                                   [
                                     {"href",
                                      dataset_path(conn, :details, dataset.slug) <> "#discussion-" <> discussion_id},
-                                    {"class", "button-outline primary small-padding"},
+                                    {"class", "button-outline primary small"},
                                     {"data-tracking-category", "espace_producteur"},
                                     {"data-tracking-action", "urgent_issues_see_discussion_button"}
                                   ],
@@ -227,7 +227,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
                                   [
                                     {"href",
                                      espace_producteur_path(conn, :edit_resource, dataset.id, resource.datagouv_id)},
-                                    {"class", "button-outline primary small-padding"},
+                                    {"class", "button-outline primary small"},
                                     {"data-tracking-category", "espace_producteur"},
                                     {"data-tracking-action", "urgent_issues_edit_resource_button"}
                                   ],
@@ -296,7 +296,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
                     [
                       {"href",
                        espace_producteur_path(TransportWeb.Endpoint, :edit_resource, dataset.id, resource.datagouv_id)},
-                      {"class", "button-outline primary small-padding"},
+                      {"class", "button-outline primary small"},
                       {"data-tracking-category", "espace_producteur"},
                       {"data-tracking-action", "urgent_issues_edit_resource_button"}
                     ], [{"i", [{"class", "fa fa-edit"}], []}, "Modifier la ressource\n  "]}
@@ -1392,7 +1392,7 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
                               {"href",
                                dataset_path(conn, :details, dataset.slug) <> ~s|#discussion-#{discussion["id"]}|},
                               {"target", "_blank"},
-                              {"class", "button-outline primary small-padding"},
+                              {"class", "button-outline primary small"},
                               {"data-tracking-category", "espace_producteur"},
                               {"data-tracking-action", "unanswered_discussion_button"}
                             ],

--- a/apps/transport/test/transport_web/controllers/page_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/page_controller_test.exs
@@ -292,7 +292,7 @@ defmodule TransportWeb.PageControllerTest do
     |> expect(:me, fn _conn -> {:ok, %{"organizations" => [%{"id" => dataset.organization_id}]}} end)
 
     Datagouvfr.Client.Organization.Mock
-    |> expect(:get, 2, fn _organization_id, [restrict_fields: true] ->
+    |> expect(:get, fn _organization_id, [restrict_fields: true] ->
       {:ok, %{"members" => []}}
     end)
 

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -41,11 +41,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       resource = insert(:resource, dataset: dataset, is_available: false)
       insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset.id, source: :follow_button)
 
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
-
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
       doc =
@@ -75,7 +70,7 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
                         {"a",
                          [
                            {"href", "/resources/#{resource.id}"},
-                           {"class", "button-outline primary small-padding"},
+                           {"class", "button-outline primary small"},
                            {"target", "_blank"},
                            {"data-tracking-category", "espace_reutilisateur"},
                            {"data-tracking-action", "urgent_issues_see_resource_button"}
@@ -112,11 +107,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
       dataset = insert(:dataset)
       insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset.id, source: :follow_button)
 
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
-
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
       assert conn
@@ -139,11 +129,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
         })
 
       insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset.id, source: :follow_button)
-
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
 
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
@@ -185,11 +170,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
         role: :reuser
       )
 
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
-
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
       conn =
@@ -220,11 +200,6 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
     download_url = "https://example.com/#{Ecto.UUID.generate()}"
 
     insert(:dataset_follower, contact_id: contact_id, dataset_id: dataset_id, source: :follow_button)
-
-    Datagouvfr.Client.Organization.Mock
-    |> expect(:get, 2, fn _organization_id, [restrict_fields: true] ->
-      {:ok, %{"members" => []}}
-    end)
 
     Datagouvfr.Client.Discussions.Mock |> expect(:get, 2, fn _datagouv_id -> [] end)
 

--- a/apps/transport/test/transport_web/live_views/notifications_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/notifications_live_test.exs
@@ -157,11 +157,6 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
       source: :user
     )
 
-    Datagouvfr.Client.Organization.Mock
-    |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-      {:ok, %{"members" => []}}
-    end)
-
     Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 
     content =
@@ -284,11 +279,6 @@ defmodule TransportWeb.Live.NotificationsLiveTest do
       %DB.Dataset{id: dataset_id} = insert(:dataset)
       %DB.Contact{id: contact_id} = insert_contact(%{datagouv_user_id: datagouv_user_id = Ecto.UUID.generate()})
       insert(:dataset_follower, contact_id: contact_id, dataset_id: dataset_id, source: :follow_button)
-
-      Datagouvfr.Client.Organization.Mock
-      |> expect(:get, fn _organization_id, [restrict_fields: true] ->
-        {:ok, %{"members" => []}}
-      end)
 
       Datagouvfr.Client.Discussions.Mock |> expect(:get, fn _datagouv_id -> [] end)
 


### PR DESCRIPTION
Passage des discussions non répondues aux discussions récentes pour les réutilisateurs.

Distingue le mode producteur et le mode réutilisateur pour `DatasetChecks`.