### PR TITLE
Correctif flaky test de +

### DIFF
--- a/apps/transport/test/transport_web/live_views/cache_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/cache_live_test.exs
@@ -1,5 +1,6 @@
 defmodule TransportWeb.Backoffice.CacheLiveTest do
-  use ExUnit.Case, async: true
+  # async: false: the LiveView reads the global Cachex state, polluted by other async tests.
+  use ExUnit.Case, async: false
   use TransportWeb.LiveCase
   import TransportWeb.ConnCase, only: [setup_admin_in_session: 1]
   import Transport.Application, only: [cache_name: 0]


### PR DESCRIPTION
Le dernier merge dans `master` a donné lieu à cette failure.

(au fond du fond, le sujet racine sera de mieux gérer Cachex, ou une abstraction de cache au dessus ou à la place ; Cachex est du global state actuellement dans les tests, sous-traite les calculs à des process enfants (cf autres correctifs flaky tests, mais pour le moment ça enlèvera un cas de + en mode pansement).