### PR TITLE
Mise à jour de protobuf

### DIFF
--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
@@ -1,11 +1,7 @@
 defmodule TransitRealtime.FeedHeader.Incrementality do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.FeedHeader.Incrementality",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:FULL_DATASET, 0)
   field(:DIFFERENTIAL, 1)
@@ -14,11 +10,7 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:SKIPPED, 1)
@@ -29,11 +21,7 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties.DropOffPickupType do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.StopTimeProperties.DropOffPickupType",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:REGULAR, 0)
   field(:NONE, 1)
@@ -44,11 +32,7 @@ end
 defmodule TransitRealtime.VehiclePosition.VehicleStopStatus do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.VehiclePosition.VehicleStopStatus",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:INCOMING_AT, 0)
   field(:STOPPED_AT, 1)
@@ -58,11 +42,7 @@ end
 defmodule TransitRealtime.VehiclePosition.CongestionLevel do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.VehiclePosition.CongestionLevel",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:UNKNOWN_CONGESTION_LEVEL, 0)
   field(:RUNNING_SMOOTHLY, 1)
@@ -74,11 +54,7 @@ end
 defmodule TransitRealtime.VehiclePosition.OccupancyStatus do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.VehiclePosition.OccupancyStatus",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:EMPTY, 0)
   field(:MANY_SEATS_AVAILABLE, 1)
@@ -94,11 +70,7 @@ end
 defmodule TransitRealtime.Alert.Cause do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.Alert.Cause",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:UNKNOWN_CAUSE, 1)
   field(:OTHER_CAUSE, 2)
@@ -118,11 +90,7 @@ end
 defmodule TransitRealtime.Alert.Effect do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.Alert.Effect",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:NO_SERVICE, 1)
   field(:REDUCED_SERVICE, 2)
@@ -140,11 +108,7 @@ end
 defmodule TransitRealtime.Alert.SeverityLevel do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.Alert.SeverityLevel",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:UNKNOWN_SEVERITY, 1)
   field(:INFO, 2)
@@ -155,11 +119,7 @@ end
 defmodule TransitRealtime.TripDescriptor.ScheduleRelationship do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.TripDescriptor.ScheduleRelationship",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:ADDED, 1)
@@ -174,11 +134,7 @@ end
 defmodule TransitRealtime.VehicleDescriptor.WheelchairAccessible do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.VehicleDescriptor.WheelchairAccessible",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:NO_VALUE, 0)
   field(:UNKNOWN, 1)
@@ -189,11 +145,7 @@ end
 defmodule TransitRealtime.Stop.WheelchairBoarding do
   @moduledoc false
 
-  use Protobuf,
-    enum: true,
-    full_name: "transit_realtime.Stop.WheelchairBoarding",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:UNKNOWN, 0)
   field(:AVAILABLE, 1)
@@ -203,10 +155,7 @@ end
 defmodule TransitRealtime.FeedMessage do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.FeedMessage",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:header, 1, required: true, type: TransitRealtime.FeedHeader)
   field(:entity, 2, repeated: true, type: TransitRealtime.FeedEntity)
@@ -217,10 +166,7 @@ end
 defmodule TransitRealtime.FeedHeader do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.FeedHeader",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:gtfs_realtime_version, 1, required: true, type: :string, json_name: "gtfsRealtimeVersion")
 
@@ -240,10 +186,7 @@ end
 defmodule TransitRealtime.FeedEntity do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.FeedEntity",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:id, 1, required: true, type: :string)
   field(:is_deleted, 2, optional: true, type: :bool, json_name: "isDeleted", default: false)
@@ -265,10 +208,7 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeEvent do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripUpdate.StopTimeEvent",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:delay, 1, optional: true, type: :int32)
   field(:time, 2, optional: true, type: :int64)
@@ -281,10 +221,7 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.StopTimeProperties",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:assigned_stop_id, 1, optional: true, type: :string, json_name: "assignedStopId")
   field(:stop_headsign, 2, optional: true, type: :string, json_name: "stopHeadsign")
@@ -309,10 +246,7 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripUpdate.StopTimeUpdate",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32, json_name: "stopSequence")
   field(:stop_id, 4, optional: true, type: :string, json_name: "stopId")
