### PR TITLE
Patchs sécurité javascript

### DIFF
--- a/apps/transport/client/package.json
+++ b/apps/transport/client/package.json
@@ -62,6 +62,8 @@
     "webpack-merge": "^6.0.1"
   },
   "resolutions": {
-    "kind-of": "^6.0.3"
+    "kind-of": "^6.0.3",
+    "fast-uri": "^3.1.2",
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4"
   }
 }

--- a/apps/transport/client/yarn.lock
+++ b/apps/transport/client/yarn.lock
@@ -481,10 +481,10 @@
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+"@babel/plugin-transform-modules-systemjs@^7.29.0", "@babel/plugin-transform-modules-systemjs@^7.29.4":
+  version "7.29.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
@@ -2507,10 +2507,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@^3.0.1, fast-uri@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"

--- a/generate_deps_changelogs.exs
+++ b/generate_deps_changelogs.exs
@@ -10,7 +10,7 @@
 # and automatically edit the PR description with this.
 #
 
-Mix.install([:jason, :req])
+Mix.install([:jason])
 
 defmodule Scanner do
   def scan(mix_lock_content) do
@@ -71,62 +71,93 @@ end)
 defmodule YarnScanner do
   @path "apps/transport/client"
 
-  def at(:local),
-    do: parse(File.read!("#{@path}/yarn.lock"), File.read!("#{@path}/package.json"))
+  # name => sorted unique list of resolved versions (a name may appear at
+  # several versions, since we bundle multiple versions at times).
+  def versions(:local), do: parse(File.read!("#{@path}/yarn.lock"))
 
-  def at(ref) do
-    {pj, 0} = System.cmd("git", ["show", "#{ref}:#{@path}/package.json"])
+  def versions(ref) do
     {yl, 0} = System.cmd("git", ["show", "#{ref}:#{@path}/yarn.lock"])
-    parse(yl, pj)
+    parse(yl)
   end
 
+  # Names declared top-level in a ref's package.json (deps / devDeps /
+  # resolutions). Used only to classify a dep into the top-level vs the
+  # transitive section — not to filter anything out.
+  def direct(:local), do: parse_direct(File.read!("#{@path}/package.json"))
+
+  def direct(ref) do
+    {pj, 0} = System.cmd("git", ["show", "#{ref}:#{@path}/package.json"])
+    parse_direct(pj)
+  end
+
+  defp parse_direct(json) do
+    json
+    |> Jason.decode!()
+    |> Map.take(~w(dependencies devDependencies resolutions))
+    |> Map.values()
+    |> Enum.flat_map(&Map.keys/1)
+    |> MapSet.new()
+  end
+
+  # npmdiff.dev diffs the published tarballs (the npm equivalent of
+  # diff.hex.pm). Scoped names need the scope slash percent-encoded.
   def diff_url(name, v1, v2) do
-    with {:ok, %{status: 200, body: body}} <- Req.get("https://registry.npmjs.org/#{name}"),
-         url <- get_in(body, ["repository", "url"]) || "",
-         [_, owner, repo] <- Regex.run(~r{github\.com[/:]([^/]+)/([^/.]+)}, url) do
-      "https://github.com/#{owner}/#{repo}/compare/v#{v1}...v#{v2}"
-    else
-      _ -> "https://www.npmjs.com/package/#{name}?activeTab=versions"
-    end
+    "https://npmdiff.dev/#{String.replace(name, "/", "%2F")}/#{v1}/#{v2}/"
   end
 
-  defp parse(lock, json) do
-    direct =
-      json
-      |> Jason.decode!()
-      |> Map.take(~w(dependencies devDependencies resolutions))
-      |> Map.values()
-      |> Enum.flat_map(&Map.keys/1)
-      |> MapSet.new()
-
+  defp parse(lock) do
     lock
     |> String.split("\n\n")
     |> Enum.reduce(%{}, fn block, acc ->
       with [_, name] <- Regex.run(~r/^"?((?:@[^\/"]+\/)?[^@"\s]+)@/m, block),
-           true <- MapSet.member?(direct, name),
            [_, ver] <- Regex.run(~r/version "([^"]+)"/, block) do
