### PR TITLE
Correction overflow des titres de ressources

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -201,7 +201,19 @@
     display: inline-block;
     margin-bottom: 0;
     font-size: 1em;
-    max-width: 80%;
+    max-width: 95%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:hover {
+      background: white;
+      margin: -3px 0 -2px -6px;
+      padding: 3px 5px 1px;
+      border: 1px solid var(--lighter-grey);
+      width: max-content;
+      max-width: unset;
+      z-index: 10;
+    }
   }
   .resource-panel-bottom {
     display: flex;


### PR DESCRIPTION
Un titre de ressource trop long ne déborde plus du cartouche d'une ressource :

<img width="1134" height="489" alt="image" src="https://github.com/user-attachments/assets/0a65f3aa-61ac-4dcd-8aa6-a58c213ba4e7" />

Au survol du titre tronqué :

<img width="1153" height="485" alt="image" src="https://github.com/user-attachments/assets/1faa2687-c955-47c8-8e06-26505fd91a52" />

* * *

Fixes #5370.