### PR TITLE
IRVE : regex d’email un peu plus stricte

### DIFF
--- a/apps/transport/lib/data_frame/validation_primitives.ex
+++ b/apps/transport/lib/data_frame/validation_primitives.ex
@@ -80,8 +80,8 @@ defmodule Transport.DataFrame.Validation.Primitives do
       iex> email?(build_series(["hello@example.com", "invalid"])) |> Series.to_list()
       [true, false]
 
-      iex> email?(build_series(["test@foo.bar", "hello@fool"])) |> Series.to_list()
-      [true, false]
+      iex> email?(build_series(["test@foo.bar", "hello@fool", "test@foo.bar>"])) |> Series.to_list()
+      [true, false, false]
   """
   def email?(series) do
     Series.re_contains(series, @simple_email_pattern)

--- a/apps/transport/lib/data_frame/validation_primitives.ex
+++ b/apps/transport/lib/data_frame/validation_primitives.ex
@@ -61,7 +61,7 @@ defmodule Transport.DataFrame.Validation.Primitives do
     Series.re_contains(series, pattern)
   end
 
-  @simple_email_pattern ~S/(?i)\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+  @simple_email_pattern ~S/(?i)\A[^@\s]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z/
 
   @doc """
   Get the simple email validation pattern.

--- a/scripts/irve/validate_and_summarize.exs
+++ b/scripts/irve/validate_and_summarize.exs
@@ -1,0 +1,11 @@
+# mix run scripts/irve/validate_and_summarize.exs
+
+# Change me
+file_path = "consolidation_transport_irve_statique.csv"
+
+Transport.LogTimeTaken.log_time_taken("Validating #{file_path}", fn ->
+  IO.puts("Starting validating downloaded copy of #{file_path}…")
+  summary = Transport.IRVE.Validator.validate_and_summarize(file_path)
+
+  IO.inspect(summary, IEx.inspect_opts())
+end)


### PR DESCRIPTION
Closes #5508

On avait une regex pour les emails un peu permissive. Or dans un des fichiers source du consolidé IRVE, un des PDC avait un email de contact opérateur du genre :  `nom.prenom@domaine.fr>` avec donc un chevron fermant après le .fr qui semblait rester d’un copier coller de quelque part.

Nous on jugeait le fichier valide, et on le reprenait dans le consolidé, mais Validata juge cela invalide (et par conséquence, notre consolidé est invalide pour Validata).  En sus, transport.data.gouv est toujours branché sur Validata comme validateur des jeux de données affichés sur le PAN (alors qu’on a changé le validateur à la demande), donc le fichier est marqué comme invalide sur notre UI et celle de data.gouv.

Bref, j’ai mis une regex qui est plus stricte au moins sur le nom de domaine. À noter que la spec officielle de TableSchema renvoie à celle de JSON schema qui dit simplement "format email: This SHOULD be an email address." https://datatracker.ietf.org/doc/html/draft-zyp-json-schema-03#anchor27 Sans plus de précisions sur ce qu’est une adresse email valide.

# Conséquences du changement

Notre consolidé va perdre 2 lignes mais devenir valide selon Validata, donc être montré comme valide sur data.gouv.fr et sur transport.data.gouv.fr

Seul un fichier est exclu, au sein de ce dataset https://www.data.gouv.fr/datasets/irve-statique-organisation-wellborne la resource `87fc91a9-00c2-4c8e-bd0d-72df29dbfbb3` qui comprend 2 lignes.