### PR TITLE
GTFS Flex: flag "Périmé" sur cartouche

### DIFF
--- a/apps/transport/lib/db/multi_validation.ex
+++ b/apps/transport/lib/db/multi_validation.ex
@@ -237,6 +237,9 @@ defmodule DB.MultiValidation do
   false
   iex> outdated?(%DB.MultiValidation{})
   nil
+  iex> validation = %DB.MultiValidation{metadata: %DB.ResourceMetadata{metadata: %{"end_date" => ""}}}
+  iex> outdated?(validation)
+  nil
   iex> validation = %DB.MultiValidation{metadata: %DB.ResourceMetadata{metadata: %{"end_date" => Date.utc_today() |> Date.to_iso8601()}}}
   iex> outdated?(validation)
   true
@@ -244,6 +247,9 @@ defmodule DB.MultiValidation do
   def outdated?(%DB.MultiValidation{} = multi_validation) do
     case DB.MultiValidation.get_metadata_info(multi_validation, "end_date") do
       nil ->
+        nil
+
+      "" ->
         nil
 
       end_date ->

--- a/apps/transport/lib/transport_web/views/dataset_view.ex
+++ b/apps/transport/lib/transport_web/views/dataset_view.ex
@@ -650,7 +650,11 @@ defmodule TransportWeb.DatasetView do
   end
 
   def pick_validator(%DB.MultiValidation{} = validation) do
-    [Transport.Validators.GTFSTransport, Transport.Validators.NeTEx.Validator]
+    [
+      Transport.Validators.GTFSTransport,
+      Transport.Validators.NeTEx.Validator,
+      Transport.Validators.MobilityDataGTFSValidator
+    ]
     |> Enum.find(fn validator -> validator.validator_name() == validation.validator end)
   end
 

--- a/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
+++ b/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
@@ -16,8 +16,16 @@ defmodule Transport.Validators.MobilityDataGTFSValidator do
 
   @behaviour Transport.Validators.Validator
 
+  @validator_name "MobilityData GTFS Validator"
+
   @impl Transport.Validators.Validator
-  def validator_name, do: "MobilityData GTFS Validator"
+  def validator_name, do: @validator_name
+
+  @impl Transport.Validators.Validator
+  def outdated?(%DB.MultiValidation{validator: @validator_name} = mv),
+    do: DB.MultiValidation.outdated?(mv)
+
+  def outdated?(_), do: nil
 
   @impl Transport.Validators.Validator
   @spec validate_and_save(DB.ResourceHistory.t() | binary()) :: :ok | map()

--- a/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/dataset_controller_test.exs
@@ -388,11 +388,13 @@ defmodule TransportWeb.DatasetControllerTest do
 
     mock_empty_history_resources()
 
-    content = conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200)
+    content =
+      conn |> get(dataset_path(conn, :details, dataset.slug)) |> html_response(200) |> extract_resource_details()
 
-    assert content |> extract_resource_details() =~ "1 erreur"
+    assert content =~ "1 erreur"
     assert content =~ "01/12/2025"
     assert content =~ "31/12/2025"
+    assert content =~ "Périmé"
   end
 
   test "displays no error when validated with the MobilityData validator", %{conn: conn} do


### PR DESCRIPTION
Les GTFS flex validés par MobilityData incluent dans leurs metadata les dates de validités mais ces dernières n'étaient pas utilisé pour affiché l'état de péremption dans le cartouche. Cette PR corrige ceci.

Avant :

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/d2bba018-480e-4f6c-ade7-da2d0bf58f2e" />

Après :

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/44b218e1-c660-42e8-8b91-8b9ed59d51a2" />
