### PR TITLE
NeTEx: identifie les grandes fonctionnalités

### DIFF
--- a/apps/transport/lib/netex/description_parser.ex
+++ b/apps/transport/lib/netex/description_parser.ex
@@ -12,7 +12,15 @@ defmodule Transport.NeTEx.DescriptionParser do
     transport_modes: [],
     lines: 0,
     quays: 0,
-    stop_places: 0
+    stop_places: 0,
+    features: %{
+      networks: false,
+      stops: false,
+      timetables: false,
+      fares: false,
+      parkings: false,
+      accessibility: false
+    }
   }
 
   def initial_state do
@@ -32,24 +40,24 @@ defmodule Transport.NeTEx.DescriptionParser do
     {:ok, state |> push(element)}
   end
 
-  def handle_event(:end_element, "Network", state) do
-    {:ok, state |> stop_capture() |> pop()}
+  def handle_event(:end_element, "Network" = element, state) do
+    {:ok, state |> stop_capture() |> end_element(element)}
   end
 
-  def handle_event(:end_element, "Line", state) do
-    {:ok, state |> increment(:lines) |> stop_capture() |> pop()}
+  def handle_event(:end_element, "Line" = element, state) do
+    {:ok, state |> increment(:lines) |> stop_capture() |> end_element(element)}
   end
 
-  def handle_event(:end_element, "Quay", state) do
-    {:ok, state |> increment(:quays) |> pop()}
+  def handle_event(:end_element, "Quay" = element, state) do
+    {:ok, state |> increment(:quays) |> end_element(element)}
   end
 
-  def handle_event(:end_element, "StopPlace", state) do
-    {:ok, state |> increment(:stop_places) |> pop()}
+  def handle_event(:end_element, "StopPlace" = element, state) do
+    {:ok, state |> increment(:stop_places) |> end_element(element)}
   end
 
-  def handle_event(:end_element, _, state) do
-    {:ok, state |> pop()}
+  def handle_event(:end_element, element, state) do
+    {:ok, state |> end_element(element)}
   end
 
   def handle_event(:characters, chars, state)
@@ -64,10 +72,151 @@ defmodule Transport.NeTEx.DescriptionParser do
 
   def handle_event(_, _, state), do: {:ok, state}
 
+  defp end_element(state, element) do
+    state |> feature_detection(element) |> pop()
+  end
+
   defp register_network(state, network), do: update_in(state, [:networks], &(&1 ++ [network]))
 
   defp register_transport_mode(state, transport_mode),
     do: update_in(state, [:transport_modes], &(&1 ++ [transport_mode]))
 
   defp increment(state, key), do: update_in(state, [key], &(&1 + 1))
