### PR TITLE
SIRI: utilise CheckStatus pour vérifier la disponibilité des flux

### DIFF
--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -97,10 +97,13 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
       {true, resource}
     else
       download_url = Resource.download_url(resource)
-      opts = case Resource.requestor_ref(resource) do
-        nil -> []
-        requestor_ref -> [requestor_ref: requestor_ref]
-      end
+
+      opts =
+        case Resource.requestor_ref(resource) do
+          nil -> []
+          requestor_ref -> [requestor_ref: requestor_ref]
+        end
+
       is_available = Transport.AvailabilityChecker.Wrapper.available?(format, download_url, opts)
       {is_available, resource}
     end

--- a/apps/transport/lib/jobs/resource_unavailable_job.ex
+++ b/apps/transport/lib/jobs/resource_unavailable_job.ex
@@ -97,7 +97,11 @@ defmodule Transport.Jobs.ResourceUnavailableJob do
       {true, resource}
     else
       download_url = Resource.download_url(resource)
-      is_available = Transport.AvailabilityChecker.Wrapper.available?(format, download_url)
+      opts = case Resource.requestor_ref(resource) do
+        nil -> []
+        requestor_ref -> [requestor_ref: requestor_ref]
+      end
+      is_available = Transport.AvailabilityChecker.Wrapper.available?(format, download_url, opts)
       {is_available, resource}
     end
   end

