### PR TITLE
StatsHandler : compte nombre de ressources

### DIFF
--- a/apps/transport/test/transport/stats_handler_test.exs
+++ b/apps/transport/test/transport/stats_handler_test.exs
@@ -274,4 +274,12 @@ defmodule Transport.StatsHandlerTest do
 
     assert %{reuses: ^reuses_stats} = compute_stats()
   end
+
+  test "count_resources_stats" do
+    insert_list(4, :resource, format: "gbfs")
+    insert_list(5, :resource, format: "GTFS")
+    insert_list(10, :resource, format: "gtfs-rt")
+
+    assert %{nb_gtfs_rt_resources: 10, nb_gtfs_resources: 5} = compute_stats()
+  end
 end


### PR DESCRIPTION
Modifie `StatsHandler` pour enregistrer le nombre de ressources par format, pour les formats les plus communs.

Il y a déjà des stats nommées par exemple `nb_gtfs` mais ceci compte le nombre de JDDs ayant au moins 1 GTFS. On veut aussi pouvoir compter le nombre de ressources.
