### PR TITLE
OnDemand : URL plus cohérente

### DIFF
--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.ex
@@ -91,7 +91,7 @@ defmodule TransportWeb.Live.OnDemandValidationSelectLive do
 
   def handle_event("select_subtile", %{"tile" => tile}, socket) do
     socket = socket |> socket_data(type: tile, selected_subtile: tile)
-    {:noreply, socket |> push_patch(to: self_path(socket))}
+    {:noreply, socket |> push_patch(to: self_path(socket) <> "#form_anchor")}
   end
 
   def icon(type) do

--- a/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
+++ b/apps/transport/lib/transport_web/live/on_demand_validation_select_live.html.heex
@@ -17,22 +17,23 @@
         </a>
       </div>
 
-      <%= for {identifier, item} <- @tiles do %>
-        <div :if={@selected_tile == identifier} class="container available-data grid pt-24 pb-48">
-          <a
-            :for={{title, type} <- item.sub_tiles}
-            href="#form_anchor"
-            class={if @selected_subtile == type, do: "tile tile-colored", else: "tile sub_tile"}
-            phx-click="select_subtile"
-            phx-value-tile={type}
-          >
-            <img class="tile__icon" src={icon(type)} alt="" />
-            <div class="tile__text">
-              <h4>{title}</h4>
-            </div>
-          </a>
-        </div>
-      <% end %>
+      <div
+        :for={{identifier, item} <- @tiles}
+        :if={@selected_tile == identifier}
+        class="container available-data grid pt-24 pb-48"
+      >
+        <a
+          :for={{title, type} <- item.sub_tiles}
+          class={if @selected_subtile == type, do: "tile tile-colored", else: "tile sub_tile"}
+          phx-click="select_subtile"
+          phx-value-tile={type}
+        >
+          <img class="tile__icon" src={icon(type)} alt="" />
+          <div class="tile__text">
+            <h4>{title}</h4>
+          </div>
+        </a>
+      </div>
 
       <div id="form_anchor"></div>
       <.form


### PR DESCRIPTION
Les subtiles ne sont plus des liens mais deviennent de vrais boutons ; et le choix d'une subtile met à jour l'URL pour inclure l'ancre HTML, rendant l'URL du navigateur cohérente avec l'état de l'écran et ainsi partageable à un tiers.

Fixes #5237