### PR TITLE
Metadata NeTEx : liste de features

### DIFF
--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -241,9 +241,7 @@ defmodule Transport.Validators.NeTEx.Validator do
   end
 
   defp features_list(%{} = features) do
-    features
-    |> Map.filter(fn {_feature, enabled} -> enabled end)
-    |> Enum.map(fn {feature, _enabled} -> feature end)
+    for {feature, true} <- features, do: feature
   end
 
   defp validate_with_enroute(filepath, metadata) do

--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -241,7 +241,7 @@ defmodule Transport.Validators.NeTEx.Validator do
   end
 
   defp features_list(%{} = features) do
-    for {feature, true} <- features, do: feature
+    Enum.sort(for {feature, true} <- features, do: feature)
   end
 
   defp validate_with_enroute(filepath, metadata) do

--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -221,7 +221,8 @@ defmodule Transport.Validators.NeTEx.Validator do
     resource_metadata =
       %DB.ResourceMetadata{
         metadata: metadata,
-        modes: metadata["modes"] || []
+        modes: metadata["modes"] || [],
+        features: features_list(metadata["features"] || %{})
       }
 
     %DB.MultiValidation{
@@ -237,6 +238,12 @@ defmodule Transport.Validators.NeTEx.Validator do
       metadata: resource_metadata
     }
     |> DB.Repo.insert!()
+  end
+
+  defp features_list(%{} = features) do
+    features
+    |> Map.filter(fn {_feature, enabled} -> enabled end)
+    |> Enum.map(fn {feature, _enabled} -> feature end)
   end
 
   defp validate_with_enroute(filepath, metadata) do

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -96,6 +96,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
              }
 
       assert multi_validation.metadata.modes == modes
+      assert multi_validation.metadata.features == ["networks"]
     end
 
     test "pending validation" do
@@ -199,6 +200,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
              }
 
       assert multi_validation.metadata.modes == modes
+      assert multi_validation.metadata.features == ["networks"]
 
       result = %{
         "xsd-schema" => [


### PR DESCRIPTION
Comme pour le GTFS, inclut une liste des features disponibles, sans remettre en question les metadata provenant du validateur.

Pour l'instant ces metadata ne sont pas exposées dans l'API.