### PR TITLE
NeTEx : téléchargement du rapport via une modale

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -171,6 +171,22 @@ table.netex_generic_issue tr.debug td code {
     display: grid;
     grid-template-columns: 1fr max-content;
     align-items: baseline;
+    gap: var(--space-m);
+  }
+
+  #download-popup {
+    max-width: 60ch;
+
+    .download-grid {
+      display: grid;
+      grid-template-columns: 1fr max-content;
+      gap: var(--space-s) var(--space-l);
+
+      button {
+        display: flex;
+        width: 100%;
+      }
+    }
   }
 
   ul.summary {

--- a/apps/transport/client/stylesheets/main.scss
+++ b/apps/transport/client/stylesheets/main.scss
@@ -105,6 +105,19 @@ nav.navigation input {
   }
 }
 
+dialog {
+  &.panel {
+    position: fixed;
+  }
+  &::backdrop {
+    background: var(--darker-grey);
+    opacity: 0.3;
+  }
+  hr {
+    margin: var(--space-m) 0;
+  }
+}
+
 @media (max-width: $breakpoint-tablet) {
   .navbar__container {
     align-items: center;

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -329,22 +329,64 @@ defmodule TransportWeb.ResourceView do
 
   def netex_validation_report_download(%{validation_report_url: _} = assigns) do
     ~H"""
-    <div>
-      <.download_button url={@validation_report_url} format="csv">
-        {dgettext("resource", "CSV report")}
-      </.download_button>
-      <.download_button url={@validation_report_url} format="parquet">
-        {dgettext("resource", "Parquet report")}
-      </.download_button>
-    </div>
+    <button class="button-outline small secondary" popovertarget="download-popup">
+      <.download_popup_title />
+    </button>
+    <dialog id="download-popup" popover class="panel">
+      <div class="header_with_action_bar">
+        <h5><.download_popup_title /></h5>
+        <button popovertarget="download-popup" popovertargetaction="hide" class="small secondary">
+          <i class="fa fa-close"></i>
+        </button>
+      </div>
+      <.download_popup_content url={@validation_report_url} />
+    </dialog>
     """
   end
 
-  def download_button(%{url: nil} = assigns) do
+  def download_popup_title(%{} = assigns) do
     ~H"""
-    <button class="button-outline small secondary" disabled title={dgettext("validations", "No validation error")}>
-      <i class="icon icon--download" aria-hidden="true"></i> {render_slot(@inner_block)}
-    </button>
+    <i class="icon icon--download" aria-hidden="true"></i> {dgettext("validations", "Download the report")}
+    """
+  end
+
+  def download_popup_content(%{url: nil} = assigns) do
+    ~H"""
+    <p>
+      {dgettext("validations", "No validation error. No report to download.")}
+    </p>
+    """
+  end
+
+  def download_popup_content(%{url: _} = assigns) do
+    ~H"""
+    <div class="download-grid">
+      <span>
+        {dgettext("validations", "As a CSV file:")}
+      </span>
+      <.download_button url={@url} format="csv">
+        validation.csv
+      </.download_button>
+      <span>
+        {dgettext("validations", "As a Parquet file:")}
+      </span>
+      <.download_button url={@url} format="parquet">
+        validation.parquet
+      </.download_button>
+    </div>
+    <hr />
+    <p>
+      {dgettext(
+        "validations",
+        "Parquet is way more compact file format but it will require you to use some dedicated tooling."
+      )}
+    </p>
+    <p>
+      {dgettext("validations", "Learn more about it <a href=\"%{parquet_url}\" target=\"_blank\">here</a>.",
+        parquet_url: "https://parquet.apache.org/"
+      )
+      |> raw()}
+    </p>
     """
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -84,11 +84,3 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Size:"
 msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "CSV report"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Parquet report"
-msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -417,3 +417,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Road mobility and bike"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "As a CSV file:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "As a Parquet file:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Download the report"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about it <a href=\"%{parquet_url}\" target=\"_blank\">here</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No validation error. No report to download."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Parquet is way more compact file format but it will require you to use some dedicated tooling."
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -84,11 +84,3 @@ msgstr "Ouvrir dans explore.data.gouv.fr"
 #, elixir-autogen, elixir-format
 msgid "Size:"
 msgstr "Taille :"
-
-#, elixir-autogen, elixir-format
-msgid "CSV report"
-msgstr "Rapport CSV"
-
-#, elixir-autogen, elixir-format
-msgid "Parquet report"
-msgstr "Rapport Parquet"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -417,3 +417,27 @@ msgstr "IRVE, ZFE, covoiturage, données cyclables etc."
 #, elixir-autogen, elixir-format
 msgid "Road mobility and bike"
 msgstr "Mobilités routières et vélo"
+
+#, elixir-autogen, elixir-format
+msgid "As a CSV file:"
+msgstr "Au format CSV :"
+
+#, elixir-autogen, elixir-format
+msgid "As a Parquet file:"
+msgstr "Au format Parquet :"
+
+#, elixir-autogen, elixir-format
+msgid "Download the report"
+msgstr "Télécharger le rapport"
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about it <a href=\"%{parquet_url}\" target=\"_blank\">here</a>."
+msgstr "En savoir plus <a href=\"%{parquet_url}\" target=\"_blank\">ici</a>."
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No validation error. No report to download."
+msgstr "Aucune erreur de validation. Aucun rapport à télécharger."
+
+#, elixir-autogen, elixir-format
+msgid "Parquet is way more compact file format but it will require you to use some dedicated tooling."
+msgstr "Le format Parquet est bien plus compact mais nécessitera que vous utilisiez des outils spécifiques."

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -84,11 +84,3 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Size:"
 msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "CSV report"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "Parquet report"
-msgstr ""

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -415,3 +415,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Road mobility and bike"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "As a CSV file:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "As a Parquet file:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Download the report"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Learn more about it <a href=\"%{parquet_url}\" target=\"_blank\">here</a>."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No validation error. No report to download."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Parquet is way more compact file format but it will require you to use some dedicated tooling."
+msgstr ""

--- a/apps/transport/test/transport_web/controllers/resource_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/resource_controller_test.exs
@@ -777,7 +777,11 @@ defmodule TransportWeb.ResourceControllerTest do
         assert content =~ "bus, ferry"
 
         if version in ["0.2.0", "0.2.1"] do
-          assert content =~ "Rapport CSV"
+          assert content =~ "Au format CSV :"
+          assert content =~ "validation.csv"
+
+          assert content =~ "Au format Parquet :"
+          assert content =~ "validation.parquet"
         end
       end
     end

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -422,7 +422,8 @@ defmodule TransportWeb.ValidationControllerTest do
       body = conn |> html_response(200) |> Floki.parse_document!() |> Floki.text()
       assert body =~ ~r{XSD NeTEx\s+\(1 erreur\)}
 
-      assert body =~ "Rapport CSV"
+      assert body =~ "Au format CSV :"
+      assert body =~ "validation.csv"
 
       assert url =
                conn
@@ -437,7 +438,8 @@ defmodule TransportWeb.ValidationControllerTest do
 
       assert 1 == length(csv_report_content)
 
-      assert body =~ "Rapport Parquet"
+      assert body =~ "Au format Parquet :"
+      assert body =~ "validation.parquet"
 
       assert url =
                conn


### PR DESCRIPTION
Offre plus d’espace pour expliquer les différentes options disponibles (CSV vs Parquet).

<img width="1100" height="1297" alt="image" src="https://github.com/user-attachments/assets/bcd77846-2db5-4ae1-805a-d03b639eb20f" />

Se ferme via le bouton, en cliquant hors de la modale, ou en appuyant sur la touche Echap. (Ces deux derniers comportements sont natifs par le navigateur pour les éléments `<dialog>`.)

<details>
<summary>Version anglaise</summary>
<img width="1100" height="1297" alt="image" src="https://github.com/user-attachments/assets/e5eebedf-2143-416a-ae6b-b2a427b1f3c2" />
</details>