### PR TITLE
Suppression des références à `Mix.env()` en cours d'exécution

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -116,6 +116,7 @@
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
         {Credo.Check.Warning.RaiseInsideRescue},
+        {Credo.Check.Warning.MixEnv},
 
         # Controversial and experimental checks (opt-in, just remove `, false`)
         #

--- a/apps/transport/lib/converters/gtfs_to_netex_enroute.ex
+++ b/apps/transport/lib/converters/gtfs_to_netex_enroute.ex
@@ -2,6 +2,10 @@ defmodule Transport.Converters.GTFSToNeTExEnRoute do
   @moduledoc """
   A client of for the EnRoute's Conversions API.
   Documentation: https://documenter.getpostman.com/view/9203997/SzmfXwrp
+
+  TODO: this module is currently orphaned (no caller, no test). It was added in
+  PR #3542 then bypassed by PR #3613 (default converter changed).
+  GTFS to NeTEx conversions are not planned anymore afaik, so we'll decommission it.
   """
   require Logger
   @behaviour Transport.Converters.Converter
@@ -78,16 +82,7 @@ defmodule Transport.Converters.GTFSToNeTExEnRoute do
   @impl Transport.Converters.Converter
   def converter_version, do: "current"
 
-  defp base_url do
-    # Use Bypass with Req in the test environment, we need to change the base URL
-    bypass = Process.get(:req_bypass)
-
-    if Mix.env() == :test and not is_nil(bypass) do
-      "http://localhost:#{bypass.port}"
-    else
-      @base_url
-    end
-  end
+  defp base_url, do: @base_url
 
   defp http_client, do: Transport.Shared.Wrapper.HTTPoison.impl()
 

--- a/apps/transport/lib/jobs/clean_multi_validation_job.ex
+++ b/apps/transport/lib/jobs/clean_multi_validation_job.ex
@@ -90,13 +90,7 @@ defmodule Transport.Jobs.CleanMultiValidationJob do
     :ok
   end
 
-  def max_records do
-    if Mix.env() == :test do
-      1
-    else
-      @max_records
-    end
-  end
+  def max_records, do: Application.get_env(:transport, :clean_multi_validation_max_records, @max_records)
 
   defp archive_records(ids) do
     DB.MultiValidation.base_query()

--- a/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
+++ b/apps/transport/lib/jobs/periodic_reminder_producers_notification_job.ex
@@ -173,10 +173,7 @@ defmodule Transport.Jobs.PeriodicReminderProducersNotificationJob do
   We set the chunk size to 1 in the test env to test the scheduling logic.
   """
   def chunk_size do
-    case Mix.env() do
-      :test -> 1
-      _ -> @max_emails_per_day
-    end
+    Application.get_env(:transport, :periodic_reminder_producers_chunk_size, @max_emails_per_day)
   end
 
   @doc """

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -80,7 +80,8 @@ defmodule Transport.Application do
   def webserver_only?, do: webserver_enabled?() && !worker_enabled?()
   def dual_mode?, do: worker_enabled?() && webserver_enabled?()
 
-  def run_explore_vehicle_positions_poller?, do: webserver_enabled?() && Mix.env() != :test
+  def run_explore_vehicle_positions_poller?,
+    do: webserver_enabled?() && Application.fetch_env!(:transport, :explore_vehicle_positions_poller_enabled)
 
   def preemptive_caching?,
     do: webserver_enabled?() && Application.fetch_env!(:transport, :app_env) in [:production, :staging]

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -96,7 +96,7 @@ defmodule Transport.Application do
 
   defp add_scheduler(children) do
     if Mix.env() != :test do
-      [Transport.Scheduler | children]
+      [Transport.QuantumScheduler | children]
     else
       children
     end

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -46,7 +46,7 @@ defmodule Transport.Application do
         ),
         Unlock.BatchMetrics
       ]
