### PR TITLE
Réutilisations : affichage auteur et phrase d'intro

### DIFF
--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -27,7 +27,7 @@ defmodule TransportWeb.ReusesLive do
             <%= for reuse <- @reuses do %>
               <div class="panel reuse">
                 <img src={reuse["image"]} alt={reuse["title"]} />
-                {dgettext("page-dataset-details", "By %{owner}", owner: owner(reuse))}
+                <div class="mt-12">{Phoenix.HTML.raw(owner(reuse))}</div>
                 <div class="reuse__links">
                   <.link href={reuse["url"]}>{dgettext("page-dataset-details", "Website")}</.link>
                   <.link href={reuse["page"]} target="_blank">
@@ -72,8 +72,8 @@ defmodule TransportWeb.ReusesLive do
     {:ok, socket}
   end
 
-  def owner(%{"organization" => %{"name" => name}}), do: name
-  def owner(%{"owner" => %{"name" => name}}), do: name
+  def owner(%{"organization" => %{"name" => name}}), do: ~s|<i class="fa fa-building icon"></i>| <> name
+  def owner(%{"owner" => %{"name" => name}}), do: ~s|<i class="fa fa-user icon"></i>| <> name
 
   def handle_info({:fetch_data_gouv_reuses, dataset_datagouv_id}, socket) do
     # in case data.gouv api is down, datasets pages should still be available on our site

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -731,9 +731,5 @@ msgid "This discussion is closed"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "By %{owner}"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "You will find below reuses created by individuals or organizations based on this dataset."
 msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -731,9 +731,5 @@ msgid "This discussion is closed"
 msgstr "Cette discussion est fermée"
 
 #, elixir-autogen, elixir-format
-msgid "By %{owner}"
-msgstr "Par %{owner}"
-
-#, elixir-autogen, elixir-format
 msgid "You will find below reuses created by individuals or organizations based on this dataset."
 msgstr "Vous trouverez dessous les réutilisations créées par des personnes ou des organisations en utilisant ce jeu de données."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -731,9 +731,5 @@ msgid "This discussion is closed"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "By %{owner}"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "You will find below reuses created by individuals or organizations based on this dataset."
 msgstr ""


### PR DESCRIPTION
Affiche clairement l'auteur d'une réutilisation et affiche une phrase d'intro pour expliquer le contexte des réutilisations.

<img width="896" height="518" alt="Screenshot 2026-01-08 at 11 45 35" src="https://github.com/user-attachments/assets/d494e8a9-1e07-4ac5-8863-34d2cf18501c" />