@@ -346,10 +280,7 @@ end
 defmodule TransitRealtime.TripUpdate.TripProperties do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripUpdate.TripProperties",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string, json_name: "tripId")
   field(:start_date, 2, optional: true, type: :string, json_name: "startDate")
@@ -364,10 +295,7 @@ end
 defmodule TransitRealtime.TripUpdate do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripUpdate",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:trip, 1, required: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 3, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -393,10 +321,7 @@ end
 defmodule TransitRealtime.VehiclePosition.CarriageDetails do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.VehiclePosition.CarriageDetails",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -424,10 +349,7 @@ end
 defmodule TransitRealtime.VehiclePosition do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.VehiclePosition",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:trip, 1, optional: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 8, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -473,10 +395,7 @@ end
 defmodule TransitRealtime.Alert do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.Alert",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:active_period, 1,
     repeated: true,
@@ -564,10 +483,7 @@ end
 defmodule TransitRealtime.TimeRange do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TimeRange",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:start, 1, optional: true, type: :uint64)
   field(:end, 2, optional: true, type: :uint64)
@@ -578,10 +494,7 @@ end
 defmodule TransitRealtime.Position do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.Position",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:latitude, 1, required: true, type: :float)
   field(:longitude, 2, required: true, type: :float)
@@ -595,10 +508,7 @@ end
 defmodule TransitRealtime.TripDescriptor.ModifiedTripSelector do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripDescriptor.ModifiedTripSelector",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:modifications_id, 1, optional: true, type: :string, json_name: "modificationsId")
   field(:affected_trip_id, 2, optional: true, type: :string, json_name: "affectedTripId")
@@ -611,10 +521,7 @@ end
 defmodule TransitRealtime.TripDescriptor do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripDescriptor",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string, json_name: "tripId")
   field(:route_id, 5, optional: true, type: :string, json_name: "routeId")
@@ -641,10 +548,7 @@ end
 defmodule TransitRealtime.VehicleDescriptor do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.VehicleDescriptor",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -664,10 +568,7 @@ end
 defmodule TransitRealtime.EntitySelector do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.EntitySelector",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:agency_id, 1, optional: true, type: :string, json_name: "agencyId")
   field(:route_id, 2, optional: true, type: :string, json_name: "routeId")
@@ -682,10 +583,7 @@ end
 defmodule TransitRealtime.TranslatedString.Translation do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TranslatedString.Translation",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:text, 1, required: true, type: :string)
   field(:language, 2, optional: true, type: :string)
@@ -696,10 +594,7 @@ end
 defmodule TransitRealtime.TranslatedString do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TranslatedString",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:translation, 1, repeated: true, type: TransitRealtime.TranslatedString.Translation)
 
@@ -709,10 +604,7 @@ end
 defmodule TransitRealtime.TranslatedImage.LocalizedImage do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TranslatedImage.LocalizedImage",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:url, 1, required: true, type: :string)
   field(:media_type, 2, required: true, type: :string, json_name: "mediaType")
@@ -724,10 +616,7 @@ end
 defmodule TransitRealtime.TranslatedImage do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TranslatedImage",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:localized_image, 1,
     repeated: true,
@@ -741,10 +630,7 @@ end
 defmodule TransitRealtime.Shape do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.Shape",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:shape_id, 1, optional: true, type: :string, json_name: "shapeId")
   field(:encoded_polyline, 2, optional: true, type: :string, json_name: "encodedPolyline")
@@ -755,10 +641,7 @@ end
 defmodule TransitRealtime.Stop do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.Stop",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:stop_id, 1, optional: true, type: :string, json_name: "stopId")
 
@@ -815,10 +698,7 @@ end
 defmodule TransitRealtime.TripModifications.Modification do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripModifications.Modification",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:start_stop_selector, 1,
     optional: true,
@@ -854,10 +734,7 @@ end
 defmodule TransitRealtime.TripModifications.SelectedTrips do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripModifications.SelectedTrips",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:trip_ids, 1, repeated: true, type: :string, json_name: "tripIds")
   field(:shape_id, 2, optional: true, type: :string, json_name: "shapeId")
@@ -868,10 +745,7 @@ end
 defmodule TransitRealtime.TripModifications do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.TripModifications",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:selected_trips, 1,
     repeated: true,
