### PR TITLE
Autocomplete : mise à jour de l'ordre des résultats

### DIFF
--- a/apps/transport/lib/transport_web/api/controllers/autocomplete_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/autocomplete_controller.ex
@@ -58,14 +58,14 @@ defmodule TransportWeb.API.AutocompleteController do
       DB.Autocomplete
       |> where([p], fragment("indexed_name ilike unaccent(?)", ^query))
       |> order_by(asc: fragment("CASE type
-          when 'dataset' then 1
-          when 'feature' then 2
-          when 'mode' then 3
-          when 'format' then 4
-          when 'offer' then 5
-          when 'region' then 6
-          when 'departement' then 7
-          when 'epci' then 8
+          when 'feature' then 1
+          when 'mode' then 2
+          when 'format' then 3
+          when 'offer' then 4
+          when 'region' then 5
+          when 'departement' then 6
+          when 'epci' then 7
+          when 'dataset' then 8
           else 9 END"))
       |> order_by(desc: fragment("similarity(indexed_name, unaccent(?))", ^query))
       |> limit(10)

--- a/apps/transport/test/transport_web/controllers/api/autocomplete_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/autocomplete_controller_test.exs
@@ -132,5 +132,24 @@ defmodule TransportWeb.API.AutocompleteControllerTest do
     assert_response_schema(json, "AutocompleteResponse", TransportWeb.API.Spec.spec())
   end
 
+  test "search a dataset and an offer", %{conn: conn} do
+    offer = insert(:offer, nom_commercial: "Astuce")
+    dataset = insert(:dataset, custom_title: "Réseau urbain Astuce")
+
+    refresh_autocomplete_view()
+
+    json =
+      conn
+      |> get(Helpers.autocomplete_path(conn, :autocomplete, q: "astuce"))
+      |> json_response(200)
+
+    assert json == [
+             %{"name" => "Astuce", "type" => "offer", "url" => "/datasets/offer/#{offer.identifiant_offre}"},
+             %{"name" => "Réseau urbain Astuce", "type" => "dataset", "url" => "/datasets/#{dataset.slug}"}
+           ]
+
+    assert_response_schema(json, "AutocompleteResponse", TransportWeb.API.Spec.spec())
+  end
+
   defp refresh_autocomplete_view, do: Ecto.Adapters.SQL.query!(DB.Repo, "REFRESH MATERIALIZED VIEW autocomplete")
 end


### PR DESCRIPTION
Fixes #5236

> Dans un 1er temps et pour tester, je te propose de le mettre en dernière position dans la liste => le nom du jeu sera affiché si besoin, mais permettra d'afficher la recherche par lieu sur laquelle on avait bien améliorer le comportement.

Les résultats de `dataset` sont passés en dernière position, la priorité est donnée au reste.
