### PR TITLE
Stats : ajout dashboard Metabase pour public-transit

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -251,7 +251,7 @@
   color: red;
 }
 
-iframe {
+iframe#email_preview {
   border-radius: 8px;
   border: 2px solid var(--grey);
   aspect-ratio: 16 / 9;

--- a/apps/transport/lib/transport_web/controllers/stats_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/stats_controller.ex
@@ -18,4 +18,35 @@ defmodule TransportWeb.StatsController do
     |> assign(:droms, ["antilles", "guyane", "nouvelle_caledonie", "reunion"])
     |> render("index.html")
   end
+
+  @spec stats_public_transit(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def stats_public_transit(conn, _params) do
+    dashboard_id = 18
+
+    conn
+    |> assign(:metabase_token, metabase_token(dashboard_id))
+    |> render("metabase_dashboard.html")
+  end
+
+  defp metabase_token(dashboard_id) do
+    secret = Application.fetch_env!(:transport, :metabase_secret_key)
+    now = System.os_time(:second)
+
+    header = Base.url_encode64(Jason.encode!(%{"alg" => "HS256", "typ" => "JWT"}), padding: false)
+
+    payload =
+      Base.url_encode64(
+        Jason.encode!(%{
+          "resource" => %{"dashboard" => dashboard_id},
+          "params" => %{},
+          "exp" => now + 600
+        }),
+        padding: false
+      )
+
+    message = "#{header}.#{payload}"
+    signature = :crypto.mac(:hmac, :sha256, secret, message) |> Base.url_encode64(padding: false)
+
+    "#{message}.#{signature}"
+  end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/email_preview_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/email_preview_live.html.heex
@@ -42,7 +42,7 @@
     <div :if={@selected_email} class="panel dashboard-description">
       <div class="">
         <h4>{@selected_email.subject}</h4>
-        <iframe id="iframe" srcdoc={@selected_email.html_body}></iframe>
+        <iframe id="email_preview" srcdoc={@selected_email.html_body}></iframe>
         <a href="#" class="mt-24 button-outline primary small" phx-click="receive_selected_email">
           <i class="fa-solid fa-envelope"></i> Recevoir
         </a>

--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -44,8 +44,9 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
         "font-src" => "*",
         "frame-ancestors" => "'none'",
         "img-src" => "'self' https: data:",
-        "script-src" => "'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js",
-        "frame-src" => "https://*.dailymotion.com",
+        "script-src" =>
+          "'self' 'unsafe-eval' 'unsafe-inline' https://stats.data.gouv.fr/matomo.js https://metabase.transport.data.gouv.fr/app/embed.js",
+        "frame-src" => "https://*.dailymotion.com http://metabase.transport.data.gouv.fr",
         "style-src" => "'self' 'nonce-#{nonce}' #{vega_hash_values}",
         "report-uri" => ""
       }

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -162,6 +162,7 @@ defmodule TransportWeb.Router do
     end
 
     get("/stats", StatsController, :index)
+    get("/stats/public-transit", StatsController, :stats_public_transit)
     get("/atom.xml", AtomController, :index)
     post("/send_mail", ContactController, :send_mail)
     get("/aoms", AOMSController, :index)

--- a/apps/transport/lib/transport_web/templates/stats/metabase_dashboard.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/metabase_dashboard.html.heex
@@ -1,0 +1,18 @@
+<div class="container">
+  <script defer src="https://metabase.transport.data.gouv.fr/app/embed.js">
+  </script>
+  <script>
+    function defineMetabaseConfig(config) {
+      window.metabaseConfig = config;
+    }
+  </script>
+  <script>
+    defineMetabaseConfig({
+      theme: { preset: "light" },
+      isGuest: true,
+      instanceUrl: "https://metabase.transport.data.gouv.fr"
+    });
+  </script>
+
+  <metabase-dashboard token={@metabase_token} with-title="true" with-downloads="true"></metabase-dashboard>
+</div>


### PR DESCRIPTION
Vu avec @cyrilmorin : on souhaite publier un premier tableau de bord Metabase pour les données TC.

Accès direct via URL, on verra pour ajouter d'autres tableaux de bord et pour la navigation ensuite.

<img width="1458" height="850" alt="Screenshot 2026-03-03 at 16 22 21" src="https://github.com/user-attachments/assets/c7f6381e-996a-4381-a3dd-24683d147c0e" />
