### PR TITLE
ImportDatasetContactPointsJob : gère cas où email est nil

### DIFF
--- a/apps/transport/lib/jobs/import_dataset_contact_points_job.ex
+++ b/apps/transport/lib/jobs/import_dataset_contact_points_job.ex
@@ -91,13 +91,17 @@ defmodule Transport.Jobs.ImportDatasetContactPointsJob do
 
   defp update_contact_points(%DB.Dataset{} = dataset, contact_points) do
     contacts = Enum.map(contact_points, &update_contact_point(dataset, &1))
-    contact_ids = Enum.map(contacts, & &1.id)
+    contact_ids = contacts |> Enum.reject(&is_nil/1) |> Enum.map(& &1.id)
 
     DB.NotificationSubscription.delete_other_producers_subscriptions(
       dataset,
       contact_ids,
       @notification_subscription_source
     )
+  end
+
+  defp update_contact_point(%DB.Dataset{} = dataset, %{"email" => nil} = _contact_point) do
+    nil
   end
 
   defp update_contact_point(%DB.Dataset{} = dataset, %{"email" => _, "name" => _} = contact_point) do

--- a/apps/transport/test/transport/jobs/import_dataset_contact_points_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_dataset_contact_points_job_test.exs
@@ -186,6 +186,22 @@ defmodule Transport.Test.Transport.Jobs.ImportDatasetContactPointsJobTest do
       assert MapSet.new(@producer_reasons) == subscribed_reasons(dataset, john)
       assert MapSet.new(@producer_reasons) == subscribed_reasons(dataset, jane)
     end
+
+    test "it does not crash when email is nil" do
+      %DB.Dataset{datagouv_id: datagouv_id} = insert(:dataset)
+
+      Datagouvfr.Client.Datasets.Mock
+      |> expect(:get, 1, fn ^datagouv_id ->
+        {:ok,
+         %{
+           "contact_points" => [
+             %{"email" => nil, "name" => "John DOE"}
+           ]
+         }}
+      end)
+
+      ImportDatasetContactPointsJob.import_contact_point(datagouv_id)
+    end
   end
 
   test "perform" do


### PR DESCRIPTION
Follow-up de #5287, gère le cas où `email == nil`, ce qui survient malheureusement dans les données de production.
