### PR TITLE
NeTEx: Dates de validité dans le cartouche

### DIFF
--- a/apps/transport/lib/db/resource_metadata.ex
+++ b/apps/transport/lib/db/resource_metadata.ex
@@ -30,7 +30,7 @@ defmodule DB.ResourceMetadata do
     |> join(:left, [resource: r], m in DB.ResourceMetadata, on: r.id == m.resource_id, as: :metadata)
   end
 
-  def where_gtfs_up_to_date(query) do
+  def where_up_to_date(query) do
     today = Date.utc_today()
 
     query

--- a/apps/transport/lib/jobs/datasets_without_gtfs_rt_related_resources_notification_job.ex
+++ b/apps/transport/lib/jobs/datasets_without_gtfs_rt_related_resources_notification_job.ex
@@ -37,7 +37,7 @@ defmodule Transport.Jobs.DatasetsWithoutGTFSRTRelatedResourcesNotificationJob do
           & &1.validator_name()
         )
       )
-      |> DB.ResourceMetadata.where_gtfs_up_to_date()
+      |> DB.ResourceMetadata.where_up_to_date()
       |> where([resource: r], r.format == "GTFS" and not r.is_community_resource)
       |> group_by([dataset: d], d.id)
       |> having([resource: r], count(r.id) > 1)

--- a/apps/transport/lib/jobs/gtfs_import_stops_job.ex
+++ b/apps/transport/lib/jobs/gtfs_import_stops_job.ex
@@ -105,7 +105,7 @@ defmodule Transport.Jobs.GTFSImportStopsJob do
     |> DB.Dataset.join_from_dataset_to_metadata(
       Enum.map(Transport.ValidatorsSelection.validators_for_feature(:gtfs_import_stops_job), & &1.validator_name())
     )
-    |> DB.ResourceMetadata.where_gtfs_up_to_date()
+    |> DB.ResourceMetadata.where_up_to_date()
     |> where([resource: r], r.format == "GTFS")
     |> select([resource_history: rh], rh)
     |> DB.Repo.all()

--- a/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/api/controllers/stats_controller.ex
@@ -278,7 +278,7 @@ defmodule TransportWeb.API.StatsController do
     |> DB.Dataset.join_from_dataset_to_metadata(
       Enum.map(Transport.ValidatorsSelection.validators_for_feature(:api_stats_controller), & &1.validator_name())
     )
-    |> DB.ResourceMetadata.where_gtfs_up_to_date()
+    |> DB.ResourceMetadata.where_up_to_date()
     |> where([resource: r], r.is_available == true)
     |> select([dataset: d, multi_validation: mv], %{dataset_id: d.id, max_error: mv.max_error})
   end

--- a/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
+++ b/apps/transport/lib/transport_web/templates/dataset/_resource.html.heex
@@ -2,11 +2,16 @@
 <% has_conversions = ResourceView.has_associated_files(@resources_related_files, @resource.id) %>
 <% unavailabilities = @resources_infos.unavailabilities %>
 <% validation = latest_validation(@resource, @resources_infos) %>
-<% gtfs_outdated? = Transport.Validators.GTFSTransport.gtfs_outdated?(validation) %>
+<% validator = pick_validator(validation) %>
+<% tc? = Resource.gtfs?(@resource) or Resource.netex?(@resource) %>
+<% outdated? =
+  if validator do
+    validator.outdated?(validation)
+  end %>
 <% related_gtfs_resource = related_gtfs_resource(@resource) %>
 
 <div
-  class={"panel resource #{valid_panel_class(@resource, gtfs_outdated?)}"}
+  class={"panel resource #{valid_panel_class(@resource, outdated?)}"}
   title={resource_tooltip_content(@resource)}
 >
   <h4>{@resource.title}</h4>
@@ -16,7 +21,7 @@
     {link(schema_label(@resource), to: documentation_url(@resource), target: "_blank")}
   </div>
 
-  <.validity_dates :if={Resource.gtfs?(@resource)} multi_validation={validation} locale={locale} />
+  <.validity_dates :if={tc?} multi_validation={validation} locale={locale} />
 
   <div class="pb-24 light-gry">
     <.resource_last_update_span
@@ -65,18 +70,18 @@
   </div>
 
   <div
-    :if={Resource.gtfs?(@resource) or not @resource.is_available}
-    class={"resource-status-corner #{resource_class(@resource.is_available, gtfs_outdated?)}"}
+    :if={tc? or not @resource.is_available}
+    class={"resource-status-corner #{resource_class(@resource.is_available, outdated?)}"}
   >
     <span class={resource_span_class(@resource)}>
       <%= unless @resource.is_available do %>
         {dgettext("page-dataset-details", "Not")} <br />
         {dgettext("page-dataset-details", "available")}
       <% else %>
