### PR TITLE
Backoffice : Nouvelle page de suivi des jobs

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -259,3 +259,123 @@ iframe#email_preview {
   margin: 0 auto;
   display: block;
 }
+
+#jobs {
+  margin: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  .job-state {
+    --taint: lightgray;
+
+    color: contrast-color(var(--taint));
+    background: var(--taint);
+    border: 1px solid var(--taint);
+    display: inline-block;
+    border-radius: 8px;
+    padding: 0 6px;
+    line-height: 1.25rem;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .job-state-executing {
+    --taint: navy;
+  }
+
+  .job-state-completed {
+    --taint: green;
+  }
+
+  .job-state-scheduled {
+    --taint: purple;
+  }
+
+  .job-state-retryable {
+    --taint: orange;
+  }
+
+  .job-state-available {
+    /* --taint: lightgray; */
+  }
+
+  .job-state-discarded {
+    --taint: color-mix(red 70%, white);
+  }
+
+  form {
+    max-width: unset;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    .vsep {
+      width: 1px;
+      margin-block: 4px;
+      align-self: stretch;
+      background-color: lightgray;
+    }
+
+    .listing-toggle {
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+
+      input[type="checkbox"] {
+        margin-right: calc(var(--space-xs) / 2);
+        transform: scale(0.8);
+      }
+    }
+
+    .listing-toggle, .total {
+      font-size: 0.85rem;
+      line-height: 1rem;
+    }
+
+    .jobs-filter {
+      max-width: unset;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+
+      input[type="text"] {
+        flex: 1;
+        line-height: 1;
+        min-width: 30ch;
+        max-width: 60ch;
+        padding: 0.25em;
+      }
+
+      label.job-state {
+        line-height: 1.25rem;
+        cursor: pointer;
+        transition: all 50ms linear;
+
+        input[type="checkbox"] {
+          display: none;
+
+          &:checked {
+            --taint: lightgray;
+
+            background-color: var(--taint);
+            color: var(--taint);
+            border-color: var(--taint);
+          }
+        }
+
+        &:not(:has(input:checked)) {
+           --taint: white;
+
+           opacity: 0.6;
+           border: 1px dashed gray;
+
+           &:hover {
+             opacity: 1;
+           }
+        }
+      }
+    }
+  }
+}

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -1,0 +1,209 @@
+defmodule TransportWeb.Backoffice.Jobs2Live do
+  @moduledoc """
+  A quick dashboard for jobs.
+  """
+  use Gettext, backend: TransportWeb.Gettext
+  use Phoenix.LiveView
+  use Phoenix.HTML
+  import Ecto.Query
+  import TransportWeb.Router.Helpers
+
+  @states [:executing, :completed, :scheduled, :retryable, :available, :discarded]
+
+  @max_jobs 100
+
+  # Authentication is assumed to happen in regular HTTP land. Here we verify
+  # the user presence + belonging to admin team, or redirect immediately.
+  @impl true
+  def mount(params, %{"current_user" => current_user} = session, socket) do
+    state =
+      %{
+        locale: Map.get(session, "locale", "fr"),
+        states: @states
+      }
+      |> Map.merge(extract_params(params))
+
+    {:ok,
+     ensure_admin_auth_or_redirect(socket, current_user, fn socket ->
+       if connected?(socket), do: schedule_next_update_data()
+
+       socket |> assign(state) |> update_data()
+     end)}
+  end
+
+  defp flag(params, key, default_value) do
+    case Map.get(params, key) do
+      "true" -> true
+      "false" -> false
+      _ -> default_value
+    end
+  end
+
+  # TO DO: DRY code with proxy live
+  # If one calls "redirect" and does not leave immediately, the remaining code will
+  # be executed, opening security issues. This method goal is to minimize this risk.
+  # See https://hexdocs.pm/phoenix_live_view/security-model.html for overall docs.
+  #
+  # Also, disconnect will have to be handled:
+  # https://hexdocs.pm/phoenix_live_view/security-model.html#disconnecting-all-instances-of-a-given-live-user
+  #
+  def ensure_admin_auth_or_redirect(socket, current_user, func) do
+    socket = assign(socket, current_user: current_user)
+
+    if TransportWeb.Session.admin?(socket) do
+      # We track down the current admin so that it can be used by next actions
+      # Then call the remaining code, which is expected to return the socket
+      func.(socket)
+    else
+      redirect(socket, to: "/login")
+    end
+  end
+
+  defp schedule_next_update_data do
+    Process.send_after(self(), :update_data, 1000)
+  end
+
+  def last_jobs_query(n) do
+    from(j in "oban_jobs",
+      select: map(j, [:id, :state, :queue, :worker, :args, :inserted_at, :scheduled_at, :errors]),
+      order_by: [desc: j.id],
+      limit: ^n
+    )
+  end
+
+  def count_jobs_query do
+    from(j in "oban_jobs",
+      select: count()
+    )
+  end
+
+  def filter_worker(query, nil), do: query
+  def filter_worker(query, ""), do: query
+
+  def filter_worker(query, worker_filter) do
+    reg = "%#{worker_filter}%"
+    query |> where([o], ilike(o.worker, ^reg))
+  end
+
+  def filter_states(query, []) do
+    query |> limit(0)
+  end
+
+  def filter_states(query, states) do
+    query |> where([o], o.state in ^states)
+  end
+
+  def jobs_count(condition) do
+    query =
+      from(j in "oban_jobs",
+        select: %{
+          worker: j.worker,
+          truncated_date_time: fragment("date_trunc('hour', ?) as truncated_date_time", j.inserted_at),
+          count: count()
+        },
+        group_by: [:worker, fragment("truncated_date_time")],
+        order_by: [desc: fragment("truncated_date_time"), asc: :worker]
+      )
+
+    query
+    |> apply_condition(condition)
+    |> oban_query()
+    |> Enum.group_by(fn d -> Shared.DateTimeDisplay.convert_to_paris_time(d.truncated_date_time) end)
+    |> Enum.sort(:desc)
+  end
+
+  def oban_query(query), do: Oban.config() |> Oban.Repo.all(query)
+
+  def last_jobs(n, condition), do: last_jobs_query(n) |> apply_condition(condition) |> oban_query
+
+  def count_jobs(condition), do: count_jobs_query() |> apply_condition(condition) |> oban_query |> Enum.at(0)
+
+  defp apply_condition(query, {worker, active_states}) do
+    query
+    |> filter_worker(worker)
+    |> filter_states(active_states)
+  end
+
+  defp update_data(socket) do
+    locale = socket.assigns |> Map.get(:locale, "fr")
+
+    condition = {socket.assigns[:worker], socket.assigns |> active_states()}
+
+    assign(socket,
+      last_updated_at: DateTime.utc_now() |> format_datetime(locale),
+      jobs: last_jobs(@max_jobs, condition),
+      count_jobs: count_jobs(condition),
+      jobs_count: jobs_count(condition)
+    )
+  end
+
+  defp active_states(assigns) do
+    @states
+    |> Enum.filter(fn state -> assigns[state] end)
+    |> Enum.map(&to_string/1)
+  end
+
+  defp format_datetime(dt, locale) do
+    dt
+    |> Shared.DateTimeDisplay.format_datetime_to_paris(locale, no_timezone: true, with_seconds: true)
+  end
+
+  @impl true
+  def handle_info(:update_data, socket) do
+    schedule_next_update_data()
+    {:noreply, update_data(socket)}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    update = extract_params(params)
+
+    socket = socket |> assign(update)
+
+    {:noreply, update_data(socket)}
+  end
+
+  @impl true
+  def handle_event("filter", params, socket) do
+    update = extract_params(params)
+
+    socket =
+      socket
+      |> push_patch(to: backoffice_live_path(socket, TransportWeb.Backoffice.Jobs2Live, update))
+
+    {:noreply, socket}
+  end
+
+  def format_1_hour_range(from) do
+    to = DateTime.add(from, 1, :hour)
+
+    days_diff = from |> DateTime.to_date() |> Date.diff(Date.utc_today())
+
+    date =
+      case days_diff do
+        0 -> "Today"
+        -1 -> "Yesterday"
+        1 -> "Tomorrow"
+        _ -> Shared.DateTimeDisplay.format_date(from, "en")
+      end
+
+    "#{date} between #{format_time(from)} and #{format_time(to)}"
+  end
+
+  defp format_time(dt) do
+    Shared.DateTimeDisplay.format_time_to_paris(dt, "en", no_timezone: true)
+  end
+
+  defp extract_params(params) do
+    %{
+      worker: Map.get(params, "worker", nil),
+      executing: flag(params, "executing", true),
+      completed: flag(params, "completed", true),
+      scheduled: flag(params, "scheduled", true),
+      retryable: flag(params, "retryable", true),
+      available: flag(params, "available", true),
+      discarded: flag(params, "discarded", true),
+      listing: flag(params, "listing", true)
+    }
+  end
+end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -31,14 +31,6 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
      end)}
   end
 
