### PR TITLE
Statistiques de téléchargements : bouton en haut de page

### DIFF
--- a/apps/transport/client/stylesheets/espace_producteur.scss
+++ b/apps/transport/client/stylesheets/espace_producteur.scss
@@ -52,7 +52,7 @@
 }
 
 // Proxy statistics styles
-.proxy-statistics {
+.proxy-statistics, .download-statistics {
   &__header {
     display: flex;
     justify-content: space-between;

--- a/apps/transport/lib/transport_web/templates/espace_producteur/download_statistics.html.heex
+++ b/apps/transport/lib/transport_web/templates/espace_producteur/download_statistics.html.heex
@@ -3,7 +3,20 @@
 </section>
 <section class="producer-actions">
   <div class="container">
-    <h2>{dgettext("espace-producteurs", "Download statistics")}</h2>
+    <div class="download-statistics__header">
+      <h2>{dgettext("espace-producteurs", "Download statistics")}</h2>
+      <a
+        class="button-outline small secondary"
+        href={espace_producteur_path(@conn, :download_statistics_csv)}
+        data-tracking-category="espace_producteur"
+        data-tracking-action="download_statistics_csv"
+      >
+        <i class="icon icon--download" aria-hidden="true"></i>{dgettext(
+          "espace-producteurs",
+          "Download download statistics"
+        )}
+      </a>
+    </div>
     <div class="panel">
       <p>
         {dgettext(
@@ -41,19 +54,6 @@
           <% end %>
         </tbody>
       </table>
-      <div class="mt-24">
-        <a
-          class="button-outline small secondary"
-          href={espace_producteur_path(@conn, :download_statistics_csv)}
-          data-tracking-category="espace_producteur"
-          data-tracking-action="download_statistics_csv"
-        >
-          <i class="icon icon--download" aria-hidden="true"></i>{dgettext(
-            "espace-producteurs",
-            "Download download statistics"
-          )}
-        </a>
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Comme fait dans #5227 pour les statistiques proxy, déplace le bouton de téléchargement en haut de page.

## Le nouveau header
<img width="1237" height="398" alt="Screenshot 2026-01-08 at 11 18 47" src="https://github.com/user-attachments/assets/29319233-c823-4338-b6b5-ff11268a7bd4" />

## L'autre header
<img width="1229" height="224" alt="Screenshot 2026-01-08 at 11 19 01" src="https://github.com/user-attachments/assets/ce637b0e-6d24-4c43-bd9f-3cb1c4096d96" />
