### PR TITLE
Matomo : désactive le HeatmapSessionRecording

### DIFF
--- a/apps/transport/lib/transport_web/templates/layout/app.html.heex
+++ b/apps/transport/lib/transport_web/templates/layout/app.html.heex
@@ -40,6 +40,7 @@
         var _paq = _paq || [];
         _paq.push(["setCookieDomain", "*.transport.data.gouv.fr"]);
         _paq.push(["setDomains", "*.transport.data.gouv.fr"]);
+        _paq.push(["HeatmapSessionRecording::disable"]);
         _paq.push(["trackPageView"]);
         _paq.push(["enableLinkTracking"]);
         window._paq = _paq;


### PR DESCRIPTION
Fixes #5062

Désactive le "heatmap session recording" de Matomo, qu'on n'utilise pas et qui crée une erreur de CSP.
