### PR TITLE
Meilleure pagination

### DIFF
--- a/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
+++ b/apps/transport/lib/transport_web/controllers/pagination_helpers.ex
@@ -21,33 +21,27 @@ defmodule TransportWeb.PaginationHelpers do
   def pagination_links(_, %{total_pages: 1}), do: {:safe, ""}
 
   def pagination_links(conn, paginator) do
-    conn.params
-    |> remove_empty_q()
-    |> case do
-      [] -> HTML.pagination_links(conn, paginator)
-      args -> HTML.pagination_links(conn, paginator, args)
+    case remove_empty_q(conn.params) do
+      [] -> HTML.pagination_links(conn, paginator, view_style: :bootstrap_v4)
+      args -> HTML.pagination_links(conn, paginator, [view_style: :bootstrap_v4] ++ args)
     end
   end
 
   def pagination_links(_, %{total_pages: 1}, _), do: {:safe, ""}
 
   def pagination_links(conn, paginator, opts) do
-    opts
-    |> remove_empty_q
-    |> case do
-      [] -> HTML.pagination_links(conn, paginator, opts)
-      opts -> HTML.pagination_links(conn, paginator, opts)
+    case remove_empty_q(opts) do
+      [] -> HTML.pagination_links(conn, paginator, view_style: :bootstrap_v4)
+      opts -> HTML.pagination_links(conn, paginator, [view_style: :bootstrap_v4] ++ opts)
     end
   end
 
   def pagination_links(_, %{total_pages: 1}, _, _), do: {:safe, ""}
 
   def pagination_links(conn, paginator, args, opts) do
-    opts
-    |> remove_empty_q()
-    |> case do
-      [] -> HTML.pagination_links(conn, paginator, opts)
-      opts -> HTML.pagination_links(conn, paginator, args, opts)
+    case remove_empty_q(opts) do
+      [] -> HTML.pagination_links(conn, paginator, args, view_style: :bootstrap_v4)
+      opts -> HTML.pagination_links(conn, paginator, args, [view_style: :bootstrap_v4] ++ opts)
     end
   end
 

--- a/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
+++ b/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
@@ -21,6 +21,17 @@ defmodule TransportWeb.PaginationHelpersTest do
 
       test_pagination(2, %{"page" => "2"})
       |> assert_has_pages([{"<<", "/datasets"}, {"1", "/datasets"}, {"2", nil}])
+
+      test_pagination(5, %{"format" => "NeTEx", "page" => "3"})
+      |> assert_has_pages([
+        {"<<", "/datasets?format=NeTEx&page=2"},
+        {"1", "/datasets?format=NeTEx"},
+        {"2", "/datasets?format=NeTEx&page=2"},
+        {"3", nil},
+        {"4", "/datasets?format=NeTEx&page=4"},
+        {"5", "/datasets?format=NeTEx&page=5"},
+        {">>", "/datasets?format=NeTEx&page=4"}
+      ])
     end
 
     test "custom path" do
@@ -34,6 +45,17 @@ defmodule TransportWeb.PaginationHelpersTest do
 
       test_pagination(2, %{"page" => "2"}, opts)
       |> assert_has_pages([{"<<", "/datasets#list"}, {"1", "/datasets#list"}, {"2", nil}])
+
+      test_pagination(5, %{"page" => "3"}, [format: "NeTEx"] ++ opts)
+      |> assert_has_pages([
+        {"<<", "/datasets?format=NeTEx&page=2#list"},
+        {"1", "/datasets?format=NeTEx#list"},
+        {"2", "/datasets?format=NeTEx&page=2#list"},
+        {"3", nil},
+        {"4", "/datasets?format=NeTEx&page=4#list"},
+        {"5", "/datasets?format=NeTEx&page=5#list"},
+        {">>", "/datasets?format=NeTEx&page=4#list"}
+      ])
     end
   end
 

--- a/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
+++ b/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
@@ -79,6 +79,13 @@ defmodule TransportWeb.PaginationHelpersTest do
     |> pagination_links(pagination, opts)
     |> Phoenix.HTML.safe_to_string()
     |> Floki.parse_document!()
+    |> assert_has_aria_label()
+  end
+
+  defp assert_has_aria_label(doc) do
+    assert [{"nav", [{"aria-label", _}], _}] = doc
+
+    doc
   end
 
   defp assert_has_pages(doc, links) do

--- a/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
+++ b/apps/transport/test/transport_web/controllers/pagination_helpers_test.exs
@@ -10,30 +10,30 @@ defmodule TransportWeb.PaginationHelpersTest do
 
   describe "pagination_links" do
     test "simple links" do
