### PR TITLE
NeTEx: erreurs XSD regroupées par message

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -130,8 +130,12 @@ table.netex_generic_issue, table.netex_xsd_schema {
   }
 }
 
-table.netex_generic_issue th:nth-child(1), table.netex_xsd_schema th:nth-child(2) {
+table.netex_generic_issue th:nth-child(1) {
   width: 60%;
+}
+
+table.netex_xsd_schema th:nth-child(1) {
+  width: 80%;
 }
 
 table.netex_generic_issue tr.debug:hover {

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -193,7 +193,7 @@ defmodule TransportWeb.ResourceController do
   defp render_netex_details(conn, params, resource, validation) do
     config = make_pagination_config(params)
 
-    {results_adapter, validation_details, issues, errors_template, max_severity} =
+    {results_adapter, validation_details, issues, errors_template, max_severity, xsd_errors} =
       build_netex_validation_details(validation, params)
 
     {filter, pagination} = issues
@@ -208,6 +208,7 @@ defmodule TransportWeb.ResourceController do
     |> assign(:validation_report_url, validation_report_url)
     |> assign(:filter, filter)
     |> assign(:issues, paginate_netex_results(pagination, config))
+    |> assign(:xsd_errors, xsd_errors)
     |> assign(:errors_template, errors_template)
     |> assign(:results_adapter, results_adapter)
     |> assign(:max_severity, max_severity)
@@ -240,7 +241,7 @@ defmodule TransportWeb.ResourceController do
     }
   end
 
-  defp build_netex_validation_details(nil, _params), do: {nil, {nil, nil, nil, []}, {%{}, {0, []}}, nil, nil}
+  defp build_netex_validation_details(nil, _params), do: {nil, {nil, nil, nil, []}, {%{}, {0, []}}, nil, nil, []}
 
   defp build_netex_validation_details(
          %{
@@ -259,8 +260,10 @@ defmodule TransportWeb.ResourceController do
 
     pagination_config = make_pagination_config(params)
     issues = results_adapter.get_issues(binary_result, params, pagination_config)
+    xsd_errors = results_adapter.summarize_xsd_errors(binary_result)
 
-    {results_adapter, {summary, stats, metadata.metadata, metadata.modes}, issues, errors_template, max_severity}
+    {results_adapter, {summary, stats, metadata.metadata, metadata.modes}, issues, errors_template, max_severity,
+     xsd_errors}
   end
 
   defp pick_netex_errors_template("0.2.1"), do: "_netex_validation_errors_v0_2_x.html"

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -138,6 +138,8 @@ defmodule TransportWeb.ValidationController do
 
         validation_report_url = validation_url(conn, :download_validation_report, validation.id, token: params["token"])
 
+        xsd_errors = results_adapter.summarize_xsd_errors(validation.binary_result)
+
         conn
         |> assign_base_validation_details(params)
         |> assign(:filter, filter)
@@ -148,6 +150,7 @@ defmodule TransportWeb.ValidationController do
         |> assign(:validation_summary, validation.digest["summary"])
         |> assign(:severities_count, validation.digest["stats"])
         |> assign(:validation_report_url, validation_report_url)
+        |> assign(:xsd_errors, xsd_errors)
         |> render(template)
 
       # Handles waiting for validation to complete, errors and

--- a/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_netex_validation_errors_v0_2_x.html.heex
@@ -1,5 +1,5 @@
 <% %{"max_level" => max_level, "worst_occurrences" => worst_occurrences} = @max_severity %>
-<% current_category = @filter["issues_category"] || "" %>
+<% current_category = @filter["issues_category"] || "xsd-schema" %>
 
 <div class="header_with_action_bar">
   <h4>{@results_adapter.format_severity(max_level, worst_occurrences) |> String.capitalize()}</h4>
@@ -13,13 +13,19 @@
   validation_summary={@validation_summary}
 />
 
-<%= if worst_occurrences > 0 do %>
-  <div class="main-pane">
+<div :if={worst_occurrences > 0} class="main-pane">
+  <%= if current_category == "xsd-schema" do %>
+    {render(netex_template(current_category),
+      xsd_errors: @xsd_errors || [],
+      validation_report_url: @validation_report_url,
+      conn: @conn
+    )}
+  <% else %>
     {pagination_links(@conn, @issues, [@resource.id],
       issues_category: current_category,
       path: &resource_path/4,
       action: :details
     )}
     {render(netex_template(current_category), issues: @issues || [], conn: @conn)}
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/_netex_xsd_schema.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_netex_xsd_schema.html.heex
@@ -1,19 +1,20 @@
+<p>
+  {dgettext(
+    "validations-explanations",
+    "Here is a summary of XSD validation errors. Full detail of those errors is available in the <a href=\"%{validation_report_url}\" target=\"_blank\">CSV report</a>. Those errors are produced by <a href=\"https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html\" target=\"_blank\">xmllint</a>.",
+    validation_report_url: @validation_report_url
+  )
+  |> raw()}
+</p>
+
 <table class="table netex_xsd_schema">
   <tr>
-    <th>{dgettext("validations-explanations", "Location")}</th>
     <th>{dgettext("validations-explanations", "Message")}</th>
+    <th>{dgettext("validations-explanations", "Occurrences")}</th>
   </tr>
 
-  <%= for issue <- @issues do %>
-    <tr class="message">
-      <td>
-        <%= if is_nil(issue["resource"]) or is_nil(issue["resource"]["filename"]) or is_nil(issue["resource"]["line"]) do %>
-          {dgettext("validations-explanations", "Unknown location")}
-        <% else %>
-          {issue["resource"]["filename"]}:{issue["resource"]["line"]}
-        <% end %>
-      </td>
-      <td>{issue["message"]}</td>
-    </tr>
-  <% end %>
+  <tr :for={xsd_error <- @xsd_errors} class="message">
+    <td>{xsd_error["message"]}</td>
+    <td>{xsd_error["counts"]}</td>
+  </tr>
 </table>

--- a/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
@@ -47,7 +47,8 @@
           results_adapter: @results_adapter,
           max_severity: @max_severity,
           filter: @filter,
-          validation_report_url: @validation_report_url
+          validation_report_url: @validation_report_url,
+          xsd_errors: @xsd_errors
         )}
         <%= unless is_nil(@metadata) or @metadata == %{} do %>
           {render("_resources_netex_validation_details.html", conn: @conn, metadata: @metadata)}

--- a/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_netex_v0_2_x.html.heex
@@ -26,7 +26,7 @@
   <div class="validation-content">
     <div id="issues" class="container">
       <% %{"worst_occurrences" => worst_occurrences} = @max_severity %>
-      <% current_category = @filter["issues_category"] || "" %>
+      <% current_category = @filter["issues_category"] || "xsd-schema" %>
       <div id="issues" class="validation-navigation">
         <nav class="issues-list validation" role="navigation">
           <.netex_validation_summary
@@ -41,18 +41,26 @@
       <div class="validation-content-details">
         <div class="panel">
           <%= if worst_occurrences > 0 do %>
-            <% pagination =
-              pagination_links(@conn, @issues, [@validation_id],
-                issues_category: current_category,
-                token: @token,
-                path: &validation_path/4,
-                action: :show
-              ) %>
-            {pagination}
-            {render(netex_template(current_category), issues: @issues || [], conn: @conn)}
-            <div class="pt-24">
+            <%= if current_category == "xsd-schema" do %>
+              {render(netex_template(current_category),
+                xsd_errors: @xsd_errors || [],
+                validation_report_url: @validation_report_url,
+                conn: @conn
+              )}
+            <% else %>
+              <% pagination =
+                pagination_links(@conn, @issues, [@validation_id],
+                  issues_category: current_category,
+                  token: @token,
+                  path: &validation_path/4,
+                  action: :show
+                ) %>
               {pagination}
-            </div>
+              {render(netex_template(current_category), issues: @issues || [], conn: @conn)}
+              <div class="pt-24">
+                {pagination}
+              </div>
+            <% end %>
           <% else %>
             <h2>{dgettext("validations", "Nice work, there are no issues!")}</h2>
           <% end %>

--- a/apps/transport/lib/validators/netex/results_adapter.ex
+++ b/apps/transport/lib/validators/netex/results_adapter.ex
@@ -14,6 +14,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapter do
   @callback french_profile_compliance_check() :: :none | :partial | :good_enough
   @callback to_dataframe(list()) :: Explorer.DataFrame.t()
   @callback to_binary_result(list()) :: binary()
+  @callback summarize_xsd_errors(binary()) :: list()
 
   def resolve("0.2.1"), do: Transport.Validators.NeTEx.ResultsAdapters.V0_2_1
   def resolve("0.2.0"), do: Transport.Validators.NeTEx.ResultsAdapters.V0_2_0

--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -135,4 +135,15 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
     |> DF.names()
     |> Enum.member?(column_name)
   end
+
+  def summarize_xsd_errors(df) do
+    if has_column?(df, "category") do
+      df
+      |> DF.frequencies(["message"])
+      |> DF.sort_by(message)
+      |> DF.to_rows()
+    else
+      []
+    end
+  end
 end

--- a/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
@@ -239,4 +239,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0 do
     |> to_dataframe()
     |> Commons.to_binary()
   end
+
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def summarize_xsd_errors(_binary_result), do: []
 end

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
@@ -240,4 +240,17 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
     |> to_dataframe()
     |> Commons.to_binary()
   end
+
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  def summarize_xsd_errors(binary_result) do
+    df = Commons.from_binary(binary_result)
+
+    if Commons.has_column?(df, "category") do
+      df
+      |> DF.filter(category == ^@xsd_schema_category)
+      |> Commons.summarize_xsd_errors()
+    else
+      []
+    end
+  end
 end

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
@@ -183,4 +183,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
     |> to_dataframe()
     |> Commons.to_binary()
   end
+
+  @impl Transport.Validators.NeTEx.ResultsAdapter
+  defdelegate summarize_xsd_errors(binary_result), to: V0_2_0
 end

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations-explanations.po
@@ -154,3 +154,11 @@ msgstr "A trip must visit more than one stop in stop_times.txt to be usable by p
 #, elixir-autogen, elixir-format
 msgid "NoCalendar"
 msgstr "<code>calendar.txt</code> and <code>calendar_dates.txt</code> are empty. The service is never running."
+
+#, elixir-autogen, elixir-format
+msgid "Here is a summary of XSD validation errors. Full detail of those errors is available in the <a href=\"%{validation_report_url}\" target=\"_blank\">CSV report</a>. Those errors are produced by <a href=\"https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html\" target=\"_blank\">xmllint</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Occurrences"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations-explanations.po
@@ -154,3 +154,11 @@ msgstr "Un trajet doit passer par plus d’un arrêt dans stop_times.txt pour ê
 #, elixir-autogen, elixir-format
 msgid "NoCalendar"
 msgstr "<code>calendar.txt</code> et <code>calendar_dates.txt</code> sont vides. Le service n'est jamais en exploitation."
+
+#, elixir-autogen, elixir-format
+msgid "Here is a summary of XSD validation errors. Full detail of those errors is available in the <a href=\"%{validation_report_url}\" target=\"_blank\">CSV report</a>. Those errors are produced by <a href=\"https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html\" target=\"_blank\">xmllint</a>."
+msgstr "Voici un résumé des erreurs de validation XSD. Le détail de ces erreurs est disponible dans le <a href=\"%{validation_report_url}\" target=\"_blank\">rapport complet</a>. Ces erreurs sont le résultat de la validation par <a href=\"https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html\" target=\"_blank\">xmllint</a>."
+
+#, elixir-autogen, elixir-format
+msgid "Occurrences"
+msgstr ""

--- a/apps/transport/priv/gettext/validations-explanations.pot
+++ b/apps/transport/priv/gettext/validations-explanations.pot
@@ -153,3 +153,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "NoCalendar"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Here is a summary of XSD validation errors. Full detail of those errors is available in the <a href=\"%{validation_report_url}\" target=\"_blank\">CSV report</a>. Those errors are produced by <a href=\"https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html\" target=\"_blank\">xmllint</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Occurrences"
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -763,7 +763,11 @@ defmodule TransportWeb.ResourceControllerTest do
 
         rows = content |> Floki.parse_document!() |> Floki.find("table tr.message")
 
-        assert page_size() == Enum.count(rows)
+        if version in ["0.2.0", "0.2.1"] do
+          assert distinct_xsd_errors(issues) == Enum.count(rows)
+        else
+          assert page_size() == Enum.count(rows)
+        end
 
         assert content =~ "réseaux"
         assert content =~ "Réseau urbain, Réseau inter-urbain"
@@ -1507,5 +1511,13 @@ defmodule TransportWeb.ResourceControllerTest do
     [body]
     |> CSV.decode!(headers: true)
     |> Enum.to_list()
+  end
+
+  defp distinct_xsd_errors(issues) do
+    issues
+    |> Enum.filter(&String.starts_with?(&1["code"], "xsd-"))
+    |> Enum.map(& &1["message"])
+    |> MapSet.new()
+    |> MapSet.size()
   end
 end


### PR DESCRIPTION
On n’affiche plus le tableau paginé d’erreurs de validation XSD. C’est
répétitif, décourageant, et peu instructif. A la place est affichée un résumé
des erreurs et du nombre d’occurrences pour chacune d’elles.

Supporte la validation automatique et la validation à la demande pour le
validateur 0.2.0 et supérieur.

## Exemple pour une ressource historisée

<img width="1271" height="1706" alt="image" src="https://github.com/user-attachments/assets/efc1f72f-3fa3-4a92-b593-66de5cd3ed21" />

## Exemple pour la validation à la demande

<img width="1709" height="2148" alt="image" src="https://github.com/user-attachments/assets/4e625b13-eb75-484e-8fe2-4709ca25011f" />

* * *

Contribue à https://github.com/etalab/transport-site/issues/5350.