### PR TITLE
NeTEx : Conversion en GeoJSON et affichage en carte

### DIFF
--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -1,7 +1,7 @@
 import L from 'leaflet'
 import { IGN } from './map-config'
 
-function initilizeMap (id) {
+function initializeMap (id) {
     const map = L.map(id, { renderer: L.canvas() }).setView([46.505, 2], 5)
     L.tileLayer(IGN.url, IGN.config).addTo(map)
 
@@ -10,7 +10,7 @@ function initilizeMap (id) {
     return { map, markersfg, linesfg }
 }
 
-function GTFSLinesStyle (feature) {
+function TransitLinesStyle (feature) {
     if (feature.geometry.type !== 'Point') {
         return { color: feature.properties.route_color, weight: 5 }
     } else {
@@ -55,21 +55,21 @@ function GeojsonMap (fillMapFunction, mapDivId, infoDivId, geojsonUrl, filesize,
     }
 }
 
-function GTFSMap (mapDivId, geojsonUrl) {
-    const { map, markersfg, linesfg } = initilizeMap(mapDivId)
+function TransitMap (mapDivId, geojsonUrl) {
+    const { map, markersfg, linesfg } = initializeMap(mapDivId)
     fetch(geojsonUrl)
         .then(data => data.json())
         .then(geojson => {
             const stops = L.geoJSON(geojson, {
                 pointToLayer: createStopsMarkers,
-                style: GTFSLinesStyle,
+                style: TransitLinesStyle,
                 filter: (feature) => feature.geometry.type === 'Point'
             }).addTo(markersfg)
 
             stops.bindPopup(layer => { return formatPopupContent(layer.feature.properties) })
 
             const lines = L.geoJSON(geojson, {
-                style: GTFSLinesStyle,
+                style: TransitLinesStyle,
                 filter: (feature) => feature.geometry.type !== 'Point',
                 onEachFeature: (_feature, layer) => {
                     layer.on('mouseover', () => {
@@ -112,7 +112,7 @@ function formatPopupContent (content) {
 }
 
 function GenericMap (mapDivId, geojsonUrl) {
-    const { map, markersfg, linesfg } = initilizeMap(mapDivId)
+    const { map, markersfg, linesfg } = initializeMap(mapDivId)
     fetch(geojsonUrl)
         .then(data => data.json())
         .then(geojson => {
@@ -142,13 +142,13 @@ function GenericMap (mapDivId, geojsonUrl) {
         .catch(_ => console.log('invalid geojson'))
 }
 
-function GTFSGeojsonMap (mapDivId, infoDivId, geojsonUrl, filesize = 0, msg1 = '', msg2 = '') {
-    GeojsonMap(GTFSMap, mapDivId, infoDivId, geojsonUrl, filesize, msg1, msg2)
+function TransitGeojsonMap (mapDivId, infoDivId, geojsonUrl, filesize = 0, msg1 = '', msg2 = '') {
+    GeojsonMap(TransitMap, mapDivId, infoDivId, geojsonUrl, filesize, msg1, msg2)
 }
 
 function GenericGeojsonMap (mapDivId, infoDivId, geojsonUrl, filesize = 0, msg1 = '', msg2 = '') {
     GeojsonMap(GenericMap, mapDivId, infoDivId, geojsonUrl, filesize, msg1, msg2)
 }
 
-window.GTFSGeojsonMap = GTFSGeojsonMap
+window.TransitGeojsonMap = TransitGeojsonMap
 window.GenericGeojsonMap = GenericGeojsonMap

--- a/apps/transport/client/javascripts/map-geojson.js
+++ b/apps/transport/client/javascripts/map-geojson.js
@@ -18,7 +18,7 @@ function GTFSLinesStyle (feature) {
     }
 }
 
-function createStopsMarkers (geoJsonPoint, latlng) {
+function createStopsMarkers (_geoJsonPoint, latlng) {
     return L.circleMarker(latlng, { fillColor: 'white', color: 'black', fillOpacity: 1, weight: 3, radius: 5 })
 }
 
@@ -71,7 +71,7 @@ function GTFSMap (mapDivId, geojsonUrl) {
             const lines = L.geoJSON(geojson, {
                 style: GTFSLinesStyle,
                 filter: (feature) => feature.geometry.type !== 'Point',
-                onEachFeature: (feature, layer) => {
+                onEachFeature: (_feature, layer) => {
                     layer.on('mouseover', () => {
                         layer.bringToFront()
                         stops.bringToFront()
@@ -99,11 +99,11 @@ function GTFSMap (mapDivId, geojsonUrl) {
         .catch(_ => console.log('invalid geojson'))
 }
 
-function GenericLinesStyle (feature) {
+function GenericLinesStyle (_feature) {
     return { weight: 3 }
 }
 
-function createPointsMarkers (geoJsonPoint, latlng) {
+function createPointsMarkers (_geoJsonPoint, latlng) {
     return L.circleMarker(latlng, { stroke: false, color: '#0066db', fillOpacity: 0.7 })
 }
 

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -10,7 +10,7 @@ defmodule DB.DataConversion do
     field(:status, Ecto.Enum, values: [:created, :pending, :success, :failed, :timeout])
     field(:converter, :string)
     field(:converter_version, :string)
-    field(:convert_from, Ecto.Enum, values: [:GTFS])
+    field(:convert_from, Ecto.Enum, values: [:GTFS, :NeTEx])
     field(:convert_to, Ecto.Enum, values: [:GeoJSON, :NeTEx])
     field(:resource_history_uuid, Ecto.UUID)
     field(:payload, :map)
@@ -51,12 +51,14 @@ defmodule DB.DataConversion do
   def join_resource_history_with_data_conversion(%Ecto.Query{} = query, convert_tos, converters \\ nil) do
     converters = converters || Enum.map(convert_tos, &converter_to_use/1)
 
+    convert_from = [:GTFS, :NeTEx]
+
     query
     |> join(:left, [resource_history: rh], dc in DB.DataConversion,
       on: fragment("(?->>'uuid')::uuid = ?", rh.payload, dc.resource_history_uuid),
       as: :data_conversion
     )
-    |> where([data_conversion: dc], dc.convert_from == :GTFS and dc.convert_to in ^convert_tos)
+    |> where([data_conversion: dc], dc.convert_from in ^convert_from and dc.convert_to in ^convert_tos)
     |> where([data_conversion: dc], dc.status == :success and dc.converter in ^converters)
   end
 

--- a/apps/transport/lib/db/data_conversion.ex
+++ b/apps/transport/lib/db/data_conversion.ex
@@ -31,35 +31,48 @@ defmodule DB.DataConversion do
   @doc """
   Finds the default converter to use for a target format.
 
-  iex> converter_to_use(:GeoJSON)
+  iex> converter_to_use(:GTFS, :GeoJSON)
   "rust-transit/gtfs-to-geojson"
-  iex> available_conversion_formats() |> Enum.each(& converter_to_use/1)
+  iex> converter_to_use(:NeTEx, :GeoJSON)
+  "etalab/transport-site"
+  iex> available_conversion_formats() |> Enum.each(& converter_to_use(:GTFS, &1))
+  :ok
+  iex> available_conversion_formats() |> Enum.each(& converter_to_use(:NeTEx, &1))
   :ok
   """
-  @spec converter_to_use(binary() | atom()) :: binary()
-  def converter_to_use(convert_to) do
+  @spec converter_to_use(binary() | atom(), binary() | atom()) :: binary()
+  def converter_to_use(convert_from, convert_to) do
     Map.fetch!(
       %{
-        "GeoJSON" => Transport.GTFSToGeoJSONConverter.converter()
+        {"GTFS", "GeoJSON"} => Transport.GTFSToGeoJSONConverter.converter(),
+        {"NeTEx", "GeoJSON"} => Transport.NeTExToGeoJSONConverter.converter()
       },
-      to_string(convert_to)
+      {to_string(convert_from), to_string(convert_to)}
     )
   end
 
   @spec join_resource_history_with_data_conversion(Ecto.Query.t(), [binary()], [binary()] | nil) :: Ecto.Query.t()
   @spec join_resource_history_with_data_conversion(Ecto.Query.t(), [binary()]) :: Ecto.Query.t()
   def join_resource_history_with_data_conversion(%Ecto.Query{} = query, convert_tos, converters \\ nil) do
-    converters = converters || Enum.map(convert_tos, &converter_to_use/1)
+    convert_froms = [:GTFS, :NeTEx]
 
-    convert_from = [:GTFS, :NeTEx]
+    converters = converters || default_converters(convert_froms, convert_tos)
 
     query
     |> join(:left, [resource_history: rh], dc in DB.DataConversion,
       on: fragment("(?->>'uuid')::uuid = ?", rh.payload, dc.resource_history_uuid),
       as: :data_conversion
     )
-    |> where([data_conversion: dc], dc.convert_from in ^convert_from and dc.convert_to in ^convert_tos)
+    |> where([data_conversion: dc], dc.convert_from in ^convert_froms and dc.convert_to in ^convert_tos)
     |> where([data_conversion: dc], dc.status == :success and dc.converter in ^converters)
+  end
+
+  defp default_converters(convert_froms, convert_tos) do
+    for convert_from <- convert_froms,
+        convert_to <- convert_tos,
+        converter = converter_to_use(convert_from, convert_to) do
+      converter
+    end
   end
 
   @spec latest_data_conversions(integer(), binary()) :: [map()]

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -257,7 +257,7 @@ defmodule DB.Resource do
     converter = DB.DataConversion.converter_to_use(format)
     # Only value supported for now but needed to make the query fast
     # https://github.com/etalab/transport-site/issues/4448
-    convert_from = :GTFS
+    convert_from = [:GTFS, :NeTEx]
 
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
@@ -269,12 +269,9 @@ defmodule DB.Resource do
       filesize: fragment("(? ->> 'filesize')::int", dc.payload),
       resource_history_last_up_to_date_at: rh.last_up_to_date_at
     })
-    |> where(
-      [rh, dc],
-      rh.resource_id == ^resource_id and
-        dc.convert_from == ^convert_from and dc.convert_to == ^format and
-        dc.status == :success and dc.converter == ^converter
-    )
+    |> where([rh, _], rh.resource_id == ^resource_id)
+    |> where([_, dc], dc.convert_from in ^convert_from and dc.convert_to == ^format)
+    |> where([_, dc], dc.status == :success and dc.converter == ^converter)
     |> order_by([rh, _], desc: rh.inserted_at)
     |> limit(1)
     |> DB.Repo.one()

--- a/apps/transport/lib/db/resource.ex
+++ b/apps/transport/lib/db/resource.ex
@@ -254,10 +254,9 @@ defmodule DB.Resource do
   def get_related_conversion_info(nil, _), do: nil
 
   def get_related_conversion_info(resource_id, format) do
-    converter = DB.DataConversion.converter_to_use(format)
-    # Only value supported for now but needed to make the query fast
-    # https://github.com/etalab/transport-site/issues/4448
     convert_from = [:GTFS, :NeTEx]
+
+    converters = convert_from |> Enum.map(&DB.DataConversion.converter_to_use(&1, format))
 
     DB.ResourceHistory
     |> join(:inner, [rh], dc in DB.DataConversion,
@@ -271,7 +270,7 @@ defmodule DB.Resource do
     })
     |> where([rh, _], rh.resource_id == ^resource_id)
     |> where([_, dc], dc.convert_from in ^convert_from and dc.convert_to == ^format)
-    |> where([_, dc], dc.status == :success and dc.converter == ^converter)
+    |> where([_, dc], dc.status == :success and dc.converter in ^converters)
     |> order_by([rh, _], desc: rh.inserted_at)
     |> limit(1)
     |> DB.Repo.one()

--- a/apps/transport/lib/jobs/conversions/generic_converter.ex
+++ b/apps/transport/lib/jobs/conversions/generic_converter.ex
@@ -1,0 +1,209 @@
+defmodule Transport.Jobs.GenericConverter do
+  @moduledoc """
+  Provides some functions to convert GTFS to another format.
+
+  Note that the EnRoute's GTFS to NeTEx converter does not use this class
+  because the conversion is not done locally but through an API.
+  """
+  alias DB.{DataConversion, Repo, ResourceHistory}
+  import Ecto.Query
+  require Logger
+
+  @allowed_formats ["GeoJSON"]
+
+  def enqueue_all_conversion_jobs(source_format, target_format, conversion_job_module) do
+    fatal_error_key = fatal_error_key(target_format)
+    converter = conversion_job_module.converter()
+
+    query =
+      ResourceHistory
+      |> where(
+        [_r],
+        fragment(
+          """
+          payload ->>'format'=?
+          AND NOT payload \\? ?
+          AND
+          payload ->>'uuid' NOT IN
+          (SELECT resource_history_uuid::text FROM data_conversion WHERE convert_from=? and convert_to=? and converter=?)
+          """,
+          ^source_format,
+          ^fatal_error_key,
+          ^source_format,
+          ^target_format,
+          ^converter
+        )
+      )
+      |> select([r], r.id)
+
+    stream = Repo.stream(query)
+
+    Repo.transaction(fn ->
+      stream
+      |> Stream.each(fn id ->
+        %{"resource_history_id" => id, "action" => "create"}
+        |> conversion_job_module.new()
+        |> Oban.insert()
+      end)
+      |> Stream.run()
+    end)
+
+    :ok
+  end
+
+  defp fatal_error_key(format) when format in @allowed_formats, do: "conversion_#{format}_fatal_error"
+
+  defp resource_of_format?(expected_format, %{payload: %{"format" => format}}), do: to_string(expected_format) == format
+  defp resource_of_format?(_, _), do: false
+
+  @spec conversion_exists?(DB.ResourceHistory.t() | nil, binary(), binary(), module()) :: boolean
+  @doc """
+  Checks if a conversion already exists for a `DB.ResourceHistory` and a target format.
+  """
+  def conversion_exists?(
+        %DB.ResourceHistory{payload: %{"uuid" => resource_uuid}},
+        source_format,
+        target_format,
+        converter_module
+      )
+      when target_format in @allowed_formats do
+    DataConversion
+    |> Repo.get_by(
+      convert_from: source_format,
+      convert_to: target_format,
+      converter: converter_module.converter(),
+      resource_history_uuid: resource_uuid
+    ) !== nil
+  end
+
+  def conversion_exists?(nil, _, _, _), do: false
+
+  @doc """
+  Converts a resource_history to the targeted format, using a converter module
+  """
+  @spec perform_single_conversion_job(integer(), binary(), binary(), module()) :: :ok
+  def perform_single_conversion_job(resource_history_id, source_format, target_format, converter_module)
+      when target_format in @allowed_formats do
+    resource_history = ResourceHistory |> Repo.get(resource_history_id)
+
+    case resource_of_format?(source_format, resource_history) and
+           not conversion_exists?(resource_history, source_format, target_format, converter_module) do
+      true ->
+        generate_and_upload_conversion(resource_history, source_format, target_format, converter_module)
+
+      false ->
+        Logger.info("Skipping #{target_format} conversion of resource history #{resource_history_id}")
+        {:cancel, "Conversion is not needed"}
+    end
+  end
+
+  defp generate_and_upload_conversion(
+         %ResourceHistory{
+           id: resource_history_id,
+           resource_id: resource_id,
+           datagouv_id: resource_datagouv_id,
+           payload: %{"uuid" => resource_uuid, "permanent_url" => resource_url, "filename" => resource_filename}
+         } = resource_history,
+         source_format,
+         target_format,
+         converter_module
+       )
+       when target_format in @allowed_formats do
+    source_format_lower = source_format |> to_string() |> String.downcase()
+    target_format_lower = target_format |> String.downcase()
+    Logger.info("Starting conversion of download uuid #{resource_uuid}, from #{source_format} to #{target_format}")
+
+    source_file_path =
+      System.tmp_dir!()
+      |> Path.join(
+        "conversion_#{source_format_lower}_#{target_format_lower}_#{resource_history_id}_#{:os.system_time(:millisecond)}"
+      )
+
+    conversion_output_path = "#{source_file_path}.#{target_format_lower}"
+    zip_path = "#{conversion_output_path}.zip"
+
+    try do
+      %{status_code: 200, body: body} = Transport.Shared.Wrapper.HTTPoison.impl().get!(resource_url)
+
+      File.write!(source_file_path, body)
+
+      case converter_module.convert(source_file_path, conversion_output_path) do
+        :ok ->
+          # gtfs2netex converter outputs a folder, we need to zip it
+          zip_conversion? = File.dir?(conversion_output_path)
+
+          path =
+            if zip_conversion? do
+              :ok = Transport.FolderZipper.zip(conversion_output_path, zip_path)
+              zip_path
+            else
+              conversion_output_path
+            end
+
+          %File.Stat{size: filesize} = File.stat!(path)
+
+          conversion_file_name =
+            resource_filename
+            |> conversion_file_name(source_format_lower, target_format_lower)
+            |> add_zip_extension(zip_conversion?)
+
+          Transport.S3.stream_to_s3!(:history, path, conversion_file_name, acl: :public_read)
+
+          %DataConversion{
+            convert_from: source_format,
+            convert_to: String.to_existing_atom(target_format),
+            status: :success,
+            converter: converter_module.converter(),
+            converter_version: converter_module.converter_version(),
+            resource_history_uuid: resource_uuid,
+            payload: %{
+              filename: conversion_file_name,
+              permanent_url: Transport.S3.permanent_url(:history, conversion_file_name),
+              resource_id: resource_id,
+              resource_datagouv_id: resource_datagouv_id,
+              filesize: filesize
+            }
+          }
+          |> Repo.insert!()
+
+          :ok
+
+        {:error, reason} ->
+          resource_history
+          |> Ecto.Changeset.change(%{
+            payload:
+              Map.merge(resource_history.payload, %{
+                fatal_error_key(target_format) => true,
+                "conversion_#{target_format}_error" => reason
+              })
+          })
+          |> Repo.update!()
+
+          {:cancel, "Converter returned an error: #{reason}"}
+      end
+    after
+      File.rm(source_file_path)
+      File.rm_rf(conversion_output_path)
+      # may not exist
+      File.rm(zip_path)
+    end
+  end
+
+  defp conversion_file_name(resource_name, source_format, target_format),
+    do: "conversions/#{source_format}-to-#{target_format}/#{resource_name}.#{target_format}"
+
+  defp add_zip_extension(path, true = _zip_conversion?), do: "#{path}.zip"
+  defp add_zip_extension(path, _), do: path
+end
+
+defmodule Transport.FolderZipper do
+  @moduledoc """
+  Zip a folder using the zip external command
+  """
+  def zip(folder_path, zip_name) do
+    case Transport.RamboLauncher.run("zip", [zip_name, "-r", "./"], cd: folder_path) do
+      {:ok, _} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+end

--- a/apps/transport/lib/jobs/conversions/gtfs_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/gtfs_to_geojson_converter_job.ex
@@ -1,6 +1,6 @@
 defmodule Transport.Jobs.GTFSToGeoJSONConverterJob do
   @moduledoc """
-  This will enqueue GTFS -> GeoJSON conversion jobs for all GTFS resources found in ResourceHistory
+  This will enqueue GTFS -> GeoJSON conversion jobs for all GTFS resources found in ResourceHistory.
   """
   use Oban.Worker, tags: ["conversions"], max_attempts: 3
   alias Transport.Jobs.GTFSGenericConverter
@@ -13,7 +13,7 @@ end
 
 defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJob do
   @moduledoc """
-  Conversion Job of a GTFS to a GeoJSON, saving the resulting file in S3
+  Conversion Job of a GTFS to a GeoJSON, saving the resulting file in S3.
   """
   use Oban.Worker, tags: ["conversions"], max_attempts: 3
   alias Transport.Jobs.GTFSGenericConverter

--- a/apps/transport/lib/jobs/conversions/netex_generic_converter.ex
+++ b/apps/transport/lib/jobs/conversions/netex_generic_converter.ex
@@ -1,9 +1,6 @@
-defmodule Transport.Jobs.GTFSGenericConverter do
+defmodule Transport.Jobs.NeTExGenericConverter do
   @moduledoc """
-  Provides some functions to convert GTFS to another format.
-
-  Note that the EnRoute's GTFS to NeTEx converter does not use this class
-  because the conversion is not done locally but through an API.
+  Provides some functions to convert NeTEx to another format.
   """
   alias Transport.Jobs.GenericConverter
 
@@ -17,7 +14,7 @@ defmodule Transport.Jobs.GTFSGenericConverter do
   end
 
   def enqueue_all_conversion_jobs(format, conversion_job_module) do
-    GenericConverter.enqueue_all_conversion_jobs("GTFS", format, conversion_job_module)
+    GenericConverter.enqueue_all_conversion_jobs("NeTEx", format, conversion_job_module)
   end
 
   @doc """
@@ -25,6 +22,6 @@ defmodule Transport.Jobs.GTFSGenericConverter do
   """
   @spec perform_single_conversion_job(integer(), binary(), module()) :: :ok
   def perform_single_conversion_job(resource_history_id, format, converter_module) do
-    GenericConverter.perform_single_conversion_job(resource_history_id, :GTFS, format, converter_module)
+    GenericConverter.perform_single_conversion_job(resource_history_id, :NeTEx, format, converter_module)
   end
 end

--- a/apps/transport/lib/jobs/conversions/netex_to_geojson_converter_job.ex
+++ b/apps/transport/lib/jobs/conversions/netex_to_geojson_converter_job.ex
@@ -1,0 +1,54 @@
+defmodule Transport.Jobs.NeTExToGeoJSONConverterJob do
+  @moduledoc """
+  This will enqueue NeTEx -> GeoJSON conversion jobs for all NeTEx resources found in ResourceHistory.
+  """
+  use Oban.Worker, tags: ["conversions"], max_attempts: 3
+  alias Transport.Jobs.NeTExGenericConverter
+
+  @impl true
+  def perform(%{}) do
+    NeTExGenericConverter.enqueue_all_conversion_jobs("GeoJSON", Transport.Jobs.SingleNeTExToGeoJSONConverterJob)
+  end
+end
+
+defmodule Transport.Jobs.SingleNeTExToGeoJSONConverterJob do
+  @moduledoc """
+  Conversion Job of a NeTEx to a GeoJSON, saving the resulting file in S3.
+  """
+  use Oban.Worker, tags: ["conversions"], max_attempts: 3
+  alias Transport.Jobs.NeTExGenericConverter
+
+  defdelegate converter(), to: Transport.NeTExToGeoJSONConverter
+
+  @impl true
+  def perform(%{args: %{"resource_history_id" => resource_history_id}}) do
+    NeTExGenericConverter.perform_single_conversion_job(
+      resource_history_id,
+      "GeoJSON",
+      Transport.NeTExToGeoJSONConverter
+    )
+  end
+end
+
+defmodule Transport.NeTExToGeoJSONConverter do
+  @moduledoc """
+  Given a NeTEx file path, create from the file the corresponding geojson with the stops and line shapes if available.
+  """
+  @behaviour Transport.Converters.Converter
+
+  def convert(netex_file_path, geojson_file_path) do
+    with {:ok, json} <- Transport.NeTEx.ArchiveParser.to_geojson(netex_file_path),
+         :ok <- File.write(geojson_file_path, JSON.encode!(json)) do
+      :ok
+    else
+      {:error, e} when is_atom(e) -> {:error, to_string(e)}
+      {:error, e} when is_binary(e) -> {:error, e}
+    end
+  end
+
+  @impl true
+  def converter, do: "etalab/transport-site"
+
+  @impl true
+  def converter_version, do: "0.1.0"
+end

--- a/apps/transport/lib/transport_web/templates/resource/_geojson.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_geojson.html.heex
@@ -6,7 +6,7 @@
   </script>
   <script>
     document.addEventListener("DOMContentLoaded", function() {
-      GTFSGeojsonMap(
+      TransitGeojsonMap(
         'resource-geojson',
         'resource-geojson-info',
         "<%= @associated_geojson.url %>",

--- a/apps/transport/lib/transport_web/templates/resource/_geojson.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_geojson.html.heex
@@ -1,0 +1,32 @@
+<% locale = get_session(@conn, :locale) %>
+<div class="panel no-padding">
+  <div id="resource-geojson-info" class="p-24"></div>
+  <div id="resource-geojson"></div>
+  <script src={static_path(@conn, "/js/mapgeojson.js")}>
+  </script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      GTFSGeojsonMap(
+        'resource-geojson',
+        'resource-geojson-info',
+        "<%= @associated_geojson.url %>",
+        "<%= @associated_geojson.filesize || 0 %>",
+        "<%= dgettext("validations", "Stops visualization is quite big") %>",
+        "<%= dgettext("validations", "Show anyway") %>"
+        )
+      })
+  </script>
+</div>
+<div :if={not is_nil(@associated_geojson.resource_history_last_up_to_date_at)} class="is-centered mt-12">
+  {dgettext("validations", "Visualization up-to-date %{hours} ago.",
+    hours: hours_ago(@associated_geojson.resource_history_last_up_to_date_at, locale)
+  )}
+  <a class="download-button" rel="nofollow" href={@associated_geojson.stable_url}>
+    <button class="button-outline secondary no-border small">
+      <i class="icon icon--download" aria-hidden="true"></i>{dgettext(
+        "page-dataset-details",
+        "Download as GeoJSON"
+      )}
+    </button>
+  </a>
+</div>

--- a/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/gtfs_details.html.heex
@@ -8,7 +8,7 @@ locale = get_session(@conn, :locale) %>
       <div class="menu-item">
         <a href="#download-availability">{dgettext("page-dataset-details", "Download availability")}</a>
       </div>
-      <div class="menu-item">
+      <div :if={not is_nil(associated_geojson)} class="menu-item">
         <a href="#visualization">{dgettext("validations", "Stops and routes visualization of the GTFS file")}</a>
       </div>
       <div class="menu-item"><a href="#validation-report">{dgettext("validations", "Validation report")}</a></div>
@@ -35,37 +35,7 @@ locale = get_session(@conn, :locale) %>
       <h2 class="mt-48" id="visualization">
         {dgettext("validations", "Stops and routes visualization of the GTFS file")}
       </h2>
-      <div class="panel no-padding">
-        <div id="resource-geojson-info" class="p-24"></div>
-        <div id="resource-geojson"></div>
-        <script src={static_path(@conn, "/js/mapgeojson.js")}>
-        </script>
-        <script>
-          document.addEventListener("DOMContentLoaded", function() {
-            GTFSGeojsonMap(
-              'resource-geojson',
-              'resource-geojson-info',
-              "<%= associated_geojson.url %>",
-              "<%= associated_geojson.filesize || 0 %>",
-              "<%= dgettext("validations", "Stops visualization is quite big") %>",
-              "<%= dgettext("validations", "Show anyway") %>"
-              )
-            })
-        </script>
-      </div>
-      <div :if={not is_nil(associated_geojson.resource_history_last_up_to_date_at)} class="is-centered mt-12">
-        {dgettext("validations", "Visualization up-to-date %{hours} ago.",
-          hours: hours_ago(associated_geojson.resource_history_last_up_to_date_at, locale)
-        )}
-        <a class="download-button" rel="nofollow" href={associated_geojson.stable_url}>
-          <button class="button-outline secondary no-border small">
-            <i class="icon icon--download" aria-hidden="true"></i>{dgettext(
-              "page-dataset-details",
-              "Download as GeoJSON"
-            )}
-          </button>
-        </a>
-      </div>
+      {render("_geojson.html", associated_geojson: associated_geojson, conn: @conn)}
     <% end %>
     <h2 id="validation-report" class="mt-48">{dgettext("validations", "Validation report")}</h2>
     <div class="panel" id="issues">

--- a/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/netex_details.html.heex
@@ -1,3 +1,4 @@
+<% associated_geojson = get_associated_geojson(@related_files) %>
 {render("_search_bar.html", conn: @conn)}
 <div class="dataset-page netex">
   <div class="dataset-menu-container">
@@ -5,6 +6,9 @@
       <div class="menu-item"><a href="#details">{dgettext("validations", "Resource details")}</a></div>
       <div class="menu-item">
         <a href="#download-availability">{dgettext("page-dataset-details", "Download availability")}</a>
+      </div>
+      <div :if={not is_nil(associated_geojson)} class="menu-item">
+        <a href="#visualization">{dgettext("validations", "Stops and routes visualization of the NeTEx file")}</a>
       </div>
       <div :if={not DB.Resource.documentation?(@resource)} class="menu-item">
         <a href="#validation-report">{dgettext("validations", "Validation report")}</a>
@@ -32,12 +36,18 @@
     <h2 id="download-availability">{dgettext("page-dataset-details", "Download availability")}</h2>
     {render("_download_availability.html", uptime_per_day: @uptime_per_day, conn: @conn)}
 
+    <%= unless is_nil(associated_geojson) do %>
+      <h2 class="mt-48" id="visualization">
+        {dgettext("validations", "Stops and routes visualization of the NeTEx file")}
+      </h2>
+      {render("_geojson.html", associated_geojson: associated_geojson, conn: @conn)}
+    <% end %>
+
     <h2 id="validation-report" class="mt-48">{dgettext("validations", "Validation report")}</h2>
     <div class="panel" id="issues">
       <%= if is_nil(@validation_summary) do %>
         {dgettext("validations", "No validation available")}
-      <% end %>
-      <%= unless is_nil(@validation_summary) do %>
+      <% else %>
         {render(@errors_template,
           conn: @conn,
           issues: @issues,
@@ -79,13 +89,9 @@
       <h2 id="other-resources">{dgettext("validations", "Other resources")}</h2>
       <div class="panel">
         <ul>
-          <%= for resource <- @other_resources do %>
-            <li>
-              {link(resource.title,
-                to: resource_path(@conn, :details, resource.id)
-              )}
-            </li>
-          <% end %>
+          <li :for={resource <- @other_resources}>
+            {link(resource.title, to: resource_path(@conn, :details, resource.id))}
+          </li>
         </ul>
       </div>
     <% end %>

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -449,3 +449,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops and routes visualization of the NeTEx file"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -449,3 +449,7 @@ msgstr "Liste des règles du profil France actuellement implémentées"
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr "En savoir plus"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stops and routes visualization of the NeTEx file"
+msgstr "Aperçu des arrêts et lignes de la ressource NeTEx"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -447,3 +447,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Learn more"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Stops and routes visualization of the NeTEx file"
+msgstr ""

--- a/apps/transport/priv/repo/migrations/20260126155921_allow_netex_to_geojson_conversion.exs
+++ b/apps/transport/priv/repo/migrations/20260126155921_allow_netex_to_geojson_conversion.exs
@@ -1,0 +1,13 @@
+defmodule DB.Repo.Migrations.AllowNeTExToGeoJSONConversion do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint("data_conversion", :allowed_from_formats))
+    create(constraint("data_conversion", :allowed_from_formats, check: "convert_from IN ('GTFS', 'NeTEx')"))
+  end
+
+  def down do
+    drop(constraint("data_conversion", :allowed_from_formats))
+    create(constraint("data_conversion", :allowed_from_formats, check: "convert_from IN ('GTFS')"))
+  end
+end

--- a/apps/transport/test/db/data_conversion_test.exs
+++ b/apps/transport/test/db/data_conversion_test.exs
@@ -73,7 +73,7 @@ defmodule DB.DataConversionTest do
     insert(:data_conversion,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
-      converter: DB.DataConversion.converter_to_use("GeoJSON"),
+      converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
       resource_history_uuid: uuid_old,
       payload: %{filename: "filename_old"}
     )
@@ -86,7 +86,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         resource_history_uuid: uuid,
         payload: %{filename: "filename"}
       )
@@ -101,7 +101,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         resource_history_uuid: uuid_2,
         payload: %{filename: "filename_2"}
       )
@@ -117,7 +117,7 @@ defmodule DB.DataConversionTest do
       insert(:data_conversion,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         resource_history_uuid: uuid_other,
         payload: %{filename: "filename"}
       )

--- a/apps/transport/test/db/dataset_test.exs
+++ b/apps/transport/test/db/dataset_test.exs
@@ -436,7 +436,7 @@ defmodule DB.DatasetDBTest do
         resource_history_uuid: uuid1,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         payload: %{"permanent_url" => "url1", "filesize" => 21}
       )
 
@@ -444,7 +444,7 @@ defmodule DB.DatasetDBTest do
         resource_history_uuid: uuid2,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         payload: %{"permanent_url" => "url2", "filesize" => 76}
       )
 
@@ -453,7 +453,7 @@ defmodule DB.DatasetDBTest do
         resource_history_uuid: uuid3,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         status: :pending,
         payload: %{"permanent_url" => "url3", "filesize" => 43}
       )
@@ -501,7 +501,7 @@ defmodule DB.DatasetDBTest do
         resource_history_uuid: uuid1,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         payload: %{"permanent_url" => "url1", "filesize" => 21}
       )
 

--- a/apps/transport/test/db/resource_test.exs
+++ b/apps/transport/test/db/resource_test.exs
@@ -42,7 +42,7 @@ defmodule DB.ResourceTest do
     insert_geojson_data_conversion(uuid3, "url3", 10)
 
     data_conversion_pending =
-      insert_geojson_data_conversion(uuid4, "url4", 10, DB.DataConversion.converter_to_use("GeoJSON"), :pending)
+      insert_geojson_data_conversion(uuid4, "url4", 10, DB.DataConversion.converter_to_use("GTFS", "GeoJSON"), :pending)
 
     assert %{url: "url2", filesize: 12, resource_history_last_up_to_date_at: _} =
              Resource.get_related_geojson_info(resource_id_1)
@@ -73,7 +73,7 @@ defmodule DB.ResourceTest do
       resource_history_uuid: uuid,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
-      converter: converter || DB.DataConversion.converter_to_use("GeoJSON"),
+      converter: converter || DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
       status: status,
       payload: %{permanent_url: permanent_url, filesize: filesize}
     })

--- a/apps/transport/test/transport/jobs/conversions/gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/gtfs_to_geojson_converter_job_test.exs
@@ -41,7 +41,7 @@ defmodule Transport.Jobs.GTFSToGeoJSONConverterJobTest do
     insert(:data_conversion,
       convert_from: :GTFS,
       convert_to: :GeoJSON,
-      converter: DB.DataConversion.converter_to_use(:GeoJSON),
+      converter: DB.DataConversion.converter_to_use(:GTFS, :GeoJSON),
       resource_history_uuid: uuid,
       payload: %{}
     )

--- a/apps/transport/test/transport/jobs/conversions/single_gtfs_to_geojson_converter_job_test.exs
+++ b/apps/transport/test/transport/jobs/conversions/single_gtfs_to_geojson_converter_job_test.exs
@@ -29,7 +29,7 @@ defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJobTest do
       convert_from: :GTFS,
       convert_to: :GeoJSON,
       resource_history_uuid: uuid,
-      converter: DB.DataConversion.converter_to_use(:GeoJSON),
+      converter: DB.DataConversion.converter_to_use(:GTFS, :GeoJSON),
       payload: %{}
     )
 
@@ -77,7 +77,7 @@ defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJobTest do
              DB.Repo.get_by!(DB.DataConversion,
                convert_from: :GTFS,
                convert_to: :GeoJSON,
-               converter: DB.DataConversion.converter_to_use(:GeoJSON),
+               converter: DB.DataConversion.converter_to_use(:GTFS, :GeoJSON),
                resource_history_uuid: uuid
              )
 
@@ -124,7 +124,7 @@ defmodule Transport.Jobs.SingleGTFSToGeoJSONConverterJobTest do
       |> DB.Repo.get_by!(
         convert_from: :GTFS,
         convert_to: :GeoJSON,
-        converter: DB.DataConversion.converter_to_use(:GeoJSON),
+        converter: DB.DataConversion.converter_to_use(:GTFS, :GeoJSON),
         resource_history_uuid: uuid
       )
     end)

--- a/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/api/datasets_controller_test.exs
@@ -586,7 +586,7 @@ defmodule TransportWeb.API.DatasetControllerTest do
       resource_history_uuid: uuid1,
       convert_from: "GTFS",
       convert_to: "GeoJSON",
-      converter: DB.DataConversion.converter_to_use("GeoJSON"),
+      converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
       payload: %{"permanent_url" => "https://example.com/url1", "filesize" => filesize = 43}
     )
 

--- a/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/conversion_controller_test.exs
@@ -42,7 +42,7 @@ defmodule TransportWeb.ConversionControllerTest do
         resource_history_uuid: uuid1,
         convert_from: "GTFS",
         convert_to: "GeoJSON",
-        converter: DB.DataConversion.converter_to_use("GeoJSON"),
+        converter: DB.DataConversion.converter_to_use("GTFS", "GeoJSON"),
         payload: %{"permanent_url" => permanent_url = "https://example.com/url1", "filesize" => 42}
       )
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -112,6 +112,7 @@ oban_prod_crontab = [
   {"0 */6 * * *", Transport.Jobs.ResourceHistoryAndValidationDispatcherJob},
   {"0 4,16 * * *", Transport.Jobs.ResourceHistoryAndValidationDispatcherJob, args: %{mode: :reuser_improved_data}},
   {"30 */6 * * *", Transport.Jobs.GTFSToGeoJSONConverterJob},
+  {"30 */6 * * *", Transport.Jobs.NeTExToGeoJSONConverterJob},
   {"0 4 * * *", Transport.Jobs.GTFSImportStopsJob},
   {"20 8 * * *", Transport.Jobs.CleanOrphanConversionsJob},
   {"0 * * * *", Transport.Jobs.ResourcesUnavailableDispatcherJob},


### PR DESCRIPTION
Exemple sur la ressource nationale SNCF :

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/87707aaf-74cf-4c75-93ca-4a0e26201a98" />

* * *

- S'appuie sur #5312.
- Mets en commun le code de conversion GTFS-GeoJSON, rendant la diff impressionnante sans raison.