### PR TITLE
Permalink pour la validation IRVE

### DIFF
--- a/apps/transport/lib/irve/validator/summary.ex
+++ b/apps/transport/lib/irve/validator/summary.ex
@@ -22,4 +22,20 @@ defmodule Transport.IRVE.Validator.Summary do
     :column_errors,
     :error_samples
   ]
+
+  @doc """
+  Rebuilds a `%Summary{}` from its persisted (JSONB, string-keyed) `result` map. `struct!/2`
+  makes an unexpected top-level key raise rather than silently render as `nil`; `error_samples` rows
+  are re-keyed to atoms too (fixed key set) so the template keeps plain dot access.
+  """
+  def from_result(result) when is_map(result) do
+    result
+    |> atomize_keys()
+    |> Map.update!(:error_samples, fn samples -> Enum.map(samples, &atomize_keys/1) end)
+    |> then(&struct!(__MODULE__, &1))
+  end
+
+  defp atomize_keys(map) do
+    Map.new(map, fn {key, value} -> {String.to_existing_atom(key), value} end)
+  end
 end

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -84,7 +84,8 @@ defmodule TransportWeb.ValidationController do
         %MultiValidation{
           validator: "on-demand-irve-statique",
           validation_timestamp: DateTime.utc_now(),
-          oban_args: %{"type" => "on-demand-irve-statique", "state" => "completed", "secret_url_token" => token},
+          # This is needed as the #show route patterns match on secret_url_token
+          oban_args: %{"type" => "irve-statique", "state" => "completed", "secret_url_token" => token},
           result: Map.from_struct(summary),
           validated_data_name: filename || "upload.csv"
         }
@@ -205,7 +206,7 @@ defmodule TransportWeb.ValidationController do
         |> assign(:xsd_errors, xsd_errors)
         |> render(template)
 
