### PR TITLE
GTFS-RT : créer une validation fatale et notifier en cas d'erreur FATAL

### DIFF
--- a/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
+++ b/apps/transport/lib/jobs/multi_validation_with_error_notification_job.ex
@@ -48,7 +48,6 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
   @notification_reason Transport.NotificationReason.reason(:dataset_with_error)
 
   @gtfs_rt_validator Transport.Validators.GTFSRT.validator_name()
-  @gtfs_rt_errors_threshold 50
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -252,10 +251,8 @@ defmodule Transport.Jobs.MultiValidationWithErrorNotificationJob do
     |> Enum.group_by(& &1.resource.dataset)
   end
 
-  def relevant_realtime_validation?(%DB.MultiValidation{validator: @gtfs_rt_validator, result: %{"errors" => errors}}) do
-    errors
-    |> Enum.filter(&(&1["error_id"] in Transport.Validators.GTFSRT.id_mismatch_error_codes()))
-    |> Enum.sum_by(& &1["errors_count"]) >= @gtfs_rt_errors_threshold
+  def relevant_realtime_validation?(%DB.MultiValidation{validator: @gtfs_rt_validator} = mv) do
+    Transport.Validators.GTFSRT.critical_errors?(mv)
   end
 
   def relevant_realtime_validation?(%DB.MultiValidation{}), do: true

--- a/apps/transport/lib/transport/dataset_checks.ex
+++ b/apps/transport/lib/transport/dataset_checks.ex
@@ -17,7 +17,6 @@ defmodule Transport.DatasetChecks do
   @recent_discussions_days 7
 
   @gtfs_rt_validator Transport.Validators.GTFSRT.validator_name()
-  @gtfs_rt_errors_threshold 50
 
   @type validation_list :: [DB.MultiValidation.t()]
   @type resource_with_validations :: {DB.Resource.t(), validation_list()}
@@ -90,10 +89,8 @@ defmodule Transport.DatasetChecks do
     |> keep_validations(validations)
     |> Enum.filter(fn {%DB.Resource{}, [mv | _]} ->
       case mv do
-        %DB.MultiValidation{validator: @gtfs_rt_validator, result: %{"errors" => errors}} ->
-          errors
-          |> Enum.filter(&(&1["error_id"] in Transport.Validators.GTFSRT.id_mismatch_error_codes()))
-          |> Enum.sum_by(& &1["errors_count"]) >= @gtfs_rt_errors_threshold
+        %DB.MultiValidation{validator: @gtfs_rt_validator} = mv ->
+          Transport.Validators.GTFSRT.critical_errors?(mv)
 
         %DB.MultiValidation{digest: %{"max_severity" => %{"max_level" => severity}}}
         when severity in ["Error", "ERROR", "Fatal"] ->

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -1,6 +1,6 @@
 defmodule Transport.Validators.GTFSRT do
   @moduledoc """
-  Validate a GTFS-RT with gtfs-realtime-validato (https://github.com/MobilityData/gtfs-realtime-validator/)
+  Validate a GTFS-RT with gtfs-realtime-validator (https://github.com/MobilityData/gtfs-realtime-validator/)
   """
   import Ecto.Query
   alias DB.{Dataset, MultiValidation, Repo, Resource, ResourceHistory, ResourceMetadata}
@@ -14,8 +14,22 @@ defmodule Transport.Validators.GTFSRT do
   # Error codes indicating that GTFS-RT identifiers do not match the GTFS identifiers.
   # See https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md
   @id_mismatch_error_codes ~w(E003 E004 E011 E034)
+  @gtfs_rt_errors_threshold 50
 
   def id_mismatch_error_codes, do: @id_mismatch_error_codes
+
+  @doc """
+  Returns true if a GTFS-RT `MultiValidation` result is considered critical:
+  either at least #{@gtfs_rt_errors_threshold} id-mismatch errors, or at least one FATAL error.
+  """
+  def critical_errors?(%DB.MultiValidation{result: %{"errors" => errors}}) do
+    id_mismatch_count =
+      errors
+      |> Enum.filter(&(&1["error_id"] in id_mismatch_error_codes()))
+      |> Enum.sum_by(& &1["errors_count"])
+
+    id_mismatch_count >= @gtfs_rt_errors_threshold or Enum.any?(errors, &(&1["error_id"] == "FATAL"))
+  end
 
   @impl Transport.Validators.Validator
   def validator_name, do: "gtfs-realtime-validator"
@@ -48,8 +62,23 @@ defmodule Transport.Validators.GTFSRT do
     download_latest_gtfs(gtfs_resource_history, gtfs_path)
     validator_args = validator_arguments(gtfs_path, gtfs_rt_path, opts)
 
-    with {:ok, _} <- GTFSRT.run_validator(validator_args),
-         {:ok, report} <- rt_resource |> gtfs_rt_result_path() |> GTFSRT.convert_validator_report(opts) do
+    report =
+      with {:ok, _} <- GTFSRT.run_validator(validator_args),
+           {:ok, report} <- rt_resource |> gtfs_rt_result_path() |> GTFSRT.convert_validator_report(opts) do
+        report
+      else
+        :error ->
+          fatal_report()
+
+        {:error, message} ->
+          if not ignore_shapes and String.contains?(message, "java.lang.OutOfMemoryError") do
+            run_validator_and_save(snapshot, ignore_shapes: true)
+          end
+
+          nil
+      end
+
+    if report do
       insert_multi_validation(
         rt_resource,
         GTFSRT.build_validation_details(gtfs_resource_history, report, cellar_filename),
@@ -57,14 +86,6 @@ defmodule Transport.Validators.GTFSRT do
         gtfs_resource,
         gtfs_resource_history
       )
-    else
-      :error ->
-        {:error, "Could not run validator. Please provide a GTFS and a GTFS-RT."}
-
-      {:error, message} ->
-        if not ignore_shapes and String.contains?(message, "java.lang.OutOfMemoryError") do
-          run_validator_and_save(snapshot, ignore_shapes: true)
-        end
     end
   end
 
@@ -188,6 +209,29 @@ defmodule Transport.Validators.GTFSRT do
       },
       "uuid" => Ecto.UUID.generate()
     })
