### PR TITLE
Validation NeTEx : plus compact si tout est valide

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -212,9 +212,12 @@ details > code {
   #issues {
     display: grid;
     grid-template-rows: max-content max-content 1fr max-content;
-    min-height: 80vh;
     container-type: inline-size;
     container-name: issues-list;
+
+    &:has(a.colorful.invalid) {
+      min-height: 80vh;
+    }
 
     .issues-footer {
       border-top: 1px solid var(--light-grey);


### PR DESCRIPTION
Le panneau du rapport de validation contient une sous-navigation par onglet, et j'avais donc forcément une taille verticale minimale, y compris quand un onglet est valide, pour éviter que le layout ne "saute" trop en passant d'un onglet à l'autre.

Ça n'est cependant pas utile quand tous les onglets sont valides.

## Avant

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/ba04c951-9dc4-40d2-87b3-7cb0fc18586a" />

## Après

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/0eeb0e07-7adf-4067-a82a-633954f505af" />