@@ -889,10 +763,7 @@ end
 defmodule TransitRealtime.StopSelector do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.StopSelector",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32, json_name: "stopSequence")
   field(:stop_id, 2, optional: true, type: :string, json_name: "stopId")
@@ -903,10 +774,7 @@ end
 defmodule TransitRealtime.ReplacementStop do
   @moduledoc false
 
-  use Protobuf,
-    full_name: "transit_realtime.ReplacementStop",
-    protoc_gen_elixir_version: "0.17.0",
-    syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto2
 
   field(:travel_time_to_stop, 1, optional: true, type: :int32, json_name: "travelTimeToStop")
   field(:stop_id, 2, optional: true, type: :string, json_name: "stopId")

--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
@@ -1,7 +1,11 @@
 defmodule TransitRealtime.FeedHeader.Incrementality do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.FeedHeader.Incrementality",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:FULL_DATASET, 0)
   field(:DIFFERENTIAL, 1)
@@ -10,7 +14,11 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:SKIPPED, 1)
@@ -21,7 +29,11 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties.DropOffPickupType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.StopTimeProperties.DropOffPickupType",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:REGULAR, 0)
   field(:NONE, 1)
@@ -32,7 +44,11 @@ end
 defmodule TransitRealtime.VehiclePosition.VehicleStopStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.VehiclePosition.VehicleStopStatus",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:INCOMING_AT, 0)
   field(:STOPPED_AT, 1)
@@ -42,7 +58,11 @@ end
 defmodule TransitRealtime.VehiclePosition.CongestionLevel do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.VehiclePosition.CongestionLevel",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:UNKNOWN_CONGESTION_LEVEL, 0)
   field(:RUNNING_SMOOTHLY, 1)
@@ -54,7 +74,11 @@ end
 defmodule TransitRealtime.VehiclePosition.OccupancyStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.VehiclePosition.OccupancyStatus",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:EMPTY, 0)
   field(:MANY_SEATS_AVAILABLE, 1)
@@ -70,7 +94,11 @@ end
 defmodule TransitRealtime.Alert.Cause do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.Alert.Cause",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:UNKNOWN_CAUSE, 1)
   field(:OTHER_CAUSE, 2)
@@ -84,12 +112,17 @@ defmodule TransitRealtime.Alert.Cause do
   field(:CONSTRUCTION, 10)
   field(:POLICE_ACTIVITY, 11)
   field(:MEDICAL_EMERGENCY, 12)
+  field(:SPECIAL_EVENT, 13)
 end
 
 defmodule TransitRealtime.Alert.Effect do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.Alert.Effect",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:NO_SERVICE, 1)
   field(:REDUCED_SERVICE, 2)
@@ -107,7 +140,11 @@ end
 defmodule TransitRealtime.Alert.SeverityLevel do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.Alert.SeverityLevel",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:UNKNOWN_SEVERITY, 1)
   field(:INFO, 2)
@@ -118,7 +155,11 @@ end
 defmodule TransitRealtime.TripDescriptor.ScheduleRelationship do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.TripDescriptor.ScheduleRelationship",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:SCHEDULED, 0)
   field(:ADDED, 1)
@@ -133,7 +174,11 @@ end
 defmodule TransitRealtime.VehicleDescriptor.WheelchairAccessible do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.VehicleDescriptor.WheelchairAccessible",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:NO_VALUE, 0)
   field(:UNKNOWN, 1)
@@ -144,7 +189,11 @@ end
 defmodule TransitRealtime.Stop.WheelchairBoarding do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    enum: true,
+    full_name: "transit_realtime.Stop.WheelchairBoarding",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:UNKNOWN, 0)
   field(:AVAILABLE, 1)
@@ -154,7 +203,10 @@ end
 defmodule TransitRealtime.FeedMessage do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.FeedMessage",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:header, 1, required: true, type: TransitRealtime.FeedHeader)
   field(:entity, 2, repeated: true, type: TransitRealtime.FeedEntity)
@@ -165,7 +217,10 @@ end
 defmodule TransitRealtime.FeedHeader do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.FeedHeader",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:gtfs_realtime_version, 1, required: true, type: :string, json_name: "gtfsRealtimeVersion")
 