+  end
+
+  @doc """
+  Builds a fatal validation report when the validator cannot process the files,
+  i.e. when valid GTFS and GTFS-RT feeds are not provided.
+  """
+  def fatal_report do
+    %{
+      "errors_count" => 1,
+      "warnings_count" => 0,
+      "has_errors" => true,
+      "ignore_shapes" => false,
+      "errors" => [
+        %{
+          "error_id" => "FATAL",
+          "severity" => "ERROR",
+          "title" => "Not a valid GTFS or GTFS-RT feed",
+          "description" => "The validator could not run. Please provide a valid GTFS and a valid GTFS-RT feed.",
+          "errors_count" => 1,
+          "errors" => []
+        }
+      ]
+    }
   end
 
   def up_to_date_gtfs_resources(%Resource{dataset_id: dataset_id}),

--- a/apps/transport/test/transport/dataset_checks_test.exs
+++ b/apps/transport/test/transport/dataset_checks_test.exs
@@ -114,17 +114,17 @@ defmodule Transport.DatasetChecksTest do
 
     errors = too_few_errors ++ [%{"error_id" => "E034", "errors_count" => 10}]
 
-    mv1 = %DB.MultiValidation{
-      validator: Transport.Validators.GTFSRT.validator_name(),
-      result: %{"errors" => too_few_errors}
-    }
+    gtfs_rt_validator = Transport.Validators.GTFSRT.validator_name()
 
+    mv1 = %DB.MultiValidation{validator: gtfs_rt_validator, result: %{"errors" => too_few_errors}}
     mv2 = %{mv1 | result: %{"errors" => errors}}
+    mv_fatal = %{mv1 | result: %{"errors" => [%{"error_id" => "FATAL", "errors_count" => 1}]}}
 
     dataset = dataset |> DB.Repo.preload(:resources)
 
     assert [] == dataset |> Transport.DatasetChecks.invalid_resource(%{resource.id => [mv1]})
     assert [{_, [^mv2]}] = dataset |> Transport.DatasetChecks.invalid_resource(%{resource.id => [mv2]})
+    assert [{_, [^mv_fatal]}] = dataset |> Transport.DatasetChecks.invalid_resource(%{resource.id => [mv_fatal]})
   end
 
   test "invalid_resource for a GTFS-RT at the check level" do

--- a/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/multi_validation_with_error_notification_job_test.exs
@@ -95,6 +95,23 @@ defmodule Transport.Test.Transport.Jobs.MultiValidationWithErrorNotificationJobT
       assert [{%DB.Dataset{id: ^dataset_id}, [%DB.MultiValidation{id: ^mv_id}]}] = relevant_validations
     end
 
+    test "for a GTFS-RT with a FATAL error" do
+      %DB.Dataset{id: dataset_id} = dataset = insert(:dataset)
+      gtfs_rt = insert(:resource, format: "gtfs-rt", dataset: dataset)
+
+      %DB.MultiValidation{id: mv_id} =
+        insert(:multi_validation, %{
+          resource_id: gtfs_rt.id,
+          validator: Transport.Validators.GTFSRT.validator_name(),
+          result: %{"has_errors" => true, "errors" => [%{"error_id" => "FATAL", "errors_count" => 1}]},
+          inserted_at: DateTime.utc_now() |> DateTime.add(-15, :minute)
+        })
+
+      dt_limit = DateTime.utc_now() |> DateTime.add(-30, :minute)
+      relevant_validations = MultiValidationWithErrorNotificationJob.relevant_validations(dt_limit)
+      assert [{%DB.Dataset{id: ^dataset_id}, [%DB.MultiValidation{id: ^mv_id}]}] = relevant_validations
+    end
+
     test "finds the MobilityData validator" do
       %DB.Dataset{id: dataset_id} = dataset = insert(:dataset)
       gtfs = insert(:resource, format: "GTFS", dataset: dataset)