-        <%= if gtfs_outdated? == true do %>
+        <%= if outdated? == true do %>
           {dgettext("page-dataset-details", "Outdated")}
         <% end %>
-        <%= if gtfs_outdated? == false do %>
+        <%= if outdated? == false do %>
           {dgettext("page-dataset-details", "Up to date")}
         <% end %>
       <% end %>
@@ -99,7 +104,7 @@
     )}
   <% end %>
 
-  <%= unless Resource.gtfs?(@resource) or Resource.netex?(@resource) do %>
+  <%= unless tc? do %>
     {render(TransportWeb.DatasetView, "_resource_validation_summary.html",
       conn: @conn,
       resource: @resource,

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -346,7 +346,7 @@ defmodule TransportWeb.DatasetView do
   def valid_panel_class(%DB.Resource{is_available: false}, _), do: "invalid-resource-panel"
 
   def valid_panel_class(%DB.Resource{} = r, is_outdated) do
-    if Resource.gtfs?(r) && is_outdated do
+    if (Resource.gtfs?(r) or Resource.netex?(r)) && is_outdated do
       "invalid-resource-panel"
     else
       ""
@@ -648,6 +648,13 @@ defmodule TransportWeb.DatasetView do
         validations |> Enum.filter(&Transport.Validators.MobilityDataGTFSValidator.mine?/1) |> hd()
     end
   end
+
+  def pick_validator(%DB.MultiValidation{} = validation) do
+    [Transport.Validators.GTFSTransport, Transport.Validators.NeTEx.Validator]
+    |> Enum.find(fn validator -> validator.validator_name() == validation.validator end)
+  end
+
+  def pick_validator(_), do: nil
 
   def empty_to_nil(""), do: nil
   def empty_to_nil(value), do: value

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -196,7 +196,7 @@ defmodule Transport.Validators.GTFSRT do
     )
     |> ResourceMetadata.join_validation_with_metadata()
     |> where([resource: r], r.format == "GTFS" and not r.is_community_resource and r.dataset_id == ^dataset_id)
-    |> ResourceMetadata.where_gtfs_up_to_date()
+    |> ResourceMetadata.where_up_to_date()
     |> preload([resource_history: rh], resource_history: rh)
     |> Repo.all()
   end

--- a/apps/transport/lib/validators/gtfs_transport_validator.ex
+++ b/apps/transport/lib/validators/gtfs_transport_validator.ex
@@ -312,37 +312,17 @@ defmodule Transport.Validators.GTFSTransport do
       "MissingAgencyId" => dgettext("gtfs-transport-validator", "Field agency_id should not be empty.")
     }
 
-  @spec gtfs_outdated?(any()) :: boolean | nil
+  @impl Transport.Validators.Validator
   @doc """
   true if the gtfs is outdated
   false if not
   nil if we don't know
-
-  iex> validation = %DB.MultiValidation{validator: validator_name(), metadata: %DB.ResourceMetadata{metadata: %{"end_date" => "1900-01-01"}}}
-  iex> gtfs_outdated?(validation)
-  true
-  iex> validation = %DB.MultiValidation{validator: validator_name(), metadata: %DB.ResourceMetadata{metadata: %{"end_date" => "2900-01-01"}}}
-  iex> gtfs_outdated?(validation)
-  false
-  iex> gtfs_outdated?(%DB.MultiValidation{})
-  nil
-  iex> validation = %DB.MultiValidation{validator: validator_name(), metadata: %DB.ResourceMetadata{metadata: %{"end_date" => Date.utc_today() |> Date.to_iso8601()}}}
-  iex> gtfs_outdated?(validation)
-  true
   """
-  def gtfs_outdated?(%DB.MultiValidation{validator: @validator_name} = multi_validation) do
-    multi_validation
-    |> DB.MultiValidation.get_metadata_info("end_date")
-    |> case do
-      nil ->
-        nil
-
-      end_date ->
-        end_date |> Date.from_iso8601!() |> Date.compare(Date.utc_today()) !== :gt
-    end
+  def outdated?(%DB.MultiValidation{validator: @validator_name} = multi_validation) do
+    DB.MultiValidation.outdated?(multi_validation)
   end
 
-  def gtfs_outdated?(_), do: nil
+  def outdated?(_), do: nil
 
   @spec find_tags(map()) :: [binary()]
   def find_tags(metadata) do

