### PR TITLE
Corrige bug décalage éléments importants pour JDDs favoris

### DIFF
--- a/apps/transport/lib/transport/cache.ex
+++ b/apps/transport/lib/transport/cache.ex
@@ -10,6 +10,10 @@ defmodule Transport.Cache do
 
   def put(cache_key, value, expire_value \\ :timer.seconds(60)), do: impl().put(cache_key, value, expire_value)
 
+  @callback delete(cache_key :: binary()) :: {:ok | :error, boolean()}
+
+  def delete(cache_key), do: impl().delete(cache_key)
+
   defp impl, do: Application.get_env(:transport, :cache_impl)
 end
 
@@ -94,6 +98,8 @@ defmodule Transport.Cache.Cachex do
     )
   end
 
+  def delete(cache_key), do: Cachex.del(cache_name(), cache_key)
+
   def cache_name, do: Transport.Application.cache_name()
 end
 
@@ -106,4 +112,6 @@ defmodule Transport.Cache.Null do
   def fetch(_cache_key, value_fn, _expire_value), do: value_fn.()
 
   def put(_cache_key, _value, _expire_value), do: {:ok, true}
+
+  def delete(_cache_key), do: {:ok, true}
 end

--- a/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex
@@ -156,9 +156,20 @@ defmodule TransportWeb.ReuserSpaceController do
     |> redirect(to: reuser_space_path(conn, :datasets_edit, dataset.id))
   end
 
-  def unfavorite(%Plug.Conn{assigns: %{dataset: %DB.Dataset{} = dataset, contact: %DB.Contact{} = contact}} = conn, _) do
+  def unfavorite(
+        %Plug.Conn{
+          assigns: %{
+            dataset: %DB.Dataset{} = dataset,
+            contact: %DB.Contact{} = contact,
+            current_user: %{"id" => user_id}
+          }
+        } =
+          conn,
+        _
+      ) do
     DB.DatasetFollower.unfollow!(contact, dataset)
     delete_notification_subscriptions(contact, dataset)
+    Transport.Cache.delete(TransportWeb.Plugs.ReuserData.followed_datasets_checks_cache_key(user_id))
 
     conn
     |> put_flash(

--- a/apps/transport/lib/transport_web/plugs/reuser_data.ex
+++ b/apps/transport/lib/transport_web/plugs/reuser_data.ex
@@ -36,7 +36,7 @@ defmodule TransportWeb.Plugs.ReuserData do
   defp followed_datasets_checks(
          %Plug.Conn{assigns: %{followed_datasets: datasets, current_user: %{"id" => user_id}}} = conn
        ) do
-    cache_key = "followed_datasets_checks::#{user_id}"
+    cache_key = followed_datasets_checks_cache_key(user_id)
 
     checks =
       case datasets do
@@ -51,6 +51,8 @@ defmodule TransportWeb.Plugs.ReuserData do
   end
 
   defp followed_datasets_checks(%Plug.Conn{} = conn), do: assign(conn, :followed_datasets_checks, [])
+
+  def followed_datasets_checks_cache_key(user_id), do: "followed_datasets_checks::#{user_id}"
 
   defp datasets_checks(datasets, cache_key) do
     Transport.Cache.fetch(

--- a/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/reuser_space_controller_test.exs
@@ -5,6 +5,8 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
   import DB.Factory
   import Mox
 
+  @cache_name Transport.Cache.Cachex.cache_name()
+
   @home_url reuser_space_path(TransportWeb.Endpoint, :espace_reutilisateur)
   @google_maps_org_id "63fdfe4f4cd1c437ac478323"
 
@@ -143,6 +145,61 @@ defmodule TransportWeb.ReuserSpaceControllerTest do
   end
 
   describe "unfavorite" do
+    test "cache is invalidated after unfavoriting to avoid checks offset", %{conn: conn} do
+      # Regression test: when the checks cache was not invalidated after unfavoriting,
+      # `Enum.zip(followed_datasets_ids, followed_datasets_checks)` would misalign
+      # dataset IDs with checks — e.g. dataset_B would receive dataset_A's checks.
+      #
+      # Setup: user follows 2 datasets.
+      # dataset_a has an unavailable resource (triggers an "important information" check).
+      # dataset_b is healthy (no checks).
+      contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
+      dataset_a = insert(:dataset)
+      dataset_b = insert(:dataset)
+      insert(:resource, dataset: dataset_a, is_available: false)
+      insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset_a.id, source: :follow_button)
+      insert(:dataset_follower, contact_id: contact.id, dataset_id: dataset_b.id, source: :follow_button)
+
+      Datagouvfr.Client.Discussions.Mock |> stub(:get, fn _datagouv_id -> [] end)
+
+      old_cache_impl = Application.fetch_env!(:transport, :cache_impl)
+      Application.put_env(:transport, :cache_impl, Transport.Cache.Cachex)
+
+      on_exit(fn ->
+        Application.put_env(:transport, :cache_impl, old_cache_impl)
+        Cachex.reset(@cache_name)
+      end)
+
+      # First page load: populates the cache with checks for [dataset_a, dataset_b].
+      # At this point 1 check row is expected (unavailable resource on dataset_a).
+      doc =
+        conn
+        |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+        |> get(@home_url)
+        |> html_response(200)
+        |> Floki.parse_document!()
+
+      assert length(important_info_rows_without_recent_features(doc)) == 1
+
+      # Unfavorite dataset_a — this should invalidate the cache.
+      conn
+      |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+      |> post(reuser_space_path(conn, :unfavorite, dataset_a.id))
+
+      # Second page load: only dataset_b is followed. The cache must have been
+      # invalidated so checks are recomputed for [dataset_b] only.
+      # Without the fix the stale cache returns [checks_a, checks_b], zip gives
+      # {dataset_b.id => checks_a}, and dataset_b incorrectly shows 1 check row.
+      doc =
+        conn
+        |> Plug.Test.init_test_session(%{current_user: %{"id" => contact.datagouv_user_id}})
+        |> get(@home_url)
+        |> html_response(200)
+        |> Floki.parse_document!()
+
+      assert Enum.empty?(important_info_rows_without_recent_features(doc))
+    end
+
     test "requested dataset is not in the user's favorites", %{conn: conn} do
       contact = insert_contact(%{datagouv_user_id: Ecto.UUID.generate()})
       dataset = insert(:dataset)


### PR DESCRIPTION
Fixes #5412

Il existait un décalage entre les JDDs favoris et les checks (qui eux sont en cache)

https://github.com/etalab/transport-site/blob/de337f1ba384e3a51cb3b717b10b2bfbe2af8602/apps/transport/lib/transport_web/controllers/reuser_space_controller.ex#L21

La correction est de supprimer le cache des checks quand on retire un JDD des favoris. Un test est ajouté pour vérifier le bon fonctionnement.