--- a/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
+++ b/apps/transport/test/transport/validators/gtfs_rt_validator_test.exs
@@ -20,6 +20,25 @@ defmodule Transport.Validators.GTFSRTTest do
 
   setup :verify_on_exit!
 
+  test "critical_errors?" do
+    mv = fn errors -> %DB.MultiValidation{result: %{"errors" => errors}} end
+
+    refute GTFSRT.critical_errors?(mv.([]))
+    refute GTFSRT.critical_errors?(mv.([%{"error_id" => "E003", "errors_count" => 49}]))
+
+    assert GTFSRT.critical_errors?(mv.([%{"error_id" => "E003", "errors_count" => 50}]))
+
+    assert GTFSRT.critical_errors?(
+             mv.([
+               %{"error_id" => "E003", "errors_count" => 10},
+               %{"error_id" => "E004", "errors_count" => 40}
+             ])
+           )
+
+    assert GTFSRT.critical_errors?(mv.([%{"error_id" => "FATAL", "errors_count" => 1}]))
+    refute GTFSRT.critical_errors?(mv.([%{"error_id" => "E001", "errors_count" => 100}]))
+  end
+
   test "get_max_severity_error" do
     assert nil == GTFSRT.get_max_severity_error([])
     assert "ERROR" == GTFSRT.get_max_severity_error([%{"severity" => "ERROR"}])
@@ -444,14 +463,75 @@ defmodule Transport.Validators.GTFSRTTest do
 
       assert :ok == GTFSRT.validate_and_save(dataset)
 
-      gtfs_rt_validation =
+      refute DB.MultiValidation.with_result()
+             |> where([mv], mv.resource_id == ^gtfs_rt.id and mv.validator == ^GTFSRT.validator_name())
+             |> DB.Repo.exists?()
+    end
+
+    test "inserts a fatal validation when the validator produces no results file (not a valid GTFS or GTFS-RT)" do
+      gtfs_permanent_url = "https://example.com/gtfs.zip"
+      gtfs_rt_url = "https://example.com/gtfs-rt"
+
+      %{dataset: dataset, resource_history: %{id: resource_history_id}, resource: %{id: gtfs_id}} =
+        insert_up_to_date_resource_and_friends(
+          resource_history_payload: %{
+            "format" => "GTFS",
+            "permanent_url" => gtfs_permanent_url,
+            "uuid" => Ecto.UUID.generate()
+          }
+        )
+
+      %DB.Resource{id: gtfs_rt_id} =
+        gtfs_rt =
+        insert(:resource,
+          dataset_id: dataset.id,
+          is_available: true,
+          format: "gtfs-rt",
+          is_community_resource: false,
+          url: gtfs_rt_url
+        )
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_rt_url, [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "not a gtfs-rt")
+        {:ok, %Req.Response{status: 200, body: "not a gtfs-rt"}}
+      end)
+
+      Transport.Req.Mock
+      |> expect(:get, fn ^gtfs_permanent_url,
+                         [compressed: false, decode_body: false, into: %File.Stream{path: stream_path}] ->
+        File.write!(stream_path, "gtfs_content")
+        {:ok, %Req.Response{status: 200}}
+      end)
+
+      mock_s3_stream_upload(gtfs_rt)
+
+      Transport.Rambo.Mock
+      |> expect(:run, fn _binary, _args, [log: false] ->
+        # Validator runs but does not produce a results file
+        {:ok, nil}
+      end)
+
+      assert :ok == GTFSRT.validate_and_save(dataset)
+
+      %DB.MultiValidation{
+        result: result,
+        max_error: "ERROR",
+        resource_id: ^gtfs_rt_id,
+        secondary_resource_id: ^gtfs_id,
+        secondary_resource_history_id: ^resource_history_id
+      } =
         DB.MultiValidation.with_result()
         |> where([mv], mv.resource_id == ^gtfs_rt.id and mv.validator == ^GTFSRT.validator_name())
-        |> order_by([mv], desc: mv.inserted_at)
-        |> limit(1)
-        |> DB.Repo.all()
+        |> DB.Repo.one!()
 
-      assert [] == gtfs_rt_validation
+      assert %{
+               "errors_count" => 1,
+               "warnings_count" => 0,
+               "has_errors" => true,
+               "max_severity" => "ERROR",
+               "errors" => [%{"error_id" => "FATAL", "severity" => "ERROR"}]
+             } = result
     end
 
     test "when there is a memory error, run the validator another time and ignore shapes" do


### PR DESCRIPTION
Fixes #5448

- Crée une `MultiValidation` avec une erreur fatale quand le validateur
  tourne mais ne produit pas de fichier de résultats
- Centralise la logique de criticité dans `GTFSRT.critical_errors?/1` :
  ≥ 50 erreurs d'id-mismatch **ou** au moins 1 erreur FATAL
- Refactorise `run_validator_and_save` pour n'appeler
  `insert_multi_validation` qu'une seule fois
- Met à jour `MultiValidationWithErrorNotificationJob` et `DatasetChecks`
  pour utiliser `critical_errors?/1`
- Ajoute des tests pour les trois modules
