### PR TITLE
Redressement des coordonnées dans la consolidation IRVE

### DIFF
--- a/apps/transport/lib/db/irve_valid_pdc.ex
+++ b/apps/transport/lib/db/irve_valid_pdc.ex
@@ -56,6 +56,7 @@ defmodule DB.IRVEValidPDC do
     field(:cable_t2_attache, :boolean)
     field(:longitude, :decimal, null: false)
     field(:latitude, :decimal, null: false)
+    field(:consolidated_is_lon_lat_correct, :boolean, null: false)
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -75,5 +76,7 @@ defmodule DB.IRVEValidPDC do
   end
 
   defp valid_fields,
-    do: Transport.IRVE.StaticIRVESchema.field_names_list() ++ ["id", "irve_valid_file_id", "longitude", "latitude"]
+    do:
+      Transport.IRVE.StaticIRVESchema.field_names_list() ++
+        ["id", "irve_valid_file_id", "longitude", "latitude", "consolidated_is_lon_lat_correct"]
 end

--- a/apps/transport/lib/irve/coordinate_correction.ex
+++ b/apps/transport/lib/irve/coordinate_correction.ex
@@ -1,0 +1,80 @@
+defmodule Transport.IRVE.CoordinateCorrection do
+  @moduledoc """
+  Detects and corrects lon/lat coordinate inversions in IRVE data.
+
+  Some producers submit `coordonneesXY` as `[latitude, longitude]` instead of the
+  schema-required `[longitude, latitude]`. Detection is based on a bounding box for
+  metropolitan France + Corsica (lon ∈ [-5.5, 9.7], lat ∈ [41.0, 51.5]); see `inverted?/2`.
+  """
+
+  @metro_lon_min -5.5
+  @metro_lon_max 9.7
+  @metro_lat_min 41.0
+  @metro_lat_max 51.5
+
+  require Explorer.DataFrame, as: DF
+  alias Explorer.Series
+
+  @doc """
+  Corrects inverted coordinates in a DataFrame with `longitude` and `latitude` float
+  columns. Adds `consolidated_is_lon_lat_correct` (`false` = row was swapped).
+
+      iex> df = Explorer.DataFrame.new(longitude: [2.35, 48.85, 55.4], latitude: [48.85, 2.35, -21.1])
+      iex> r = Transport.IRVE.CoordinateCorrection.detect_and_correct(df)
+      iex> Explorer.Series.to_list(r["longitude"])
+      [2.35, 2.35, 55.4]
+      iex> Explorer.Series.to_list(r["latitude"])
+      [48.85, 48.85, -21.1]
+      iex> Explorer.Series.to_list(r["consolidated_is_lon_lat_correct"])
+      [true, false, true]
+
+  """
+  def detect_and_correct(%DF{} = df) do
+    DF.mutate_with(df, fn df ->
+      lon = df["longitude"]
+      lat = df["latitude"]
+      inverted = inverted?(lon, lat)
+
+      %{
+        longitude: Series.select(inverted, lat, lon),
+        latitude: Series.select(inverted, lon, lat),
+        consolidated_is_lon_lat_correct: Series.not(inverted)
+      }
+    end)
+  end
+
+  @doc """
+  Returns a boolean Series: `true` where `lon_series` ∈ [#{@metro_lat_min}, #{@metro_lat_max}]
+  AND `lat_series` ∈ [#{@metro_lon_min}, #{@metro_lon_max}].
+
+  Test cases:
+
+  1. Metro France, correct — lon 2.35 (Paris), not in lat range → `false`
+  2. Metro France, inverted — lon 48.85 is in [41, 51.5] and lat 2.35 is in [-5.5, 9.7] → `true`
+  3. Mayotte, correct — lon 45.1 falls in the lat range [41, 51.5], but lat −12.8 is
+     below −5.5, so both conditions are not met → `false`
+  4. Corsica, inverted — edge case: lat 9.56 is just above the 9.5 ceiling one might
+     naively use; the 9.7 upper bound is required to catch it → `true`
+
+      iex> lon = Explorer.Series.from_list([2.35, 48.85, 45.1, 42.4])
+      iex> lat = Explorer.Series.from_list([48.85, 2.35, -12.8, 9.56])
+      iex> Explorer.Series.to_list(Transport.IRVE.CoordinateCorrection.inverted?(lon, lat))
+      [false, true, false, true]
+
+  """
+  def inverted?(lon_series, lat_series) do
+    lon_in_lat_range =
+      Series.and(
+        Series.greater_equal(lon_series, @metro_lat_min),
+        Series.less_equal(lon_series, @metro_lat_max)
+      )
+
+    lat_in_lon_range =
+      Series.and(
+        Series.greater_equal(lat_series, @metro_lon_min),
+        Series.less_equal(lat_series, @metro_lon_max)
+      )
+
+    Series.and(lon_in_lat_range, lat_in_lon_range)
+  end
+end

