### PR TITLE
DatasetController : suppression code mort

### DIFF
--- a/apps/transport/lib/transport_web/controllers/dataset_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/dataset_controller.ex
@@ -249,18 +249,12 @@ defmodule TransportWeb.DatasetController do
 
     params
     |> Dataset.list_datasets()
-    |> preload_spatial_areas(params)
+    |> preload_spatial_areas()
     |> Repo.paginate(page: config.page_number)
   end
 
-  # pre-optimisation version kept, in order to allow side-by-side prod benchmark
-  defp preload_spatial_areas(query, %{"before_optim" => "1"}) do
-    query |> preload([:declarative_spatial_areas])
-  end
-
-  defp preload_spatial_areas(query, _params) do
+  defp preload_spatial_areas(query) do
     DB.AdministrativeDivision
-    # avoid loading `:geom` (total for `/datasets` can be several MB)
     |> select([a], struct(a, [:type, :nom]))
     |> then(&preload(query, declarative_spatial_areas: ^&1))
   end


### PR DESCRIPTION
Supprime du code qui avait été utilisé pour faire du benchmark.

Désormais plus nécessaire.