-      %MultiValidation{oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique"}} = validation ->
+      %MultiValidation{oban_args: %{"state" => "completed", "type" => "irve-statique"}} = validation ->
         conn
         |> assign(:summary, validation.result)
         |> assign(:filename, validation.validated_data_name)
@@ -397,7 +398,7 @@ defmodule TransportWeb.ValidationController do
   # This allows the feature usage metadata to be different from other TableSchema validations
   # See TransportWeb.ValidationController.log_usage/2
   defp build_oban_args(%{"type" => "etalab/schema-irve-statique"}) do
-    %{"type" => "on-demand-irve-statique"}
+    %{"type" => "irve-statique"}
   end
 
   defp build_oban_args(%{"type" => type}), do: build_oban_args(type)
@@ -457,11 +458,14 @@ defmodule TransportWeb.ValidationController do
   def temporary_on_demand_validator_name, do: "on demand validation requested"
 
   defp log_usage(%Plug.Conn{} = conn, _options) do
+    # dbg(conn)
+
     DB.FeatureUsage.insert!(
       :on_demand_validation,
       get_in(conn.assigns.current_contact.id),
       build_oban_args(conn.params["upload"])
       |> Map.take(["type", "schema_name"])
+      # |> dbg()
     )
 
     conn

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -60,13 +60,38 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
-  # IRVE statique validation doesn’t use an Oban job and doesn’t store anything
-  # It’s just a display and forget validation, and it’s quick enough so that it can be done synchronously
-  # This clause intercepts the validation instead of sending to Validata like other TableSchema validations
+  # Intercepts IRVE before it falls through to the TableSchema path, because
+  # it uses a dedicated validator and oban_args format.
   def validate(%Plug.Conn{} = conn, %{
         "upload" => %{"file" => %{path: file_path, filename: filename}, "type" => "etalab/schema-irve-statique"}
       }) do
-    validate_irve_statique(conn, file_path, filename, File.stat!(file_path).size)
+    if File.stat!(file_path).size > @max_irve_file_size_bytes do
+      conn
+      |> put_flash(
+        :error,
+        dgettext("validations", "File is too large, must be <%{max_file_size}.",
+          max_file_size: Sizeable.filesize(@max_irve_file_size_bytes)
+        )
+      )
+      |> redirect(
+        to: live_path(conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "etalab/schema-irve-statique")
+      )
+    else
+      token = Ecto.UUID.generate()
+      summary = Transport.IRVE.Validator.validate_and_summarize(file_path, irve_extension(filename))
+
+      validation =
+        %MultiValidation{
+          validator: "on-demand-irve-statique",
+          validation_timestamp: DateTime.utc_now(),
+          oban_args: %{"type" => "on-demand-irve-statique", "state" => "completed", "secret_url_token" => token},
+          result: Map.from_struct(summary),
+          validated_data_name: filename || "upload.csv"
+        }
+        |> Repo.insert!()
+
+      redirect_to_validation_show(conn, validation)
+    end
   end
 
   def validate(%Plug.Conn{} = conn, %{
@@ -96,28 +121,6 @@ defmodule TransportWeb.ValidationController do
     conn |> bad_request()
   end
 
-  defp validate_irve_statique(conn, _file_path, _filename, size) when size > @max_irve_file_size_bytes do
-    conn
-    |> put_flash(
-      :error,
-      dgettext("validations", "File is too large, must be <%{max_file_size}.",
-        max_file_size: Sizeable.filesize(@max_irve_file_size_bytes)
-      )
-    )
-    |> redirect(
-      to: live_path(conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "etalab/schema-irve-statique")
-    )
-  end
-
-  defp validate_irve_statique(conn, file_path, filename, _size) do
-    summary = Transport.IRVE.Validator.validate_and_summarize(file_path, irve_extension(filename))
-
-    conn
-    |> assign(:summary, summary)
-    |> assign(:filename, filename || "upload.csv")
-    |> render("show_irve_statique.html")
-  end
-
   defp irve_extension(filename) when is_binary(filename) and filename != "" do
     case Path.extname(filename) do
       "" -> ".csv"
@@ -134,6 +137,7 @@ defmodule TransportWeb.ValidationController do
     redirect(conn, to: validation_path(conn, :show, id, token: token))
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def show(%Plug.Conn{} = conn, %{} = params) do
     token = params["token"]
 
@@ -200,6 +204,12 @@ defmodule TransportWeb.ValidationController do
         |> assign(:validation_report_url, validation_report_url)
         |> assign(:xsd_errors, xsd_errors)
         |> render(template)
+
+      %MultiValidation{oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique"}} = validation ->
+        conn
+        |> assign(:summary, validation.result)
+        |> assign(:filename, validation.validated_data_name)
+        |> render("show_irve_statique.html")
 
       # Handles waiting for validation to complete, errors and
       # validation for schemas
@@ -382,12 +392,9 @@ defmodule TransportWeb.ValidationController do
     %{"type" => "gbfs", "state" => "submitted", "feed_url" => url}
   end
 
-  # For IRVE statique, we don’t use Oban to perform validation
-  # This function is just here to log the usage
-  # This allows the feature usage metadata to be different from other TableSchema validations
-  # See TransportWeb.ValidationController.log_usage/2
+  # Used only by log_usage/2 to track feature usage with type metadata.
   defp build_oban_args(%{"type" => "etalab/schema-irve-statique"}) do
-    %{"type" => "irve-statique"}
+    %{"type" => "on-demand-irve-statique"}
   end
 
   defp build_oban_args(%{"type" => type}), do: build_oban_args(type)

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -138,7 +138,6 @@ defmodule TransportWeb.ValidationController do
     redirect(conn, to: validation_path(conn, :show, id, token: token))
   end
 
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def show(%Plug.Conn{} = conn, %{} = params) do
     token = params["token"]
 
@@ -147,82 +146,106 @@ defmodule TransportWeb.ValidationController do
       |> preload(:metadata)
       |> Repo.get(params["id"])
 
-    case validation do
-      nil ->
-        not_found(conn)
+    show_validation(conn, params, token, validation)
+  end
 
-      %MultiValidation{oban_args: %{"secret_url_token" => expected_token}}
-      when expected_token != token ->
-        unauthorized(conn)
+  defp show_validation(conn, _params, _token, nil) do
+    not_found(conn)
+  end
 
-      %MultiValidation{oban_args: %{"state" => "completed"}, binary_result: nil, result: nil} = validation ->
-        conn |> assign(:validation, validation) |> render("expired.html")
+  defp show_validation(conn, _params, token, %MultiValidation{oban_args: %{"secret_url_token" => expected_token}})
+       when expected_token != token do
+    unauthorized(conn)
+  end
 
-      %MultiValidation{oban_args: %{"state" => "completed", "type" => "gtfs"}} = validation ->
-        validator = Transport.Validators.GTFSTransport
-        current_issues = validator.get_issues(validation.result, params)
+  defp show_validation(
+         conn,
+         _params,
+         _token,
+         %MultiValidation{
+           oban_args: %{"state" => "completed"},
+           binary_result: nil,
+           result: nil
+         } = validation
+       ) do
+    conn |> assign(:validation, validation) |> render("expired.html")
+  end
 
-        issue_type =
-          case params["issue_type"] do
-            nil -> validator.issue_type(current_issues)
-            issue_type -> issue_type
-          end
+  defp show_validation(
+         conn,
+         params,
+         _token,
+         %MultiValidation{oban_args: %{"state" => "completed", "type" => "gtfs"}} = validation
+       ) do
+    validator = Transport.Validators.GTFSTransport
+    current_issues = validator.get_issues(validation.result, params)
 
-        conn
-        |> assign_base_validation_details(params)
-        |> assign(:issues, Scrivener.paginate(current_issues, make_pagination_config(params)))
-        |> assign(:validator, validator)
-        |> assign(:metadata, validation.metadata.metadata)
-        |> assign(:modes, validation.metadata.modes)
-        |> assign(:data_vis, data_vis(validation, issue_type))
-        |> assign(:validation_summary, validator.summary(validation.result))
-        |> assign(:severities_count, validator.count_by_severity(validation.result))
-        |> render("show_gtfs.html")
+    issue_type =
+      case params["issue_type"] do
+        nil -> validator.issue_type(current_issues)
+        issue_type -> issue_type
+      end
 
-      %MultiValidation{oban_args: %{"state" => "completed", "type" => "netex"}} = validation ->
-        config = make_pagination_config(params)
+    conn
+    |> assign_base_validation_details(params)
+    |> assign(:issues, Scrivener.paginate(current_issues, make_pagination_config(params)))
+    |> assign(:validator, validator)
+    |> assign(:metadata, validation.metadata.metadata)
+    |> assign(:modes, validation.metadata.modes)
+    |> assign(:data_vis, data_vis(validation, issue_type))
+    |> assign(:validation_summary, validator.summary(validation.result))
+    |> assign(:severities_count, validator.count_by_severity(validation.result))
+    |> render("show_gtfs.html")
+  end
 
-        results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(validation.validator_version)
+  defp show_validation(
+         conn,
+         params,
+         _token,
+         %MultiValidation{oban_args: %{"state" => "completed", "type" => "netex"}} = validation
+       ) do
+    config = make_pagination_config(params)
+    results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(validation.validator_version)
+    template = pick_netex_template(validation.validator_version)
+    pagination_config = make_pagination_config(params, @netex_issues_page_size)
+    {filter, pagination} = results_adapter.get_issues(validation.binary_result, params, pagination_config)
+    validation_report_url = validation_url(conn, :download_validation_report, validation.id, token: params["token"])
+    xsd_errors = results_adapter.summarize_xsd_errors(validation.binary_result)
 
-        template = pick_netex_template(validation.validator_version)
+    conn
+    |> assign_base_validation_details(params)
+    |> assign(:filter, filter)
+    |> assign(:issues, TransportWeb.ResourceController.paginate_netex_results(pagination, config))
+    |> assign(:results_adapter, results_adapter)
+    |> assign(:metadata, validation.metadata.metadata)
+    |> assign(:max_severity, validation.digest["max_severity"])
+    |> assign(:validation_summary, validation.digest["summary"])
+    |> assign(:severities_count, validation.digest["stats"])
+    |> assign(:validation_report_url, validation_report_url)
+    |> assign(:xsd_errors, xsd_errors)
+    |> render(template)
+  end
 
-        pagination_config = make_pagination_config(params, @netex_issues_page_size)
-        {filter, pagination} = results_adapter.get_issues(validation.binary_result, params, pagination_config)
+  defp show_validation(
+         conn,
+         _params,
+         _token,
+         %MultiValidation{oban_args: %{"state" => "completed", "type" => "irve-statique"}} = validation
+       ) do
+    conn
+    |> assign(:summary, validation.result)
+    |> assign(:filename, validation.validated_data_name)
+    |> render("show_irve_statique.html")
+  end
 
-        validation_report_url = validation_url(conn, :download_validation_report, validation.id, token: params["token"])
-
-        xsd_errors = results_adapter.summarize_xsd_errors(validation.binary_result)
-
-        conn
-        |> assign_base_validation_details(params)
-        |> assign(:filter, filter)
-        |> assign(:issues, TransportWeb.ResourceController.paginate_netex_results(pagination, config))
-        |> assign(:results_adapter, results_adapter)
-        |> assign(:metadata, validation.metadata.metadata)
-        |> assign(:max_severity, validation.digest["max_severity"])
-        |> assign(:validation_summary, validation.digest["summary"])
-        |> assign(:severities_count, validation.digest["stats"])
-        |> assign(:validation_report_url, validation_report_url)
-        |> assign(:xsd_errors, xsd_errors)
-        |> render(template)
-
-      %MultiValidation{oban_args: %{"state" => "completed", "type" => "irve-statique"}} = validation ->
-        conn
-        |> assign(:summary, validation.result)
-        |> assign(:filename, validation.validated_data_name)
-        |> render("show_irve_statique.html")
-
-      # Handles waiting for validation to complete, errors and
-      # validation for schemas
-      _ ->
-        live_render(conn, TransportWeb.Live.OnDemandValidationLive,
-          session: %{
-            "validation_id" => params["id"],
-            "issue_type" => params["issue_type"],
-            "current_url" => validation_path(conn, :show, params["id"], token: token)
-          }
-        )
-    end
+  defp show_validation(conn, params, token, _validation) do
+    live_render(conn, TransportWeb.Live.OnDemandValidationLive,
+      session: %{
+        "validation_id" => params["id"],
+        "issue_type" => params["issue_type"],
+        "current_url" => validation_path(conn, :show, params["id"], token: token)
+      }
+    )
   end
 
   def download_validation_report(%Plug.Conn{method: "GET"} = conn, %{} = params) do

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -60,8 +60,10 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
-  # This clause intercepts IRVE statique validation instead of sending to Validata like other TableSchema validations
-  # IRVE statique validation doesn’t use an Oban job, as it’s quick enough so that it can be done synchronously.
+  # This clause intercepts IRVE statique validation instead of sending to Validata like other TableSchema validations.
+  # IRVE statique validation doesn’t use an Oban job, as it’s quick enough so that it can be done synchronously,
+  # and it avoids passing files through S3 between servers.
+  # To be noted: the validation is processed directly on the web server.
   def validate(%Plug.Conn{} = conn, %{
         "upload" => %{"file" => %{path: file_path, filename: filename}, "type" => "etalab/schema-irve-statique"}
       }) do

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -60,8 +60,8 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
-  # Intercepts IRVE before it falls through to the TableSchema path, because
-  # it uses a dedicated validator and oban_args format.
+  # This clause intercepts IRVE statique validation instead of sending to Validata like other TableSchema validations
+  # IRVE statique validation doesn’t use an Oban job, as it’s quick enough so that it can be done synchronously.
   def validate(%Plug.Conn{} = conn, %{
         "upload" => %{"file" => %{path: file_path, filename: filename}, "type" => "etalab/schema-irve-statique"}
       }) do
@@ -392,7 +392,10 @@ defmodule TransportWeb.ValidationController do
     %{"type" => "gbfs", "state" => "submitted", "feed_url" => url}
   end
 
-  # Used only by log_usage/2 to track feature usage with type metadata.
+  # For IRVE statique, we don’t use Oban to perform validation
+  # This function is just here to log the usage
+  # This allows the feature usage metadata to be different from other TableSchema validations
+  # See TransportWeb.ValidationController.log_usage/2
   defp build_oban_args(%{"type" => "etalab/schema-irve-statique"}) do
     %{"type" => "on-demand-irve-statique"}
   end

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -60,41 +60,16 @@ defmodule TransportWeb.ValidationController do
     end
   end
 
-  # This clause intercepts IRVE statique validation instead of sending to Validata like other TableSchema validations.
-  # IRVE statique validation doesn’t use an Oban job, as it’s quick enough so that it can be done synchronously,
-  # and it avoids passing files through S3 between servers.
-  # To be noted: the validation is processed directly on the web server.
+  # This clause intercepts IRVE statique validation instead of routing it to Validata like the other
+  # TableSchema validations, running it synchronously on the web server (which enables the permalink below)
+  # rather than on a worker. The catch: it takes an order of magnitude more RAM than the raw CSV (at time of
+  # writing), and the web node should stay isolated from that pressure to keep serving requests, so it would
+  # be a good idea not to reproduce this pattern:
+  # https://github.com/etalab/transport-site/pull/5524#pullrequestreview-4407262217
   def validate(%Plug.Conn{} = conn, %{
         "upload" => %{"file" => %{path: file_path, filename: filename}, "type" => "etalab/schema-irve-statique"}
       }) do
-    if File.stat!(file_path).size > @max_irve_file_size_bytes do
-      conn
-      |> put_flash(
-        :error,
-        dgettext("validations", "File is too large, must be <%{max_file_size}.",
-          max_file_size: Sizeable.filesize(@max_irve_file_size_bytes)
-        )
-      )
-      |> redirect(
-        to: live_path(conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "etalab/schema-irve-statique")
-      )
-    else
-      token = Ecto.UUID.generate()
-      summary = Transport.IRVE.Validator.validate_and_summarize(file_path, irve_extension(filename))
-
-      validation =
-        %MultiValidation{
-          validator: "on-demand-irve-statique",
-          validation_timestamp: DateTime.utc_now(),
-          # This is needed as the #show route patterns match on secret_url_token
-          oban_args: %{"type" => "irve-statique", "state" => "completed", "secret_url_token" => token},
-          result: Map.from_struct(summary),
-          validated_data_name: filename || "upload.csv"
-        }
-        |> Repo.insert!()
-
-      redirect_to_validation_show(conn, validation)
-    end
+    validate_irve_statique(conn, file_path, filename, File.stat!(file_path).size)
   end
 
   def validate(%Plug.Conn{} = conn, %{
@@ -124,6 +99,36 @@ defmodule TransportWeb.ValidationController do
     conn |> bad_request()
   end
 
+  defp validate_irve_statique(conn, _file_path, _filename, size) when size > @max_irve_file_size_bytes do
+    conn
+    |> put_flash(
+      :error,
+      dgettext("validations", "File is too large, must be <%{max_file_size}.",
+        max_file_size: Sizeable.filesize(@max_irve_file_size_bytes)
+      )
+    )
+    |> redirect(
+      to: live_path(conn, TransportWeb.Live.OnDemandValidationSelectLive, type: "etalab/schema-irve-statique")
+    )
+  end
+
+  defp validate_irve_statique(conn, file_path, filename, _size) do
+    summary = Transport.IRVE.Validator.validate_and_summarize(file_path, irve_extension(filename))
+
+    validation =
+      %MultiValidation{
+        validator: "on-demand-irve-statique",
+        validation_timestamp: DateTime.utc_now(),
+        # The #show route patterns match on secret_url_token
+        oban_args: %{"type" => "irve-statique", "state" => "completed", "secret_url_token" => Ecto.UUID.generate()},
+        result: Map.from_struct(summary),
+        validated_data_name: filename || "upload.csv"
+      }
+      |> Repo.insert!()
+
+    redirect_to_validation_show(conn, validation)
+  end
+
   defp irve_extension(filename) when is_binary(filename) and filename != "" do
     case Path.extname(filename) do
       "" -> ".csv"
@@ -148,106 +153,78 @@ defmodule TransportWeb.ValidationController do
       |> preload(:metadata)
       |> Repo.get(params["id"])
 
-    show_validation(conn, params, token, validation)
-  end
+    case validation do
+      nil ->
+        not_found(conn)
 
-  defp show_validation(conn, _params, _token, nil) do
-    not_found(conn)
-  end
+      %MultiValidation{oban_args: %{"secret_url_token" => expected_token}}
+      when expected_token != token ->
+        unauthorized(conn)
 
-  defp show_validation(conn, _params, token, %MultiValidation{oban_args: %{"secret_url_token" => expected_token}})
-       when expected_token != token do
-    unauthorized(conn)
-  end
+      %MultiValidation{oban_args: %{"state" => "completed"}, binary_result: nil, result: nil} = validation ->
+        conn |> assign(:validation, validation) |> render("expired.html")
 
-  defp show_validation(
-         conn,
-         _params,
-         _token,
-         %MultiValidation{
-           oban_args: %{"state" => "completed"},
-           binary_result: nil,
-           result: nil
-         } = validation
-       ) do
-    conn |> assign(:validation, validation) |> render("expired.html")
-  end
+      %MultiValidation{oban_args: %{"state" => "completed", "type" => "gtfs"}} = validation ->
+        validator = Transport.Validators.GTFSTransport
+        current_issues = validator.get_issues(validation.result, params)
 
-  defp show_validation(
-         conn,
-         params,
-         _token,
-         %MultiValidation{oban_args: %{"state" => "completed", "type" => "gtfs"}} = validation
-       ) do
-    validator = Transport.Validators.GTFSTransport
-    current_issues = validator.get_issues(validation.result, params)
+        issue_type = params["issue_type"] || validator.issue_type(current_issues)
 
-    issue_type =
-      case params["issue_type"] do
-        nil -> validator.issue_type(current_issues)
-        issue_type -> issue_type
-      end
+        conn
+        |> assign_base_validation_details(params)
+        |> assign(:issues, Scrivener.paginate(current_issues, make_pagination_config(params)))
+        |> assign(:validator, validator)
+        |> assign(:metadata, validation.metadata.metadata)
+        |> assign(:modes, validation.metadata.modes)
+        |> assign(:data_vis, data_vis(validation, issue_type))
+        |> assign(:validation_summary, validator.summary(validation.result))
+        |> assign(:severities_count, validator.count_by_severity(validation.result))
+        |> render("show_gtfs.html")
 
-    conn
-    |> assign_base_validation_details(params)
-    |> assign(:issues, Scrivener.paginate(current_issues, make_pagination_config(params)))
-    |> assign(:validator, validator)
-    |> assign(:metadata, validation.metadata.metadata)
-    |> assign(:modes, validation.metadata.modes)
-    |> assign(:data_vis, data_vis(validation, issue_type))
-    |> assign(:validation_summary, validator.summary(validation.result))
-    |> assign(:severities_count, validator.count_by_severity(validation.result))
-    |> render("show_gtfs.html")
-  end
+      %MultiValidation{oban_args: %{"state" => "completed", "type" => "netex"}} = validation ->
+        config = make_pagination_config(params)
 
-  defp show_validation(
-         conn,
-         params,
-         _token,
-         %MultiValidation{oban_args: %{"state" => "completed", "type" => "netex"}} = validation
-       ) do
-    config = make_pagination_config(params)
-    results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(validation.validator_version)
-    template = pick_netex_template(validation.validator_version)
-    pagination_config = make_pagination_config(params, @netex_issues_page_size)
-    {filter, pagination} = results_adapter.get_issues(validation.binary_result, params, pagination_config)
-    validation_report_url = validation_url(conn, :download_validation_report, validation.id, token: params["token"])
-    xsd_errors = results_adapter.summarize_xsd_errors(validation.binary_result)
+        results_adapter = Transport.Validators.NeTEx.ResultsAdapter.resolve(validation.validator_version)
 
-    conn
-    |> assign_base_validation_details(params)
-    |> assign(:filter, filter)
-    |> assign(:issues, TransportWeb.ResourceController.paginate_netex_results(pagination, config))
-    |> assign(:results_adapter, results_adapter)
-    |> assign(:metadata, validation.metadata.metadata)
-    |> assign(:max_severity, validation.digest["max_severity"])
-    |> assign(:validation_summary, validation.digest["summary"])
-    |> assign(:severities_count, validation.digest["stats"])
-    |> assign(:validation_report_url, validation_report_url)
-    |> assign(:xsd_errors, xsd_errors)
-    |> render(template)
-  end
+        template = pick_netex_template(validation.validator_version)
 
-  defp show_validation(
-         conn,
-         _params,
-         _token,
-         %MultiValidation{oban_args: %{"state" => "completed", "type" => "irve-statique"}} = validation
-       ) do
-    conn
-    |> assign(:summary, validation.result)
-    |> assign(:filename, validation.validated_data_name)
-    |> render("show_irve_statique.html")
-  end
+        pagination_config = make_pagination_config(params, @netex_issues_page_size)
+        {filter, pagination} = results_adapter.get_issues(validation.binary_result, params, pagination_config)
 
-  defp show_validation(conn, params, token, _validation) do
-    live_render(conn, TransportWeb.Live.OnDemandValidationLive,
-      session: %{
-        "validation_id" => params["id"],
-        "issue_type" => params["issue_type"],
-        "current_url" => validation_path(conn, :show, params["id"], token: token)
-      }
-    )
+        validation_report_url = validation_url(conn, :download_validation_report, validation.id, token: params["token"])
+
+        xsd_errors = results_adapter.summarize_xsd_errors(validation.binary_result)
+
+        conn
+        |> assign_base_validation_details(params)
+        |> assign(:filter, filter)
+        |> assign(:issues, TransportWeb.ResourceController.paginate_netex_results(pagination, config))
+        |> assign(:results_adapter, results_adapter)
+        |> assign(:metadata, validation.metadata.metadata)
+        |> assign(:max_severity, validation.digest["max_severity"])
+        |> assign(:validation_summary, validation.digest["summary"])
+        |> assign(:severities_count, validation.digest["stats"])
+        |> assign(:validation_report_url, validation_report_url)
+        |> assign(:xsd_errors, xsd_errors)
+        |> render(template)
+
+      %MultiValidation{oban_args: %{"state" => "completed", "type" => "irve-statique"}} = validation ->
+        conn
+        |> assign(:summary, Transport.IRVE.Validator.Summary.from_result(validation.result))
+        |> assign(:filename, validation.validated_data_name)
+        |> render("show_irve_statique.html")
+
+      # Handles waiting for validation to complete, errors and
+      # validation for schemas
+      _ ->
+        live_render(conn, TransportWeb.Live.OnDemandValidationLive,
+          session: %{
+            "validation_id" => params["id"],
+            "issue_type" => params["issue_type"],
+            "current_url" => validation_path(conn, :show, params["id"], token: token)
+          }
+        )
+    end
   end
 
   def download_validation_report(%Plug.Conn{method: "GET"} = conn, %{} = params) do
@@ -418,6 +395,14 @@ defmodule TransportWeb.ValidationController do
     %{"type" => "gbfs", "state" => "submitted", "feed_url" => url}
   end
 
+  # For IRVE statique, we don’t use Oban to perform validation
+  # This function is just here to log the usage
+  # This allows the feature usage metadata to be different from other TableSchema validations
+  # See TransportWeb.ValidationController.log_usage/2
+  defp build_oban_args(%{"type" => "etalab/schema-irve-statique"}) do
+    %{"type" => "irve-statique"}
+  end
+
   defp build_oban_args(%{"type" => type}), do: build_oban_args(type)
 
   defp build_oban_args(type) do
@@ -478,16 +463,10 @@ defmodule TransportWeb.ValidationController do
     DB.FeatureUsage.insert!(
       :on_demand_validation,
       get_in(conn.assigns.current_contact.id),
-      type_and_schema_for_stats(conn.params["upload"])
+      build_oban_args(conn.params["upload"])
+      |> Map.take(["type", "schema_name"])
     )
 
     conn
-  end
-
-  defp type_and_schema_for_stats(upload_params) do
-    case upload_params do
-      %{"type" => "etalab/schema-irve-statique"} -> %{"type" => "irve-statique"}
-      _ -> build_oban_args(upload_params) |> Map.take(["type", "schema_name"])
-    end
   end
 end

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -393,14 +393,6 @@ defmodule TransportWeb.ValidationController do
     %{"type" => "gbfs", "state" => "submitted", "feed_url" => url}
   end
 
-  # For IRVE statique, we don’t use Oban to perform validation
-  # This function is just here to log the usage
-  # This allows the feature usage metadata to be different from other TableSchema validations
-  # See TransportWeb.ValidationController.log_usage/2
-  defp build_oban_args(%{"type" => "etalab/schema-irve-statique"}) do
-    %{"type" => "irve-statique"}
-  end
-
   defp build_oban_args(%{"type" => type}), do: build_oban_args(type)
 
   defp build_oban_args(type) do
@@ -458,16 +450,19 @@ defmodule TransportWeb.ValidationController do
   def temporary_on_demand_validator_name, do: "on demand validation requested"
 
   defp log_usage(%Plug.Conn{} = conn, _options) do
-    # dbg(conn)
-
     DB.FeatureUsage.insert!(
       :on_demand_validation,
       get_in(conn.assigns.current_contact.id),
-      build_oban_args(conn.params["upload"])
-      |> Map.take(["type", "schema_name"])
-      # |> dbg()
+      type_and_schema_for_stats(conn.params["upload"])
     )
 
     conn
+  end
+
+  defp type_and_schema_for_stats(upload_params) do
+    case upload_params do
+      %{"type" => "etalab/schema-irve-statique"} -> %{"type" => "irve-statique"}
+      _ -> build_oban_args(upload_params) |> Map.take(["type", "schema_name"])
+    end
   end
 end

--- a/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
@@ -2,9 +2,6 @@
   <div class="container">
     <div class="validation-title">
       <h2>{dgettext("validations", "IRVE Statique validation report")}</h2>
-      <p>
-        {dgettext("validations", "Validation file")}: <b>{@filename}</b>
-      </p>
       <p class="notification">
         {dgettext("validations", "This validation now uses our integrated IRVE Statique validator.")}
         {" "}
@@ -15,6 +12,16 @@
             url: "https://validata.fr/table-schema?schema_name=schema-datagouvfr.etalab%2Fschema-irve-statique"
           )
         )}
+      </p>
+      <p>
+        {dgettext("validations", "Validation file")}: <b>{@filename}</b>
+      </p>
+      <p>
+        {dgettext("validations", "This report can be shared with")}
+        {link(dgettext("validations", "this permanent link"), to: current_url(@conn))}
+        {dgettext("validations", "during %{retention_days} days",
+          retention_days: Transport.Jobs.CleanOnDemandValidationJob.retention_days()
+        )}.
       </p>
     </div>
   </div>

--- a/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
@@ -24,7 +24,7 @@
       <div class="panel">
         <p>
           <b>
-            <%= if @summary.valid do %>
+            <%= if @summary["valid"] do %>
               <span class="icon--validation">✅</span>{dgettext("validations", "No error detected")}
             <% else %>
               <span class="icon--validation">❌</span>{dgettext("validations", "Invalid file")}
@@ -32,30 +32,30 @@
           </b>
         </p>
 
-        <%= if is_nil(@summary.total_row_count) do %>
+        <%= if is_nil(@summary["total_row_count"]) do %>
           <p>{dgettext("validations", "Could not validate file rows because of file-level errors.")}</p>
         <% else %>
           <ul>
             <li>
-              {dgettext("validations", "Total rows")}: {@summary.total_row_count}
+              {dgettext("validations", "Total rows")}: {@summary["total_row_count"]}
             </li>
             <li>
-              {dgettext("validations", "Valid rows")}: {@summary.valid_row_count}
+              {dgettext("validations", "Valid rows")}: {@summary["valid_row_count"]}
             </li>
             <li>
-              {dgettext("validations", "Invalid rows")}: {@summary.invalid_row_count}
+              {dgettext("validations", "Invalid rows")}: {@summary["invalid_row_count"]}
             </li>
           </ul>
         <% end %>
 
-        <%= unless Enum.empty?(@summary.file_level_errors) do %>
+        <%= unless Enum.empty?(@summary["file_level_errors"]) do %>
           <h4>{dgettext("validations", "File-level errors")}</h4>
           <ul>
-            <li :for={error <- @summary.file_level_errors}>{error}</li>
+            <li :for={error <- @summary["file_level_errors"]}>{error}</li>
           </ul>
         <% end %>
 
-        <%= unless Enum.empty?(@summary.column_errors) do %>
+        <%= unless Enum.empty?(@summary["column_errors"]) do %>
           <h4>{dgettext("validations", "Errors by column")}</h4>
           <table class="table">
             <thead>
@@ -65,7 +65,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr :for={{column, error_count} <- Enum.sort_by(@summary.column_errors, &elem(&1, 0))}>
+              <tr :for={{column, error_count} <- Enum.sort_by(@summary["column_errors"], &elem(&1, 0))}>
                 <td>{column}</td>
                 <td>{error_count}</td>
               </tr>
@@ -73,7 +73,7 @@
           </table>
         <% end %>
 
-        <%= unless Enum.empty?(@summary.error_samples) do %>
+        <%= unless Enum.empty?(@summary["error_samples"]) do %>
           <h4>{dgettext("validations", "Error samples")}</h4>
           <table class="table">
             <thead>
@@ -84,10 +84,10 @@
               </tr>
             </thead>
             <tbody>
-              <tr :for={sample <- @summary.error_samples}>
-                <td>{sample.id_pdc_itinerance}</td>
-                <td>{sample.column}</td>
-                <td>{sample.value}</td>
+              <tr :for={sample <- @summary["error_samples"]}>
+                <td>{sample["id_pdc_itinerance"]}</td>
+                <td>{sample["column"]}</td>
+                <td>{sample["value"]}</td>
               </tr>
             </tbody>
           </table>

--- a/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
@@ -31,7 +31,7 @@
       <div class="panel">
         <p>
           <b>
-            <%= if @summary["valid"] do %>
+            <%= if @summary.valid do %>
               <span class="icon--validation">✅</span>{dgettext("validations", "No error detected")}
             <% else %>
               <span class="icon--validation">❌</span>{dgettext("validations", "Invalid file")}
@@ -39,30 +39,30 @@
           </b>
         </p>
 
-        <%= if is_nil(@summary["total_row_count"]) do %>
+        <%= if is_nil(@summary.total_row_count) do %>
           <p>{dgettext("validations", "Could not validate file rows because of file-level errors.")}</p>
         <% else %>
           <ul>
             <li>
-              {dgettext("validations", "Total rows")}: {@summary["total_row_count"]}
+              {dgettext("validations", "Total rows")}: {@summary.total_row_count}
             </li>
             <li>
-              {dgettext("validations", "Valid rows")}: {@summary["valid_row_count"]}
+              {dgettext("validations", "Valid rows")}: {@summary.valid_row_count}
             </li>
             <li>
-              {dgettext("validations", "Invalid rows")}: {@summary["invalid_row_count"]}
+              {dgettext("validations", "Invalid rows")}: {@summary.invalid_row_count}
             </li>
           </ul>
         <% end %>
 
-        <%= unless Enum.empty?(@summary["file_level_errors"]) do %>
+        <%= unless Enum.empty?(@summary.file_level_errors) do %>
           <h4>{dgettext("validations", "File-level errors")}</h4>
           <ul>
-            <li :for={error <- @summary["file_level_errors"]}>{error}</li>
+            <li :for={error <- @summary.file_level_errors}>{error}</li>
           </ul>
         <% end %>
 
-        <%= unless Enum.empty?(@summary["column_errors"]) do %>
+        <%= unless Enum.empty?(@summary.column_errors) do %>
           <h4>{dgettext("validations", "Errors by column")}</h4>
           <table class="table">
             <thead>
@@ -72,7 +72,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr :for={{column, error_count} <- Enum.sort_by(@summary["column_errors"], &elem(&1, 0))}>
+              <tr :for={{column, error_count} <- Enum.sort_by(@summary.column_errors, &elem(&1, 0))}>
                 <td>{column}</td>
                 <td>{error_count}</td>
               </tr>
@@ -80,7 +80,7 @@
           </table>
         <% end %>
 
-        <%= unless Enum.empty?(@summary["error_samples"]) do %>
+        <%= unless Enum.empty?(@summary.error_samples) do %>
           <h4>{dgettext("validations", "Error samples")}</h4>
           <table class="table">
             <thead>
@@ -91,10 +91,10 @@
               </tr>
             </thead>
             <tbody>
-              <tr :for={sample <- @summary["error_samples"]}>
-                <td>{sample["id_pdc_itinerance"]}</td>
-                <td>{sample["column"]}</td>
-                <td>{sample["value"]}</td>
+              <tr :for={sample <- @summary.error_samples}>
+                <td>{sample.id_pdc_itinerance}</td>
+                <td>{sample.column}</td>
+                <td>{sample.value}</td>
               </tr>
             </tbody>
           </table>

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -256,7 +256,7 @@ defmodule TransportWeb.ValidationControllerTest do
         assert 1 == count_validations()
 
         assert %{
-                 oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique", "secret_url_token" => token},
+                 oban_args: %{"state" => "completed", "type" => "irve-statique", "secret_url_token" => token},
                  result: %{"valid" => true},
                  validator: "on-demand-irve-statique",
                  validated_data_name: "irve.csv",
@@ -270,7 +270,7 @@ defmodule TransportWeb.ValidationControllerTest do
                  %DB.FeatureUsage{
                    feature: :on_demand_validation,
                    contact_id: nil,
-                   metadata: %{"type" => "on-demand-irve-statique"}
+                   metadata: %{"type" => "irve-statique"}
                  }
                ] = DB.FeatureUsage |> DB.Repo.all()
       end)
@@ -294,7 +294,7 @@ defmodule TransportWeb.ValidationControllerTest do
         assert 1 == count_validations()
 
         assert %{
-                 oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique"},
+                 oban_args: %{"state" => "completed", "type" => "irve-statique"},
                  result: %{"valid" => false}
                } = DB.MultiValidation.with_result() |> DB.Repo.one!()
 
@@ -827,7 +827,7 @@ defmodule TransportWeb.ValidationControllerTest do
         insert(:multi_validation,
           oban_args: %{
             "state" => "completed",
-            "type" => "on-demand-irve-statique",
+            "type" => "irve-statique",
             "secret_url_token" => token
           },
           result: %{

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -253,17 +253,24 @@ defmodule TransportWeb.ValidationControllerTest do
             }
           })
 
-        response = html_response(conn, 200)
-        assert response =~ "icon--validation\">✅</span>"
-        assert response =~ "validata.fr/table-schema"
+        assert 1 == count_validations()
 
-        assert 0 == count_validations()
+        assert %{
+                 oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique", "secret_url_token" => token},
+                 result: %{"valid" => true},
+                 validator: "on-demand-irve-statique",
+                 validated_data_name: "irve.csv",
+                 id: validation_id
+               } = DB.MultiValidation.with_result() |> DB.Repo.one!()
+
+        assert [] == all_enqueued(worker: Transport.Jobs.OnDemandValidationJob, queue: :on_demand_validation)
+        assert redirected_to(conn, 302) == validation_path(conn, :show, validation_id, token: token)
 
         assert [
                  %DB.FeatureUsage{
                    feature: :on_demand_validation,
                    contact_id: nil,
-                   metadata: %{"type" => "irve-statique"}
+                   metadata: %{"type" => "on-demand-irve-statique"}
                  }
                ] = DB.FeatureUsage |> DB.Repo.all()
       end)
