### PR TITLE
Correctif pour tests fragiles

### DIFF
--- a/apps/transport/test/support/live_view_test_helpers.ex
+++ b/apps/transport/test/support/live_view_test_helpers.ex
@@ -1,0 +1,20 @@
+defmodule TransportWeb.LiveViewTestHelpers do
+  @moduledoc """
+  Shared helpers for Phoenix LiveView tests.
+  """
+  import ExUnit.Assertions
+  import Phoenix.LiveViewTest
+
+  @doc """
+  Like `assert_patched/2`, but compares query params as a map
+  to avoid flaky failures due to non-deterministic parameter ordering in URLs.
+  """
+  def assert_patched_any_params_order(view, expected_url) do
+    # assert_patch/1 waits for a patch to happen and returns the actual URL
+    actual_url = assert_patch(view)
+    actual_uri = URI.parse(actual_url)
+    expected_uri = URI.parse(expected_url)
+    assert actual_uri.path == expected_uri.path
+    assert URI.decode_query(actual_uri.query) == URI.decode_query(expected_uri.query)
+  end
+end

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -6,6 +6,7 @@ defmodule TransportWeb.ValidationControllerTest do
   import Mox
   import NeTExValidationReportHelpers
   import Phoenix.LiveViewTest
+  import TransportWeb.LiveViewTestHelpers
   alias Transport.Test.S3TestUtils
   alias Transport.Validators.NeTEx.ResultsAdapter
   alias TransportWeb.Live.OnDemandValidationSelectLive
@@ -46,7 +47,7 @@ defmodule TransportWeb.ValidationControllerTest do
 
       view |> element(~s|[phx-value-tile="gbfs"]|) |> render_click()
 
-      assert_patched(
+      assert_patched_any_params_order(
         view,
         live_path(conn, OnDemandValidationSelectLive,
           type: "gbfs",
@@ -76,7 +77,7 @@ defmodule TransportWeb.ValidationControllerTest do
 
       view |> element(~s|[phx-value-tile="gtfs"]|) |> render_click()
 
-      assert_patched(
+      assert_patched_any_params_order(
         view,
         live_path(conn, OnDemandValidationSelectLive,
           type: "gtfs",
@@ -91,7 +92,7 @@ defmodule TransportWeb.ValidationControllerTest do
       # Select "NeTEx"
       view |> element(~s|[phx-value-tile="netex"]|) |> render_click()
 
-      assert_patched(
+      assert_patched_any_params_order(
         view,
         live_path(conn, OnDemandValidationSelectLive,
           type: "netex",
@@ -106,7 +107,7 @@ defmodule TransportWeb.ValidationControllerTest do
       # Select "GTFS-RT"
       view |> element(~s|[phx-value-tile="gtfs-rt"]|) |> render_click()
 
-      assert_patched(
+      assert_patched_any_params_order(
         view,
         live_path(conn, OnDemandValidationSelectLive,
           type: "gtfs-rt",


### PR DESCRIPTION
Rencontré de façon fréquente / quasi-systématique en faisant la review de #5470 en local:

```
1) test GET /validation  updates inputs (TransportWeb.ValidationControllerTest)
     apps/transport/test/transport_web/controllers/validation_controller_test.exs:30
     ** (ArgumentError) expected TransportWeb.Live.OnDemandValidationSelectLive to patch to "/validation?type=gbfs&selected_subtile=gbfs&selected_tile=vehicles-sharing", but got a patch to "/validation?type=gbfs&selected_tile=vehicles-sharing&selected_subtile=gbfs"
     code: assert_patched(
     stacktrace:
       (phoenix_live_view 1.1.19) lib/phoenix_live_view/test/live_view_test.ex:1452: Phoenix.LiveViewTest.assert_navigation/4
       (phoenix_live_view 1.1.19) lib/phoenix_live_view/test/live_view_test.ex:1346: Phoenix.LiveViewTest.assert_patch/3
       test/transport_web/controllers/validation_controller_test.exs:50: (test)
```

L'explication est que l'ordre des paramètres de la génération d'URL n'est pas déterministe, comme on le voit sur l'assertion (`selected_tile` est attendu au milieu des paramètres, mais se retrouve régulièrement à la fin).

Dans cette PR, j'introduis un nouveau helper pour faire une comparaison qui soit plus insensible à l'ordre. Assisté par IA 🤖 plutôt pour gagner du temps que pour le raisonnement lui-même.