### PR TITLE
Ajout du flux dynamique dans le calcul de stats d'unicité des pdc IRVE

### DIFF
--- a/scripts/irve/stats.exs
+++ b/scripts/irve/stats.exs
@@ -10,7 +10,8 @@ sources = [
    "consolidation-nationale-irve-statique-brute-v1.csv", :original_resource_id},
   {"https://www.data.gouv.fr/fr/datasets/r/eb76d20a-8501-400e-b336-d85724de5435", "consolidation-data-gouv.csv",
    :datagouv_resource_id},
-  {"https://proxy.transport.data.gouv.fr/resource/consolidation-nationale-irve-dynamique?include_source=1", "dynamic-irve.csv", :slug}
+  {"https://proxy.transport.data.gouv.fr/resource/consolidation-nationale-irve-dynamique?include_source=1",
+   "dynamic-irve.csv", :slug}
   # # generate with `mix run dump-simple-consolidation.exs`
   # {:on_disk, "simple-consolidation.csv", :datagouv_resource_id}
 ]


### PR DESCRIPTION
Cette PR fait suite à:
- #5453 
- https://github.com/transportdatagouvfr/proxy-config/pull/181
 
Je fais ici le premier calcul d'unicité (sur la base de `id_pdc_itinerance`). On voit ainsi le nombre de doublons (16k), pour analyse.

```
❯ elixir scripts/irve/stats.exs 
+------------------------------------------------------------------------------------------------+
|                           Explorer DataFrame: [rows: 4, columns: 4]                            |
+---------------------------------------------------------+--------+----------------+------------+
|                          path                           | count  | distinct_count | duplicates |
|                        <string>                         | <s64>  |     <s64>      |   <s64>    |
+=========================================================+========+================+============+
| consolidation-transport-avec-doublons-irve-statique.csv | 388495 | 150112         | 238383     |
| consolidation-nationale-irve-statique-brute-v1.csv      | 372540 | 153041         | 219499     |
| consolidation-data-gouv.csv                             | 203199 | 145565         | 57634      |
| dynamic-irve.csv                                        | 108567 | 92227          | 16340      |
+---------------------------------------------------------+--------+----------------+------------+
```