### PR TITLE
NeTEx: modes de transports et réseaux

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
@@ -1,4 +1,6 @@
 <% locale = get_session(@conn, :locale) %>
+<% networks = Map.get(@metadata, "networks", []) %>
+<% modes = Map.get(@metadata, "modes", []) %>
 <p :if={@metadata["start_date"] != nil and @metadata["end_date"] != nil}>
   {dgettext("validations", "It is valid from")}
   <strong>{DateTimeDisplay.format_date(@metadata["start_date"], locale)}</strong> {dgettext(
@@ -6,3 +8,17 @@
     "to"
   )} <strong><%= DateTimeDisplay.format_date(@metadata["end_date"], locale) %></strong>.
 </p>
+<ul>
+  <li :if={networks != []}>
+    <div>
+      <div class="networks-list">
+        {dngettext("validations", "network", "networks", length(networks))} :
+        <strong>{Enum.join(networks, ", ")}</strong>
+      </div>
+    </div>
+  </li>
+  <li :if={modes != []}>
+    {dngettext("validations", "transport mode", "transport modes", length(modes))} :
+    <strong>{Enum.join(modes, ", ")}</strong>
+  </li>
+</ul>

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -727,6 +727,9 @@ defmodule TransportWeb.ResourceControllerTest do
 
       results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(version)
 
+      networks = ["Réseau urbain", "Réseau inter-urbain"]
+      modes = ["bus", "ferry"]
+
       insert(:multi_validation, %{
         resource_history_id: resource_history_id,
         validator: Transport.Validators.NeTEx.Validator.validator_name(),
@@ -735,8 +738,8 @@ defmodule TransportWeb.ResourceControllerTest do
         binary_result: results_adapter.to_binary_result(result),
         max_error: "error",
         metadata: %DB.ResourceMetadata{
-          metadata: %{"elapsed_seconds" => 42},
-          modes: [],
+          metadata: %{"elapsed_seconds" => 42, "networks" => networks, "modes" => modes},
+          modes: modes,
           features: []
         },
         validation_timestamp: ~U[2022-10-28 14:12:29.041243Z]
@@ -752,6 +755,12 @@ defmodule TransportWeb.ResourceControllerTest do
       rows = content |> Floki.parse_document!() |> Floki.find("table tr.message")
 
       assert page_size() == Enum.count(rows)
+
+      assert content =~ "réseaux"
+      assert content =~ "Réseau urbain, Réseau inter-urbain"
+
+      assert content =~ "modes de transport"
+      assert content =~ "bus, ferry"
     end
   end
 


### PR DESCRIPTION
Affichage des modes de transport et réseaux dans le détail d'une ressource NeTEx.

Mimique ce qui est fait pour une ressource GTFS toujours dans la perspective d'une convergence fonctionnelle entre les deux formats. Sans doute pourrait-on faire mieux mais ça n'est pas le bon moment. En NeTEx il existe un concept de `SubTransportMode` qui n'est pas exploité en l'état.

Voici ce que ça donne pour IDFM:

<img width="2280" height="1387" alt="image" src="https://github.com/user-attachments/assets/a29859c2-5ae1-4022-8564-587ce15ff2a9" />

Les modes de transport ne sont pas traduits à l'instar des ressources GTFS. On pourrait certainement améliorer cela ultérieurement si ça fait consensus.

Contribue à #5301.