### PR TITLE
Arrêt du job de consolidation brute

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,7 +185,6 @@ oban_prod_crontab = [
   {"0 8 * * *", Transport.Jobs.WarnUserInactivityJob},
   {"*/5 * * * *", Transport.Jobs.UpdateCounterCacheJob},
   {"0 4 * * *", Transport.Jobs.StopsRegistrySnapshotJob},
-  {"30 2 * * *", Transport.Jobs.IRVERawConsolidationJob},
   {"45 4 * * *", Transport.Jobs.IRVESimpleConsolidationJob},
   {"10 * * * *", Transport.Jobs.DefaultTokensJob},
   {"0 2 * * *", Transport.Jobs.CleanOnDemandValidationJob},


### PR DESCRIPTION
Je vais prochainement supprimer le code de la consolidation brute IRVE et la démantibuler en gardant les parties utiles pour la consolidation définitive.

Afin d’être tranquille pour mon travail de suppression de code et de refactoring, une première étape est de désactiver le job nocturne de consolidation brute (non validée, qui tournait encore en parrallèle de la consolidation normale), ce que fait cette PR.

@stephane-pignal