-      |> add_scheduler()
+      |> add_quantum_scheduler()
       |> add_if(fn -> run_explore_vehicle_positions_poller?() end, Transport.ExploreVehiclePositionsPoller)
       |> add_if(fn -> preemptive_caching?() end, Transport.PreemptiveHomeStatsCache)
       |> add_if(fn -> preemptive_caching?() end, Transport.PreemptiveAPICache)
@@ -94,8 +94,8 @@ defmodule Transport.Application do
     end
   end
 
-  defp add_scheduler(children) do
-    if Mix.env() != :test do
+  defp add_quantum_scheduler(children) do
+    if Application.fetch_env!(:transport, :quantum_scheduler_enabled) do
       [Transport.QuantumScheduler | children]
     else
       children

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -47,7 +47,7 @@ defmodule Transport.Application do
         Unlock.BatchMetrics
       ]
       |> add_scheduler()
-      |> add_if(fn -> run_realtime_poller?() end, Transport.RealtimePoller)
+      |> add_if(fn -> run_explore_vehicle_positions_poller?() end, Transport.ExploreVehiclePositionsPoller)
       |> add_if(fn -> preemptive_caching?() end, Transport.PreemptiveHomeStatsCache)
       |> add_if(fn -> preemptive_caching?() end, Transport.PreemptiveAPICache)
       |> add_if(fn -> preemptive_caching?() end, Transport.PreemptiveStatsCache)
@@ -80,7 +80,7 @@ defmodule Transport.Application do
   def webserver_only?, do: webserver_enabled?() && !worker_enabled?()
   def dual_mode?, do: worker_enabled?() && webserver_enabled?()
 
-  def run_realtime_poller?, do: webserver_enabled?() && Mix.env() != :test
+  def run_explore_vehicle_positions_poller?, do: webserver_enabled?() && Mix.env() != :test
 
   def preemptive_caching?,
     do: webserver_enabled?() && Application.fetch_env!(:transport, :app_env) in [:production, :staging]

--- a/apps/transport/lib/transport/application.ex
+++ b/apps/transport/lib/transport/application.ex
@@ -17,12 +17,8 @@ defmodule Transport.Application do
   def cache_name, do: @cache_name
 
   def start(_type, _args) do
-    unless Mix.env() == :test do
-      cond do
-        worker_only?() -> Logger.info("Booting in worker-only mode...")
-        webserver_only?() -> Logger.info("Booting in webserver-only mode...")
-        dual_mode?() -> Logger.info("Booting in worker+webserver mode...")
-      end
+    if worker_enabled?() or webserver_enabled?() do
+      Logger.info("Booting in #{boot_mode_label()} mode...")
     end
 
     children =
