### PR TITLE
Ajout support override "response_headers" pour le type S3

### DIFF
--- a/apps/transport/lib/unlock/config.ex
+++ b/apps/transport/lib/unlock/config.ex
@@ -149,7 +149,8 @@ defmodule Unlock.Config do
         identifier: Map.fetch!(item, "identifier"),
         bucket: Map.fetch!(item, "bucket"),
         path: Map.fetch!(item, "path"),
-        ttl: Map.get(item, "ttl", 10)
+        ttl: Map.get(item, "ttl", 10),
+        response_headers: parse_config_http_headers(Map.get(item, "response_headers", []))
       }
     end
 

--- a/apps/transport/test/unlock/config_fetcher_test.exs
+++ b/apps/transport/test/unlock/config_fetcher_test.exs
@@ -179,6 +179,30 @@ defmodule Unlock.ConfigFetcherTest do
     end
   end
 
+  test "S3 items" do
+    yaml_config = """
+    ---
+    feeds:
+      - identifier: "irve-statique"
+        type: "s3"
+        bucket: "aggregates"
+        path: "consolidation_irve_statique.csv"
+        ttl: 300
+        response_headers:
+          - ["content-type", "text/csv"]
+    """
+
+    assert parse_config(yaml_config) == [
+             %Unlock.Config.Item.S3{
+               identifier: "irve-statique",
+               bucket: "aggregates",
+               path: "consolidation_irve_statique.csv",
+               ttl: 300,
+               response_headers: [{"content-type", "text/csv"}]
+             }
+           ]
+  end
+
   test "for a GBFS feed" do
     yaml_config = """
     ---


### PR DESCRIPTION
Cette PR est nécessaire pour:
- https://github.com/transportdatagouvfr/proxy-config/pull/185

Je ne refactore volontairement pas +, ça viendra dans d'autres tours.