### PR TITLE
Correctif warning CI

### DIFF
--- a/.github/actions/checkout-compile/action.yml
+++ b/.github/actions/checkout-compile/action.yml
@@ -14,7 +14,7 @@ runs:
 
     - name: Cache deps
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-elixir-deps
       with:
@@ -26,7 +26,7 @@ runs:
 
     - name: Cache compiled build
       id: cache-build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-compiled-build-v2
       with:
@@ -38,7 +38,7 @@ runs:
 
     - name: Cache JS assets
       id: cache-js-assets
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-js-assets
       with:


### PR DESCRIPTION
Je corrige ce point précis:

<img width="1972" height="490" alt="CleanShot 2026-05-04 at 18 22 04@2x" src="https://github.com/user-attachments/assets/df697c0c-daa4-451e-8987-24149bb59ab8" />

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/