### PR TITLE
ResourceUnavailableJob : skip de certaines ressources

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -177,7 +177,12 @@ config :transport,
   contact_email: "contact@transport.data.gouv.fr",
   tech_email: "tech@transport.data.gouv.fr",
   security_email: "securite@transport.data.gouv.fr",
-  transport_tools_folder: Path.absname("transport-tools/")
+  transport_tools_folder: Path.absname("transport-tools/"),
+  resource_unavailable_skip_resource_ids:
+    System.get_env("RESOURCE_UNAVAILABLE_SKIP_RESOURCE_IDS", "")
+    |> String.split(",")
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(&String.to_integer/1)
 
 # Disable sending events to Sentry by default.
 # Sentry events are only sent when `dsn` is not nil

--- a/config/test.exs
+++ b/config/test.exs
@@ -110,6 +110,7 @@ config :transport, DB.Repo,
   queue_target: 5000
 
 config :transport,
+  resource_unavailable_skip_resource_ids: [],
   datagouvfr_site: "https://demo.data.gouv.fr",
   datagouvfr_apikey: "fake-datagouv-api-key",
   # NOTE: some tests still rely on ExVCR cassettes at the moment. We configure the


### PR DESCRIPTION
Certaines ressources, comme https://transport.data.gouv.fr/resources/83282, doivent être ignorées lors de leur test d'indisponibilité et être considérées comme étant disponibles.

Ajoute une configuration pour "skip" certaines ressources et les considérer comme disponibles.
