### PR TITLE
Fix export ressources : agrégation des régions pour éviter les doublons

### DIFF
--- a/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/backoffice/page_controller.ex
@@ -363,7 +363,7 @@ defmodule TransportWeb.Backoffice.PageController do
       ds.dataset_sub_types,
       case when d.custom_tags is null or cardinality(d.custom_tags) = 0 then null else d.custom_tags end dataset_custom_tags,
       d.organization_type type_publicateur,
-      re.nom nom_region,
+      re.noms nom_region,
       o.offre_mobilite,
       administrative_division.noms couverture_spatiale,
       nullif(concat_ws(', ', legal_owners.noms, case when d.legal_owner_company_siren is not null then coalesce(c.nom_complet || ' (' || d.legal_owner_company_siren || ')', d.legal_owner_company_siren) end), '') representants_legaux,
@@ -387,8 +387,14 @@ defmodule TransportWeb.Backoffice.PageController do
       compliance_score.score score_conformite
     from resource r
     join dataset d on d.id = r.dataset_id
-    left join dataset_geographic_view dgv on dgv.dataset_id = d.id
-    left join region re on re.id = dgv.region_id
+    left join (
+      select
+        dgv.dataset_id,
+        string_agg(re.nom, ', ' order by re.nom) noms
+      from dataset_geographic_view dgv
+      join region re on re.id = dgv.region_id
+      group by dgv.dataset_id
+    ) re on re.dataset_id = d.id
     left join (
       select
         d.id dataset_id,


### PR DESCRIPTION
Fixes #5455

Le left join direct sur `region` produisait une ligne par région associée au dataset. Remplacé par une sous-requête avec string_agg pour regrouper les noms de régions séparés par des virgules.
