### PR TITLE
new_datagouv_datasets : corrige erreur HTML

### DIFF
--- a/apps/transport/lib/transport_web/templates/email/new_datagouv_datasets.html.heex
+++ b/apps/transport/lib/transport_web/templates/email/new_datagouv_datasets.html.heex
@@ -8,7 +8,7 @@
 </ul>
 <br />
 <hr />
-<%= @rule_explanation %>
+<%= raw(@rule_explanation) %>
 <p>
   Vous pouvez modifier <a href="https://github.com/etalab/transport-site/blob/master/apps/transport/lib/jobs/new_datagouv_datasets_job.ex">les règles de cette tâche</a>.
 </p>


### PR DESCRIPTION
Fixes #5219

Le HTML a besoin d'être mis en `raw` pour ne pas être échappé dans les e-mails.
