### PR TITLE
NeTEx : parseur résistant aux dossiers

### DIFF
--- a/apps/transport/lib/netex/netex_archive_parser.ex
+++ b/apps/transport/lib/netex/netex_archive_parser.ex
@@ -148,7 +148,7 @@ defmodule Transport.NeTEx.ArchiveParser do
       # Entry names ending with a slash `/` are directories. Skip them.
       # https://github.com/akash-akya/unzip/blob/689a1ca7a134ab2aeb79c8c4f8492d61fa3e09a0/lib/unzip.ex#L69
       String.ends_with?(file_name, "/") ->
-        {:ok, []}
+        {:ok, parser.initial_state() |> parser.unwrap_result()}
 
       extension |> String.downcase() == ".zip" ->
         {:error, "Insupported zip inside zip for file #{file_name}"}

--- a/apps/transport/test/netex/netex_archive_parser_test.exs
+++ b/apps/transport/test/netex/netex_archive_parser_test.exs
@@ -357,10 +357,10 @@ defmodule Transport.NeTEx.ArchiveParserTest do
   end
 
   defp extract(extractor, xml) do
-    tmp_file = create_tmp_netex([{"file.xml", xml}])
+    tmp_file = create_tmp_netex([{"directory/", ""}, {"directory/file.xml", xml}])
 
     try do
-      [{"file.xml", types}] = extractor.(tmp_file)
+      [{"directory/", _}, {"directory/file.xml", types}] = extractor.(tmp_file)
 
       types
     after

--- a/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
+++ b/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
@@ -44,7 +44,7 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
         </PublicationDelivery>
       """
 
-      ZipCreator.with_tmp_zip([{"resource.xml", calendar_content}], fn filepath ->
+      ZipCreator.with_tmp_zip([{"resource.xml", calendar_content}] |> in_sub_directory(), fn filepath ->
         assert %{"start_date" => "2025-07-05", "end_date" => "2025-08-31", "networks" => [], "modes" => []} ==
                  MetadataExtractor.extract(filepath)
       end)
@@ -77,7 +77,7 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
         </PublicationDelivery>
       """
 
-      ZipCreator.with_tmp_zip([{"resource.xml", service_calendar_content}], fn filepath ->
+      ZipCreator.with_tmp_zip([{"resource.xml", service_calendar_content}] |> in_sub_directory(), fn filepath ->
         assert %{"start_date" => "2025-11-03", "end_date" => "2025-11-28", "networks" => [], "modes" => []} ==
                  MetadataExtractor.extract(filepath)
       end)
@@ -114,7 +114,7 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
         </PublicationDelivery>
       """
 
-      ZipCreator.with_tmp_zip([{"network.xml", multiple_networks}], fn filepath ->
+      ZipCreator.with_tmp_zip([{"network.xml", multiple_networks}] |> in_sub_directory(), fn filepath ->
         assert %{
                  "no_validity_dates" => true,
                  "networks" => ["Réseau Urbain", "Réseau Régional"],
@@ -123,5 +123,10 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                  MetadataExtractor.extract(filepath)
       end)
     end
+  end
+
+  defp in_sub_directory(filespecs) do
+    [{"directory/", ""}] ++
+      Enum.map(filespecs, fn {filename, content} -> {Path.join("directory", filename), content} end)
   end
 end


### PR DESCRIPTION
Quand une archive NeTEx contient des dossiers, le résultat du parsing n'était pas compatible avec tous les parseurs, renvoyant une liste vide quand certains parseurs produisent des maps.