### PR TITLE
Espace producteur : accès quand non producteur

### DIFF
--- a/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/espace_producteur_controller.ex
@@ -23,7 +23,7 @@ defmodule TransportWeb.EspaceProducteurController do
 
   def espace_producteur(%Plug.Conn{} = conn, _params) do
     {conn, datasets} =
-      case conn.assigns.datasets_for_user do
+      case Map.get(conn.assigns, :datasets_for_user, []) do
         datasets when is_list(datasets) ->
           {conn, datasets}
 
@@ -44,6 +44,8 @@ defmodule TransportWeb.EspaceProducteurController do
   defp datasets_checks(%Plug.Conn{assigns: %{datasets_for_user: datasets_for_user, datasets_checks: datasets_checks}}) do
     Enum.map(datasets_for_user, & &1.id) |> Enum.zip(datasets_checks) |> Map.new()
   end
+
+  defp datasets_checks(%Plug.Conn{}), do: %{}
 
   def edit_dataset(%Plug.Conn{assigns: %{dataset: %DB.Dataset{} = dataset}} = conn, %{"dataset_id" => _}) do
     # Awkard page, but no real choice: some parts (logo…) are from the local database

--- a/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/espace_producteur_controller_test.exs
@@ -114,6 +114,15 @@ defmodule TransportWeb.EspaceProducteurControllerTest do
              ]
     end
 
+    test "when user is not a producer", %{conn: conn} do
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+
+      conn
+      |> init_test_session(%{"is_producer" => false, "current_user" => %{"id" => contact.datagouv_user_id}})
+      |> get(espace_producteur_path(conn, :espace_producteur))
+      |> html_response(200)
+    end
+
     test "with an OAuth2 error", %{conn: conn} do
       Datagouvfr.Client.User.Mock
       |> expect(:me, fn %Plug.Conn{} -> {:error, "its broken"} end)


### PR DESCRIPTION
Corrige [une erreur 500](https://transport-data-gouv-fr.sentry.io/issues/7165558218/) qui survient quand un non producteur tente d'accéder à l'Espace Producteur, ce qui doit être possible.
