### PR TITLE
Ajout job pour créer des DB.Company

### DIFF
--- a/apps/transport/lib/db/company.ex
+++ b/apps/transport/lib/db/company.ex
@@ -1,0 +1,45 @@
+defmodule DB.Company do
+  @moduledoc """
+  Represents a French company identified by its SIREN number.
+  Data is fetched from the "Recherche d'entreprises API".
+  See `Transport.Companies`.
+  """
+  use Ecto.Schema
+  use TypedEctoSchema
+  import Ecto.Changeset
+
+  @primary_key {:siren, :string, []}
+
+  typed_schema "company" do
+    field(:nom_complet, :string)
+    field(:nom_raison_sociale, :string)
+    field(:sigle, :string)
+    field(:date_mise_a_jour_rne, :date)
+    field(:siege_adresse, :string)
+    field(:siege_latitude, :float)
+    field(:siege_longitude, :float)
+    field(:collectivite_territoriale, :map)
+    field(:est_service_public, :boolean)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @fields [
+    :siren,
+    :nom_complet,
+    :nom_raison_sociale,
+    :sigle,
+    :date_mise_a_jour_rne,
+    :siege_adresse,
+    :siege_latitude,
+    :siege_longitude,
+    :collectivite_territoriale,
+    :est_service_public
+  ]
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, @fields)
+    |> validate_required([:siren])
+  end
+end

--- a/apps/transport/lib/jobs/import_companies_job.ex
+++ b/apps/transport/lib/jobs/import_companies_job.ex
@@ -1,0 +1,77 @@
+defmodule Transport.Jobs.ImportCompaniesJob do
+  @moduledoc """
+  Imports or updates `DB.Company` records from the "Recherche d'entreprises API"
+  for every distinct SIREN found in `DB.Dataset.legal_owner_company_siren`.
+
+  The API has a rate limit of 7 requests per second.
+  The orchestrator schedules individual worker jobs spread over time to stay within
+  this limit: at most 7 jobs are scheduled per second using `schedule_in: div(index, 7)`.
+  """
+  use Oban.Worker, max_attempts: 3
+  import Ecto.Query
+  require Logger
+
+  @rate_limit 7
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) when is_nil(args) or args == %{} do
+    sirens()
+    |> Enum.with_index()
+    |> Enum.map(fn {siren, index} ->
+      new(%{siren: siren}, schedule_in: div(index, @rate_limit))
+    end)
+    |> Oban.insert_all()
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"siren" => siren}}) do
+    case Transport.Companies.by_siren(siren) do
+      {:ok, result} ->
+        upsert!(siren, result)
+
+      {:error, reason} ->
+        Logger.warning("#{inspect(__MODULE__)} could not fetch SIREN #{siren}: #{inspect(reason)}")
+    end
+
+    :ok
+  end
+
+  @doc """
+  Returns distinct valid SIRENs from datasets.
+  """
+  def sirens do
+    DB.Dataset.base_query()
+    |> where([dataset: d], not is_nil(d.legal_owner_company_siren))
+    |> select([dataset: d], d.legal_owner_company_siren)
+    |> distinct(true)
+    |> DB.Repo.all()
+    |> Enum.filter(&Transport.Companies.is_valid_siren?/1)
+  end
+
+  defp parse_date(nil), do: nil
+  defp parse_date(value), do: Date.from_iso8601!(value)
+
+  defp parse_float(nil), do: nil
+  defp parse_float(value), do: String.to_float(value)
+
+  defp upsert!(siren, result) do
+    attrs = %{
+      siren: siren,
+      nom_complet: result["nom_complet"],
+      nom_raison_sociale: result["nom_raison_sociale"],
+      sigle: result["sigle"],
+      date_mise_a_jour_rne: parse_date(result["date_mise_a_jour_rne"]),
+      siege_adresse: get_in(result, ["siege", "adresse"]),
+      siege_latitude: parse_float(get_in(result, ["siege", "latitude"])),
+      siege_longitude: parse_float(get_in(result, ["siege", "longitude"])),
+      collectivite_territoriale: get_in(result, ["complements", "collectivite_territoriale"]),
+      est_service_public: get_in(result, ["complements", "est_service_public"])
+    }
+
+    (DB.Repo.get(DB.Company, siren) || %DB.Company{})
+    |> DB.Company.changeset(attrs)
+    |> DB.Repo.insert_or_update!()
+  end
+end

