### PR TITLE
Stabilise test de navigation

### DIFF
--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -46,7 +46,9 @@ defmodule TransportWeb.ValidationController do
             live_path(
               conn,
               TransportWeb.Live.OnDemandValidationSelectLive,
-              params |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
+              params
+              |> Enum.sort_by(fn {k, _} -> k end)
+              |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
             )
         )
     end


### PR DESCRIPTION
Les paramètres n'étaient pas triés de façon déterministe, menant à des faux positifs (très agaçants) dans les tests.

Ce test échouait très fréquemment sur ma machine (linux).