### PR TITLE
URL de ressource mal encodée (workaround)

### DIFF
--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -261,21 +261,35 @@ defmodule Transport.ImportData do
   "http://example.com/file.zip"
   iex> cleaned_url("http://exs.sismo2.cityway.fr")
   "https://exs.sismo2.cityway.fr"
+  iex> cleaned_url("https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_URB|COROLIS_INT&dataFormat=NETEX&dataProfil=OPENDATA")
+  "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_URB%7CCOROLIS_INT&dataFormat=NETEX&dataProfil=OPENDATA"
   """
   def cleaned_url(url) do
     uri = URI.parse(url)
 
-    if is_binary(uri.host) and String.match?(uri.host, ~r/^exs\.(\w)+\.cityway\.fr$/) do
-      cleaned_query =
-        if is_nil(uri.query) do
-          nil
-        else
-          uri.query |> String.replace("&amp;", "&")
-        end
+    cond do
+      is_binary(uri.host) and String.match?(uri.host, ~r/^exs\.(\w)+\.cityway\.fr$/) ->
+        cleaned_query =
+          if is_nil(uri.query) do
+            nil
+          else
+            uri.query |> String.replace("&amp;", "&")
+          end
 
-      %{uri | scheme: "https", query: cleaned_query, port: 443} |> URI.to_string()
-    else
-      url
+        %{uri | scheme: "https", query: cleaned_query, port: 443} |> URI.to_string()
+
+      is_binary(uri.host) and String.match?(uri.host, ~r/^api\.(\w)+\.cityway\.fr$/) ->
+        cleaned_query =
+          if is_nil(uri.query) do
+            nil
+          else
+            uri.query |> String.replace("|", "%7C")
+          end
+
+        %{uri | scheme: "https", query: cleaned_query, port: 443} |> URI.to_string()
+
+      true ->
+        url
     end
   end
 


### PR DESCRIPTION
Ce fix encode explicitement (et uniquement) ce caractère à l’import.

Une mauvaise URL pose problème à l’historisation et à la validation.

Ceci se manifeste essentiellement pour l'API NeTEx de cityway qui utilise le
caractère `|` comme séparateur pour encoder des listes. On observera que c'est
le second workaround spécifique à ce fournisseur.

Fixes #5361.