@@ -284,11 +291,14 @@ defmodule TransportWeb.ValidationControllerTest do
             }
           })
 
-        response = html_response(conn, 200)
-        assert response =~ "icon--validation\">❌</span>"
-        assert response =~ "puissance_nominale"
+        assert 1 == count_validations()
 
-        assert 0 == count_validations()
+        assert %{
+                 oban_args: %{"state" => "completed", "type" => "on-demand-irve-statique"},
+                 result: %{"valid" => false}
+               } = DB.MultiValidation.with_result() |> DB.Repo.one!()
+
+        assert redirected_to(conn, 302) =~ "/validation/"
       end)
     end
 
@@ -808,6 +818,34 @@ defmodule TransportWeb.ValidationControllerTest do
 
       assert render(view) =~ "2 erreurs"
       assert render(view) =~ "Value is not allowed in enum."
+    end
+
+    test "with a completed IRVE Statique validation", %{conn: conn} do
+      token = Ecto.UUID.generate()
+
+      mv =
+        insert(:multi_validation,
+          oban_args: %{
+            "state" => "completed",
+            "type" => "on-demand-irve-statique",
+            "secret_url_token" => token
+          },
+          result: %{
+            "valid" => true,
+            "valid_row_count" => 1,
+            "invalid_row_count" => 0,
+            "total_row_count" => 1,
+            "file_level_errors" => [],
+            "column_errors" => %{},
+            "error_samples" => []
+          },
+          validated_data_name: "irve.csv"
+        )
+
+      response = conn |> get(validation_path(conn, :show, mv.id, token: token)) |> html_response(200)
+      assert response =~ "icon--validation\">✅</span>"
+      assert response =~ "validata.fr/table-schema"
+      assert response =~ "irve.csv"
     end
 
     test "with a GTFS-RT validation", %{conn: conn} do


### PR DESCRIPTION
Cette PR permet de créer un lien permanent pour la validation IRVE, dont les résultats sont désormais stockés en base (dans une Multivalidation).

<img width="2877" height="1440" alt="image" src="https://github.com/user-attachments/assets/679080ce-1e46-4272-b40f-19eea43ca95b" />

## Note technique

Au début j’avais envisagé «d’harmoniser» comme les autres validations à la demande avec un job Oban qui processe la Multivalidation. Sauf que ça fait recevoir le fichier en cache en local sur le serveur web, l’uploader sur S3, puis le retélécharger sur le worker en local pour faire tourner la validation, et enfin effacer le cache local sur le worker et sur S3… Et tout ça avec du code custom, puisque chaque validateur fonctionne séparément, et que le job de validation à la demande est différent du job de validation sur les resources référencées par le PAN. Du coup je me suis dit que le jeu n’en valait pas la chandelle. 

J’ai du code qui marche avec un job Oban, mais ça rajoute de la complexité pour rien.

PR créée avec Santa Claude :robot:, relecture attentive avant de committer, correction manuelle.