+
+  @elements_per_feature %{
+    :networks => [
+      "Network",
+      "GroupOfLines",
+      "RoutingConstraintZone",
+      "Line",
+      "Direction",
+      "Route",
+      "RoutePoint",
+      "PointOnRoute",
+      "FlexibleLine",
+      "FlexibleRoute",
+      "DestinationDisplay",
+      "FlexiblePointProperties",
+      "ServiceJourneyPattern",
+      "PointInJourneyPattern",
+      "ScheduledStopPoint",
+      "TimingPoint",
+      "TransferRestriction",
+      "PassengerStopAssignment",
+      "FlexibleStopAssignment",
+      "TrainStopAssignment",
+      "SchematicMap"
+    ],
+    :stops => [
+      "StopPlace",
+      "FlexibleStopPlace",
+      "Quay",
+      "TopographicPlace",
+      "StopPlaceEntrance",
+      "Entrance",
+      "AccessSpace"
+    ],
+    :timetables => [
+      "ServiceJourney",
+      "ServiceLink",
+      "FlexibleServiceProperties",
+      "TemplateServiceJourney",
+      "HeadwayJourneyGroup",
+      "RhythmicalJourneyGroup",
+      "CoupledJourney",
+      "JourneyPartCouple",
+      "JourneyPart",
+      "Train",
+      "TrainComponent",
+      "CompoundTrain",
+      "TrainNumber",
+      "TrainComponentLabelAssignment"
+    ],
+    :fares => [
+      "FareZone",
+      "FareStructureElement",
+      "UserProfile",
+      "DistributionChannel",
+      "PreassignedFareProduct",
+      "SaleDiscountRight",
+      "UsageDiscountRight",
+      "AmountOfPriceUnitProduct",
+      "SalesOfferPackageElement",
+      "SalesOfferPackage",
+      "TypeOfTravelDocument",
+      "TypeOfPricingRule",
+      "DiscountingRule",
+      "FareTable",
+      "DistanceMatrixElement"
+    ],
+    :parkings => [
+      "Parking",
+      "ParkingBay"
+    ],
+    :accessibility => [
+      "SitePathLink",
+      "PathLink",
+      "PathJunction",
+      "NavigationPath",
+      "FacilitySet",
+      "PassengerEquipment",
+      "PassengerSafetyEquipment",
+      "SanitaryEquipment",
+      "RubbishDisposalEquipment",
+      "LuggageLockerEquipment",
+      "TrolleyStandEquipment",
+      "WaitingEquipment",
+      "SeatingEquipment",
+      "ShelterEquipment",
+      "WaitingRoomEquipment",
+      "AccessEquipment",
+      "CrossingEquipment",
+      "EntranceEquipment",
+      "QueueingEquipment",
+      "RampEquipment",
+      "PlaceLighting",
+      "RoughSurface",
+      "StaircaseEquipment",
+      "StairEnd",
+      "StairFlight",
+      "EscalatorEquipment",
+      "TravelatorEquipment",
+      "LiftEquipment",
+      "SignEquipment",
+      "HeadingSign",
+      "GeneralSign",
+      "PlaceSign",
+      "TicketValidatorEquipment",
+      "TicketingEquipment",
+      "LocalService",
+      "AssistanceService",
+      "LuggageService",
+      "CustomerService",
+      "LostPropertyService",
+      "MeetingPoint",
+      "TicketingService",
+      "HireService",
+      "AccessibilityAssessment",
+      "WheelchairAccess",
+      "StepFreeAccess",
+      "VisualSignsAvailable",
+      "AudibleSignalsAvailable",
+      "EscalatorFreeAccess",
+      "LiftFreeAccess",
+      "TactileGuidanceAvailable"
+    ]
+  }
+
+  defp feature_detection(state, element_name) do
+    @elements_per_feature
+    |> Enum.reduce(state, fn {feature, element_names}, state ->
+      if element_names |> Enum.member?(element_name) do
+        state |> has(feature)
+      else
+        state
+      end
+    end)
+  end
+
+  defp has(state, feature), do: update_in(state, [:features, feature], fn _ -> true end)
 end

--- a/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
+++ b/apps/transport/lib/transport_web/templates/resource/_resources_details_netex.html.heex
@@ -2,6 +2,8 @@
 <% networks = Map.get(@metadata, "networks", []) %>
 <% modes = Map.get(@metadata, "modes", []) %>
 <% stats = Map.get(@metadata, "stats", %{}) %>
+<% features = Map.get(@metadata, "features", %{}) %>
+
 <p :if={@metadata["start_date"] != nil and @metadata["end_date"] != nil}>
   {dgettext("validations", "It is valid from")}
   <strong>{DateTimeDisplay.format_date(@metadata["start_date"], locale)}</strong> {dgettext(
@@ -10,6 +12,7 @@
   )} <strong><%= DateTimeDisplay.format_date(@metadata["end_date"], locale) %></strong>.
 </p>
 <ul>
+  <.netex_features features={features} />
   <li :if={networks != []}>
     <div>
       <div class="networks-list">

--- a/apps/transport/lib/transport_web/views/resource_view.ex
+++ b/apps/transport/lib/transport_web/views/resource_view.ex
@@ -319,6 +319,47 @@ defmodule TransportWeb.ResourceView do
     "https://explore.data.gouv.fr/fr/datasets/#{dataset_datagouv_id}/#/resources/#{resource_datagouv_id}"
   end
 
