### PR TITLE
Page de suivi des jobs : 2ème passe

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -304,6 +304,32 @@ iframe#email_preview {
     --taint: color-mix(red 70%, white);
   }
 
+  table tr th,
+  table tr td {
+    font-size: 0.9rem;
+    line-height: 1.1rem;
+    padding: var(--space-xs) var(--space-s);
+  }
+
+  table tr td {
+    vertical-align: top;
+
+    ol.errors {
+      margin: 0;
+      padding: 0;
+
+      li {
+        margin: 0;
+        padding: 0;
+
+        code {
+          font-size: 0.75rem;
+          line-height: 1rem;
+        }
+      }
+    }
+  }
+
   form {
     max-width: unset;
     display: flex;

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -313,6 +313,8 @@ iframe#email_preview {
 
   table tr th {
     text-wrap: nowrap;
+    position: sticky;
+    top: 0;
   }
 
   table tr td {

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -311,6 +311,10 @@ iframe#email_preview {
     padding: var(--space-xs) var(--space-s);
   }
 
+  table tr th {
+    text-wrap: nowrap;
+  }
+
   table tr td {
     vertical-align: top;
 

--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -334,11 +334,20 @@ iframe#email_preview {
     }
   }
 
-  form {
+  form.jobs-filter {
     max-width: unset;
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: center;
     gap: 8px;
+
+    input[type="text"] {
+      flex: 1;
+      line-height: 1;
+      min-width: 30ch;
+      max-width: 60ch;
+      padding: 0.25em;
+    }
 
     .vsep {
       width: 1px;
@@ -363,48 +372,36 @@ iframe#email_preview {
       line-height: 1rem;
     }
 
-    .jobs-filter {
-      max-width: unset;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 8px;
+    button {
+      margin: 0;
+    }
 
-      input[type="text"] {
-        flex: 1;
-        line-height: 1;
-        min-width: 30ch;
-        max-width: 60ch;
-        padding: 0.25em;
+    label.job-state {
+      line-height: 1.25rem;
+      cursor: pointer;
+      transition: all 50ms linear;
+
+      input[type="checkbox"] {
+        display: none;
+
+        &:checked {
+          --taint: lightgray;
+
+          background-color: var(--taint);
+          color: var(--taint);
+          border-color: var(--taint);
+        }
       }
 
-      label.job-state {
-        line-height: 1.25rem;
-        cursor: pointer;
-        transition: all 50ms linear;
+      &:not(:has(input:checked)) {
+         --taint: white;
 
-        input[type="checkbox"] {
-          display: none;
+         opacity: 0.6;
+         border: 1px dashed gray;
 
-          &:checked {
-            --taint: lightgray;
-
-            background-color: var(--taint);
-            color: var(--taint);
-            border-color: var(--taint);
-          }
-        }
-
-        &:not(:has(input:checked)) {
-           --taint: white;
-
-           opacity: 0.6;
-           border: 1px dashed gray;
-
-           &:hover {
-             opacity: 1;
-           }
-        }
+         &:hover {
+           opacity: 1;
+         }
       }
     }
   }

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -8,7 +8,7 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
   import Ecto.Query
   import TransportWeb.Router.Helpers
 
-  @states [:executing, :completed, :scheduled, :retryable, :available, :discarded]
+  @states [:executing, :completed, :scheduled, :retryable, :available, :discarded, :cancelled]
 
   @max_jobs 100
 

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -156,9 +156,15 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
   end
 
   @impl true
-  def handle_event("filter", params, socket) do
-    update = extract_params(params) |> drop_defaults()
+  def handle_event("filter", %{"_target" => ["reset"]} = _params, socket) do
+    %{} |> sync_query_params(socket)
+  end
 
+  def handle_event("filter", params, socket) do
+    extract_params(params) |> drop_defaults() |> sync_query_params(socket)
+  end
+
+  defp sync_query_params(update, socket) do
     socket =
       socket
       |> push_patch(to: backoffice_live_path(socket, TransportWeb.Backoffice.Jobs2Live, update))
@@ -215,6 +221,5 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
     Map.reject(updates, fn {_key, value} ->
       value == true or value == ""
     end)
-
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -58,7 +58,7 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
   def last_jobs_query(n) do
     from(j in "oban_jobs",
       select: map(j, [:id, :state, :queue, :worker, :args, :inserted_at, :scheduled_at, :errors]),
-      order_by: [desc: j.attempted_at],
+      order_by: [desc: j.id],
       limit: ^n
     )
   end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -58,7 +58,7 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
   def last_jobs_query(n) do
     from(j in "oban_jobs",
       select: map(j, [:id, :state, :queue, :worker, :args, :inserted_at, :scheduled_at, :errors]),
-      order_by: [desc: j.id],
+      order_by: [desc: j.attempted_at],
       limit: ^n
     )
   end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -157,7 +157,7 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
 
   @impl true
   def handle_event("filter", params, socket) do
-    update = extract_params(params)
+    update = extract_params(params) |> drop_defaults()
 
     socket =
       socket
@@ -209,5 +209,12 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
       "false" -> false
       _ -> true
     end
+  end
+
+  defp drop_defaults(updates) do
+    Map.reject(updates, fn {_key, value} ->
+      value == true or value == ""
+    end)
+
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -18,7 +18,9 @@
       </label>
       <div :if={@listing and @count_jobs} class="vsep"></div>
       <div :if={@listing and @count_jobs} class="total">
-        {dgettext("backoffice", "total:")} {Helpers.format_number(@count_jobs)}
+        {dngettext("backoffice", "total: %{n_jobs} job", "total: %{n_jobs} jobs", @count_jobs,
+          n_jobs: Helpers.format_number(@count_jobs)
+        )}
       </div>
     </div>
   </.form>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -4,24 +4,24 @@
     <span>{dgettext("backoffice", "Last update:")} {@last_updated_at}</span>
   </div>
 
-  <.form :let={f} for={%{}} phx-change="filter" class="no-margin">
-    <div class="jobs-filter">
-      {text_input(f, :worker, value: @worker, autofocus: true)}
-      <div class="vsep"></div>
-      <label :for={state <- @states} class={"job-state job-state-#{state}"}>
-        {checkbox(f, state, value: assigns[state])} {state}
-      </label>
-      <div class="vsep"></div>
-      <label class="listing-toggle">
-        {checkbox(f, :listing, value: @listing)}
-        {dgettext("backoffice", "listing")}
-      </label>
-      <div :if={@listing and @count_jobs} class="vsep"></div>
-      <div :if={@listing and @count_jobs} class="total">
-        {dngettext("backoffice", "total: %{n_jobs} job", "total: %{n_jobs} jobs", @count_jobs,
-          n_jobs: Helpers.format_number(@count_jobs)
-        )}
-      </div>
+  <.form :let={f} for={%{}} phx-change="filter" class="no-margin jobs-filter">
+    {text_input(f, :worker, value: @worker, autofocus: true)}
+    <div class="vsep"></div>
+    <label :for={state <- @states} class={"job-state job-state-#{state}"}>
+      {checkbox(f, state, value: assigns[state])} {state}
+    </label>
+    <div class="vsep"></div>
+    <label class="listing-toggle">
+      {checkbox(f, :listing, value: @listing)}
+      {dgettext("backoffice", "listing")}
+    </label>
+    <div class="vsep"></div>
+    <button class="button-outline secondary small" type="reset" name="reset">{dgettext("backoffice", "Reset")}</button>
+    <div :if={@listing and @count_jobs} class="vsep"></div>
+    <div :if={@listing and @count_jobs} class="total">
+      {dngettext("backoffice", "total: %{n_jobs} job", "total: %{n_jobs} jobs", @count_jobs,
+        n_jobs: Helpers.format_number(@count_jobs)
+      )}
     </div>
   </.form>
 

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -27,9 +27,9 @@ defmodule JobsTableComponent do
           <td>{job.queue}</td>
           <td>{job.worker}</td>
           <td>{inspect(job.args)}</td>
-          <td>{format_datetime(job.inserted_at)}</td>
+          <td>{format_time(job.inserted_at)}</td>
           <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}><.compact_errors errors={job.errors} /></td>
-          <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{format_datetime(job.scheduled_at)}</td>
+          <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{format_time(job.scheduled_at)}</td>
         </tr>
       </tbody>
     </table>
@@ -40,7 +40,7 @@ defmodule JobsTableComponent do
     render(Map.merge(%{state: nil}, assigns))
   end
 
-  defp format_datetime(dt) do
+  defp format_time(dt) do
     Shared.DateTimeDisplay.format_time_to_paris(dt, "en", no_timezone: true, with_seconds: true)
   end
 
@@ -58,7 +58,7 @@ defmodule JobsTableComponent do
 
   defp split_error(error) do
     %{
-      at: Map.get(error, "at") |> maybe(&format_datetime/1),
+      at: Map.get(error, "at") |> maybe(&format_time/1),
       error: Map.get(error, "error", "") |> extract_message()
     }
   end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -46,11 +46,11 @@ defmodule JobsTableComponent do
 
   defp compact_errors(%{errors: _} = assigns) do
     ~H"""
-    <ul>
+    <ol class="errors">
       <li :for={error <- split_errors(@errors)}>
         {error.at} : <code>{error.error}</code>
       </li>
-    </ul>
+    </ol>
     """
   end
 

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -28,7 +28,7 @@ defmodule JobsTableComponent do
           <td>{job.worker}</td>
           <td>{inspect(job.args)}</td>
           <td>{format_datetime(job.inserted_at)}</td>
-          <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}>{inspect(job.errors)}</td>
+          <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}><.compact_errors errors={job.errors} /></td>
           <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{format_datetime(job.scheduled_at)}</td>
         </tr>
       </tbody>
@@ -42,5 +42,31 @@ defmodule JobsTableComponent do
 
   defp format_datetime(dt) do
     Shared.DateTimeDisplay.format_datetime_to_paris(dt, "en", no_timezone: true, with_seconds: true)
+  end
+
+  defp compact_errors(%{errors: _} = assigns) do
+    ~H"""
+    <ul>
+      <li :for={error <- split_errors(@errors)}>
+        {error.at} : <code>{error.error}</code>
+      </li>
+    </ul>
+    """
+  end
+
+  defp split_errors(errors), do: Enum.map(errors, &split_error/1)
+
+  defp split_error(error) do
+    %{
+      at: Map.get(error, "at") |> maybe(&format_datetime/1),
+      error: Map.get(error, "error", "") |> extract_message()
+    }
+  end
+
+  defp maybe(nil, _f), do: nil
+  defp maybe(value, f), do: f.(value)
+
+  defp extract_message(message) do
+    message |> String.split("\n") |> List.first("") |> String.trim_leading("** ")
   end
 end

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -41,7 +41,7 @@ defmodule JobsTableComponent do
   end
 
   defp format_datetime(dt) do
-    Shared.DateTimeDisplay.format_datetime_to_paris(dt, "en", no_timezone: true, with_seconds: true)
+    Shared.DateTimeDisplay.format_time_to_paris(dt, "en", no_timezone: true, with_seconds: true)
   end
 
   defp compact_errors(%{errors: _} = assigns) do

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -349,5 +349,7 @@ msgid "listing"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "total:"
-msgstr ""
+msgid "total: %{n_jobs} job"
+msgid_plural "total: %{n_jobs} jobs"
+msgstr[0] ""
+msgstr[1] ""

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -353,3 +353,7 @@ msgid "total: %{n_jobs} job"
 msgid_plural "total: %{n_jobs} jobs"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Reset"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -349,5 +349,7 @@ msgid "listing"
 msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "total:"
-msgstr ""
+msgid "total: %{n_jobs} job"
+msgid_plural "total: %{n_jobs} jobs"
+msgstr[0] ""
+msgstr[1] ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -353,3 +353,7 @@ msgid "total: %{n_jobs} job"
 msgid_plural "total: %{n_jobs} jobs"
 msgstr[0] ""
 msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Reset"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -353,3 +353,7 @@ msgid "total: %{n_jobs} job"
 msgid_plural "total: %{n_jobs} jobs"
 msgstr[0] "total : %{n_jobs} job"
 msgstr[1] "total : %{n_jobs} jobs"
+
+#, elixir-autogen, elixir-format
+msgid "Reset"
+msgstr "Valeurs par défaut"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -349,5 +349,7 @@ msgid "listing"
 msgstr "liste"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "total:"
-msgstr "total :"
+msgid "total: %{n_jobs} job"
+msgid_plural "total: %{n_jobs} jobs"
+msgstr[0] "total : %{n_jobs} job"
+msgstr[1] "total : %{n_jobs} jobs"


### PR DESCRIPTION
2ème passe d'améliorations :

- Tableau plus compact ; Les titres de colonnes sont sticky au scroll ;
- Les cellules sont alignées verticalement en haut pour rendre le layout plus simple à lire d'un coup d'oeil ;
- Dates moins verbeuses ;
- Erreurs parsées pour être plus lisibles (et plus compactes) ;
- L'état "cancelled" est supporté ;
- ~~Les jobs sont désormais triés par `attempted_at` descendant~~ Ce n'était pas une si bonne idée ;
- L'URL n'incluent plus les valeurs par défaut, pour la rendre moins verbeuse ;
- Ajout d'un bouton pour réinitialiser les filtres aux valeurs par défaut.

<img width="2256" height="1392" alt="image" src="https://github.com/user-attachments/assets/60eb0f8c-d25d-4581-852f-3d4f0e077d0d" />