### PR TITLE
[Validateur IRVE] Autoriser les coordonnées XY avec des espaces

### DIFF
--- a/apps/transport/lib/data_frame/validation_primitives.ex
+++ b/apps/transport/lib/data_frame/validation_primitives.ex
@@ -214,7 +214,7 @@ defmodule Transport.DataFrame.Validation.Primitives do
     )
   end
 
-  @geopoint_array_pattern ~S/\A\[\-?\d+(\.\d+)?\s?,\s?\-?\d+(\.\d+)?\]\z/
+  @geopoint_array_pattern ~S/\A\s?\[\-?\d+(\.\d+)?\s?,\s?\-?\d+(\.\d+)?\]\s?\z/
 
   @doc """
   Check if values are valid geopoint arrays (TableSchema format).
@@ -226,7 +226,7 @@ defmodule Transport.DataFrame.Validation.Primitives do
 
   ## Examples
 
-      iex> geopoint?(build_series(["[1,2]", "[-3,4.5]", "[0.0, -0.99]", "[-123.456,789]", "[42, 0]", "[1.2 , 3.4]"]), "array") |> Series.to_list()
+      iex> geopoint?(build_series(["[1,2]", "[-3,4.5]", "[0.0, -0.99]", "[-123.456,789]", "[42, 0]", " [1.2 , 3.4] "]), "array") |> Series.to_list()
       [true, true, true, true, true, true]
 
       iex> geopoint?(build_series(["1,2", "[1,2,3]", "[1;2]", "[1. ,2]", "[a, b]", "[,]"]), "array") |> Series.to_list()


### PR DESCRIPTION
Le fichier Gireve n’était pas valable parce que le format des coordonnées XY était  ` [8.73889 , 41.929317] ` avec un espace avant la virgule de séparation et aussi avant et après les crochets, et que ce format là n’était pas accepté par notre validateur. Cette PR rend ce format valide dans notre validateur.

## Est-ce un format vraiment valable ?

La spec du schéma IRVE dit pour cette colonne : "Type : point géographique (format array)". En renvoyant vers Frictionless pour la définition du type point géographique.

La spec de frictionless dit (voir https://specs.frictionlessdata.io/table-schema/#types-and-formats) qu’est accepté comme Geopoint valable trois formats différents.  Nous n’acceptons que le deuxième : 

> A JSON array, or a string parsable as a JSON array, of exactly two items, where each item is a number, and the first item is lon and the second item is lat e.g. [90, 45]

La question est donc de savoir si un espace avant la virgule est accepté dans la norme JSON. Je n’ai pas réussi à mettre la main sur la spec, mais au moins c’est parsé correctement par la lib JS de Node :

```
Welcome to Node.js v22.16.0.
Type ".help" for more information.
> JSON.parse("[1.2, 3.4]")
[ 1.2, 3.4 ]
> JSON.parse("[1.2 , 3.4]")
[ 1.2, 3.4 ]
> JSON.parse(" [1.2 , 3.4] ")
[ 1.2, 3.4 ]
```

Donc ça me paraît acceptable de considérer que c’est un format valide.

## Quid du parsing avant import dans la base de données ?

C’était déjà couvert ici : 

https://github.com/etalab/transport-site/blob/6a00baf3d91d8652782a5e64ab4fd7aa4534d3c1/apps/transport/lib/irve/data_frame.ex#L256

## Vérification que tout marche bien

Je vérifie que l’import en base se passe bien, tout comme le parsing des coordonnées avant l’import en base !

```
iex(1)> path = "gireve-irve-statique.csv"
"gireve-irve-statique.csv"
iex(2)> path |> Transport.IRVE.Validator.validate |> Transport.IRVE.Validator.full_file_valid?
true
iex(3)> Transport.IRVE.DatabaseImporter.write_to_db(path, "dataset-id", "resource-datagouv-id")
{:ok, {0, nil}}
iex(8)> DB.IRVEValidPDC |> select([v], [v.latitude, v.longitude]) |> where(irve_valid_file_id: ^file.id) |> Ecto.Query.last |> DB.Repo.one!
[Decimal.new("48.87849"), Decimal.new("2.78968")]
```