### PR TITLE
Correctif flaky tests (Cachex)

### DIFF
--- a/apps/transport/test/transport_web/plugs/producer_data_test.exs
+++ b/apps/transport/test/transport_web/plugs/producer_data_test.exs
@@ -21,6 +21,10 @@ defmodule TransportWeb.Plugs.ProducerDataTest do
     end)
 
     Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
+    # Cachex runs the cache computation function in a separate Courier process,
+    # which would otherwise have no DB sandbox ownership. Shared mode locks
+    # this file in async: false but is the simplest fix.
+    Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, {:shared, self()})
   end
 
   describe "call" do

--- a/apps/transport/test/unlock/batch_metrics_test.exs
+++ b/apps/transport/test/unlock/batch_metrics_test.exs
@@ -5,10 +5,10 @@ defmodule Unlock.BatchMetricsTest do
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(DB.Repo)
-    # because the upserts happen in a separate process (the GenServer),
-    # we must tweak the sandbox to be able to see them from here
-    pid = Process.whereis(Unlock.BatchMetrics)
-    Ecto.Adapters.SQL.Sandbox.allow(DB.Repo, self(), pid)
+    # The GenServer fires `Task.start/1` for each upsert, and `$callers` propagation
+    # to those transient tasks is racy under load. Shared mode covers the GenServer
+    # AND its spawned tasks. Locks this file in async: false (already the case).
+    Ecto.Adapters.SQL.Sandbox.mode(DB.Repo, {:shared, self()})
     :ok
   end
 

--- a/apps/transport/test/unlock/plugs/token_auth_test.exs
+++ b/apps/transport/test/unlock/plugs/token_auth_test.exs
@@ -1,4 +1,6 @@
 defmodule Unlock.Plugs.TokenAuthTest do
+  # UUID slugs remove cache-key collisions, but full async: true still requires
+  # tackling Mox global mode, Application.put_env for the auth flag, and global telemetry handlers.
   use TransportWeb.ConnCase, async: false
   import DB.Factory
   import Mox
@@ -17,7 +19,7 @@ defmodule Unlock.Plugs.TokenAuthTest do
     end
 
     test "valid token passed: request is logged" do
-      slug = "an-existing-identifier"
+      slug = "valid-token-logged-#{Ecto.UUID.generate()}"
       %DB.Token{id: token_id} = token = insert_token()
 
       setup_proxy_config(%{
@@ -45,7 +47,7 @@ defmodule Unlock.Plugs.TokenAuthTest do
     end
 
     test "no token passed" do
-      slug = "another-identifier"
+      slug = "no-token-#{Ecto.UUID.generate()}"
 
       setup_proxy_config(%{
         slug => %Unlock.Config.Item.Generic.HTTP{
@@ -85,7 +87,7 @@ defmodule Unlock.Plugs.TokenAuthTest do
     end
 
     test "valid token passed: no requests logged" do
-      slug = "an-existing-identifier-valid-token"
+      slug = "valid-token-not-logged-#{Ecto.UUID.generate()}"
       token = insert_token()
 
       setup_proxy_config(%{
@@ -109,7 +111,7 @@ defmodule Unlock.Plugs.TokenAuthTest do
     end
 
     test "invalid token passes through without authentication" do
-      slug = "an-identifier"
+      slug = "invalid-token-passthrough-#{Ecto.UUID.generate()}"
 
       setup_proxy_config(%{
         slug => %Unlock.Config.Item.Generic.HTTP{


### PR DESCRIPTION
Vu en travaillant sur une PR, la même clé de cache devait être utilisée ailleurs je pense. J'ai rendu concurrency-compatible en introduisant des UUIDs.

J'ai au passage regardé les étapes nécessaires à passer en vrai `async: true`, ça ferait trop gros dans cette PR, mais j'ai mis une note pour un prochain tour.