### PR TITLE
Validation : ajout NeTEx pour véhicules en libre-service

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
@@ -34,8 +34,8 @@ defmodule TransportWeb.Live.OnDemandValidationSelectLive do
               %{
                 icon: static_path(socket, "/images/icons/vehicles-sharing.svg"),
                 title: dgettext("validations", "Vehicles sharing"),
-                subtitle: "GBFS",
-                sub_tiles: [{"GBFS", "gbfs"}]
+                subtitle: "GBFS, NeTEx",
+                sub_tiles: ["GBFS", "NeTEx"] |> Enum.map(&{&1, String.downcase(&1)})
               }},
              {"schemas",
               %{

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -39,7 +39,8 @@ defmodule TransportWeb.ValidationControllerTest do
                {"h4", [], ["Transport public collectif"]},
                {"h4", [], ["Véhicules en libre-service"]},
                {"h4", [], ["Mobilités routières et vélo"]},
-               {"h4", [], ["GBFS"]}
+               {"h4", [], ["GBFS"]},
+               {"h4", [], ["NeTEx"]}
              ] == view |> render() |> Floki.parse_document!() |> Floki.find(".tile__text h4")
 
       view |> element(~s|[phx-value-tile="gbfs"]|) |> render_click()


### PR DESCRIPTION
Ajoute la catégorie NeTEx pour les véhicules libre-service en plus du GBFS.