-  defp flag(params, key, default_value) do
-    case Map.get(params, key) do
-      "true" -> true
-      "false" -> false
-      _ -> default_value
-    end
-  end
-
   # TO DO: DRY code with proxy live
   # If one calls "redirect" and does not leave immediately, the remaining code will
   # be executed, opening security issues. This method goal is to minimize this risk.
@@ -195,15 +187,27 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
   end
 
   defp extract_params(params) do
+    flags = flags(params, [:listing | @states])
+
     %{
-      worker: Map.get(params, "worker", nil),
-      executing: flag(params, "executing", true),
-      completed: flag(params, "completed", true),
-      scheduled: flag(params, "scheduled", true),
-      retryable: flag(params, "retryable", true),
-      available: flag(params, "available", true),
-      discarded: flag(params, "discarded", true),
-      listing: flag(params, "listing", true)
+      worker: Map.get(params, "worker", nil)
     }
+    |> Map.merge(flags)
+  end
+
+  defp flags(params, keys) do
+    keys
+    |> Enum.map(fn key ->
+      {key, flag(params, to_string(key))}
+    end)
+    |> Map.new()
+  end
+
+  defp flag(params, key) do
+    case Map.get(params, key) do
+      "true" -> true
+      "false" -> false
+      _ -> true
+    end
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -1,0 +1,48 @@
+<section id="jobs">
+  <div class="header_with_action_bar">
+    <h1>{dgettext("backoffice", "Jobs Observation Center")}</h1>
+    <span>{dgettext("backoffice", "Last update:")} {@last_updated_at}</span>
+  </div>
+
+  <.form :let={f} for={%{}} phx-change="filter" class="no-margin">
+    <div class="jobs-filter">
+      {text_input(f, :worker, value: @worker, autofocus: true)}
+      <div class="vsep"></div>
+      <label :for={state <- @states} class={"job-state job-state-#{state}"}>
+        {checkbox(f, state, value: assigns[state])} {state}
+      </label>
+      <div class="vsep"></div>
+      <label class="listing-toggle">
+        {checkbox(f, :listing, value: @listing)}
+        {dgettext("backoffice", "listing")}
+      </label>
+      <div :if={@listing} class="vsep"></div>
+      <div :if={@listing} class="total">{dgettext("backoffice", "total:")} {Helpers.format_number(@count_jobs)}</div>
+    </div>
+  </.form>
+
+  <%= if @listing do %>
+    <.live_component module={JobsTableComponent} jobs={@jobs} id="live_jobs" />
+  <% else %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>{dgettext("backoffice", "time range")}</th>
+          <th>{dgettext("backoffice", "worker")}</th>
+          <th>{dgettext("backoffice", "count")}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for {hour, rows} <- @jobs_count do %>
+          <tr :for={{row, index} <- Enum.with_index(rows)}>
+            <td :if={index == 0} rowspan={Enum.count(rows)}>
+              {format_1_hour_range(hour)}
+            </td>
+            <td>{row.worker}</td>
+            <td>{Helpers.format_number(row.count)}</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -16,8 +16,10 @@
         {checkbox(f, :listing, value: @listing)}
         {dgettext("backoffice", "listing")}
       </label>
