### PR TITLE
Page de suivi des jobs : phase 3

### DIFF
--- a/apps/transport/client/stylesheets/components/_backoffice.scss
+++ b/apps/transport/client/stylesheets/components/_backoffice.scss
@@ -304,6 +304,32 @@ iframe#email_preview {
     --taint: color-mix(red 70%, white);
   }
 
+  span.timestamp {
+    cursor: help;
+
+    &::before {
+      content: attr(data-datetime);
+      position-anchor: --timestamp;
+      position: fixed;
+      display: none;
+      bottom: calc(anchor(top) + 4px);
+      justify-self: anchor-center;
+      background: white;
+      border: 1px solid var(--light-grey);
+      border-radius: calc(var(--space-xs) / 2);
+      box-shadow: 0 0 15px $box-shadow;
+      padding: calc(var(--space-xs) / 2) var(--space-xs);
+    }
+
+    &:hover {
+      anchor-name: --timestamp;
+    }
+
+    &:hover::before {
+      display: block;
+    }
+  }
+
   table tr th,
   table tr td {
     font-size: 0.9rem;

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -172,20 +172,21 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
     {:noreply, socket}
   end
 
-  def format_1_hour_range(from) do
+  def format_1_hour_range(from, locale) do
     to = DateTime.add(from, 1, :hour)
 
     days_diff = from |> DateTime.to_date() |> Date.diff(Date.utc_today())
 
     date =
       case days_diff do
-        0 -> "Today"
-        -1 -> "Yesterday"
-        1 -> "Tomorrow"
-        _ -> Shared.DateTimeDisplay.format_date(from, "en")
+        0 -> dgettext("backoffice", "Today")
+        -1 -> dgettext("backoffice", "Yesterday")
+        1 -> dgettext("backoffice", "Tomorrow")
+        _ -> Shared.DateTimeDisplay.format_date(from, locale)
       end
 
-    "#{date} between #{format_time(from)} and #{format_time(to)}"
+    # "#{date} between #{format_time(from)} and #{format_time(to)}"
+    dgettext("backoffice", "%{date} between %{from} and %{to}", date: date, from: format_time(from), to: format_time(to))
   end
 
   defp format_time(dt) do

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.ex
@@ -186,7 +186,11 @@ defmodule TransportWeb.Backoffice.Jobs2Live do
       end
 
     # "#{date} between #{format_time(from)} and #{format_time(to)}"
-    dgettext("backoffice", "%{date} between %{from} and %{to}", date: date, from: format_time(from), to: format_time(to))
+    dgettext("backoffice", "%{date} between %{from} and %{to}",
+      date: date,
+      from: format_time(from),
+      to: format_time(to)
+    )
   end
 
   defp format_time(dt) do

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -40,7 +40,7 @@
         <%= for {hour, rows} <- @jobs_count do %>
           <tr :for={{row, index} <- Enum.with_index(rows)}>
             <td :if={index == 0} rowspan={Enum.count(rows)}>
-              {format_1_hour_range(hour)}
+              {format_1_hour_range(hour, @locale)}
             </td>
             <td>{row.worker}</td>
             <td>{Helpers.format_number(row.count)}</td>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -26,7 +26,7 @@
   </.form>
 
   <%= if @listing do %>
-    <.live_component module={JobsTableComponent} jobs={@jobs} id="live_jobs" />
+    <.live_component module={JobsTableComponent} jobs={@jobs} locale={@locale} id="live_jobs" />
   <% else %>
     <table class="table">
       <thead>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs2_live.html.heex
@@ -27,6 +27,9 @@
 
   <%= if @listing do %>
     <.live_component module={JobsTableComponent} jobs={@jobs} locale={@locale} id="live_jobs" />
+    <div :if={@count_jobs > length(@jobs)} class="small is-centered">
+      {dgettext("backoffice", "truncated (%{hidden} jobs hidden)", hidden: @count_jobs - length(@jobs))}
+    </div>
   <% else %>
     <table class="table">
       <thead>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_live.html.heex
@@ -42,26 +42,38 @@
   </table>
 
   <h2>Executing jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@executing_jobs} state="executing" id="executing_jobs" />
