### PR TITLE
Rapport IRVE opérationnel (suivi global + détaillé)

### DIFF
--- a/scripts/irve/stats.exs
+++ b/scripts/irve/stats.exs
@@ -8,8 +8,8 @@ sources = [
    "consolidation-transport-avec-doublons-irve-statique.csv", :resource_datagouv_id},
   {"https://proxy.transport.data.gouv.fr/resource/consolidation-nationale-irve-statique-brute-v1",
    "consolidation-nationale-irve-statique-brute-v1.csv", :original_resource_id},
-  {"https://www.data.gouv.fr/fr/datasets/r/eb76d20a-8501-400e-b336-d85724de5435",
-   "consolidation-data-gouv.csv", :datagouv_resource_id},
+  {"https://www.data.gouv.fr/fr/datasets/r/eb76d20a-8501-400e-b336-d85724de5435", "consolidation-data-gouv.csv",
+   :datagouv_resource_id}
   # # generate with `mix run dump-simple-consolidation.exs`
   # {:on_disk, "simple-consolidation.csv", :datagouv_resource_id}
 ]
@@ -62,6 +62,7 @@ defmodule Stats do
   def compute_stats({url_or_atom, identifier, _resource_id_column}) do
     local_path = local_path(identifier)
     maybe_download(url_or_atom, local_path)
+
     Stats.compute(local_path)
     |> Map.put(:path, local_path |> Path.basename())
   end


### PR DESCRIPTION
Cette PR prend les 3 ressources suivantes:
1. le consolidé statique de data gouv
2. notre "consolidé brut" (non validé, non dédoublonné)
3. notre "consolidé simple" (validé, non dédoublonné)

et affiche des statistiques groupées. Objectif : savoir ce qu'il nous manque à intégrer à la consolidation "simple".

Attention: il faut créer `cache-dir` avant, et le vider d'éventuelles versions cachées avant.

Output avec les données fraîches d'à l'instant:

<img width="716" height="245" alt="Screenshot 2026-02-03 at 13 58 14" src="https://github.com/user-attachments/assets/cf9dc91a-6939-4912-8948-316bc3479f1d" />

@vdegove je garde le diagramme d'UpSet pour un prochain tour.