@@ -185,7 +240,10 @@ end
 defmodule TransitRealtime.FeedEntity do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.FeedEntity",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:id, 1, required: true, type: :string)
   field(:is_deleted, 2, optional: true, type: :bool, json_name: "isDeleted", default: false)
@@ -207,7 +265,10 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeEvent do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripUpdate.StopTimeEvent",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:delay, 1, optional: true, type: :int32)
   field(:time, 2, optional: true, type: :int64)
@@ -220,7 +281,10 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate.StopTimeProperties do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripUpdate.StopTimeUpdate.StopTimeProperties",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:assigned_stop_id, 1, optional: true, type: :string, json_name: "assignedStopId")
   field(:stop_headsign, 2, optional: true, type: :string, json_name: "stopHeadsign")
@@ -245,7 +309,10 @@ end
 defmodule TransitRealtime.TripUpdate.StopTimeUpdate do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripUpdate.StopTimeUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32, json_name: "stopSequence")
   field(:stop_id, 4, optional: true, type: :string, json_name: "stopId")
@@ -279,7 +346,10 @@ end
 defmodule TransitRealtime.TripUpdate.TripProperties do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripUpdate.TripProperties",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string, json_name: "tripId")
   field(:start_date, 2, optional: true, type: :string, json_name: "startDate")
@@ -294,7 +364,10 @@ end
 defmodule TransitRealtime.TripUpdate do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:trip, 1, required: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 3, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -320,7 +393,10 @@ end
 defmodule TransitRealtime.VehiclePosition.CarriageDetails do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.VehiclePosition.CarriageDetails",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -348,7 +424,10 @@ end
 defmodule TransitRealtime.VehiclePosition do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.VehiclePosition",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:trip, 1, optional: true, type: TransitRealtime.TripDescriptor)
   field(:vehicle, 8, optional: true, type: TransitRealtime.VehicleDescriptor)
@@ -394,7 +473,10 @@ end
 defmodule TransitRealtime.Alert do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.Alert",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:active_period, 1,
     repeated: true,
@@ -482,7 +564,10 @@ end
 defmodule TransitRealtime.TimeRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TimeRange",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:start, 1, optional: true, type: :uint64)
   field(:end, 2, optional: true, type: :uint64)
@@ -493,7 +578,10 @@ end
 defmodule TransitRealtime.Position do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.Position",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:latitude, 1, required: true, type: :float)
   field(:longitude, 2, required: true, type: :float)
@@ -507,7 +595,10 @@ end
 defmodule TransitRealtime.TripDescriptor.ModifiedTripSelector do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripDescriptor.ModifiedTripSelector",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:modifications_id, 1, optional: true, type: :string, json_name: "modificationsId")
   field(:affected_trip_id, 2, optional: true, type: :string, json_name: "affectedTripId")
@@ -520,7 +611,10 @@ end
 defmodule TransitRealtime.TripDescriptor do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripDescriptor",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:trip_id, 1, optional: true, type: :string, json_name: "tripId")
   field(:route_id, 5, optional: true, type: :string, json_name: "routeId")
@@ -547,7 +641,10 @@ end
 defmodule TransitRealtime.VehicleDescriptor do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.VehicleDescriptor",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:id, 1, optional: true, type: :string)
   field(:label, 2, optional: true, type: :string)
@@ -567,7 +664,10 @@ end
 defmodule TransitRealtime.EntitySelector do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.EntitySelector",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:agency_id, 1, optional: true, type: :string, json_name: "agencyId")
   field(:route_id, 2, optional: true, type: :string, json_name: "routeId")
@@ -582,7 +682,10 @@ end
 defmodule TransitRealtime.TranslatedString.Translation do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TranslatedString.Translation",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:text, 1, required: true, type: :string)
   field(:language, 2, optional: true, type: :string)
@@ -593,7 +696,10 @@ end
 defmodule TransitRealtime.TranslatedString do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TranslatedString",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:translation, 1, repeated: true, type: TransitRealtime.TranslatedString.Translation)
 
@@ -603,7 +709,10 @@ end
 defmodule TransitRealtime.TranslatedImage.LocalizedImage do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TranslatedImage.LocalizedImage",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:url, 1, required: true, type: :string)
   field(:media_type, 2, required: true, type: :string, json_name: "mediaType")
