### PR TITLE
Exclusion des datasets produits par transport.data.gouv dans la consolidation IRVE

### DIFF
--- a/apps/transport/lib/irve/raw_static_consolidation.ex
+++ b/apps/transport/lib/irve/raw_static_consolidation.ex
@@ -37,7 +37,7 @@ defmodule Transport.IRVE.RawStaticConsolidation do
   require Explorer.DataFrame
 
   # needed to filter out the existing, data-gouv provided consolidation
-  @datagouv_organization_id "646b7187b50b2a93b1ae3d45"
+  @datagouv_organization_id Application.compile_env!(:transport, :datagouvfr_publisher_id)
   # Filter also our own consolidation!
   @transport_organization_id Application.compile_env!(:transport, :datagouvfr_transport_publisher_id)
   # similarly, required to eliminate a test file


### PR DESCRIPTION
Fixes #5422

Au passage j’en ai profité pour utiliser la configuration du projet (plus propre).

J’ai eu un warning qui m’a dit que dans le corps du module il valait mieux utiliser `Application.compile_env!/2` plutôt que `Application.fetch_env!/2` comme ailleurs, je me suis exécuté, et j’ai vérifié en local que ça marchait bien. J’ai un micro-doute cela dit si c’est une bonne idée si on veut un jour compiler notre application en amont. Sinon je bouge ça en variables dans le corps de la fonction avec fetch_env.