### PR TITLE
IRVE : utilisation de floats en base de données pour la valeur puissance_nominale

### DIFF
--- a/apps/transport/lib/db/irve_valid_pdc.ex
+++ b/apps/transport/lib/db/irve_valid_pdc.ex
@@ -31,7 +31,7 @@ defmodule DB.IRVEValidPDC do
     field(:nbre_pdc, :integer, null: false)
     field(:id_pdc_itinerance, :string, null: false)
     field(:id_pdc_local, :string)
-    field(:puissance_nominale, :decimal, null: false)
+    field(:puissance_nominale, :float, null: false)
     field(:prise_type_ef, :boolean, null: false)
     field(:prise_type_2, :boolean, null: false)
     field(:prise_type_combo_ccs, :boolean, null: false)

--- a/apps/transport/lib/irve/data_frame.ex
+++ b/apps/transport/lib/irve/data_frame.ex
@@ -116,17 +116,9 @@ defmodule Transport.IRVE.DataFrame do
 
   Congratulations for reading this far.
   """
+
   def dataframe_from_csv_body!(body, schema \\ Transport.IRVE.StaticIRVESchema.schema_content(), strict \\ true) do
-    dtypes =
-      schema
-      |> Map.fetch!("fields")
-      |> Enum.map(fn %{"name" => name, "type" => type} ->
-        {
-          String.to_atom(name),
-          String.to_atom(type)
-          |> Transport.IRVE.DataFrame.remap_schema_type(strict)
-        }
-      end)
+    dtypes = schema_dtypes(schema, strict)
 
     delimiter = guess_delimiter!(body)
 
@@ -135,6 +127,26 @@ defmodule Transport.IRVE.DataFrame do
       {:ok, df} -> df
       {:error, error} -> raise(error)
     end
+  end
+
+  @doc """
+  Computes Explorer dtypes from a TableSchema, using `remap_schema_type/2`.
+
+  iex> Transport.IRVE.DataFrame.schema_dtypes() |> Keyword.fetch!(:puissance_nominale)
+  {:f, 64}
+  iex> Transport.IRVE.DataFrame.schema_dtypes() |> Keyword.fetch!(:id_pdc_itinerance)
+  :string
+  """
+  def schema_dtypes(schema \\ Transport.IRVE.StaticIRVESchema.schema_content(), strict \\ true) do
+    schema
+    |> Map.fetch!("fields")
+    |> Enum.map(fn %{"name" => name, "type" => type} ->
+      {
+        String.to_atom(name),
+        String.to_atom(type)
+        |> Transport.IRVE.DataFrame.remap_schema_type(strict)
+      }
+    end)
   end
 
   defmodule ColumnDelimiterGuessError do

--- a/apps/transport/lib/irve/database_exporter.ex
+++ b/apps/transport/lib/irve/database_exporter.ex
@@ -30,7 +30,7 @@ defmodule Transport.IRVE.DatabaseExporter do
             stream
             |> Stream.map(&Map.merge(elem(&1, 0), elem(&1, 1)))
             |> Enum.into([])
-            |> Explorer.DataFrame.new()
+            |> Explorer.DataFrame.new(dtypes: Transport.IRVE.DataFrame.schema_dtypes())
 
           {:ok, result}
         end,

--- a/apps/transport/priv/repo/migrations/20260605083835_change_irve_puissance_nominale_to_float.exs
+++ b/apps/transport/priv/repo/migrations/20260605083835_change_irve_puissance_nominale_to_float.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.ChangeIrvePuissanceNominaleToFloat do
+  use Ecto.Migration
+
+  def change do
+    alter table(:irve_valid_pdc) do
+      modify(:puissance_nominale, :float, from: :decimal)
+    end
+  end
+end


### PR DESCRIPTION
@stephane-pignal m’a alerté sur le fait que la puissance nominale dans le fichier de consolidation comportait des zéros inutiles après le séparateur décimal, comme `22.00000000`.

Cela était causé par le fait que cette valeur était stockée sous forme de decimal dans la base de donnée Postgres, qui ensuite était castée en `Ecto.Decimal{}` par Ecto, puis par la librairie Explorer dans son propre type Decimal (on ne spécifiait pas de types lors de la création du Dataframe exporté de la base de données, Explorer ne faisait qu’inférer à partir des types Elixir), ce qui donne ces zéros dans l’export csv.

Or en pratique, avant l’import en base de données, on castait déjà les données brutes en float lors de la création du dataframe, ici :

https://github.com/etalab/transport-site/blob/29de3167bb4c55c90d0f8630e5b2691ea9237dcc/apps/transport/lib/irve/data_frame.ex#L50

Puisque cette donnée était traitée comme un float, j’ai aligné le typage de la base de données sur le schéma et les dtypes utilisés. Par ailleurs, la retransformation de la base de données en dataframe utilise maintenant les mêmes dtypes que l’opération inverse.