+  <.live_component module={JobsTableComponent} jobs={@executing_jobs} locale="en" state="executing" id="executing_jobs" />
   <p class="small">Total: {Helpers.format_number(@count_executing_jobs, locale: "en")}</p>
 
   <h2>Completed jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@last_completed_jobs} state="completed" id="completed_jobs" />
+  <.live_component
+    module={JobsTableComponent}
+    jobs={@last_completed_jobs}
+    locale="en"
+    state="completed"
+    id="completed_jobs"
+  />
   <p class="small">Total: {Helpers.format_number(@count_completed_jobs, locale: "en")}</p>
 
   <h2>Scheduled jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@scheduled_jobs} state="scheduled" id="scheduled_jobs" />
+  <.live_component module={JobsTableComponent} jobs={@scheduled_jobs} locale="en" state="scheduled" id="scheduled_jobs" />
   <p class="small">Total: {Helpers.format_number(@count_scheduled_jobs, locale: "en")}</p>
 
   <h2>Retryable jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@retryable_jobs} state="retryable" id="retryable_jobs" />
+  <.live_component module={JobsTableComponent} jobs={@retryable_jobs} locale="en" state="retryable" id="retryable_jobs" />
   <p class="small">Total: {Helpers.format_number(@count_retryable_jobs, locale: "en")}</p>
 
   <h2>Available jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@available_jobs} state="available" id="available_jobs" />
+  <.live_component module={JobsTableComponent} jobs={@available_jobs} locale="en" state="available" id="available_jobs" />
   <p class="small">Total: {Helpers.format_number(@count_available_jobs, locale: "en")}</p>
 
   <h2>Discarded jobs</h2>
-  <.live_component module={JobsTableComponent} jobs={@last_discarded_jobs} state="discarded" id="discarded_jobs" />
+  <.live_component
+    module={JobsTableComponent}
+    jobs={@last_discarded_jobs}
+    locale="en"
+    state="discarded"
+    id="discarded_jobs"
+  />
   <p class="small">Total: {Helpers.format_number(@count_discarded_jobs, locale: "en")}</p>
 </section>

--- a/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
+++ b/apps/transport/lib/transport_web/live/backoffice/jobs_table_component.ex
@@ -5,7 +5,7 @@ defmodule JobsTableComponent do
   use Phoenix.LiveComponent
   use Gettext, backend: TransportWeb.Gettext
 
-  def render(%{state: _, jobs: _} = assigns) do
+  def render(%{state: _, locale: _, jobs: _} = assigns) do
     ~H"""
     <table class="table">
       <thead>
@@ -27,38 +27,52 @@ defmodule JobsTableComponent do
           <td>{job.queue}</td>
           <td>{job.worker}</td>
           <td>{inspect(job.args)}</td>
-          <td>{format_time(job.inserted_at)}</td>
-          <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}><.compact_errors errors={job.errors} /></td>
-          <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>{format_time(job.scheduled_at)}</td>
+          <td><.timestamp dt={job.inserted_at} } locale={@locale} /></td>
+          <td :if={is_nil(@state) or @state in ["discarded", "retryable"]}>
+            <.compact_errors errors={job.errors} locale={@locale} />
+          </td>
+          <td :if={is_nil(@state) or @state in ["scheduled", "retryable"]}>
+            <.timestamp dt={job.scheduled_at} } locale={@locale} />
+          </td>
         </tr>
       </tbody>
     </table>
     """
   end
 
-  def render(%{jobs: _} = assigns) do
+  def render(%{jobs: _, locale: _} = assigns) do
     render(Map.merge(%{state: nil}, assigns))
   end
 