--- a/apps/transport/priv/repo/migrations/20260311000000_create_company.exs
+++ b/apps/transport/priv/repo/migrations/20260311000000_create_company.exs
@@ -1,0 +1,20 @@
+defmodule DB.Repo.Migrations.CreateCompany do
+  use Ecto.Migration
+
+  def change do
+    create table(:company) do
+      add(:siren, :string, primary_key: true)
+      add(:nom_complet, :string)
+      add(:nom_raison_sociale, :string)
+      add(:sigle, :string)
+      add(:date_mise_a_jour_rne, :date)
+      add(:siege_adresse, :string)
+      add(:siege_latitude, :float)
+      add(:siege_longitude, :float)
+      add(:collectivite_territoriale, :map)
+      add(:est_service_public, :boolean)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+  end
+end

--- a/apps/transport/test/transport/jobs/import_companies_job_test.exs
+++ b/apps/transport/test/transport/jobs/import_companies_job_test.exs
@@ -1,0 +1,194 @@
+defmodule Transport.Test.Transport.Jobs.ImportCompaniesJobTest do
+  use ExUnit.Case, async: true
+  import DB.Factory
+  import Ecto.Query
+  import Mox
+  use Oban.Testing, repo: DB.Repo
+  alias Transport.Jobs.ImportCompaniesJob
+
+  setup :verify_on_exit!
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+  end
+
+  # Société Air France
+  @siren "420495178"
+  # Danone
+  @other_siren "552032534"
+
+  describe "orchestrator" do
+    test "enqueues one job per distinct valid SIREN" do
+      insert(:dataset, legal_owner_company_siren: @siren)
+      insert(:dataset, legal_owner_company_siren: @siren)
+      insert(:dataset, legal_owner_company_siren: @other_siren)
+      # Invalid SIREN: should be ignored
+      insert(:dataset, legal_owner_company_siren: "123456789")
+      # nil: should be ignored
+      insert(:dataset, legal_owner_company_siren: nil)
+
+      assert :ok == perform_job(ImportCompaniesJob, %{})
+
+      enqueued = all_enqueued(worker: ImportCompaniesJob)
+      assert length(enqueued) == 2
+      assert Enum.map(enqueued, & &1.args["siren"]) |> MapSet.new() == MapSet.new([@siren, @other_siren])
+    end
+
+    test "schedules jobs to respect rate limit of 7 requests per second" do
+      # 7 additional valid SIRENs + @siren = 8 total
+      # With rate limit 7: indices 0-6 at second 0, index 7 at second 1 → 2 distinct scheduled times
+      valid_sirens = [
+        "552032534",
+        "320878499",
+        "552144503",
+        "775670417",
+        "334024155",
+        "253800825",
+        "217500016"
+      ]
+
+      for siren <- [@siren | valid_sirens] do
+        # insert duplicates to verify deduplication
+        insert(:dataset, legal_owner_company_siren: siren)
+        insert(:dataset, legal_owner_company_siren: siren)
+      end
+
+      assert :ok == perform_job(ImportCompaniesJob, %{})
+
+      enqueued = all_enqueued(worker: ImportCompaniesJob)
+      assert length(enqueued) == 8
+
+      # Truncate to the second to compare scheduling buckets
+      scheduled_buckets =
+        enqueued
+        |> Enum.map(& &1.scheduled_at)
+        |> Enum.map(&DateTime.truncate(&1, :second))
+        |> Enum.uniq()
+
+      assert length(scheduled_buckets) == 2
+    end
+  end
+
+  describe "worker" do
+    test "creates a company when it does not exist" do
+      result = api_result(@siren)
+
+      setup_http_response(
+        @siren,
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"results" => [result]})}}
+      )
+
+      assert :ok == perform_job(ImportCompaniesJob, %{siren: @siren})
+
+      company = DB.Repo.one!(from(c in DB.Company, where: c.siren == ^@siren))
+      assert company.nom_complet == "AIR FRANCE"
+      assert company.nom_raison_sociale == "AIR FRANCE"
+      assert company.sigle == "AF"
+      assert company.date_mise_a_jour_rne == ~D[2023-01-15]
+      assert company.siege_adresse == "45 RUE DE PARIS 95747 ROISSY-EN-FRANCE"
+      assert company.siege_latitude == 49.003869
+      assert company.siege_longitude == 2.563512
+      assert company.collectivite_territoriale == nil
+      assert company.est_service_public == true
+    end
+
+    test "updates an existing company" do
+      DB.Repo.insert!(%DB.Company{siren: @siren, nom_complet: "OLD NAME"})
+
+      result = api_result(@siren)
+
+      setup_http_response(
+        @siren,
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"results" => [result]})}}
+      )
+
+      assert :ok == perform_job(ImportCompaniesJob, %{siren: @siren})
+
+      assert DB.Repo.one!(from(c in DB.Company, where: c.siren == ^@siren)).nom_complet == "AIR FRANCE"
+      assert DB.Repo.aggregate(DB.Company, :count) == 1
+    end
+
+    test "collectivite_territoriale stores the map from the API response" do
+      ct = %{"code" => "75", "code_insee" => "75056"}
+
+      result =
+        @siren
+        |> api_result()
+        |> put_in(["complements", "collectivite_territoriale"], ct)
+
+      setup_http_response(
+        @siren,
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"results" => [result]})}}
+      )
+
+      assert :ok == perform_job(ImportCompaniesJob, %{siren: @siren})
+
+      assert DB.Repo.one!(from(c in DB.Company, where: c.siren == ^@siren)).collectivite_territoriale == ct
+    end
+
+    test "logs a warning and does not crash when the API returns an error" do
+      setup_http_response(@siren, {:ok, %HTTPoison.Response{status_code: 500}})
+
+      {result, log} = ExUnit.CaptureLog.with_log(fn -> perform_job(ImportCompaniesJob, %{siren: @siren}) end)
+
+      assert result == :ok
+      assert log =~ "could not fetch SIREN #{@siren}"
+      assert log =~ "invalid_http_response"
+      assert DB.Repo.aggregate(DB.Company, :count) == 0
+    end
+
+    test "logs a warning and does not crash when SIREN is not found in API results" do
+      setup_http_response(@siren, {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"results" => []})}})
+
+      {result, log} = ExUnit.CaptureLog.with_log(fn -> perform_job(ImportCompaniesJob, %{siren: @siren}) end)
+
+      assert result == :ok
+      assert log =~ "could not fetch SIREN #{@siren}"
+      assert log =~ "result_not_found"
+      assert DB.Repo.aggregate(DB.Company, :count) == 0
+    end
+  end
+
+  describe "sirens/0" do
+    test "returns distinct valid SIRENs from datasets" do
+      insert(:dataset, legal_owner_company_siren: @siren)
+      insert(:dataset, legal_owner_company_siren: @siren)
+      insert(:dataset, legal_owner_company_siren: @other_siren)
+      insert(:dataset, legal_owner_company_siren: nil)
+      insert(:dataset, legal_owner_company_siren: "123456789")
+
+      assert MapSet.new(ImportCompaniesJob.sirens()) == MapSet.new([@siren, @other_siren])
+    end
+  end
+
+  defp api_result(siren) do
+    %{
+      "siren" => siren,
+      "nom_complet" => "AIR FRANCE",
+      "nom_raison_sociale" => "AIR FRANCE",
+      "sigle" => "AF",
+      "date_mise_a_jour_rne" => "2023-01-15",
+      "siege" => %{
+        "adresse" => "45 RUE DE PARIS 95747 ROISSY-EN-FRANCE",
+        "latitude" => "49.003869",
+        "longitude" => "2.563512"
+      },
+      "complements" => %{
+        "collectivite_territoriale" => nil,
+        "est_service_public" => true
+      }
+    }
+  end
+
+  defp setup_http_response(siren, response) do
+    uri = %URI{
+      scheme: "https",
+      host: "recherche-entreprises.api.gouv.fr",
+      port: 443,
+      path: "/search",
+      query: "mtm_campaign=transport-data-gouv-fr&q=#{siren}"
+    }
+
+    Transport.HTTPoison.Mock |> expect(:get, fn ^uri -> response end)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -149,6 +149,7 @@ oban_prod_crontab = [
   {"45 2 * * *", Transport.Jobs.RemoveHistoryJob, args: %{schema_name: "etalab/schema-irve-dynamique", days_limit: 7}},
   {"0 16 * * *", Transport.Jobs.DatasetQualityScoreDispatcher},
   {"40 3 * * *", Transport.Jobs.UpdateContactsJob},
+  {"0 3 * * *", Transport.Jobs.ImportCompaniesJob},
   {"40 4 * * *", Transport.Jobs.CreateTokensJob, args: %{action: "set_default_token_for_contacts"}},
   {"50 3 * * *", Transport.Jobs.CreateTokensJob, args: %{action: "create_tokens_for_organizations"}},
   {"30 4 * * *", Transport.Jobs.CreateTokensJob, args: %{action: "create_tokens_for_contacts_without_org"}},


### PR DESCRIPTION
En lien avec les [spécifications sur Notion](https://www.notion.so/transport-data-gouv-fr/Cr-er-une-entit-Entreprise-Company-31eba07fbe2a80b7be76dbc12c96b809).

- Crée un modèle et la migration associée pour `DB.Company`
- Crée des `DB.Company` à partir des numéros de SIREN renseignés toutes les nuits
- Met à jour les informations des entreprises connues quotidiennnement
