### PR TITLE
NeTEx : affichage des metadata

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
@@ -1,10 +1,8 @@
 <% locale = get_session(@conn, :locale) %>
-<% duration =
-  if @metadata["elapsed_seconds"] < 1 do
-    dgettext("validations", "less than 1 second")
-  else
-    format_duration(@metadata["elapsed_seconds"], locale)
-  end %>
-<div>
-  {dgettext("validations", "Elapsed time: %{duration}.", duration: duration)}
-</div>
+<p :if={@metadata["start_date"] != nil and @metadata["end_date"] != nil}>
+  {dgettext("validations", "It is valid from")}
+  <strong>{DateTimeDisplay.format_date(@metadata["start_date"], locale)}</strong> {dgettext(
+    "validations",
+    "to"
+  )} <strong><%= DateTimeDisplay.format_date(@metadata["end_date"], locale) %></strong>.
+</p>

--- a/apps/transport/lib/transport_web/templates/resource/_resources_netex_validation_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_netex_validation_details.html.heex
@@ -1,0 +1,10 @@
+<% locale = get_session(@conn, :locale) %>
+<% duration =
+  if @metadata["elapsed_seconds"] < 1 do
+    dgettext("validations", "less than 1 second")
+  else
+    format_duration(@metadata["elapsed_seconds"], locale)
+  end %>
+<div>
+  {dgettext("validations", "Elapsed time: %{duration}.", duration: duration)}
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
@@ -19,6 +19,9 @@
     </h2>
     <div class="panel">
       {render("_resource_description.html", conn: @conn, resource: @resource, resource_history: @resource_history)}
+      <%= unless is_nil(@metadata) or @metadata == %{} do %>
+        {render("_resources_details_netex.html", conn: @conn, metadata: @metadata)}
+      <% end %>
     </div>
 
     <%= unless Enum.empty?(@resource.resources_related) do %>
@@ -46,7 +49,7 @@
           filter: @filter
         )}
         <%= unless is_nil(@metadata) or @metadata == %{} do %>
-          {render("_resources_details_netex.html", conn: @conn, metadata: @metadata)}
+          {render("_resources_netex_validation_details.html", conn: @conn, metadata: @metadata)}
         <% end %>
         <p>
           {raw(


### PR DESCRIPTION
Reprend ce qui a été fait pour les GTFS:

<img width="66%" alt="image" src="https://github.com/user-attachments/assets/1291848d-a120-4834-b2fa-d035997b82ef" />

Contribue à #5305.