### PR TITLE
Unlock S3 : possibilité d'override les headers de réponse

### DIFF
--- a/apps/transport/lib/unlock/config.ex
+++ b/apps/transport/lib/unlock/config.ex
@@ -54,7 +54,13 @@ defmodule Unlock.Config do
     """
 
     @enforce_keys [:identifier, :bucket, :path, :ttl]
-    defstruct [:identifier, :bucket, :path, :ttl]
+    defstruct [
+      :identifier,
+      :bucket,
+      :path,
+      :ttl,
+      response_headers: []
+    ]
   end
 
   defmodule Item.GBFS do

--- a/apps/transport/lib/unlock/controller.ex
+++ b/apps/transport/lib/unlock/controller.ex
@@ -147,7 +147,7 @@ defmodule Unlock.Controller do
   ```
   """
   def override_resp_headers_if_configured(conn, %module{} = item)
-      when module in [Unlock.Config.Item.Generic.HTTP, Unlock.Config.Item.GBFS] do
+      when module in [Unlock.Config.Item.Generic.HTTP, Unlock.Config.Item.GBFS, Unlock.Config.Item.S3] do
     Enum.reduce(item.response_headers, conn, fn {header, value}, conn ->
       conn
       |> put_resp_header(header |> String.downcase(), value)
@@ -185,7 +185,11 @@ defmodule Unlock.Controller do
     Unlock.Telemetry.trace_request(item.identifier, :external)
 
     displayed_filename = Path.basename(item.path)
-    conn = conn |> put_resp_header("content-disposition", "attachment; filename=#{displayed_filename}")
+
+    conn =
+      conn
+      |> put_resp_header("content-disposition", "attachment; filename=#{displayed_filename}")
+      |> override_resp_headers_if_configured(item)
 
     case fetch_remote(item) do
       %Unlock.HTTP.Response{status: 200} = response ->

--- a/apps/transport/test/unlock/controllers/unlock_controller_test.exs
+++ b/apps/transport/test/unlock/controllers/unlock_controller_test.exs
@@ -904,7 +904,8 @@ defmodule Unlock.ControllerTest do
           identifier: slug,
           bucket: bucket_key,
           path: path,
-          ttl: ttl_in_seconds
+          ttl: ttl_in_seconds,
+          response_headers: [{"x-key", "foobar"}]
         }
       })
 
@@ -943,6 +944,8 @@ defmodule Unlock.ControllerTest do
       assert Plug.Conn.get_resp_header(resp, "x-header") == []
       # enforce the filename provided via the config (especially to get its extension passed to clients)
       assert Plug.Conn.get_resp_header(resp, "content-disposition") == ["attachment; filename=#{path}"]
+      # response_headers from the configuration are added
+      assert Plug.Conn.get_resp_header(resp, "x-key") == ["foobar"]
 
       assert_received {:telemetry_event, [:proxy, :request, :internal], %{},
                        %{target: "proxy:an-existing-s3-identifier"}}


### PR DESCRIPTION
Fixes #5425

Offre la possibilité d'override les headers en réponse d'un item S3 dans le proxy.
