### PR TITLE
Unlock : désactive le log de requêtes dans plug TokenAuth

### DIFF
--- a/apps/transport/lib/unlock/plugs/token_auth.ex
+++ b/apps/transport/lib/unlock/plugs/token_auth.ex
@@ -8,12 +8,24 @@ defmodule Unlock.Plugs.TokenAuth do
   - Otherwise, respond with a 401 response.
 
   If the request does not contain a token, the request can go through.
+
+  This plug is only active when the config value `:unlock_token_auth_enabled` is set to `true`.
   """
   import Plug.Conn
 
   def init(default), do: default
 
   def call(%Plug.Conn{} = conn, _) do
+    if enabled?() do
+      do_call(conn)
+    else
+      conn
+    end
+  end
+
+  defp enabled?, do: Application.fetch_env!(:transport, :unlock_token_auth_enabled)
+
+  defp do_call(%Plug.Conn{} = conn) do
     conn = fetch_query_params(conn)
 
     case find_client(Map.get(conn.query_params, "token")) do

--- a/apps/transport/test/unlock/plugs/token_auth_test.exs
+++ b/apps/transport/test/unlock/plugs/token_auth_test.exs
@@ -11,66 +11,134 @@ defmodule Unlock.Plugs.TokenAuthTest do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
   end
 
-  test "valid token passed" do
-    slug = "an-existing-identifier"
-    %DB.Token{id: token_id} = token = insert_token()
+  describe "when enabled" do
+    setup do
+      setup_token_auth_enabled(true)
+    end
 
-    setup_proxy_config(%{
-      slug => %Unlock.Config.Item.Generic.HTTP{
-        identifier: slug,
-        target_url: target_url = "http://localhost/some-remote-resource",
-        ttl: 30
-      }
-    })
+    test "valid token passed: request is logged" do
+      slug = "an-existing-identifier"
+      %DB.Token{id: token_id} = token = insert_token()
 
-    Unlock.HTTP.Client.Mock
-    |> expect(:get!, fn url, _headers = [], _options = [] ->
-      assert url == target_url
-      %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
-    end)
+      setup_proxy_config(%{
+        slug => %Unlock.Config.Item.Generic.HTTP{
+          identifier: slug,
+          target_url: target_url = "http://localhost/some-remote-resource",
+          ttl: 30
+        }
+      })
 
-    resp = proxy_conn() |> get("/resource/#{slug}?token=#{token.secret}")
+      Unlock.HTTP.Client.Mock
+      |> expect(:get!, fn url, _headers = [], _options = [] ->
+        assert url == target_url
+        %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
+      end)
 
-    assert resp.resp_body == "somebody-to-love"
-    assert %DB.Token{id: ^token_id} = resp.assigns[:token]
+      resp = proxy_conn() |> get("/resource/#{slug}?token=#{token.secret}")
 
-    assert [
-             %DB.ProxyRequest{proxy_id: ^slug, token_id: ^token_id}
-           ] = DB.ProxyRequest |> DB.Repo.all()
+      assert resp.resp_body == "somebody-to-love"
+      assert %DB.Token{id: ^token_id} = resp.assigns[:token]
+
+      assert [
+               %DB.ProxyRequest{proxy_id: ^slug, token_id: ^token_id}
+             ] = DB.ProxyRequest |> DB.Repo.all()
+    end
+
+    test "no token passed" do
+      slug = "another-identifier"
+
+      setup_proxy_config(%{
+        slug => %Unlock.Config.Item.Generic.HTTP{
+          identifier: slug,
+          target_url: target_url = "http://localhost/some-remote-resource",
+          ttl: 30
+        }
+      })
+
+      Unlock.HTTP.Client.Mock
+      |> expect(:get!, fn url, _headers = [], _options = [] ->
+        assert url == target_url
+        %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
+      end)
+
+      resp = proxy_conn() |> get("/resource/#{slug}")
+
+      assert resp.resp_body == "somebody-to-love"
+      assert is_nil(resp.assigns[:token])
+
+      assert [] = DB.ProxyRequest |> DB.Repo.all()
+    end
+
+    test "invalid token passed" do
+      resp = proxy_conn() |> get("/resource/slug?token=invalid")
+
+      assert resp.status == 401
+      assert resp.resp_body == ~s|{"error":"You must set a valid token in the query parameters"}|
+
+      assert DB.ProxyRequest |> DB.Repo.all() == []
+    end
   end
 
-  test "no token passed" do
-    slug = "another-identifier"
+  describe "when disabled" do
+    setup do
+      setup_token_auth_enabled(false)
+    end
 
-    setup_proxy_config(%{
-      slug => %Unlock.Config.Item.Generic.HTTP{
-        identifier: slug,
-        target_url: target_url = "http://localhost/some-remote-resource",
-        ttl: 30
-      }
-    })
+    test "valid token passed: no requests logged" do
+      slug = "an-existing-identifier-valid-token"
+      token = insert_token()
 
-    Unlock.HTTP.Client.Mock
-    |> expect(:get!, fn url, _headers = [], _options = [] ->
-      assert url == target_url
-      %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
-    end)
+      setup_proxy_config(%{
+        slug => %Unlock.Config.Item.Generic.HTTP{
+          identifier: slug,
+          target_url: target_url = "http://localhost/some-remote-resource",
+          ttl: 30
+        }
+      })
 
-    resp = proxy_conn() |> get("/resource/#{slug}")
+      Unlock.HTTP.Client.Mock
+      |> expect(:get!, fn url, _headers = [], _options = [] ->
+        assert url == target_url
+        %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
+      end)
 
-    assert resp.resp_body == "somebody-to-love"
-    assert is_nil(resp.assigns[:token])
+      resp = proxy_conn() |> get("/resource/#{slug}?token=#{token.secret}")
+      assert resp.resp_body == "somebody-to-love"
 
-    assert [] = DB.ProxyRequest |> DB.Repo.all()
+      assert [] = DB.ProxyRequest |> DB.Repo.all()
+    end
+
+    test "invalid token passes through without authentication" do
+      slug = "an-identifier"
+
+      setup_proxy_config(%{
+        slug => %Unlock.Config.Item.Generic.HTTP{
+          identifier: slug,
+          target_url: target_url = "http://localhost/some-remote-resource",
+          ttl: 30
+        }
+      })
+
+      Unlock.HTTP.Client.Mock
+      |> expect(:get!, fn url, _headers = [], _options = [] ->
+        assert url == target_url
+        %Unlock.HTTP.Response{body: "somebody-to-love", status: 200, headers: []}
+      end)
+
+      resp = proxy_conn() |> get("/resource/#{slug}?token=invalid")
+
+      assert resp.status == 200
+      assert resp.resp_body == "somebody-to-love"
+      assert is_nil(resp.assigns[:token])
+
+      assert [] = DB.ProxyRequest |> DB.Repo.all()
+    end
   end
 
-  test "invalid token passed" do
-    resp = proxy_conn() |> get("/resource/slug?token=invalid")
-
-    assert resp.status == 401
-    assert resp.resp_body == ~s|{"error":"You must set a valid token in the query parameters"}|
-
-    assert DB.ProxyRequest |> DB.Repo.all() == []
+  defp setup_token_auth_enabled(enabled) do
+    current_value = Application.get_env(:transport, :unlock_token_auth_enabled)
+    Application.put_env(:transport, :unlock_token_auth_enabled, enabled)
+    on_exit(fn -> Application.put_env(:transport, :unlock_token_auth_enabled, current_value) end)
   end
 
   defp setup_proxy_config(config) do

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,8 @@ config :transport,
     "https://raw.githubusercontent.com/transportdatagouvfr/proxy-config/refs/heads/master/proxy-config.yml",
   unlock_github_auth_token: System.get_env("TRANSPORT_PROXY_CONFIG_GITHUB_TOKEN"),
   unlock_siri_public_requestor_ref: "transport-data-gouv-fr",
-  unlock_event_incrementer: Unlock.BatchMetrics
+  unlock_event_incrementer: Unlock.BatchMetrics,
+  unlock_token_auth_enabled: false
 
 config :transport, Unlock.Endpoint, []
 


### PR DESCRIPTION
En lien avec #5313 : désactive le log de requêtes dans `proxy_request`.

Auparavant on loggait 1 requête par requête HTTP authentifiée, on arrive à déjà 31M de lignes.
