### PR TITLE
Transport.Validators.GTFSRT : gère nil pour critical_errors?

### DIFF
--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -31,6 +31,8 @@ defmodule Transport.Validators.GTFSRT do
     id_mismatch_count >= @gtfs_rt_errors_threshold or Enum.any?(errors, &(&1["error_id"] == "FATAL"))
   end
 
+  def critical_errors?(%DB.MultiValidation{result: nil}), do: false
+
   @impl Transport.Validators.Validator
   def validator_name, do: "gtfs-realtime-validator"
 


### PR DESCRIPTION
Corrige [cette exception](https://transport-data-gouv-fr.sentry.io/issues/7362928970/) Sentry
