### PR TITLE
Feed Atom : corrige tag de début

### DIFF
--- a/apps/transport/lib/transport_web/templates/atom/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/atom/index.html.heex
@@ -1,27 +1,26 @@
-<?xml version="1.0" encoding="utf-8" ?>
-  <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>transport.data.gouv.fr</title>
-    <subtitle>Jeux de données GTFS</subtitle>
-    {raw(~s(<link href="#{atom_url(@conn, :index)}" rel="self" />))}
-    <id>tag:transport.data.gouv.fr,2019-02-27:/20190227161047181</id>
-    <updated>{last_updated(@resources)}</updated>
+{raw(~s(<?xml version="1.0" encoding="utf-8" ?>))}
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>transport.data.gouv.fr</title>
+  <subtitle>Jeux de données GTFS</subtitle>
+  {raw(~s(<link href="#{atom_url(@conn, :index)}" rel="self" />))}
+  <id>tag:transport.data.gouv.fr,2019-02-27:/20190227161047181</id>
+  <updated>{last_updated(@resources)}</updated>
 
-    <%= for resource <- @resources do %>
-      <entry>
-        <title>{resource.dataset.custom_title} — {resource.title}</title>
-        {raw(~s(<link href="#{resource.latest_url}" />))}
-        <id>{resource_url(@conn, :details, resource.id)}</id>
-        <updated>{resource.last_update |> DateTime.to_iso8601()}</updated>
-        <summary>Cette ressource fait partie du jeux de données {resource.dataset.custom_title}</summary>
-        <content type="html">
-          {raw(
-            "<![CDATA[#{elem(TransportWeb.MarkdownHandler.markdown_to_safe_html!(resource.dataset.description), 1)}]]>"
-          )}
-        </content>
-        <author>
-          <name>{resource.dataset.organization}</name>
-        </author>
-      </entry>
-    <% end %>
-  </feed>
-</?xml>
+  <%= for resource <- @resources do %>
+    <entry>
+      <title>{resource.dataset.custom_title} — {resource.title}</title>
+      {raw(~s(<link href="#{resource.latest_url}" />))}
+      <id>{resource_url(@conn, :details, resource.id)}</id>
+      <updated>{resource.last_update |> DateTime.to_iso8601()}</updated>
+      <summary>Cette ressource fait partie du jeux de données {resource.dataset.custom_title}</summary>
+      <content type="html">
+        {raw(
+          "<![CDATA[#{elem(TransportWeb.MarkdownHandler.markdown_to_safe_html!(resource.dataset.description), 1)}]]>"
+        )}
+      </content>
+      <author>
+        <name>{resource.dataset.organization}</name>
+      </author>
+    </entry>
+  <% end %>
+</feed>

--- a/apps/transport/test/transport_web/controllers/atom_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/atom_controller_test.exs
@@ -71,7 +71,7 @@ defmodule TransportWeb.AtomControllerTest do
                    {"id", [], ["http://127.0.0.1:5100/resources/#{resource_id}"]},
                    {"updated", [], [last_update |> DateTime.to_iso8601()]},
                    {"summary", [], ["Cette ressource fait partie du jeux de données Custom Title"]},
-                   {"content", [{"type", "html"}], ["\n          <p>\n  Hello</p>\n\n        "]},
+                   {"content", [{"type", "html"}], ["\n        <p>\n  Hello</p>\n\n      "]},
                    {"author", [], [{"name", [], ["BusCorp"]}]}
                  ]}
               ]}


### PR DESCRIPTION
Corrige le flux Atom qui a une mauvaise syntaxe, il ne faut pas de "closing tag".

Trouvé [suite à un signalement](https://app.frontapp.com/open/cnv_1bptc992?key=KUcukBOa7QPj0sXpLpHjtpHHTnEH4Njd).
