### PR TITLE
NeTEx: Documentation de la mise à jour des règles

### DIFF
--- a/apps/transport/lib/netex/Readme.md
+++ b/apps/transport/lib/netex/Readme.md
@@ -1,10 +1,45 @@
 # NeTEx support
 
+- How-Tos
+  - How to publish the latest ruleset
+  - How to list published rulesets
 - Extraction of stop places from a streamed NeTEx
 - Validation of French profile via enRoute Chouette Valid
   - Ruleset generation
   - Client for enRoute Chouette Valid rulesets management API
   - French profile implementation
+
+## How-Tos
+
+### How to publish the latest ruleset
+
+_Prerequisite: the API token is set by the `ENROUTE_RULESETS_TOKEN` env var._
+
+You can publish the latest ruleset to enRoute with the following command:
+
+```bash
+mix run scripts/chouette_valid_rulesets.exs publish-ruleset
+```
+
+This command will publish the latest ruleset defined in `Transport.NeTEx.FrenchProfile`
+to the enRoute API. It is an upsert operation, the slug is reused if necessary.
+
+The ruleset is an adjonction of the rules defined in `Transport.NeTEx.FrenchProfile`
+which are specific to the French profile (as the name suggests) and the "base rules"
+edited by enRoute. The PAN is only responsible for the french profile rules.
+
+Later on we could envision adding rules not specific to the French profile, for
+instance for data quality. It is not implemented yet nor is it planned.
+
+### How to list published rulesets
+
+_Prerequisite: the API token is set by the `ENROUTE_RULESETS_TOKEN` env var._
+
+You can check what revisions are available with the following command:
+
+```bash
+mix run scripts/chouette_valid_rulesets.exs list-rulesets
+```
 
 ## Extraction of stop places from a streamed NeTEx
 

--- a/scripts/chouette_valid_rulesets.exs
+++ b/scripts/chouette_valid_rulesets.exs
@@ -1,7 +1,16 @@
 defmodule Script do
   @moduledoc """
-  Script to debug and inspect current implementation of validation rules for the
-  French NeTEx profile.
+  Script to interact with the enRoute Chouette Valid rulesets API.
+
+  Used to:
+  - list published rulesets
+  - publish the latest rulesets
+  - debug and inspect current implementation of validation rules for the
+    French NeTEx profile.
+  - convert existing rules to markdown or JSON for documentation. This is a
+    legacy command which will be droped. Documentation of published rules is
+    still useful but should be done via the interface instead. Until the later
+    is implemented this command remain.
   """
 
   import Transport.NeTEx.FrenchProfile
@@ -16,14 +25,6 @@ defmodule Script do
   def list_rulesets do
     Wrapper.impl().list_rulesets()
     |> IO.inspect()
-  end
-
-  def purge_rulesets do
-    Wrapper.impl().list_rulesets()
-    |> Enum.each(fn %{"id" => ruleset_id, "slug" => slug} ->
-      IO.puts("Deleting profile #{slug}")
-      Wrapper.impl().delete_ruleset(ruleset_id)
-    end)
   end
 
   def list_revisions(slug) do
@@ -100,7 +101,6 @@ defmodule CLI do
       ["list-rulesets"] -> Script.list_rulesets()
       ["document-rulesets", filename] -> Script.document_rulesets(filename)
       ["document-rulesets"] -> Script.document_rulesets("chouette_ruleset")
-      ["purge-rulesets"] -> Script.purge_rulesets()
       ["help"] -> help()
       _ -> help()
     end
@@ -116,12 +116,11 @@ defmodule CLI do
       publish-ruleset              # publish our ruleset to the given slug from the definition
       list-rulesets                # list all published rulesets
       get-ruleset <slug>           # inspect ruleset for a given slug
-      document-rulesets (filename) # dump rulesets as json definition and markdown (filename.md & filename.json)
 
       find-ruleset-id <slug>       # find ruleset-id of a given slug (ruleset-id in Chouette Valid API)
       list-revisions <slug>        # list revisions of a given slug
 
-      purge-rulesets               # purge all published rulesets (DANGEROUS). This will break production.
+      document-rulesets (filename) # dump rulesets as json definition and markdown (filename.md & filename.json). Deprecated command ; will be superseeded by a proper inline documentation.
 
       help                         # this message
     """)


### PR DESCRIPTION
Documente l'API de gestions des règles de validation NeTEx chez enRoute.

Inclut notamment de quoi publier des jeux de règles.