@@ -615,7 +724,10 @@ end
 defmodule TransitRealtime.TranslatedImage do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TranslatedImage",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:localized_image, 1,
     repeated: true,
@@ -629,7 +741,10 @@ end
 defmodule TransitRealtime.Shape do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.Shape",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:shape_id, 1, optional: true, type: :string, json_name: "shapeId")
   field(:encoded_polyline, 2, optional: true, type: :string, json_name: "encodedPolyline")
@@ -640,7 +755,10 @@ end
 defmodule TransitRealtime.Stop do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.Stop",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:stop_id, 1, optional: true, type: :string, json_name: "stopId")
 
@@ -697,7 +815,10 @@ end
 defmodule TransitRealtime.TripModifications.Modification do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripModifications.Modification",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:start_stop_selector, 1,
     optional: true,
@@ -733,7 +854,10 @@ end
 defmodule TransitRealtime.TripModifications.SelectedTrips do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripModifications.SelectedTrips",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:trip_ids, 1, repeated: true, type: :string, json_name: "tripIds")
   field(:shape_id, 2, optional: true, type: :string, json_name: "shapeId")
@@ -744,7 +868,10 @@ end
 defmodule TransitRealtime.TripModifications do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.TripModifications",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:selected_trips, 1,
     repeated: true,
@@ -762,7 +889,10 @@ end
 defmodule TransitRealtime.StopSelector do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.StopSelector",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:stop_sequence, 1, optional: true, type: :uint32, json_name: "stopSequence")
   field(:stop_id, 2, optional: true, type: :string, json_name: "stopId")
@@ -773,7 +903,10 @@ end
 defmodule TransitRealtime.ReplacementStop do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
+  use Protobuf,
+    full_name: "transit_realtime.ReplacementStop",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
 
   field(:travel_time_to_stop, 1, optional: true, type: :int32, json_name: "travelTimeToStop")
   field(:stop_id, 2, optional: true, type: :string, json_name: "stopId")

--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
@@ -644,6 +644,7 @@ message Alert {
     CONSTRUCTION = 10;
     POLICE_ACTIVITY = 11;
     MEDICAL_EMERGENCY = 12;
+    SPECIAL_EVENT = 13;     // A special one-time or recurring event such as a parade, festival, performance, farmers market, or sporting event.
   }
   optional Cause cause = 6 [default = UNKNOWN_CAUSE];
 

--- a/apps/transport/lib/transport/protobuf/readme.md
+++ b/apps/transport/lib/transport/protobuf/readme.md
@@ -28,7 +28,4 @@ Then:
 ```sh
 cd apps/transport/lib/transport/protobuf
 protoc --elixir_out=. gtfs-realtime.proto
-# If protoc generated transit_realtime/gtfs-realtime.pb.ex, keep a single canonical file:
-mv transit_realtime/gtfs-realtime.pb.ex ./gtfs-realtime.pb.ex
-rmdir transit_realtime
 ```

