### PR TITLE
Notification ressource indisponible : affiche la durée

### DIFF
--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -660,6 +660,29 @@ defmodule TransportWeb.DatasetView do
     """
   end
 
+  def notification_sent_details(
+        %{
+          reason: :resource_unavailable,
+          payload: %{"resource_ids" => resource_ids, "hours_consecutive_downtime" => _}
+        } = assigns
+      ) do
+    assigns =
+      assign(
+        assigns,
+        :resources,
+        DB.Resource |> where([r], r.id in ^resource_ids) |> Ecto.Query.select([r], [:title, :id]) |> DB.Repo.all()
+      )
+
+    ~H"""
+    <td>
+      <a :for={resource <- @resources} href={resource_path(TransportWeb.Endpoint, :details, resource.id)} target="_blank">
+        {resource.title}
+      </a>
+      &mdash;&nbsp;{@payload["hours_consecutive_downtime"]}h
+    </td>
+    """
+  end
+
   def notification_sent_details(%{reason: reason, payload: %{"resource_ids" => resource_ids}} = assigns)
       when reason in [:dataset_with_error, :resource_unavailable] do
     assigns =

--- a/apps/transport/test/transport_web/views/dataset_view_test.exs
+++ b/apps/transport/test/transport_web/views/dataset_view_test.exs
@@ -310,7 +310,7 @@ defmodule TransportWeb.DatasetViewTest do
                locale: "fr",
                notification: %{
                  timestamp: ~U[2025-12-30 11:27:23.516350Z],
-                 payload: %{"resource_ids" => [resource.id]},
+                 payload: %{"resource_ids" => [resource.id], "hours_consecutive_downtime" => 48},
                  reason: :resource_unavailable
                }
              )
@@ -324,7 +324,8 @@ defmodule TransportWeb.DatasetViewTest do
                     [
                       {"a",
                        [{"href", resource_path(TransportWeb.Endpoint, :details, resource.id)}, {"target", "_blank"}],
-                       ["\n    GTFS\n  "]}
+                       ["\n    GTFS\n  "]},
+                      "\n  —\u00A048h\n"
                     ]},
                    {"td", [], ["30/12/2025 à 12h27 Europe/Paris"]}
                  ]


### PR DESCRIPTION
Affiche la durée en nombre d'heures constaté pour une notification en cas d'indisponibilité.

<img width="890" height="788" alt="Screenshot 2026-01-12 at 17 38 01" src="https://github.com/user-attachments/assets/40c3061f-ca21-40a7-819d-e07dc402582b" />
