### PR TITLE
Correctif : le scheduler référence `refresh_places` mais la méthode a été renommée

### DIFF
--- a/apps/transport/lib/transport/scheduler.ex
+++ b/apps/transport/lib/transport/scheduler.ex
@@ -24,6 +24,7 @@ defmodule Transport.Scheduler do
       {"0 3 * * *", &Transport.LogCleaner.clean_old_logs/0},
       # compute some global stats and store them in the DB
       {"0 20 * * *", &Transport.StatsHandler.store_stats/0},
+      # Duplicate `Transport.Jobs.RefreshAutocompleteJob` (Oban, see #5114). Kept for now.
       {"0 * * * *", &Transport.ImportData.refresh_autocomplete/0}
     ]
   end

--- a/apps/transport/lib/transport/scheduler.ex
+++ b/apps/transport/lib/transport/scheduler.ex
@@ -21,7 +21,7 @@ defmodule Transport.Scheduler do
       {"0 3 * * *", {Transport.LogCleaner, :clean_old_logs, []}},
       # compute some global stats and store them in the DB
       {"0 20 * * *", {Transport.StatsHandler, :store_stats, []}},
-      {"0 * * * *", {Transport.ImportData, :refresh_places, []}}
+      {"0 * * * *", {Transport.ImportData, :refresh_autocomplete, []}}
     ]
   end
 end

--- a/apps/transport/lib/transport/scheduler.ex
+++ b/apps/transport/lib/transport/scheduler.ex
@@ -9,10 +9,8 @@ defmodule Transport.Scheduler do
   @doc """
   The jobs are defined here, but only programmatically activated on one node. See `config/runtime.exs`.
 
-  Tasks are written as 0-arity captures (`&Mod.fun/0`) rather than `{Mod, :fun, []}` tuples so
-  the compiler catches references to undefined/renamed functions. Caveat: switching to a
-  Quantum storage backend other than the default `Noop` would require MFA tuples (captures
-  don't serialise).
+  Tasks use `&Mod.fun/0` captures rather than `{Mod, :fun, []}` tuples to get compile-time
+  checking of the references (e.g. catch #5046).
   """
   def scheduled_jobs do
     [

--- a/apps/transport/lib/transport/scheduler.ex
+++ b/apps/transport/lib/transport/scheduler.ex
@@ -8,20 +8,25 @@ defmodule Transport.Scheduler do
 
   @doc """
   The jobs are defined here, but only programmatically activated on one node. See `config/runtime.exs`.
+
+  Tasks are written as 0-arity captures (`&Mod.fun/0`) rather than `{Mod, :fun, []}` tuples so
+  the compiler catches references to undefined/renamed functions. Caveat: switching to a
+  Quantum storage backend other than the default `Noop` would require MFA tuples (captures
+  don't serialise).
   """
   def scheduled_jobs do
     [
       # Every day at 4am UTC
-      {"0 4 * * *", {Transport.ImportData, :import_validate_all, []}},
+      {"0 4 * * *", &Transport.ImportData.import_validate_all/0},
       # Set inactive data
-      {"@daily", {Transport.DataChecker, :inactive_data, []}},
+      {"@daily", &Transport.DataChecker.inactive_data/0},
       # Watch for new comments on datasets
-      {"@daily", {Transport.CommentsChecker, :check_for_new_comments, []}},
+      {"@daily", &Transport.CommentsChecker.check_for_new_comments/0},
       # clean old logs
-      {"0 3 * * *", {Transport.LogCleaner, :clean_old_logs, []}},
+      {"0 3 * * *", &Transport.LogCleaner.clean_old_logs/0},
       # compute some global stats and store them in the DB
-      {"0 20 * * *", {Transport.StatsHandler, :store_stats, []}},
-      {"0 * * * *", {Transport.ImportData, :refresh_autocomplete, []}}
+      {"0 20 * * *", &Transport.StatsHandler.store_stats/0},
+      {"0 * * * *", &Transport.ImportData.refresh_autocomplete/0}
     ]
   end
 end


### PR DESCRIPTION
Le renommage dans #5046 a laissé de côté le nom de la méthode, qui vu le système n'était pas vérifié à compile-time.

Impacts:
- pas grand chose car entre temps il y a un job Oban qui tourne aussi toutes les heures
- mais une erreur Sentry par heure en théorie
- surtout, c'est cool de détecter ça là, sur un cas non problématique, et de changer le système pour avoir une erreur à compile-time, ce qui est en fait tout à fait possible, depuis longtemps dans Quantum (ce que j'ai fait), par rapport aux autres éléments dans le scheduler

### La correction de la typo

```diff
-     {"0 * * * *", {Transport.ImportData, :refresh_places, []}}
+      {"0 * * * *", {Transport.ImportData, :refresh_autocomplete, []}}
```

### Le reste du diff

Je transforme les tuples MFA en référence à des fonctions, qui sont vérifiées à compile-time, pour tous les éléments schédulés par Quantum ici.

Ça catche comme suit dès le CI:

```
warning: Transport.ImportData.refresh_places/0 is undefined or private. Did you mean:

      * refresh_autocomplete/0
```

### Explication historique

Les "tuples MFA" (Module/Function/Arity, voir `mfa()` https://hexdocs.pm/elixir/typespecs.html#built-in-types) étaient il y a longtemps une façon recommandée de cibler des méthodes depuis la configuration d'une application Elixir.

Entre temps toutefois, les anciens systèmes de releases ont graduellement été remplacés par un support officiel dans le langage (https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/), qui n'exige plus de "sérialiser" les références de fonctions via des MFA. On peut donc simplement utiliser les références de fonctions plus fortement typées.