### PR TITLE
Autocomplete : amélioration touche Entrée

### DIFF
--- a/apps/transport/client/javascripts/autocomplete.js
+++ b/apps/transport/client/javascripts/autocomplete.js
@@ -69,7 +69,27 @@ const autoCompletejs = new AutoComplete({
             return match.join('')
         }
     },
-    submit: false,
+    events: {
+        input: {
+            keydown (event) {
+                switch (event.keyCode) {
+                // Down/Up arrow
+                case 40:
+                case 38:
+                    event.preventDefault()
+                    event.keyCode === 40 ? autoCompletejs.next() : autoCompletejs.previous()
+                    break
+                // Enter
+                case 13:
+                    if (autoCompletejs.cursor >= 0) {
+                        event.preventDefault()
+                        autoCompletejs.select(event)
+                    }
+                    break
+                }
+            }
+        }
+    },
     resultsList: {
         maxResults: 7,
         id: 'autoComplete_list',


### PR DESCRIPTION
Amélioration de la touche "Entrée" pour l'autocomplete de la recherche :
- quand rien n'est sélectionné "Entrée" sélectionne le 1er choix
- on peut naviguer avec les flèches et valider avec la touche "Entrée"