-      <div :if={@listing} class="vsep"></div>
-      <div :if={@listing} class="total">{dgettext("backoffice", "total:")} {Helpers.format_number(@count_jobs)}</div>
+      <div :if={@listing and @count_jobs} class="vsep"></div>
+      <div :if={@listing and @count_jobs} class="total">
+        {dgettext("backoffice", "total:")} {Helpers.format_number(@count_jobs)}
+      </div>
     </div>
   </.form>
 

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -1,5 +1,10 @@
 <section class="container pt-48 pb-48">
-  <h1>Jobs Observation Center</h1>
+  <div class="header_with_action_bar">
+    <h1>Jobs Observation Center</h1>
+    {link("version expérimentale",
+      to: backoffice_live_path(@socket, TransportWeb.Backoffice.Jobs2Live, worker: @worker)
+    )}
+  </div>
   <p class="small">Dernière mise à jour: {@last_updated_at}</p>
 
   <div class="pb-24">

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -8,6 +8,7 @@
       {text_input(f, :worker, value: @worker)}
     </.form>
   </div>
+  <p>Timezone: Europe/Paris</p>
 
   <h2>Counts</h2>
   <table class="table">

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -3,46 +3,41 @@ defmodule JobsTableComponent do
   A live view table for Oban jobs monitoring
   """
   use Phoenix.LiveComponent
+  use Gettext, backend: TransportWeb.Gettext
 
-  def render(assigns) do
+  def render(%{state: _, jobs: _} = assigns) do
     ~H"""
     <table class="table">
       <thead>
         <tr>
           <th>id</th>
-          <th>state</th>
-          <th>queue</th>
-          <th>worker</th>
-          <th>args</th>
-          <th>inserted_at (Paris time)</th>
-          <%= if @state in ["discarded", "retryable"] do %>
-            <th>errors</th>
-          <% end %>
-          <%= if @state in ["scheduled", "retryable"] do %>
-            <th>scheduled_at (Paris time)</th>
-          <% end %>
+          <th :if={is_nil(@state)}>{dgettext("backoffice", "state")}</th>
+          <th>{dgettext("backoffice", "queue")}</th>
+          <th>{dgettext("backoffice", "worker")}</th>
+          <th>{dgettext("backoffice", "args")}</th>
+          <th>{dgettext("backoffice", "inserted_at")}</th>
+          <th :if={is_nil(@state) or @state in ["discarded", "retryable"]}>{dgettext("backoffice", "errors")}</th>
+          <th :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{dgettext("backoffice", "scheduled_at")}</th>
         </tr>
       </thead>
       <tbody>
