### PR TITLE
Notifications en cas d'erreur : répétition tous les x jours

### DIFF
--- a/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
+++ b/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
@@ -1,13 +1,46 @@
 defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   @moduledoc """
-  Job in charge of sending notifications to subscribers when resources have validation errors.
+  An Oban worker responsible for notifying subscribers (Producers and Reusers)
+  when datasets fail validation checks.
 
-  It has a list of enabled validators and is capable of handling static and real-time data.
-  The delay to wait before sending a notification again can vary by validator (it will typically
-  be longer for real-time as it takes more time to fix these errors).
+  This job implements a "cooling-off" period and multi-stage notification logic
+  to prevent spam while ensuring critical data errors are addressed.
 
-  This job should be scheduled every 30 minutes because it looks at validations
-  that have been created in the last 30 minutes.
+  ## Orchestration & Scheduling
+  * **Initial Run:** Should be scheduled every **30 minutes**. It scans for new
+    `DB.MultiValidation` records created within the last 30 minutes.
+  * **Recursive Retries:** If errors persist, the job re-enqueues itself with a
+    specific delay based on the validator type (e.g., 7 days for static data,
+    30 days for real-time data).
+
+  ## Notification Logic
+  The job distinguishes between two roles defined in `DB.NotificationSubscription`:
+
+  1.  **Producers:** Always notified when a validation error occurs, provided the
+      cooling-off period has passed. They receive specific details about the
+      resource and the validator that failed.
+  2.  **Reusers:** Notified only on the **first attempt** (`attempt == 1`) to
+      alert them of potential quality issues in the data they consume.
+
+  ## Validator Types
+  The job handles two distinct categories of validators:
+
+  * **Static Data Validators:** (e.g., GTFS, TableSchema). Matches records with
+      severity "Error", "Fatal", or explicit "has_errors" flags.
+  * **Real-time Data Validators:** (e.g., GTFS-RT). Includes a threshold
+      mechanism (`@gtfs_rt_errors_threshold`). For GTFS-RT, notifications are
+      only triggered if the sum of high-severity error counts exceeds the threshold.
+
+  ## Suppression (Anti-Spam)
+  Before sending an email, the job checks the `DB.Notification` history. If a
+  notification for the same dataset and validator was sent within the
+  `sending_delay_by_validator/1` window, the email is suppressed.
+
+  ## Expected Arguments
+  * `%{"dataset_id" => id, "multi_validation_ids" => [...], "attempt" => n}`
+      Used for scheduled follow-ups/retries.
+  * `%{}`
+      Used for the primary 30-minute recurring scan.
   """
   use Oban.Worker, max_attempts: 3, tags: ["notifications"]
   import Ecto.Query
@@ -18,9 +51,51 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   @gtfs_rt_errors_threshold 50
 
   @impl Oban.Worker
+  def perform(%Oban.Job{
+        id: job_id,
+        args: %{"dataset_id" => dataset_id, "multi_validation_ids" => multi_validation_ids, "attempt" => attempt}
+      }) do
+    dataset = DB.Repo.get!(DB.Dataset, dataset_id)
+
+    filtered_validations =
+      DB.MultiValidation.dataset_latest_validation(dataset_id, static_data_validators())
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.filter(fn %DB.MultiValidation{id: id} -> id in multi_validation_ids end)
+      |> Enum.map(&DB.Repo.preload(&1, resource_history: [resource: [:dataset]]))
+
+    validations = [{dataset, filtered_validations}]
+
+    validations |> Enum.each(&send_notifications_for_dataset(&1, job_id: job_id, attempt: attempt))
+    enqueue_next_job(validations, attempt)
+  end
+
+  @impl Oban.Worker
   def perform(%Oban.Job{id: job_id, inserted_at: %DateTime{} = inserted_at}) do
-    relevant_validations(inserted_at)
-    |> Enum.each(&send_notifications_for_dataset(&1, job_id))
+    attempt = 1
+    validations = relevant_validations(inserted_at)
+    validations |> Enum.each(&send_notifications_for_dataset(&1, job_id: job_id, attempt: attempt))
+
+    enqueue_next_job(validations, attempt)
+  end
+
+  defp enqueue_next_job(validations, attempt) do
+    validator_names = Enum.map(static_data_validators(), & &1.validator_name())
+
+    validations
+    |> Enum.map(fn {%DB.Dataset{} = dataset, multi_validations} ->
+      {dataset,
+       Enum.filter(multi_validations, fn %DB.MultiValidation{validator: validator} -> validator in validator_names end)}
+    end)
+    |> Enum.reject(fn {_, mv} -> Enum.empty?(mv) end)
+    |> Enum.each(fn {%DB.Dataset{} = dataset, multi_validations} ->
+      [delay] = Enum.map(multi_validations, &sending_delay_by_validator(&1.validator)) |> Enum.uniq()
+
+      new(%{dataset_id: dataset.id, multi_validation_ids: Enum.map(multi_validations, & &1.id), attempt: attempt + 1},
+        schedule_in: delay
+      )
+      |> Oban.insert!()
+    end)
   end
 
   @doc """
@@ -28,37 +103,53 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   Notifications are grouped by validator because the sending delay window is different for each validator
   (static data VS real time data for example).
   """
