### PR TITLE
Corrige la police du menu principal

### DIFF
--- a/apps/transport/client/stylesheets/home.scss
+++ b/apps/transport/client/stylesheets/home.scss
@@ -40,11 +40,13 @@ html {
 }
 
 button.dropdown {
+  font-family: $font-family-primary;
+  font-size: 16px;
+  line-height: 1.5em;
   background: unset;
   border: none;
   display: inline-block;
   min-height: 24px;
-  line-height: 24px;
 }
 
 .nav__item > :focus,


### PR DESCRIPTION
Les boutons héritent de valeurs autres et mes tests en local n’avaient pas identifié cette différence.

Ça saute aux yeux sous Windows, probablement également sous MacOS/Safari :

<img width="820" height="67" alt="image" src="https://github.com/user-attachments/assets/1d17b9ec-fbd0-4301-a8ea-682a52f1c1a0" />