--- a/apps/transport/lib/transport/protobuf/readme.md
+++ b/apps/transport/lib/transport/protobuf/readme.md
@@ -5,12 +5,13 @@ Do not edit it by hand please!
 ## How to regenerate the files
 
 * [gtfs-realtime.proto source](https://raw.githubusercontent.com/google/transit/master/gtfs-realtime/proto/gtfs-realtime.proto)
+* Check `mix.lock` and use the same `protobuf` version for `protoc-gen-elixir`.
 
 On Mac:
 
 ```sh
 brew install protobuf
-mix escript.install hex protobuf
+mix escript.install hex protobuf 0.15.0 # change this to match mix.lock
 asdf reshim elixir
 ```
 
@@ -18,7 +19,7 @@ On Fedora (with asdf):
 
 ```sh
 sudo dnf install -y protobuf-compiler
-mix escript.install hex protobuf
+mix escript.install hex protobuf 0.15.0 # change this to match mix.lock
 asdf reshim elixir
 ```
 

--- a/apps/transport/lib/transport/protobuf/readme.md
+++ b/apps/transport/lib/transport/protobuf/readme.md
@@ -14,8 +14,20 @@ mix escript.install hex protobuf
 asdf reshim elixir
 ```
 
+On Fedora (with asdf):
+
+```sh
+sudo dnf install -y protobuf-compiler
+mix escript.install hex protobuf
+asdf reshim elixir
+```
+
 Then:
 
 ```sh
+cd apps/transport/lib/transport/protobuf
 protoc --elixir_out=. gtfs-realtime.proto
+# If protoc generated transit_realtime/gtfs-realtime.pb.ex, keep a single canonical file:
+mv transit_realtime/gtfs-realtime.pb.ex ./gtfs-realtime.pb.ex
+rmdir transit_realtime
 ```

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -198,7 +198,6 @@ defmodule Transport.GTFSRTTest do
            "Protobuf file seems to have been updated. Consider updating it. See https://github.com/google/transit/tree/master/gtfs-realtime/proto and https://github.com/etalab/transport-site/issues/3891"
   end
 
-  @tag :ci_only_on_mondays
   test "generated .pb.ex version matches mix.lock" do
     mix_lock_content = File.read!("#{__DIR__}/../../../../mix.lock")
 

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -198,6 +198,23 @@ defmodule Transport.GTFSRTTest do
            "Protobuf file seems to have been updated. Consider updating it. See https://github.com/google/transit/tree/master/gtfs-realtime/proto and https://github.com/etalab/transport-site/issues/3891"
   end
 
+  @tag :ci_only_on_mondays
+  test "generated .pb.ex version matches mix.lock" do
+    mix_lock_content = File.read!("#{__DIR__}/../../../../mix.lock")
+
+    generated_content =
+      File.read!("#{__DIR__}/../../lib/transport/protobuf/gtfs-realtime.pb.ex")
+
+    [_, mix_lock_version] =
+      Regex.run(~r/"protobuf": \{:hex, :protobuf, "([^"]+)"/, mix_lock_content)
+
+    [_, generated_version] =
+      Regex.run(~r/protoc_gen_elixir_version:\s*"([^"]+)"/, generated_content)
+
+    assert generated_version == mix_lock_version,
+           "Generated protobuf version (#{generated_version}) does not match mix.lock protobuf version (#{mix_lock_version}). Re-generate apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex with the version from mix.lock."
+  end
+
   def timerange(start_date, end_date) do
     %TimeRange{start: unix_seconds_delta(start_date), end: unix_seconds_delta(end_date)}
   end

--- a/apps/transport/test/transport/gtfs_rt_test.exs
+++ b/apps/transport/test/transport/gtfs_rt_test.exs
@@ -199,16 +199,13 @@ defmodule Transport.GTFSRTTest do
   end
 
   test "generated .pb.ex version matches mix.lock" do
-    mix_lock_content = File.read!("#{__DIR__}/../../../../mix.lock")
-
     generated_content =
       File.read!("#{__DIR__}/../../lib/transport/protobuf/gtfs-realtime.pb.ex")
 
-    [_, mix_lock_version] =
-      Regex.run(~r/"protobuf": \{:hex, :protobuf, "([^"]+)"/, mix_lock_content)
-
     [_, generated_version] =
       Regex.run(~r/protoc_gen_elixir_version:\s*"([^"]+)"/, generated_content)
+
+    mix_lock_version = Application.spec(:protobuf, :vsn) |> to_string()
 
     assert generated_version == mix_lock_version,
            "Generated protobuf version (#{generated_version}) does not match mix.lock protobuf version (#{mix_lock_version}). Re-generate apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex with the version from mix.lock."


### PR DESCRIPTION
J’ai suivi les instructions suite à cette erreur dans la suite de tests, sur une autre PR :

```
  1) test .proto file is up-to-date (Transport.GTFSRTTest)
Error:      apps/transport/test/transport/gtfs_rt_test.exs:187
     Protobuf file seems to have been updated. Consider updating it. See https://github.com/google/transit/tree/master/gtfs-realtime/proto and https://github.com/etalab/transport-site/issues/3891
     code: assert normalize_whitespace.(remote_content) == normalize_whitespace.(local_content),
     stacktrace:
       test/transport/gtfs_rt_test.exs:197: (test)
```

J’en ai profité pour enrichir un peu le fichier README spécifique au protobuf.