-      assert paginate(1, %{}) == ""
-      assert paginate(1, %{"page" => "1"}) == ""
+      assert test_pagination(1, %{}) == []
+      assert test_pagination(1, %{"page" => "1"}) == []
 
-      assert paginate(2, %{}) ==
-               "<nav><ul class=\"pagination\"><li class=\"active\"><a class=\"\">1</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2\" rel=\"next\">2</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2\" rel=\"next\">&gt;&gt;</a></li></ul></nav>"
+      test_pagination(2, %{})
+      |> assert_has_pages([{"1", nil}, {"2", "/datasets?page=2"}, {">>", "/datasets?page=2"}])
 
-      assert paginate(2, %{"page" => "1"}) ==
-               "<nav><ul class=\"pagination\"><li class=\"active\"><a class=\"\">1</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2\" rel=\"next\">2</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2\" rel=\"next\">&gt;&gt;</a></li></ul></nav>"
+      test_pagination(2, %{"page" => "1"})
+      |> assert_has_pages([{"1", nil}, {"2", "/datasets?page=2"}, {">>", "/datasets?page=2"}])
 
-      assert paginate(2, %{"page" => "2"}) ==
-               "<nav><ul class=\"pagination\"><li class=\"\"><a class=\"\" href=\"/datasets\" rel=\"prev\">&lt;&lt;</a></li><li class=\"\"><a class=\"\" href=\"/datasets\" rel=\"prev\">1</a></li><li class=\"active\"><a class=\"\">2</a></li></ul></nav>"
+      test_pagination(2, %{"page" => "2"})
+      |> assert_has_pages([{"<<", "/datasets"}, {"1", "/datasets"}, {"2", nil}])
     end
 
     test "custom path" do
       opts = [path: &custom_path/3]
 
-      assert paginate(2, %{}, opts) ==
-               "<nav><ul class=\"pagination\"><li class=\"active\"><a class=\"\">1</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2#list\" rel=\"next\">2</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2#list\" rel=\"next\">&gt;&gt;</a></li></ul></nav>"
+      test_pagination(2, %{}, opts)
+      |> assert_has_pages([{"1", nil}, {"2", "/datasets?page=2#list"}, {">>", "/datasets?page=2#list"}])
 
-      assert paginate(2, %{"page" => "1"}, opts) ==
-               "<nav><ul class=\"pagination\"><li class=\"active\"><a class=\"\">1</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2#list\" rel=\"next\">2</a></li><li class=\"\"><a class=\"\" href=\"/datasets?page=2#list\" rel=\"next\">&gt;&gt;</a></li></ul></nav>"
+      test_pagination(2, %{"page" => "1"}, opts)
+      |> assert_has_pages([{"1", nil}, {"2", "/datasets?page=2#list"}, {">>", "/datasets?page=2#list"}])
 
-      assert paginate(2, %{"page" => "2"}, opts) ==
-               "<nav><ul class=\"pagination\"><li class=\"\"><a class=\"\" href=\"/datasets#list\" rel=\"prev\">&lt;&lt;</a></li><li class=\"\"><a class=\"\" href=\"/datasets#list\" rel=\"prev\">1</a></li><li class=\"active\"><a class=\"\">2</a></li></ul></nav>"
+      test_pagination(2, %{"page" => "2"}, opts)
+      |> assert_has_pages([{"<<", "/datasets#list"}, {"1", "/datasets#list"}, {"2", nil}])
     end
   end
 
@@ -41,20 +41,38 @@ defmodule TransportWeb.PaginationHelpersTest do
     dataset_path(conn, action, params) <> "#list"
   end
 
-  defp paginate(n_pages, params) do
+  defp test_pagination(n_pages, params) do
     {conn, pagination} = setup_pagination(n_pages, params)
 
     conn
     |> pagination_links(pagination)
     |> Phoenix.HTML.safe_to_string()
+    |> Floki.parse_document!()
   end
 
-  defp paginate(n_pages, params, opts) do
+  defp test_pagination(n_pages, params, opts) do
     {conn, pagination} = setup_pagination(n_pages, params)
 
     conn
     |> pagination_links(pagination, opts)
     |> Phoenix.HTML.safe_to_string()
+    |> Floki.parse_document!()
+  end
+
+  defp assert_has_pages(doc, links) do
+    assert links == doc |> Floki.find("a") |> Enum.map(&extract_link/1)
+
+    doc
+  end
+
+  defp extract_link(link) do
+    href =
+      case Floki.attribute(link, "href") do
+        [href] -> href
+        _ -> nil
+      end
+
+    {Floki.text(link), href}
   end
 
   defp setup_pagination(n_pages, params) do


### PR DESCRIPTION
- meilleure couverture de tests du helper de liens de pagination
- le HTML résultant inclut l'attribut d'accessibilité pour différencier la `nav` des autres.