### PR TITLE
TokenAuth Unlock : bucket par heure des requêtes

### DIFF
--- a/apps/transport/lib/db/proxy_request.ex
+++ b/apps/transport/lib/db/proxy_request.ex
@@ -10,6 +10,7 @@ defmodule DB.ProxyRequest do
   typed_schema "proxy_request" do
     field(:time, :utc_datetime_usec)
     field(:proxy_id, :string)
+    field(:count, :integer, default: 1)
     belongs_to(:token, DB.Token)
   end
 end

--- a/apps/transport/priv/repo/migrations/20260203171828_proxy_request_add_count.exs
+++ b/apps/transport/priv/repo/migrations/20260203171828_proxy_request_add_count.exs
@@ -1,0 +1,11 @@
+defmodule DB.Repo.Migrations.ProxyRequestAddCount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:proxy_request) do
+      add(:count, :integer, default: 1, null: false)
+    end
+
+    create_if_not_exists(unique_index(:proxy_request, [:time, :token_id, :proxy_id]))
+  end
+end


### PR DESCRIPTION
Suite de #5314, cette PR bucketise les requêtes par heure pour le proxy Unlock. Les requêtes sont logguées uniquement quand un token est passé.

La clé d'unicité est `(token, slug, time)`.
