### PR TITLE
OnDemand: Téléchargement du rapport NeTEx

### DIFF
--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -294,6 +294,7 @@ defmodule TransportWeb.Router do
       post("/", ValidationController, :validate)
       post("/convert", ValidationController, :convert)
       get("/:id", ValidationController, :show)
+      get("/:id/download-validation-report", ValidationController, :download_validation_report)
     end
 
     scope "/tools" do

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
@@ -1,7 +1,11 @@
 <section class="netex">
   <div class="container">
     <div class="validation-title">
-      <h2>{dgettext("validations", "NeTEx review report")}</h2>
+      <div class="header_with_action_bar">
+        <h2>{dgettext("validations", "NeTEx review report")}</h2>
+        <.netex_validation_report_download validation_report_url={@validation_report_url} />
+      </div>
+
       <p>
         {dgettext("validations", "explanations-netex")}
       </p>

--- a/apps/transport/lib/transport_web/views/validation_view.ex
+++ b/apps/transport/lib/transport_web/views/validation_view.ex
@@ -3,7 +3,13 @@ defmodule TransportWeb.ValidationView do
   import Phoenix.Controller, only: [current_url: 1]
 
   import TransportWeb.ResourceView,
-    only: [gtfs_template: 1, netex_template: 0, netex_template: 1, netex_validation_summary: 1]
+    only: [
+      gtfs_template: 1,
+      netex_template: 0,
+      netex_template: 1,
+      netex_validation_summary: 1,
+      netex_validation_report_download: 1
+    ]
 
   import TransportWeb.PaginationHelpers
 


### PR DESCRIPTION
Cela était fait pour la validation automatique ; aucune raison de ne pas le proposer pour la validation à la demande.

<img width="1721" height="775" alt="image" src="https://github.com/user-attachments/assets/1bd18cae-e2ad-4b8d-94cb-0783ce63fcb0" />

Contibue à #5350.