### PR TITLE
Resource#details : gère result = nil pour GTFS-RT

### DIFF
--- a/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_validation_report_gtfs_rt.html.heex
@@ -1,6 +1,7 @@
-<% locale = get_session(@conn, :locale) %>
+<% locale = get_session(@conn, :locale)
+validation_result = @validation.result || %{} %>
 <div class="panel">
-  <% errors = Map.fetch!(@validation.result, "errors") %>
+  <% errors = Map.get(validation_result, "errors", []) %>
   <% errors_error_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "ERROR")) %>
   <% errors_warning_level = errors |> Enum.filter(&(Map.fetch!(&1, "severity") == "WARNING")) %>
   {render("_errors_warnings_count.html",
@@ -8,10 +9,10 @@
     nb_warnings: warnings_count(@validation),
     locale: locale
   )}
-  <p :if={Map.get(@validation.result, "ignore_shapes", false)} class="notification">
+  <p :if={Map.get(validation_result, "ignore_shapes", false)} class="notification">
     {dgettext("validations", "Shapes present in the GTFS have been ignored, some rules are not enforced.")}
   </p>
-  <p>
+  <p :if={validation_result != %{}}>
     {raw(
       dgettext(
         "validations",

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -836,6 +836,38 @@ defmodule TransportWeb.ResourceControllerTest do
       refute conn2 |> html_response(200) =~ "Pas de validation disponible"
     end
 
+    test "GTFS-RT validation when result is nil", %{conn: conn} do
+      %{id: dataset_id} = insert(:dataset)
+      %{id: gtfs_id} = insert(:resource, format: "GTFS", dataset_id: dataset_id)
+
+      %{id: resource_id} =
+        insert(:resource, %{
+          dataset_id: dataset_id,
+          format: "gtfs-rt",
+          url: "https://example.com/file"
+        })
+
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200, body: ""}} end)
+
+      %{id: resource_history_id} = insert(:resource_history, %{resource_id: resource_id})
+
+      insert(:multi_validation, %{
+        resource_history_id: resource_history_id,
+        validator: Transport.Validators.GTFSRT.validator_name(),
+        result: nil,
+        digest: %{"errors_count" => 1, "warnings_count" => 0},
+        secondary_resource_id: gtfs_id,
+        metadata: %DB.ResourceMetadata{metadata: %{}}
+      })
+
+      {response, _} = with_log(fn -> conn |> get(resource_path(conn, :details, resource_id)) end)
+      assert response |> html_response(200) =~ "Rapport de validation"
+      assert response |> html_response(200) =~ "1 erreur"
+      assert response |> html_response(200) =~ "Valider ce GTFS-RT maintenant"
+      refute response |> html_response(200) =~ "Pas de validation disponible"
+    end
+
     test "Table Schema validation is shown", %{conn: conn} do
       %{id: dataset_id} = insert(:dataset)
 


### PR DESCRIPTION
Gère l'exception suivante : https://transport-data-gouv-fr.sentry.io/issues/7175041366/


Ceci survient quand un rapport de validation GTFS-RT a été effacé (vieux de plus de 30 jours) mais que ceci est le dernier rapport, car la ressource est indisponible depuis par exemple.

Actuellement ceci fait une erreur 500 : https://transport.data.gouv.fr/resources/79823

On devrait pouvoir afficher quand même la page de détails avec les informations du digest (nombre d'erreurs et de warnings).
