### PR TITLE
NeTEx : bouton de téléchargement toujours présent

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -159,6 +159,13 @@ table.netex_generic_issue tr.debug td code {
   width: 100%;
 }
 
+.download-button {
+  text-decoration: none;
+  &:hover {
+    background-color: unset;
+  }
+}
+
 .netex {
   div.header_with_action_bar {
     display: grid;

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -327,16 +327,35 @@ defmodule TransportWeb.ResourceView do
     """
   end
 
-  def netex_validation_report_download(%{validation_report_url: nil} = assigns) do
+  def netex_validation_report_download(%{validation_report_url: _} = assigns) do
     ~H"""
+    <.download_button url={@validation_report_url}>
+      <.netex_csv_report />
+    </.download_button>
     """
   end
 
-  def netex_validation_report_download(%{validation_report_url: _} = assigns) do
+  def download_button(%{url: nil} = assigns) do
     ~H"""
-    <a class="button-outline small secondary" href={@validation_report_url} target="_blank">
-      <i class="icon icon--download" aria-hidden="true"></i>{dgettext("resource", "CSV report")}
+    <button class="button-outline small secondary" disabled title={dgettext("validations", "No validation error")}>
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  def download_button(%{url: _} = assigns) do
+    ~H"""
+    <a class="download-button" href={@url} target="_blank">
+      <button class="button-outline small secondary">
+        {render_slot(@inner_block)}
+      </button>
     </a>
+    """
+  end
+
+  defp netex_csv_report(%{} = assigns) do
+    ~H"""
+    <i class="icon icon--download" aria-hidden="true"></i>{dgettext("resource", "CSV report")}
     """
   end
 


### PR DESCRIPTION
Il est inactif si la validation est sans erreur.

<img width="1340" height="516" alt="image" src="https://github.com/user-attachments/assets/3e1e8b89-6ce4-432e-866e-b7c06f6e64e4" />

Principe de moindre surprise : un bouton manquant pourrait faire penser à une erreur. Le bouton est inactif avec un tooltip expliquant que tout est normal. Motivé par https://github.com/etalab/transport-site/issues/5361#issuecomment-3960743177 .