-  defp format_time(dt) do
-    Shared.DateTimeDisplay.format_time_to_paris(dt, "en", no_timezone: true, with_seconds: true)
+  defp timestamp(%{dt: _, locale: _} = assigns) do
+    ~H"""
+    <span class="timestamp" data-datetime={format_datetime(@dt, @locale)}>{format_time(@dt, @locale)}</span>
+    """
   end
 
-  defp compact_errors(%{errors: _} = assigns) do
+  defp format_time(dt, locale) do
+    Shared.DateTimeDisplay.format_time_to_paris(dt, locale || "en", no_timezone: true, with_seconds: true)
+  end
+
+  defp format_datetime(dt, locale) do
+    Shared.DateTimeDisplay.format_datetime_to_paris(dt, locale || "en", no_timezone: true, with_seconds: true)
+  end
+
+  defp compact_errors(%{errors: _, locale: _} = assigns) do
     ~H"""
     <ol class="errors">
-      <li :for={error <- split_errors(@errors)}>
-        {error.at} : <code>{error.error}</code>
+      <li :for={error <- split_errors(@errors, @locale)}>
+        <.timestamp dt={error.at} locale={@locale} /> : <code>{error.error}</code>
       </li>
     </ol>
     """
   end
 
-  defp split_errors(errors), do: Enum.map(errors, &split_error/1)
+  defp split_errors(errors, locale), do: Enum.map(errors, &split_error(&1, locale))
 
-  defp split_error(error) do
+  defp split_error(error, locale) do
     %{
-      at: Map.get(error, "at") |> maybe(&format_time/1),
+      at: Map.get(error, "at"),
       error: Map.get(error, "error", "") |> extract_message()
     }
   end

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -357,3 +357,19 @@ msgstr[1] ""
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Tomorrow"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Yesterday"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "%{date} between %{from} and %{to}"
+msgstr ""

--- a/apps/transport/priv/gettext/backoffice.pot
+++ b/apps/transport/priv/gettext/backoffice.pot
@@ -373,3 +373,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{date} between %{from} and %{to}"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "truncated (%{hidden} jobs hidden)"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -357,3 +357,19 @@ msgstr[1] ""
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Tomorrow"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Yesterday"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "%{date} between %{from} and %{to}"
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/backoffice.po
@@ -373,3 +373,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{date} between %{from} and %{to}"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "truncated (%{hidden} jobs hidden)"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -357,3 +357,19 @@ msgstr[1] "total : %{n_jobs} jobs"
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr "Valeurs par défaut"
+
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr "Aujourd’hui"
+
+#, elixir-autogen, elixir-format
+msgid "Tomorrow"
+msgstr "Demain"
+
+#, elixir-autogen, elixir-format
+msgid "Yesterday"
+msgstr "Hier"
+
+#, elixir-autogen, elixir-format
+msgid "%{date} between %{from} and %{to}"
+msgstr "%{date} entre %{from} et %{to}"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/backoffice.po
@@ -373,3 +373,7 @@ msgstr "Hier"
 #, elixir-autogen, elixir-format
 msgid "%{date} between %{from} and %{to}"
 msgstr "%{date} entre %{from} et %{to}"
+
+#, elixir-autogen, elixir-format
+msgid "truncated (%{hidden} jobs hidden)"
+msgstr "tronqué (%{hidden} jobs masqués)"


### PR DESCRIPTION
- Localisation des plages horaires dans le suivi résumé (voir screenshot ci-après) ;
- Composant de date/heure qui indique au survol le timestamp complet (permet d'afficher uniquement l'heure dans le tableau mais de conserver l'information en cas de doute) ;
- Affiche le nombre de jobs masqués si pertinent (on n'affiche que 100 jobs dans la liste détaillée).

<img width="1073" height="411" alt="image" src="https://github.com/user-attachments/assets/b611c9af-9d5a-4457-8f87-a6a7ded99f75" />