--- a/apps/transport/lib/irve/database_exporter.ex
+++ b/apps/transport/lib/irve/database_exporter.ex
@@ -58,7 +58,7 @@ defmodule Transport.IRVE.DatabaseExporter do
   def database_field_list do
     Transport.IRVE.StaticIRVESchema.field_names_list()
     |> Enum.reject(&(&1 == "coordonneesXY"))
-    |> Enum.concat(["longitude", "latitude"])
+    |> Enum.concat(["longitude", "latitude", "consolidated_is_lon_lat_correct"])
   end
 
   def additional_file_field_list do
@@ -78,7 +78,7 @@ defmodule Transport.IRVE.DatabaseExporter do
   """
   def export_field_list do
     Transport.IRVE.StaticIRVESchema.field_names_list()
-    |> Enum.concat(["consolidated_longitude", "consolidated_latitude"])
+    |> Enum.concat(["consolidated_longitude", "consolidated_latitude", "consolidated_is_lon_lat_correct"])
     |> Enum.concat(additional_file_field_list())
   end
 end

--- a/apps/transport/lib/irve/processing.ex
+++ b/apps/transport/lib/irve/processing.ex
@@ -12,6 +12,7 @@ defmodule Transport.IRVE.Processing do
     |> convert_to_dataframe!()
     |> add_missing_optional_columns()
     |> preprocess_coordinates()
+    |> Transport.IRVE.CoordinateCorrection.detect_and_correct()
     |> preprocess_boolean_fields()
     |> select_fields()
   end
@@ -88,7 +89,7 @@ defmodule Transport.IRVE.Processing do
     |> Explorer.DataFrame.select(
       (Transport.IRVE.StaticIRVESchema.field_names_list() --
          ["coordonneesXY", "cable_t2_attache"]) ++
-        ["longitude", "latitude"]
+        ["longitude", "latitude", "consolidated_is_lon_lat_correct"]
     )
   end
 end

--- a/apps/transport/priv/repo/migrations/20260611000000_add_consolidated_is_lon_lat_correct_to_irve_valid_pdc.exs
+++ b/apps/transport/priv/repo/migrations/20260611000000_add_consolidated_is_lon_lat_correct_to_irve_valid_pdc.exs
@@ -1,0 +1,9 @@
+defmodule Transport.Repo.Migrations.AddConsolidatedIsLonLatCorrectToIrveValidPdc do
+  use Ecto.Migration
+
+  def change do
+    alter table(:irve_valid_pdc) do
+      add(:consolidated_is_lon_lat_correct, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/apps/transport/test/db/irve_valid_pdc_test.exs
+++ b/apps/transport/test/db/irve_valid_pdc_test.exs
@@ -12,6 +12,14 @@ defmodule DB.IRVEValidPDCTest do
 
     assert official_schema_fields -- ["coordonneesXY"] ==
              ecto_schema_fields --
-               ["id", "irve_valid_file_id", "inserted_at", "updated_at", "longitude", "latitude"]
+               [
+                 "id",
+                 "irve_valid_file_id",
+                 "inserted_at",
+                 "updated_at",
+                 "longitude",
+                 "latitude",
+                 "consolidated_is_lon_lat_correct"
+               ]
   end
 end

--- a/apps/transport/test/transport/irve/consolidation_test.exs
+++ b/apps/transport/test/transport/irve/consolidation_test.exs
@@ -129,6 +129,7 @@ defmodule Transport.IRVE.ConsolidationTest do
           |> Map.put("datagouv_organization_or_owner", "the-org")
           |> Map.put("datagouv_last_modified", "2024-02-29T07:43:59.000000+0000")
           |> Map.put("deduplication_status", "unique")
+          |> Map.put("consolidated_is_lon_lat_correct", true)
         ]
         |> Explorer.DataFrame.new()
         # Use the same column order as in the actual implementation
@@ -137,6 +138,7 @@ defmodule Transport.IRVE.ConsolidationTest do
           |> Enum.concat([
             "consolidated_longitude",
             "consolidated_latitude",
+            "consolidated_is_lon_lat_correct",
             "datagouv_dataset_id",
             "datagouv_resource_id",
             "dataset_title",
@@ -158,7 +160,7 @@ defmodule Transport.IRVE.ConsolidationTest do
         start_path: "consolidation_transport_avec_doublons_irve_statique_#{date}",
         bucket: bucket_name,
         acl: :private,
-        file_content: "6c76cfc5918ead5a10e36f39e34995370184c47801c7568e5b7b2dc2a2a75714"
+        file_content: sha256_of(consolidation_content)
       )
 
       Transport.Test.S3TestUtils.s3_mocks_remote_copy_file(
@@ -185,7 +187,7 @@ defmodule Transport.IRVE.ConsolidationTest do
         start_path: "consolidation_transport_irve_statique_#{date}",
         bucket: bucket_name,
         acl: :private,
-        file_content: "6c76cfc5918ead5a10e36f39e34995370184c47801c7568e5b7b2dc2a2a75714"
+        file_content: sha256_of(consolidation_content)
       )
 
       Transport.Test.S3TestUtils.s3_mocks_remote_copy_file(
@@ -279,5 +281,9 @@ defmodule Transport.IRVE.ConsolidationTest do
     body = DB.Factory.IRVE.to_csv_body(rows)
     File.write!(path, body)
     %Req.Response{status: 200, body: File.stream!(path)}
+  end
+
+  defp sha256_of(content) do
+    :crypto.hash(:sha256, content) |> Base.encode16() |> String.downcase()
   end
 end

--- a/apps/transport/test/transport/irve/coordinate_correction_test.exs
+++ b/apps/transport/test/transport/irve/coordinate_correction_test.exs
@@ -1,0 +1,4 @@
+defmodule Transport.IRVE.CoordinateCorrectionTest do
+  use ExUnit.Case, async: true
+  doctest Transport.IRVE.CoordinateCorrection, import: true
+end

--- a/apps/transport/test/transport/irve/processing_test.exs
+++ b/apps/transport/test/transport/irve/processing_test.exs
@@ -66,7 +66,8 @@ defmodule Transport.IRVE.ProcessingTest do
                # This was added and coordonneesXY removed
                "longitude" => -0.799141,
                # Same
-               "latitude" => 45.91914
+               "latitude" => 45.91914,
+               "consolidated_is_lon_lat_correct" => true
              }
            ]
   end


### PR DESCRIPTION
Le schéma statique IRVE a une unique colonne CoordonnesXY sous forme de tableau JSON avec 2 éléments, X représentant la longitude et Y la latitude, et il arrive – évidemment – que les producteurs fournissent l’inverse avec latitude puis longitude. La consolidation nationale reprend la donnée produite telle quelle, sans vérifier que les coordonnées soient correctes, ce qui envoie des points dans l’océan au large de l’Afrique. 

Cela représente actuellement 15% des PDC dans la consolidation actuelle. La plupart des inversions correspondent à la France métropolitaine ou la Corse :

| Categorie | Compte | % |
|---|---|---|
| France métropolitaine normal | 135,404 | 84.60% |
| France métropolitaine inversée | 23,876 | 14.92% |
|Outremer normal | 618 | 0.39% |
|Outremer inversé | 62 | 0.04% |
|Bizarrerie | 93 | 0.06% |

La consolidation historique data.gouv.fr détectait puis rectifiait ces inversions, il s’agit ici de faire la même chose. Par simplicité, on commence par uniquement s’attaquer au cas d’inversions de coordonnées pour la France métropolitaine, et on ne détecte pas spécifiquement ce qui ne tombe sur aucun territoire français.

## Modifications de la consolidation

- Les coordonnées fournies sont comparées avec une bounding box représentant les coordonnées inverses de la France métropolitaine + Corse. La France + la Corse ayant longitude incluse entre −5.5° et 9.7°, et latitude entre 41.0° et 51.5°, on regarde donc ce qui tombe dans un rectangle de latitude incluse entre −5.5° et 9.7°, et longitude entre 41.0° et 51.5°. **Si les coordonnées sont inversées selon cette détection, alors on les rectifie.**
- Un flag consolidated_is_lon_lat_correct est créé pour l’ensemble des PDC.
- Les coordonnées rectifiées et ce flag sont stockés en base de données.
- Ces coordonnées rectifiées et ce flag sont exposés dans la consolidation nationale.

## Validation

Pour l’instant cette rectification survient en dehors de la validation, juste après la validation et juste avant l’insertion en base de données.

**Histoire d’avoir une PR d’une taille correcte, je ne traite pas le cas de la validation ici.**  Mais l’idée par la suite est de créer un warning lors de la validation, et de l’afficher sur la page de la validation à la demande.

En prévision de cela, j’ai mis le code de détection et de rectification dans un module spécifique qui pourra être réutilisé par la validation. Pour les devs, pour rappel, on traite le fichier source deux fois de suite, une fois pour la validation, et une autre fois pour l’insertion en base, c’est un problème identifié qui ne sera pas traité ici (mais on a une issue à ce sujet, voir #5232).

## Rectification de la donnée existante en base

Cette PR ne contient à l’heure actuelle rien pour rectifier la donnée existante en base, donc une fois mergée le consolidé continuera à contenir des PDL avec coordonnées inversées si rien n’est fait pour le contenu de la base, et il y a la question du backfill de la nouvelle colonne `consolidated_is_lon_lat_correct` qui sera exposée quoi qu’il arrive (et si on fait rien, ce contenu sera faux).

Deux solutions possibles (à discuter en commentaires de PR) :
1. On fait un reset global de la base de données
2. On fait un script spécifique one shot post-migration pour la rectification : extrait de la base, passage en dataframe, on applique le traitement, et on réinsère en édition.

Je penche plutôt pour la 1ère solution.

## Utilisation de Claude, conseil de relecture

**Cette PR se lit plus facilement commit par commit.**

J’ai utilisé Claude pour coder, mais en divisant la fonctionnalité en plusieurs commits, et en relisant et corrigeant le code avant de valider chaque commit. Par ailleurs, la doc a été amendée à la main, tout comme la description de cette PR, et tout a bien été relu.
