### PR TITLE
Validateur IRVE : autoriser plusieurs espaces dans les coordonnées

### DIFF
--- a/apps/transport/lib/data_frame/validation_primitives.ex
+++ b/apps/transport/lib/data_frame/validation_primitives.ex
@@ -226,13 +226,11 @@ defmodule Transport.DataFrame.Validation.Primitives do
 
   ## Examples
 
-      iex> geopoint?(build_series(["[1,2]", "[-3,4.5]", "[0.0, -0.99]", "[-123.456,789]", "[42, 0]", " [1.2 , 3.4] ", "[ 1.2, 3.4 ]"]), "array") |> Series.to_list()
-      [true, true, true, true, true, true, true]
+      iex> geopoint?(build_series(["[1,2]", "[-3,4.5]", "[0.0, -0.99]", "[-123.456,789]", "[42, 0]", " [1.2 , 3.4] ", "[ 1.2, 3.4 ]", "[43.901514,  -0.480207]"]), "array") |> Series.to_list()
+      [true, true, true, true, true, true, true, true]
 
       iex> geopoint?(build_series(["1,2", "[1,2,3]", "[1;2]", "[1. ,2]", "[a, b]", "[,]"]), "array") |> Series.to_list()
       [false, false, false, false, false, false]
-
-      iex> geopoint?(build_series(["[43.901514,  -0.480207]"]), "array") |> Series.to_list()
   """
   def geopoint?(series, "array" = _format) do
     Series.re_contains(series, @geopoint_array_pattern)


### PR DESCRIPTION
Petite amélioration encore de la Regex qui valide le champ CoordonneesXY : pour l’instant, on autorisait comme espaces autour des délimitateurs soit un espace, soit une tabublation. Certains PDC ont deux espaces, par exemple `FRALLEGO9004091` : `[43.901514,  -0.480207]` (il y a deux espaces à la suite avant le signe moins).

Cette PR allège donc cette contrainte en autorisant un nombre infini d’espaces ou de tabulations autour des séparateurs.