### PR TITLE
Recherche : corrige tri sur JDDs les plus récents

### DIFF
--- a/apps/transport/lib/transport/dataset_index.ex
+++ b/apps/transport/lib/transport/dataset_index.ex
@@ -241,7 +241,7 @@ defmodule Transport.DatasetIndex do
       fn id ->
         case index[id].inserted_at do
           nil -> {0, nil}
-          dt -> {1, dt}
+          dt -> {1, DateTime.to_iso8601(dt)}
         end
       end,
       :desc


### PR DESCRIPTION
Fixes #5371, régression dans #5345

La recherche en mémoire faisait un tri erroné sur les dates les plus récentes en comparant des structs.