@@ -68,6 +64,14 @@ defmodule Transport.Application do
 
     opts = [strategy: :one_for_one, name: Transport.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp boot_mode_label do
+    cond do
+      worker_only?() -> "worker-only"
+      webserver_only?() -> "webserver-only"
+      dual_mode?() -> "worker+webserver"
+    end
   end
 
   def webserver_enabled?, do: Application.fetch_env!(:transport, :webserver)

--- a/apps/transport/lib/transport/explore_vehicle_positions_poller.ex
+++ b/apps/transport/lib/transport/explore_vehicle_positions_poller.ex
@@ -1,7 +1,7 @@
-defmodule Transport.RealtimePoller do
+defmodule Transport.ExploreVehiclePositionsPoller do
   @moduledoc """
-  A system to poll all active GTFS-RT feeds in the database, and broadcast
-  the data via pubsub to the subscribed clients.
+  Polls vehicle positions from active GTFS-RT feeds and broadcasts them via
+  PubSub on the Explore channel, feeding the realtime vehicle map.
   """
   use GenServer
   import Ecto.Query

--- a/apps/transport/lib/transport/quantum_scheduler.ex
+++ b/apps/transport/lib/transport/quantum_scheduler.ex
@@ -1,6 +1,8 @@
-defmodule Transport.Scheduler do
+defmodule Transport.QuantumScheduler do
   @moduledoc """
-  This made to launch schedule tasks
+  In-memory cron scheduler (Quantum) for jobs that don't need DB-backed
+  scheduling (no retries, no persistence, no UI). Coexists with Oban Cron
+  (`config/runtime.exs`) which handles jobs needing those features.
   """
 
   use Quantum,

--- a/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
+++ b/apps/transport/lib/transport_web/plugs/custom_secure_browser_headers.ex
@@ -9,7 +9,14 @@ defmodule TransportWeb.Plugs.CustomSecureBrowserHeaders do
 
   def call(conn, _opts) do
     nonce = generate_nonce()
-    csp_headers = csp_headers(Mix.env(), Application.fetch_env!(:transport, :app_env), nonce)
+
+    csp_headers =
+      csp_headers(
+        Application.fetch_env!(:transport, :mix_env),
+        Application.fetch_env!(:transport, :app_env),
+        nonce
+      )
+
     headers = Map.merge(csp_headers, %{"x-frame-options" => "DENY"})
 
     conn

--- a/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
+++ b/apps/transport/lib/transport_web/plugs/worker_healthcheck.ex
@@ -65,15 +65,15 @@ defmodule TransportWeb.Plugs.WorkerHealthcheck do
   """
   def stop_the_beam! do
     # "Asynchronously and carefully stops the Erlang runtime system."
-    if Mix.env() == :test do
-      # We do not want to stop the system during tests, because it
+    if Application.fetch_env!(:transport, :worker_healthcheck_halts_beam) do
+      # Make sure to return with a non-zero exit code, to more clearly
+      # indicate that this is not the normal output
+      System.stop(1)
+    else
+      # In test the flag is false: we do not want to stop the system, because it
       # gives the impression the test suite completed successfully, but
       # it would actually just bypass all the tests after the one running this!
       raise "would halt the BEAM"
-    else
-      # Also make sure to return with a non-zero exit code, to more clearly
-      # indicate that this is not the normal output
-      System.stop(1)
     end
   end
 

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -373,7 +373,7 @@ defmodule TransportWeb.Router do
   # private
 
   defp assign_mix_env(conn, _) do
-    assign(conn, :mix_env, Mix.env())
+    assign(conn, :mix_env, Application.fetch_env!(:transport, :mix_env))
   end
 
   defp assign_current_user(conn, _) do

--- a/apps/transport/lib/unlock/controller.ex
+++ b/apps/transport/lib/unlock/controller.ex
@@ -111,15 +111,18 @@ defmodule Unlock.Controller do
       # NOTE: we catch the exception to return a controlled/blank answer in production.
       Logger.error("An exception occurred (#{exception |> inspect}")
 
-      cond do
+      case Application.fetch_env!(:transport, :unlock_controller_rescue_mode) do
         # give a bit more context when working in development
-        Mix.env() == :dev ->
+        :verbose ->
           Logger.error(Exception.format_stacktrace())
 
-        # in test, it is inconvenient to receive a 500, instead we
-        # re-raise to make it easier to do ExUnit assertions & avoid swallowed Mox expectations
-        Mix.env() == :test ->
+        # in test, it is inconvenient to receive a 500, instead we re-raise
+        # to make it easier to do ExUnit assertions & avoid swallowed Mox expectations
+        :reraise ->
           reraise exception, __STACKTRACE__
+
+        :silent ->
+          :ok
       end
 
       conn

--- a/apps/transport/lib/validators/gtfs_rt_validator.ex
+++ b/apps/transport/lib/validators/gtfs_rt_validator.ex
@@ -123,7 +123,7 @@ defmodule Transport.Validators.GTFSRT do
 
   def run_validator({binary_path, args}) do
     # See https://github.com/MobilityData/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing
-    Transport.RamboLauncher.run(binary_path, args, log: Mix.env() == :dev)
+    Transport.RamboLauncher.run(binary_path, args, log: Application.fetch_env!(:transport, :gtfs_rt_validator_cli_log))
   end
 
   @spec convert_validator_report(binary(), ignore_shapes: boolean()) :: {:ok, map()} | :error

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,7 @@ config :transport,
 config :transport, Unlock.Endpoint, []
 
 config :transport, explore_vehicle_positions_poller_enabled: true
+config :transport, quantum_scheduler_enabled: true
 
 if System.get_env("CELLAR_NAMESPACE") do
   # We believe CELLAR_NAMESPACE was a previous attempt at siloting S3 envs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,6 +31,7 @@ config :transport, Unlock.Endpoint, []
 config :transport, explore_vehicle_positions_poller_enabled: true
 config :transport, quantum_scheduler_enabled: true
 config :transport, gtfs_rt_validator_cli_log: false
+config :transport, worker_healthcheck_halts_beam: true
 
 if System.get_env("CELLAR_NAMESPACE") do
   # We believe CELLAR_NAMESPACE was a previous attempt at siloting S3 envs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,8 @@ config :transport,
 
 config :transport, Unlock.Endpoint, []
 
+config :transport, explore_vehicle_positions_poller_enabled: true
+
 if System.get_env("CELLAR_NAMESPACE") do
   # We believe CELLAR_NAMESPACE was a previous attempt at siloting S3 envs.
   # We will instead rely on separate buckets in the short-term future.

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,7 @@ config :transport, Unlock.Endpoint, []
 
 config :transport, explore_vehicle_positions_poller_enabled: true
 config :transport, quantum_scheduler_enabled: true
+config :transport, gtfs_rt_validator_cli_log: false
 
 if System.get_env("CELLAR_NAMESPACE") do
   # We believe CELLAR_NAMESPACE was a previous attempt at siloting S3 envs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,7 @@ config :transport, explore_vehicle_positions_poller_enabled: true
 config :transport, quantum_scheduler_enabled: true
 config :transport, gtfs_rt_validator_cli_log: false
 config :transport, worker_healthcheck_halts_beam: true
+config :transport, unlock_controller_rescue_mode: :silent
 
 if System.get_env("CELLAR_NAMESPACE") do
   # We believe CELLAR_NAMESPACE was a previous attempt at siloting S3 envs.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -89,6 +89,9 @@ config :phoenix_live_view,
   debug_attributes: true,
   enable_expensive_runtime_checks: true
 
+# Forward GTFS-RT validator subprocess output to the parent for local debugging
+config :transport, gtfs_rt_validator_cli_log: true
+
 extra_config_file = Path.join(__DIR__, "#{config_env()}.secret.exs")
 
 if File.exists?(extra_config_file) do

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -92,6 +92,9 @@ config :phoenix_live_view,
 # Forward GTFS-RT validator subprocess output to the parent for local debugging
 config :transport, gtfs_rt_validator_cli_log: true
 
+# Log full stacktrace when Unlock.Controller catches an exception
+config :transport, unlock_controller_rescue_mode: :verbose
+
 extra_config_file = Path.join(__DIR__, "#{config_env()}.secret.exs")
 
 if File.exists?(extra_config_file) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,7 +55,7 @@ iex_started? = Code.ensure_loaded?(IEx) && IEx.started?()
 # https://www.clever-cloud.com/doc/reference/reference-environment-variables/#set-by-the-deployment-process
 # They should not run in an iex session either.
 if config_env() == :prod && !iex_started? && worker && System.fetch_env!("INSTANCE_NUMBER") == "0" do
-  config :transport, Transport.Scheduler, jobs: Transport.Scheduler.scheduled_jobs()
+  config :transport, Transport.QuantumScheduler, jobs: Transport.QuantumScheduler.scheduled_jobs()
 end
 
 # Make sure that APP_ENV is set in production to distinguish
@@ -106,7 +106,7 @@ base_oban_conf = [repo: DB.Repo, insert_trigger: false]
 #
 # - There is "app_env :prod" in contrast to :staging (ie production website vs prochainement)
 #   and "config_env :prod" in contrast to :dev et :test
-# - ⚠️ There is another legacy crontab in `Transport.Scheduler`, see `scheduler.ex`
+# - ⚠️ There is another (in-memory) crontab in `Transport.QuantumScheduler`, see `quantum_scheduler.ex`
 # See https://hexdocs.pm/oban/Oban.html#module-cron-expressions
 oban_prod_crontab = [
   {"0 */6 * * *", Transport.Jobs.ResourceHistoryAndValidationDispatcherJob},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,7 +85,8 @@ domain_name =
 config :transport, domain_name: domain_name
 
 config :transport,
-  app_env: app_env
+  app_env: app_env,
+  mix_env: config_env()
 
 # Override configuration specific to staging
 if app_env == :staging do

--- a/config/test.exs
+++ b/config/test.exs
@@ -180,3 +180,6 @@ config :transport, quantum_scheduler_enabled: false
 
 # Safety: tests that exercise WorkerHealthcheck.stop_the_beam! must not actually halt the suite
 config :transport, worker_healthcheck_halts_beam: false
+
+# Re-raise exceptions caught in Unlock.Controller so ExUnit assertions can catch them
+config :transport, unlock_controller_rescue_mode: :reraise

--- a/config/test.exs
+++ b/config/test.exs
@@ -168,3 +168,6 @@ config :phoenix_live_view,
 
 # Override the default `@max_records` defined in the module, to keep tests fast
 config :transport, clean_multi_validation_max_records: 1
+
+# Disabled by default during tests; tests that need it should start the poller locally
+config :transport, explore_vehicle_positions_poller_enabled: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -165,3 +165,6 @@ config :sentry,
 
 config :phoenix_live_view,
   enable_expensive_runtime_checks: true
+
+# Override the default `@max_records` defined in the module, to keep tests fast
+config :transport, clean_multi_validation_max_records: 1

--- a/config/test.exs
+++ b/config/test.exs
@@ -171,3 +171,6 @@ config :transport, clean_multi_validation_max_records: 1
 
 # Disabled by default during tests; tests that need it should start the poller locally
 config :transport, explore_vehicle_positions_poller_enabled: false
+
+# Disabled by default during tests; tests that need it should start it locally
+config :transport, quantum_scheduler_enabled: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -177,3 +177,6 @@ config :transport, explore_vehicle_positions_poller_enabled: false
 
 # Disabled by default during tests; tests that need it should start it locally
 config :transport, quantum_scheduler_enabled: false
+
+# Safety: tests that exercise WorkerHealthcheck.stop_the_beam! must not actually halt the suite
+config :transport, worker_healthcheck_halts_beam: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -169,6 +169,9 @@ config :phoenix_live_view,
 # Override the default `@max_records` defined in the module, to keep tests fast
 config :transport, clean_multi_validation_max_records: 1
 
+# Override the default `@max_emails_per_day` defined in the module, to test the scheduling logic
+config :transport, periodic_reminder_producers_chunk_size: 1
+
 # Disabled by default during tests; tests that need it should start the poller locally
 config :transport, explore_vehicle_positions_poller_enabled: false
 


### PR DESCRIPTION
https://hexdocs.pm/mix/Mix.html#env/0

> This (`Mix.env()`) function should not be used at runtime in application code (as opposed to infrastructure and build code like Mix tasks). Mix is a build tool and may not be available after the code is compiled (for example in a release).
>
> To differentiate the program behavior depending on the environment, it is recommended to use application environment through [Application.get_env/3](https://hexdocs.pm/elixir/Application.html#get_env/3). Proper configuration can be set in config files, often per-environment (see the [Config](https://hexdocs.pm/elixir/Config.html) module for more information).

Je fais ici:
- suppression de toutes les références `Mix.env()` au runtime, comme recommandé dans la doc
- activation d'un check Credo qui les détecte et bloque la build