-        <%= for job <- @jobs do %>
-          <tr>
-            <td>{job.id}</td>
-            <td>{job.state}</td>
-            <td>{job.queue}</td>
-            <td>{job.worker}</td>
-            <td>{inspect(job.args)}</td>
-            <td>{format_datetime(job.inserted_at)}</td>
-            <%= if @state in ["discarded", "retryable"] do %>
-              <td>{inspect(job.errors)}</td>
-            <% end %>
-            <%= if @state in ["scheduled", "retryable"] do %>
-              <td>{format_datetime(job.scheduled_at)}</td>
-            <% end %>
-          </tr>
-        <% end %>
+        <tr :for={job <- @jobs}>
+          <td>{job.id}</td>
+          <td :if={is_nil(@state)}><span class={"job-state job-state-#{job.state}"}>{job.state}</span></td>
+          <td>{job.queue}</td>
+          <td>{job.worker}</td>
+          <td>{inspect(job.args)}</td>
+          <td>{format_datetime(job.inserted_at)}</td>
+          <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}>{inspect(job.errors)}</td>
+          <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{format_datetime(job.scheduled_at)}</td>
+        </tr>
       </tbody>
     </table>
     """
+  end
+
+  def render(%{jobs: _} = assigns) do
+    render(Map.merge(%{state: nil}, assigns))
   end
 
   defp format_datetime(dt) do

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -235,7 +235,7 @@ defmodule TransportWeb.Router do
 
       live_session :backoffice_jobs, root_layout: {TransportWeb.LayoutView, :app} do
         live("/jobs", JobsLive)
-        live("/jobs2", Jobs2Live)
+        live("/jobs/experimental", Jobs2Live)
       end
 
       live_session :cache, root_layout: {TransportWeb.LayoutView, :app} do

--- a/apps/transport/lib/transport_web/router.ex
+++ b/apps/transport/lib/transport_web/router.ex
@@ -235,6 +235,7 @@ defmodule TransportWeb.Router do
 
       live_session :backoffice_jobs, root_layout: {TransportWeb.LayoutView, :app} do
         live("/jobs", JobsLive)
+        live("/jobs2", Jobs2Live)
       end
 
       live_session :cache, root_layout: {TransportWeb.LayoutView, :app} do

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -299,3 +299,55 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Email preview"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Jobs Observation Center"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "count"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "worker"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Last update:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "args"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "errors"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "queue"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "state"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "inserted_at"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "scheduled_at"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "time range"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "listing"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "total:"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -299,3 +299,55 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Email preview"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Jobs Observation Center"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "count"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "worker"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Last update:"
+msgstr "Dernière mise à jour :"
+
+#, elixir-autogen, elixir-format
+msgid "args"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "errors"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "queue"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "state"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "inserted_at"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "scheduled_at"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "time range"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "listing"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "total:"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -299,3 +299,55 @@ msgstr "Territoire couvert déclaré"
 #, elixir-autogen, elixir-format
 msgid "Email preview"
 msgstr "Prévisualisation d'e-mails"
+
+#, elixir-autogen, elixir-format
+msgid "Jobs Observation Center"
+msgstr "Suivi des jobs"
+
+#, elixir-autogen, elixir-format
+msgid "count"
+msgstr "nombre"
+
+#, elixir-autogen, elixir-format
+msgid "worker"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Last update:"
+msgstr "Dernière mise à jour :"
+
+#, elixir-autogen, elixir-format
+msgid "args"
+msgstr "arguments"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "errors"
+msgstr "erreurs"
+
+#, elixir-autogen, elixir-format
+msgid "queue"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "state"
+msgstr "état"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "inserted_at"
+msgstr "inséré à"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "scheduled_at"
+msgstr "programmé à"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "time range"
+msgstr "plage horaire"
+
+#, elixir-autogen, elixir-format
+msgid "listing"
+msgstr "liste"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "total:"
+msgstr "total :"


### PR DESCRIPTION
Propose une liste globale des jobs, avec filtre sur l'état :

<img width="1294" height="1297" alt="image" src="https://github.com/user-attachments/assets/b6dc7d83-afa0-4dbe-993e-eebe1c5685c1" />

<img width="1294" height="1297" alt="image" src="https://github.com/user-attachments/assets/ac542be4-7b46-4c7f-a51e-1470a0b4f98f" />


(J'ai pas encore testé avec de vrais jobs.)