--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -29,8 +29,10 @@ defmodule Transport.Validators.NeTEx.Validator do
   def poll_interval(nb_tries) when nb_tries < 6, do: 10
   def poll_interval(_), do: 20
 
+  @validator_name "enroute-chouette-netex-validator"
+
   @impl Transport.Validators.Validator
-  def validator_name, do: "enroute-chouette-netex-validator"
+  def validator_name, do: @validator_name
 
   # This will change with an actual versioning of the validator
   def validator_version, do: "0.2.1"
@@ -255,6 +257,18 @@ defmodule Transport.Validators.NeTEx.Validator do
         {:error, :unexpected_validation_status}
     end
   end
+
+  @impl Transport.Validators.Validator
+  @doc """
+  - true if the NeTEx is outdated.
+  - false if not.
+  - nil if we don't know.
+  """
+  def outdated?(%DB.MultiValidation{validator: @validator_name} = multi_validation) do
+    DB.MultiValidation.outdated?(multi_validation)
+  end
+
+  def outdated?(_), do: nil
 
   defp client do
     Transport.EnRouteChouetteValidClient.Wrapper.impl()

--- a/apps/transport/lib/validators/validator.ex
+++ b/apps/transport/lib/validators/validator.ex
@@ -7,6 +7,13 @@ defmodule Transport.Validators.Validator do
 
   @callback validate_and_save(any()) :: :ok | {:error, any()}
   @callback validator_name() :: binary()
+
+  @doc """
+  - true if the validated resource is outdated.
+  - false if not.
+  - nil if we don't know.
+  """
+  @callback outdated?(%DB.MultiValidation{}) :: boolean | nil
 end
 
 defmodule Transport.Validators.Dummy do
@@ -23,4 +30,7 @@ defmodule Transport.Validators.Dummy do
 
   @impl Transport.Validators.Validator
   def validator_name, do: "dummy validator"
+
+  @impl Transport.Validators.Validator
+  def outdated?(_multi_validation), do: nil
 end

--- a/apps/transport/test/db/resource_metadata_test.exs
+++ b/apps/transport/test/db/resource_metadata_test.exs
@@ -23,7 +23,7 @@ defmodule DB.ResourceMetadataTest do
     assert [validation_1] ==
              DB.MultiValidation.base_query()
              |> DB.ResourceMetadata.join_validation_with_metadata()
-             |> DB.ResourceMetadata.where_gtfs_up_to_date()
+             |> DB.ResourceMetadata.where_up_to_date()
              |> DB.Repo.all()
   end
 end

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -527,7 +527,7 @@ defmodule TransportWeb.DatasetControllerTest do
     for version <- ["0.1.0", "0.2.0", "0.2.1"] do
       dataset = insert(:dataset)
 
-      resource = insert(:resource, dataset: dataset, format: "NeTEx", url: "url")
+      resource = insert(:resource, title: "NeTEx.zip", dataset: dataset, format: "NeTEx", url: "url")
 
       resource_history = insert(:resource_history, resource: resource)
 
@@ -548,7 +548,7 @@ defmodule TransportWeb.DatasetControllerTest do
         result: result,
         digest: digest,
         metadata: %DB.ResourceMetadata{
-          metadata: %{"elapsed_seconds" => 42},
+          metadata: %{"elapsed_seconds" => 42, "start_date" => "2025-12-01", "end_date" => "2025-12-31"},
           modes: [],
           features: []
         }
@@ -557,7 +557,11 @@ defmodule TransportWeb.DatasetControllerTest do
       mock_empty_history_resources()
 
       conn = conn |> get(dataset_path(conn, :details, dataset.slug))
-      assert conn |> html_response(200) |> extract_resource_details() =~ "1 erreur"
+      content = conn |> html_response(200) |> extract_resource_details()
+      assert content =~ "1 erreur"
+      assert content =~ "01/12/2025"
+      assert content =~ "31/12/2025"
+      assert content =~ "Périmé"
     end
   end
 


### PR DESCRIPTION
Affiche les dates de validité des ressources NeTEx dans la liste des ressources d'un dataset. Affiche également le badge dans le coin supérieur droit (Périmé / À jour / Non disponible).

N'affiche pas encore dans la page de détail d'une ressource pour limiter la diff.

Généralise la logique d'interprétation des metadata à différents validateurs.

<img width="50%" alt="Carte d'une ressource NeTEx incluant désormais les dates de validité" src="https://github.com/user-attachments/assets/5163f634-1b2d-492a-8430-f9af34420c8b" />

* * *

Contribue à #5305.