### PR TITLE
[IRVE] Transformation en UTF8 avant de stocker en base de données (pour que les fichiers latin-1 y soient)

### DIFF
--- a/apps/transport/lib/irve/database_importer.ex
+++ b/apps/transport/lib/irve/database_importer.ex
@@ -33,7 +33,9 @@ defmodule Transport.IRVE.DatabaseImporter do
   end
 
   def write_to_db(file_path, dataset_datagouv_id, resource_datagouv_id) do
-    content = File.read!(file_path)
+    content =
+      File.read!(file_path)
+      |> Transport.IRVE.RawStaticConsolidation.ensure_utf8()
 
     rows_stream =
       content |> Transport.IRVE.Processing.read_as_data_frame() |> Explorer.DataFrame.to_rows_stream()


### PR DESCRIPTION
On avait des erreurs de type PolarsError au moment d’importer des fichiers pourtant valides en base de données, typiquement le fichier Tesla :

```
iex(1)> Transport.IRVE.DatabaseImporter.write_to_db("irve-tesla-supercharger-2025-09-04.csv", "tesla-datagouv-id", "tesla-resource-id")
** (RuntimeError) Polars Error: invalid utf-8 sequence
    (transport 0.0.1) lib/irve/data_frame.ex:136: Transport.IRVE.DataFrame.dataframe_from_csv_body!/3
    (transport 0.0.1) lib/irve/processing.ex:12: Transport.IRVE.Processing.read_as_data_frame/1
    (transport 0.0.1) lib/irve/database_importer.ex:39: Transport.IRVE.DatabaseImporter.write_to_db/3
    iex:1: (file)
```

La raison est que on transformait du latin-1 à l’UTF-8 avant de valider… mais pas avant de stocker en base de données. Ce traitement est rajouté, ce qui permet de rajouter ces fichiers redressés en base de données.

Avec ma donnée locale, on passe de :

```
Number of valid PDCs in database: 290755
Number of distinct id_pdc_itinerance in these PDCs: 133927
Number of valid files in database: 1233
```

À :

```
End of processing. Final counts:
Number of valid PDCs in database: 324073
Number of distinct id_pdc_itinerance in these PDCs: 138315
Number of valid files in database: 1337
```