### PR TITLE
NeTEx pris en compte pour le suivi

### DIFF
--- a/apps/transport/lib/transport_web/templates/stats/index.html.heex
+++ b/apps/transport/lib/transport_web/templates/stats/index.html.heex
@@ -149,12 +149,12 @@
               <a href="#public-transport-freshness"><i class="fa fa-link fa-small"></i></a>
             </span>
             <p>
-              Les données GTFS de la plateforme sont analysées pour connaitre leur periode de validité,
+              Les données GTFS et NeTEx de la plateforme sont analysées pour connaitre leur periode de validité,
               qui correspond à la période de circulation des différents services du jeu de données.
             </p>
             <br />
             <p>
-              Note : on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS.
+              Note : on ne peut calculer une période de validité que pour les jeux de données respectants les spécifications GTFS ou NeTEx.
             </p>
           </div>
         </div>
@@ -170,7 +170,7 @@
               <a href="#public-transport-quality"><i class="fa fa-link fa-small"></i></a>
             </span>
             <p>
-              Cette carte représente la qualité des données GTFS actuellement valides.
+              Cette carte représente la qualité des données GTFS et NeTEx actuellement valides.
             </p>
             <p>
               Pour contrôler la qualité des jeux de données de transport, la plateforme transport.data.gouv.fr utilise des outils de validation.
@@ -204,7 +204,7 @@
             <h3>{@aom_with_fatal}</h3>
             <div>
               <acronym title="autorité organisatrice de mobilité">AOM</acronym>
-              avec des jeux de données ne respectant pas les spécifications GTFS
+              avec des jeux de données ne respectant pas les spécifications GTFS ou NeTEx
             </div>
           </div>
         </div>

--- a/apps/transport/lib/validators/validator_selection.ex
+++ b/apps/transport/lib/validators/validator_selection.ex
@@ -68,9 +68,6 @@ defmodule Transport.ValidatorsSelection.Impl do
       when feature in [
              :datasets_without_gtfs_rt_related_resouces,
              :gtfs_import_stops_job,
-             :api_stats_controller,
-             :aoms_controller,
-             :backoffice_page_controller,
              :gtfs_rt_validator
            ],
       do: [
@@ -81,6 +78,9 @@ defmodule Transport.ValidatorsSelection.Impl do
   def validators_for_feature(feature)
       when feature in [
              :api_datasets_controller,
+             :api_stats_controller,
+             :aoms_controller,
+             :backoffice_page_controller,
              :expiration_notification
            ],
       do: [


### PR DESCRIPTION
Dans les pages suivantes :

- `/backoffice` : liste des datasets expirés
- `/stats` : NeTEx dans le suivi de fraicheur et de qualité
- `/aoms`