### PR TITLE
Backoffice.DatasetControllerTest : shared mode pour Ecto

### DIFF
--- a/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/backoffice/dataset_controller_test.exs
@@ -9,7 +9,7 @@ defmodule TransportWeb.Backoffice.DatasetControllerTest do
 
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
-    Ecto.Adapters.SQL.Sandbox.allow(DB.Repo, self(), Process.whereis(Transport.DatasetIndex))
+    Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, {:shared, self()})
     # Using the real implementation for the moment, then it falls back on `HTTPoison.Mock`
     Mox.stub_with(Datagouvfr.Client.Datasets.Mock, Datagouvfr.Client.Datasets.External)
     :ok


### PR DESCRIPTION
Les tests semblent instables depuis #5431, cette PR essaie de corriger ça.