-        Map.put(acc, name, ver)
+        Map.update(acc, name, [ver], &Enum.uniq([ver | &1]))
       else
         _ -> acc
       end
     end)
+    |> Map.new(fn {name, vers} -> {name, Enum.sort(vers)} end)
   end
 end
 
-IO.puts "\n### JS dependencies (top-level only)"
-IO.puts "(may include duplicates, since we bundle multiple versions at times)\n"
-yarn_master = YarnScanner.at("master")
-yarn_current = YarnScanner.at(:local)
+yarn_master = YarnScanner.versions("master")
+yarn_current = YarnScanner.versions(:local)
+# Union of both refs so a name dropped from resolutions on one side is still
+# classified the same way.
+direct = MapSet.union(YarnScanner.direct("master"), YarnScanner.direct(:local))
 
-(Map.keys(yarn_master) ++ Map.keys(yarn_current))
-|> Enum.uniq()
-|> Enum.sort()
-|> Enum.each(fn name ->
-  case {yarn_master[name], yarn_current[name]} do
-    {v1, v2} when not is_nil(v1) and not is_nil(v2) and v1 != v2 ->
-      IO.puts "* #{YarnScanner.diff_url(name, v1, v2)}"
-    {nil, v2} when not is_nil(v2) -> IO.puts "* ADDED: #{name}@#{v2}"
-    {v1, nil} when not is_nil(v1) -> IO.puts "* REMOVED: #{name}@#{v1}"
-    _ -> :ok
+# Same treatment for everyone; only the section a line lands in differs.
+render = fn name ->
+  case {Map.get(yarn_master, name), Map.get(yarn_current, name)} do
+    {same, same} ->
+      nil
+
+    {nil, news} ->
+      "* ADDED: #{name}@#{Enum.join(news, ", ")}"
+
+    {olds, nil} ->
+      "* REMOVED: #{name}@#{Enum.join(olds, ", ")}"
+
+    {[old], [new]} ->
+      "* #{YarnScanner.diff_url(name, old, new)}"
+
+    {olds, news} ->
+      # Multi-version (bundled duplicates): no single tarball diff applies.
+      "* #{name}: #{Enum.join(olds, ", ")} → #{Enum.join(news, ", ")}"
   end
-end)
+end
+
+{top_level, lock_only} =
+  (Map.keys(yarn_master) ++ Map.keys(yarn_current))
+  |> Enum.uniq()
+  |> Enum.sort()
+  |> Enum.map(&{&1, render.(&1)})
+  |> Enum.reject(fn {_name, line} -> is_nil(line) end)
+  |> Enum.split_with(fn {name, _line} -> MapSet.member?(direct, name) end)
+
+IO.puts "\n### JS dependencies — top-level (package.json: dependencies / devDependencies / resolutions)\n"
+Enum.each(top_level, fn {_name, line} -> IO.puts(line) end)
+
+IO.puts "\n### JS dependencies — transitive (yarn.lock only)"
+IO.puts "(may include duplicates, since we bundle multiple versions at times)\n"
+Enum.each(lock_only, fn {_name, line} -> IO.puts(line) end)


### PR DESCRIPTION
Cette PR traite les 3 alertes "sécurité et qualité" de GitHub actuellement ouvertes, à cause de:
- CVE-2026-6321
- CVE-2026-6322
- CVE-2026-44728

Je retouche aussi le script pour qu'il utilise npmdiff pour les dépendances javascript, et qu'il affiche tout plutôt que juste le top-level, sinon on ne voit rien quand parfois que du "non top level" change.

### JS dependencies — top-level (package.json: dependencies / devDependencies / resolutions)

* https://npmdiff.dev/@babel%2Fplugin-transform-modules-systemjs/7.29.0/7.29.4/
* https://npmdiff.dev/fast-uri/3.1.0/3.1.2/

### JS dependencies — transitive (yarn.lock only)
(may include duplicates, since we bundle multiple versions at times)