-  def send_notifications_for_dataset({%DB.Dataset{} = dataset, multi_validations}, job_id) do
+  def send_notifications_for_dataset({%DB.Dataset{} = dataset, multi_validations}, job_id: job_id, attempt: attempt) do
     multi_validations
     |> Enum.group_by(& &1.validator)
     |> Enum.each(fn {validator_name, errors} ->
       producer_subscriptions = dataset |> subscriptions(:producer, validator_name)
-      send_to_producers(producer_subscriptions, dataset, errors, validator_name: validator_name, job_id: job_id)
 
-      dataset
-      |> subscriptions(:reuser, validator_name)
-      |> send_to_reusers(dataset,
-        producer_warned: not Enum.empty?(producer_subscriptions),
+      send_to_producers(producer_subscriptions, dataset, errors,
         validator_name: validator_name,
-        job_id: job_id
+        job_id: job_id,
+        attempt: attempt
       )
+
+      if attempt == 1 do
+        dataset
+        |> subscriptions(:reuser, validator_name)
+        |> send_to_reusers(dataset,
+          producer_warned: not Enum.empty?(producer_subscriptions),
+          validator_name: validator_name,
+          job_id: job_id,
+          attempt: attempt
+        )
+      end
     end)
   end
 
   defp send_to_reusers(subscriptions, %DB.Dataset{} = dataset,
          producer_warned: producer_warned,
          validator_name: validator_name,
-         job_id: job_id
+         job_id: job_id,
+         attempt: attempt
        ) do
     Enum.each(
       subscriptions,
-      &send_mail(&1, dataset: dataset, producer_warned: producer_warned, validator_name: validator_name, job_id: job_id)
+      &send_mail(&1,
+        dataset: dataset,
+        producer_warned: producer_warned,
+        validator_name: validator_name,
+        job_id: job_id,
+        attempt: attempt
+      )
     )
   end
 
   defp send_to_producers(subscriptions, %DB.Dataset{} = dataset, multi_validations,
          validator_name: validator_name,
-         job_id: job_id
+         job_id: job_id,
+         attempt: attempt
        ) do
     Enum.each(
       subscriptions,
@@ -66,7 +157,8 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
         dataset: dataset,
         resources: Enum.map(multi_validations, fn %DB.MultiValidation{} = mv -> multi_validation_to_resource(mv) end),
         validator_name: validator_name,
-        job_id: job_id
+        job_id: job_id,
+        attempt: attempt
       )
     )
   end
@@ -92,11 +184,13 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     producer_warned = Keyword.fetch!(args, :producer_warned)
     job_id = Keyword.fetch!(args, :job_id)
     validator_name = Keyword.fetch!(args, :validator_name)
+    attempt = Keyword.fetch!(args, :attempt)
 
     DB.Notification.insert!(dataset, subscription, %{
       producer_warned: producer_warned,
       validator_name: validator_name,
-      job_id: job_id
+      job_id: job_id,
+      attempt: attempt
     })
   end
 
@@ -104,12 +198,14 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     resources = Keyword.fetch!(args, :resources)
     job_id = Keyword.fetch!(args, :job_id)
     validator_name = Keyword.fetch!(args, :validator_name)
+    attempt = Keyword.fetch!(args, :attempt)
 
     DB.Notification.insert!(dataset, subscription, %{
       resource_ids: Enum.map(resources, fn %DB.Resource{id: resource_id} -> resource_id end),
       resource_formats: Enum.map(resources, fn %DB.Resource{format: format} -> format end),
       validator_name: validator_name,
-      job_id: job_id
+      job_id: job_id,
+      attempt: attempt
     })
   end
 
@@ -187,6 +283,8 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   {30, :day}
   iex> all_validators() |> Enum.map(& &1.validator_name()) |> Enum.each(&sending_delay_by_validator/1)
   :ok
+  iex> static_data_validators() |> Enum.map(& sending_delay_by_validator(&1.validator_name())) |> Enum.uniq()
+  [{7, :day}]
   """
   @spec sending_delay_by_validator(binary()) :: {pos_integer(), :day}
   def sending_delay_by_validator(validator) do

--- a/apps/transport/lib/mailer/user_notifier.ex
+++ b/apps/transport/lib/mailer/user_notifier.ex
@@ -62,7 +62,8 @@ defmodule Transport.UserNotifier do
         dataset: dataset,
         resources: resources,
         validator_name: _,
-        job_id: _
+        job_id: _,
+        attempt: _
       ) do
     contact
     |> common_email_options()
@@ -74,7 +75,8 @@ defmodule Transport.UserNotifier do
         dataset: dataset,
         producer_warned: producer_warned,
         validator_name: _,
-        job_id: _
+        job_id: _,
+        attempt: _
       ) do
     contact
     |> common_email_options()

--- a/apps/transport/lib/transport_web/live/backoffice/email_preview_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/email_preview_live.ex
@@ -51,14 +51,16 @@ defmodule TransportWeb.Backoffice.EmailPreviewLive do
          dataset: dataset,
          resources: dataset.resources,
          validator_name: nil,
-         job_id: nil
+         job_id: nil,
+         attempt: nil
        )},
       {:multi_validation_with_error_notification, ["reuser", "notification", "error"],
        Transport.UserNotifier.multi_validation_with_error_notification(contact, :reuser,
          dataset: dataset,
          producer_warned: true,
          validator_name: nil,
-         job_id: nil
+         job_id: nil,
+         attempt: nil
        )},
       {:resource_unavailable, ["producer", "notification", "availability"],
        Transport.UserNotifier.resource_unavailable(contact, :producer,


### PR DESCRIPTION
Modifie `MultiValidationWithErrorNotificationJob` pour envoyer des e-mails de rappel en cas d'erreur aux producteurs, tous les 7 jours pour des données statiques, si jamais la dernière validation est toujours la même.
