### PR TITLE
Dataset order_datasets : population n'est plus null

### DIFF
--- a/apps/transport/lib/db/dataset.ex
+++ b/apps/transport/lib/db/dataset.ex
@@ -559,9 +559,7 @@ defmodule DB.Dataset do
           "case when organization_id = ? and custom_title ilike 'base nationale%' then 1 else 0 end",
           ^pan_publisher
         ),
-      # Gotcha, population can be null for datasets covering France/Europe
-      # https://github.com/etalab/transport-site/issues/3848
-      desc: fragment("coalesce(population, 100000000)"),
+      desc: :population,
       asc: :custom_title
     )
   end


### PR DESCRIPTION
Avec le passage aux territoires, le champ `population` n'est plus `null` pour les JDDs couvrant la France.
