### PR TITLE
Correctif flaky test (métriques)

### DIFF
--- a/apps/shared/test/support/test_utils.ex
+++ b/apps/shared/test/support/test_utils.ex
@@ -3,6 +3,28 @@ defmodule Transport.Test.TestUtils do
   Some useful functions for testing
   """
 
+  @doc """
+  Polls `fun` until it returns a truthy value, or fails the test after `timeout_ms`.
+  Useful as a sync barrier in tests where work happens in async tasks.
+  """
+  def wait_until(fun, timeout_ms \\ 2_000, interval_ms \\ 10) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline, interval_ms, timeout_ms)
+  end
+
+  defp do_wait_until(fun, deadline, interval_ms, timeout_ms) do
+    if fun.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) > deadline do
+        ExUnit.Assertions.flunk("wait_until: condition not met within #{timeout_ms}ms")
+      else
+        Process.sleep(interval_ms)
+        do_wait_until(fun, deadline, interval_ms, timeout_ms)
+      end
+    end
+  end
+
   def ensure_no_tmp_files!(file_prefix) do
     tmp_files = System.tmp_dir!() |> File.ls!()
 

--- a/apps/transport/test/unlock/batch_metrics_test.exs
+++ b/apps/transport/test/unlock/batch_metrics_test.exs
@@ -1,6 +1,7 @@
 defmodule Unlock.BatchMetricsTest do
   use ExUnit.Case, async: false
   import DB.Factory
+  import Transport.Test.TestUtils, only: [wait_until: 1]
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
@@ -24,7 +25,8 @@ defmodule Unlock.BatchMetricsTest do
     assert %{{"foo", "external"} => 3, {"bar", "internal"} => 1} == :sys.get_state(Unlock.BatchMetrics)
 
     send(Unlock.BatchMetrics, :work)
-    :timer.sleep(100)
+    # upserts run in async tasks — poll until the records have been inserted
+    wait_until(fn -> DB.Repo.aggregate(DB.Metrics, :count) == 2 end)
 
     assert [
              # Metric has been updated


### PR DESCRIPTION
Ça plante en CI (vu sur #5482 par exemple), je mets en place un fix, avec un helper qui nous resservira sur les scénarios asynchrones.

La cause: en gros, le CI est plus lent, la vérification des métriques en base intervient avant que les métriques soient insérés, une portion du temps.

Le fix: j'attends que la condition attendue soit vérifiée, avec un `wait_until`, qui timeout au bout de 2 secondes pour ne pas tout bloquer en cas de souci.