+  def netex_features(%{features: _} = assigns) do
+    ~H"""
+    <% features = enumerate_netex_features(@features) %>
+    <li :if={not Enum.empty?(features)}>
+      {dgettext("resource", "NeTEx features:")}
+      {safe_join(features, ", ")}.
+    </li>
+    """
+  end
+
+  defp enumerate_netex_features(features) do
+    features
+    |> Enum.filter(fn {_feature, active} -> active end)
+    |> Enum.sort_by(&feature_order/1)
+    |> Enum.map(fn {feature, _} -> "<strong>#{netex_feature(feature)}</strong>" |> raw() end)
+  end
+
+  defp feature_order({"networks", _}), do: 1
+  defp feature_order({"stops", _}), do: 2
+  defp feature_order({"fares", _}), do: 3
+  defp feature_order({"timetables", _}), do: 4
+  defp feature_order({"parkings", _}), do: 5
+  defp feature_order({"accessibility", _}), do: 6
+  defp feature_order({_, _}), do: 100
+
+  defp netex_feature("networks"), do: dgettext("resource", "networks")
+  defp netex_feature("stops"), do: dgettext("resource", "stops")
+  defp netex_feature("fares"), do: dgettext("resource", "fares")
+  defp netex_feature("timetables"), do: dgettext("resource", "timetables")
+  defp netex_feature("parkings"), do: dgettext("resource", "parkings")
+  defp netex_feature("accessibility"), do: dgettext("resource", "accessibility")
+  defp netex_feature(_), do: ""
+
+  defp safe_join(safe_htmls, separator) do
+    html =
+      safe_htmls
+      |> Enum.map_join(separator, fn {:safe, html} -> html end)
+
+    {:safe, html}
+  end
+
   def netex_statistics(%{stats: _, locale: _} = assigns) do
     ~H"""
     <.netex_statistic stats={@stats} locale={@locale} concept={:line} />

--- a/apps/transport/lib/validators/netex/metadata_extractor.ex
+++ b/apps/transport/lib/validators/netex/metadata_extractor.ex
@@ -33,6 +33,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractor do
         "lines_count" => 0,
         "quays_count" => 0,
         "stop_places_count" => 0
+      },
+      "features" => %{
+        "networks" => false,
+        "stops" => false,
+        "timetables" => false,
+        "fares" => false,
+        "parkings" => false,
+        "accessibility" => false
       }
     }
 
@@ -45,6 +53,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractor do
             "lines_count" => acc["stats"]["lines_count"] + elem.lines,
             "quays_count" => acc["stats"]["quays_count"] + elem.quays,
             "stop_places_count" => acc["stats"]["stop_places_count"] + elem.stop_places
+          },
+          "features" => %{
+            "networks" => acc["features"]["networks"] || elem.features.networks,
+            "stops" => acc["features"]["stops"] || elem.features.stops,
+            "timetables" => acc["features"]["timetables"] || elem.features.timetables,
+            "fares" => acc["features"]["fares"] || elem.features.fares,
+            "parkings" => acc["features"]["parkings"] || elem.features.parkings,
+            "accessibility" => acc["features"]["accessibility"] || elem.features.accessibility
           }
         }
       end)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/resource.po
@@ -100,3 +100,31 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "number of stop places:"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "NeTEx features:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "accessibility"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "fares"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "networks"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "parkings"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "stops"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "timetables"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/resource.po
@@ -100,3 +100,31 @@ msgstr "nombre de zones d’embarquement :"
 #, elixir-autogen, elixir-format
 msgid "number of stop places:"
 msgstr "nombre de lieux d’arrêt :"
+
+#, elixir-autogen, elixir-format
+msgid "NeTEx features:"
+msgstr "fonctionnalités NeTEx :"
+
+#, elixir-autogen, elixir-format
+msgid "accessibility"
+msgstr " accessibilité"
+
+#, elixir-autogen, elixir-format
+msgid "fares"
+msgstr "tarifs"
+
+#, elixir-autogen, elixir-format
+msgid "networks"
+msgstr "description des réseaux"
+
+#, elixir-autogen, elixir-format
+msgid "parkings"
+msgstr "parkings"
+
+#, elixir-autogen, elixir-format
+msgid "stops"
+msgstr "description des arrêts"
+
+#, elixir-autogen, elixir-format
+msgid "timetables"
+msgstr "horaires"

--- a/apps/transport/priv/gettext/resource.pot
+++ b/apps/transport/priv/gettext/resource.pot
@@ -100,3 +100,31 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "number of stop places:"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "NeTEx features:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "accessibility"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "fares"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "networks"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "parkings"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "stops"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "timetables"
+msgstr ""

--- a/apps/transport/test/netex/archive_parser_test.exs
+++ b/apps/transport/test/netex/archive_parser_test.exs
@@ -384,6 +384,14 @@ defmodule Transport.NeTEx.ArchiveParserTest do
     assert 1 == statistics.lines
     assert 3 == statistics.quays
     assert 2 == statistics.stop_places
+
+    assert statistics.features.networks
+    assert statistics.features.stops
+
+    refute statistics.features.timetables
+    refute statistics.features.fares
+    refute statistics.features.parkings
+    refute statistics.features.accessibility
   end
 
   defp extract(extractor, xml) do

--- a/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
+++ b/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
@@ -18,6 +18,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                          "lines_count" => 0,
                          "quays_count" => 0,
                          "stop_places_count" => 0
+                       },
+                       "features" => %{
+                         "networks" => false,
+                         "stops" => false,
+                         "timetables" => false,
+                         "fares" => false,
+                         "parkings" => false,
+                         "accessibility" => false
                        }
                      } ==
                        MetadataExtractor.extract(filepath)
@@ -38,6 +46,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                    "lines_count" => 0,
                    "quays_count" => 0,
                    "stop_places_count" => 0
+                 },
+                 "features" => %{
+                   "networks" => false,
+                   "stops" => false,
+                   "timetables" => false,
+                   "fares" => false,
+                   "parkings" => false,
+                   "accessibility" => false
                  }
                } ==
                  MetadataExtractor.extract(filepath)
@@ -72,6 +88,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                    "lines_count" => 0,
                    "quays_count" => 0,
                    "stop_places_count" => 0
+                 },
+                 "features" => %{
+                   "networks" => false,
+                   "stops" => false,
+                   "timetables" => false,
+                   "fares" => false,
+                   "parkings" => false,
+                   "accessibility" => false
                  }
                } ==
                  MetadataExtractor.extract(filepath)
@@ -115,6 +139,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                    "lines_count" => 0,
                    "quays_count" => 0,
                    "stop_places_count" => 0
+                 },
+                 "features" => %{
+                   "networks" => false,
+                   "stops" => false,
+                   "timetables" => false,
+                   "fares" => false,
+                   "parkings" => false,
+                   "accessibility" => false
                  }
                } ==
                  MetadataExtractor.extract(filepath)
@@ -161,6 +193,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                    "lines_count" => 3,
                    "quays_count" => 0,
                    "stop_places_count" => 0
+                 },
+                 "features" => %{
+                   "networks" => true,
+                   "stops" => false,
+                   "timetables" => false,
+                   "fares" => false,
+                   "parkings" => false,
+                   "accessibility" => false
                  }
                } ==
                  MetadataExtractor.extract(filepath)
@@ -210,6 +250,14 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
                    "lines_count" => 1,
                    "quays_count" => 3,
                    "stop_places_count" => 2
+                 },
+                 "features" => %{
+                   "networks" => true,
+                   "stops" => true,
+                   "timetables" => false,
+                   "fares" => false,
+                   "parkings" => false,
+                   "accessibility" => false
                  }
                } ==
                  MetadataExtractor.extract(filepath)

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -84,6 +84,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                  "lines_count" => length(lines),
                  "quays_count" => 0,
                  "stop_places_count" => 0
+               },
+               "features" => %{
+                 "networks" => true,
+                 "stops" => false,
+                 "timetables" => false,
+                 "fares" => false,
+                 "parkings" => false,
+                 "accessibility" => false
                }
              }
 
@@ -124,6 +132,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
               "lines_count" => length(lines),
               "quays_count" => 0,
               "stop_places_count" => 0
+            },
+            "features" => %{
+              "networks" => true,
+              "stops" => false,
+              "timetables" => false,
+              "fares" => false,
+              "parkings" => false,
+              "accessibility" => false
             }
           }
         }
@@ -171,6 +187,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                  "lines_count" => length(lines),
                  "quays_count" => 0,
                  "stop_places_count" => 0
+               },
+               "features" => %{
+                 "networks" => true,
+                 "stops" => false,
+                 "timetables" => false,
+                 "fares" => false,
+                 "parkings" => false,
+                 "accessibility" => false
                }
              }
 
@@ -254,6 +278,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                     "lines_count" => length(lines),
                     "quays_count" => 0,
                     "stop_places_count" => 0
+                  },
+                  "features" => %{
+                    "networks" => true,
+                    "stops" => false,
+                    "timetables" => false,
+                    "fares" => false,
+                    "parkings" => false,
+                    "accessibility" => false
                   }
                 }
               }} ==
@@ -326,6 +358,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                     "lines_count" => length(lines),
                     "quays_count" => 0,
                     "stop_places_count" => 0
+                  },
+                  "features" => %{
+                    "networks" => true,
+                    "stops" => false,
+                    "timetables" => false,
+                    "fares" => false,
+                    "parkings" => false,
+                    "accessibility" => false
                   }
                 }
               }} ==
@@ -355,6 +395,14 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
           "lines_count" => length(lines),
           "quays_count" => 0,
           "stop_places_count" => 0
+        },
+        "features" => %{
+          "networks" => true,
+          "stops" => false,
+          "timetables" => false,
+          "fares" => false,
+          "parkings" => false,
+          "accessibility" => false
         }
       }
 


### PR DESCRIPTION
Détecte les fonctionnalités NeTEx utilisées par une ressource NeTEx, reprenant la nomenclature des sous-profils du profil France. Exemple avec Région Centre Val de Loire :

<img width="1086" height="789" alt="image" src="https://github.com/user-attachments/assets/9723f7d3-7c3d-4d37-bd03-f3b6b62aa292" />

* * *

Reprend le découpage en sous-profil du Profil France pour commencer, associant certains éléments XML typiques à chaque sous-profil.

La présence d’un élément typique d’un sous-profil est considéré comme un indice suffisant, et impliquerait d’appliquer les règles de validation propres à chaque sous-profil.

* * *

Fixes #5440.