--- a/apps/transport/lib/transport/availability_checker.ex
+++ b/apps/transport/lib/transport/availability_checker.ex
@@ -3,9 +3,10 @@ defmodule Transport.AvailabilityChecker.Wrapper do
   Defines a behavior
   """
 
-  @callback available?(binary(), binary()) :: boolean
-  def impl, do: Application.get_env(:transport, :availability_checker_impl)
-  def available?(resource_format, url), do: impl().available?(resource_format, url)
+  @callback available?(binary(), binary(), keyword()) :: boolean
+  def available?(resource_format, url, opts \\ []), do: impl().available?(resource_format, url, opts)
+
+  defp impl, do: Application.get_env(:transport, :availability_checker_impl)
 end
 
 defmodule Transport.AvailabilityChecker.Dummy do
@@ -15,7 +16,7 @@ defmodule Transport.AvailabilityChecker.Dummy do
   @behaviour Transport.AvailabilityChecker.Wrapper
 
   @impl Transport.AvailabilityChecker.Wrapper
-  def available?(_, _), do: true
+  def available?(_, _, _), do: true
 end
 
 defmodule Transport.AvailabilityChecker do
@@ -28,31 +29,22 @@ defmodule Transport.AvailabilityChecker do
   @behaviour Transport.AvailabilityChecker.Wrapper
 
   @impl Transport.AvailabilityChecker.Wrapper
-  @spec available?(binary(), binary()) :: boolean
-  def available?(format, target, use_http_streaming \\ false)
+  @spec available?(binary(), binary(), keyword()) :: boolean
+  def available?(format, target, opts \\ [])
 
-  def available?(format, url, _) when is_binary(url) and format in ["SIRI", "SIRI Lite"] do
-    case http_client().get(url, [], follow_redirect: true) do
-      {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code in [401, 405] ->
-        true
-
-      # At least one SIRI server returns a 500 despite being reachable and returning proper SOAP.
-      # Accept it, until we implement the better `CheckStatus` SIRI availability check.
-      # https://github.com/etalab/transport-site/issues/4283
-      {:ok, %Response{status_code: 500, body: body}} ->
-        body |> String.downcase() |> String.contains?("soap:envelope")
-
-      # Bug affecting Hackney (dependency of HTTPoison)
-      # 303 status codes on `GET` requests should be fine but they're returned as errors
-      # https://github.com/edgurgel/httpoison/issues/171#issuecomment-244029927
-      # https://github.com/etalab/transport-site/issues/3463
-      {:error, %HTTPoison.Error{reason: {:invalid_redirection, _}}} ->
-        # NOTE: this does not actually verifies that the target is available at the moment!
-        true
-
-      _ ->
-        false
+  def available?("SIRI", url, opts) when is_binary(url) do
+    case Keyword.get(opts, :requestor_ref) do
+      nil -> siri_get_available?(url)
+      requestor_ref -> siri_check_status_available?(url, requestor_ref)
     end
+  end
+
+  def available?("SIRI Lite", url, _opts) when is_binary(url) do
+    siri_get_available?(url)
+  end
+
+  def available?(format, url, opts) when is_binary(url) and is_list(opts) do
+    available?(format, url, _use_http_streaming = false)
   end
 
   def available?(format, url, false) when is_binary(url) do
@@ -88,6 +80,40 @@ defmodule Transport.AvailabilityChecker do
   def available?(_format, url, true = _use_http_streaming) do
     case HTTPStreamV2.fetch_status_follow_redirect(url) do
       {:ok, 200} -> true
+      _ -> false
+    end
+  end
+
+  defp siri_get_available?(url) do
+    case http_client().get(url, [], follow_redirect: true) do
+      {:ok, %Response{status_code: code}} when (code >= 200 and code < 300) or code in [401, 405] ->
+        true
+
+      # At least one SIRI server returns a 500 despite being reachable and returning proper SOAP.
+      # https://github.com/etalab/transport-site/issues/4283
+      {:ok, %Response{status_code: 500, body: body}} ->
+        body |> String.downcase() |> String.contains?("soap:envelope")
+
+      # Bug affecting Hackney (dependency of HTTPoison)
+      # 303 status codes on `GET` requests should be fine but they're returned as errors
+      # https://github.com/edgurgel/httpoison/issues/171#issuecomment-244029927
+      # https://github.com/etalab/transport-site/issues/3463
+      {:error, %HTTPoison.Error{reason: {:invalid_redirection, _}}} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp siri_check_status_available?(url, requestor_ref) do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    message_id = Ecto.UUID.generate()
+    body = Transport.SIRI.check_status(timestamp, requestor_ref, message_id)
+    headers = [{"Content-Type", "text/xml"}]
+
+    case http_client().post(url, body, headers) do
+      {:ok, %Response{status_code: 200}} -> true
       _ -> false
     end
   end

--- a/apps/transport/lib/transport/import_data.ex
+++ b/apps/transport/lib/transport/import_data.ex
@@ -10,7 +10,7 @@ defmodule Transport.ImportData do
   require Logger
   import Ecto.Query
 
-  defp availability_checker, do: Transport.AvailabilityChecker.Wrapper.impl()
+  defp availability_checker, do: Transport.AvailabilityChecker.Wrapper
 
   def max_import_concurrent_jobs do
     Application.fetch_env!(:transport, :max_import_concurrent_jobs)

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -332,7 +332,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI and SIRI Lite feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful. In case of HTTP 500, the feed will be considered unavailable, unless the body appears to contain SOAP."
+msgstr "We test this resource download availability every hour by making an HTTP <code class=\"inline\">HEAD</code> request with a timeout of 5 seconds. If we detect a downtime, we perform subsequent tests every 10 minutes, until the resource is back online.<br><br>For SIRI feeds with a <code class=\"inline\">requestor_ref</code>, we perform a SOAP <code class=\"inline\">POST CheckStatus</code> request: only a 200 status code is considered successful. For other SIRI feeds and SIRI Lite feeds, we perform a <code class=\"inline\">GET</code> request: a 401 or 405 status code is considered successful. In case of HTTP 500, the feed will be considered unavailable, unless the body appears to contain SOAP."
 
 #, elixir-autogen, elixir-format
 msgid "unknown"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -332,7 +332,7 @@ msgstr "En savoir plus"
 
 #, elixir-autogen, elixir-format
 msgid "availability-test-explanations"
-msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI et SIRI Lite, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible. En cas d'erreur 500, nous considèrerons que le flux est indisponible, sauf si il semble contenir du SOAP."
+msgstr "Nous testons la disponibilité de cette ressource au téléchargement toutes les heures, en effectuant une requête HTTP de type <code class=\"inline\">HEAD</code> dont le temps de réponse doit être inférieur à 5 secondes. Si nous détectons une indisponibilité, nous effectuons un nouveau test toutes les 10 minutes, jusqu'à ce que la ressource soit à nouveau disponible.<br><br>Pour les flux SIRI disposant d'un <code class=\"inline\">requestor_ref</code>, nous effectuons une requête SOAP <code class=\"inline\">POST CheckStatus</code> : seule une réponse avec un code 200 est considérée comme disponible. Pour les autres flux SIRI et les flux SIRI Lite, nous effectuons une requête HTTP de type <code class=\"inline\">GET</code> : nous considérons une réponse avec un code 401 ou 405 comme étant disponible. En cas d'erreur 500, nous considèrerons que le flux est indisponible, sauf si il semble contenir du SOAP."
 
 #, elixir-autogen, elixir-format
 msgid "unknown"

--- a/apps/transport/test/transport/availability_checker_test.exs
+++ b/apps/transport/test/transport/availability_checker_test.exs
@@ -26,7 +26,7 @@ defmodule Transport.AvailabilityCheckerTest do
     refute AvailabilityChecker.available?("GTFS", "url204")
   end
 
-  describe "SIRI or SIRI Lite resource" do
+  describe "SIRI or SIRI Lite resource (GET fallback, no requestor_ref)" do
     test "401" do
       Transport.HTTPoison.Mock
       |> expect(:get, 2, fn _url, [], [follow_redirect: true] ->
@@ -73,6 +73,51 @@ defmodule Transport.AvailabilityCheckerTest do
       end)
 
       assert AvailabilityChecker.available?("SIRI", "url500soap")
+    end
+  end
+
+  describe "SIRI resource with requestor_ref (CheckStatus)" do
+    test "200 response is available" do
+      Transport.HTTPoison.Mock
+      |> expect(:post, fn url, body, [{"Content-Type", "text/xml"}] ->
+        assert url == "http://siri.example.com"
+        assert body =~ "<sw:CheckStatus"
+        assert body =~ "<siri:RequestorRef>my_ref</siri:RequestorRef>"
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
+      assert AvailabilityChecker.available?("SIRI", "http://siri.example.com", requestor_ref: "my_ref")
+    end
+
+    test "non-200 response is unavailable" do
+      Transport.HTTPoison.Mock
+      |> expect(:post, fn _url, body, [{"Content-Type", "text/xml"}] ->
+        assert body =~ "<sw:CheckStatus"
+        assert body =~ "<siri:RequestorRef>my_ref</siri:RequestorRef>"
+        {:ok, %HTTPoison.Response{status_code: 500, body: "<soap:Envelope></soap:Envelope>"}}
+      end)
+
+      refute AvailabilityChecker.available?("SIRI", "http://siri.example.com", requestor_ref: "my_ref")
+    end
+
+    test "error response is unavailable" do
+      Transport.HTTPoison.Mock
+      |> expect(:post, fn _url, body, [{"Content-Type", "text/xml"}] ->
+        assert body =~ "<sw:CheckStatus"
+        assert body =~ "<siri:RequestorRef>my_ref</siri:RequestorRef>"
+        {:error, %HTTPoison.Error{reason: :timeout}}
+      end)
+
+      refute AvailabilityChecker.available?("SIRI", "http://siri.example.com", requestor_ref: "my_ref")
+    end
+
+    test "SIRI Lite with requestor_ref still uses GET" do
+      Transport.HTTPoison.Mock
+      |> expect(:get, fn _url, [], [follow_redirect: true] ->
+        {:ok, %HTTPoison.Response{status_code: 200}}
+      end)
+
+      assert AvailabilityChecker.available?("SIRI Lite", "http://siri-lite.example.com", requestor_ref: "my_ref")
     end
   end
 

--- a/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
+++ b/apps/transport/test/transport/jobs/resource_unavailable_job_test.exs
@@ -135,7 +135,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
           dataset: insert(:dataset)
         )
 
-      Transport.AvailabilityChecker.Mock |> expect(:available?, fn _format, ^latest_url -> true end)
+      Transport.AvailabilityChecker.Mock |> expect(:available?, fn _format, ^latest_url, _opts -> true end)
 
       assert DB.Resource.download_url(resource) == latest_url
 
@@ -245,7 +245,7 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
         {:ok, %HTTPoison.Response{status_code: 404}}
       end)
 
-      expect(Transport.AvailabilityChecker.Mock, :available?, fn _format, ^latest_url -> false end)
+      expect(Transport.AvailabilityChecker.Mock, :available?, fn _format, ^latest_url, _opts -> false end)
 
       assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
 
@@ -266,7 +266,29 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
         )
 
       Transport.AvailabilityChecker.Mock
-      |> expect(:available?, fn "SIRI", ^url -> true end)
+      |> expect(:available?, fn "SIRI", ^url, _opts -> true end)
+
+      assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
+
+      assert 0 == count_resource_unavailabilities()
+      assert %DB.Resource{is_available: true} = Repo.reload(resource)
+    end
+
+    test "passes requestor_ref in opts for a SIRI resource with a requestor_ref custom tag" do
+      requestor_ref = "my_requestor_ref"
+
+      resource =
+        insert(:resource,
+          url: url = "https://example.com/stop-monitoring",
+          latest_url: "https://static.data.gouv.fr/latest_url",
+          is_available: true,
+          format: "SIRI",
+          datagouv_id: "foo",
+          dataset: insert(:dataset, custom_tags: ["requestor_ref:#{requestor_ref}"])
+        )
+
+      Transport.AvailabilityChecker.Mock
+      |> expect(:available?, fn "SIRI", ^url, [requestor_ref: ^requestor_ref] -> true end)
 
       assert :ok == perform_job(ResourceUnavailableJob, %{"resource_id" => resource.id})
 
@@ -334,14 +356,14 @@ defmodule Transport.Test.Transport.Jobs.ResourceUnavailableJobTest do
     url = @resource_url
 
     Transport.AvailabilityChecker.Mock
-    |> expect(:available?, fn _format, ^url -> false end)
+    |> expect(:available?, fn _format, ^url, _opts -> false end)
   end
 
   defp setup_mock_available do
     url = @resource_url
 
     Transport.AvailabilityChecker.Mock
-    |> expect(:available?, fn _format, ^url -> true end)
+    |> expect(:available?, fn _format, ^url, _opts -> true end)
   end
 
   defp count_resources do


### PR DESCRIPTION
Pour les flux SIRI avec un `requestor_ref` dans les custom tags du dataset, effectue une requête SOAP POST CheckStatus plutôt qu'un GET. Seul un code 200 est considéré comme disponible.

