### PR TITLE
TableSizeHistoryJob : correction taille des hypertables TimescaleDB

### DIFF
--- a/apps/transport/test/test_helper.exs
+++ b/apps/transport/test/test_helper.exs
@@ -11,7 +11,7 @@ extra_exclude =
       _ -> [:ci_only_on_mondays]
     end
   else
-    [:transport_tools, :ci_only_on_mondays, :external]
+    [:transport_tools, :ci_only_on_mondays, :external, :timescaledb]
   end
 
 ExUnit.configure(exclude: exclude ++ extra_exclude)

--- a/apps/transport/test/transport/jobs/table_size_history_job_test.exs
+++ b/apps/transport/test/transport/jobs/table_size_history_job_test.exs
@@ -3,6 +3,8 @@ defmodule Transport.Test.Transport.Jobs.TableSizeHistoryJobTest do
   use Oban.Testing, repo: DB.Repo
   alias Transport.Jobs.TableSizeHistoryJob
 
+  @moduletag :timescaledb
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end


### PR DESCRIPTION
Utilise une requête spécifique pour avoir la véritable taille des tables TimescaleDB. cc @thbar
