### PR TITLE
Stabilisation de tests

### DIFF
--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -28,7 +28,6 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   # slugs from `datagouv_dataset_slugs`
   @datasets_list_csv_url "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/main/datasets.csv"
   @bnlc_github_url "https://raw.githubusercontent.com/etalab/transport-base-nationale-covoiturage/main/bnlc-.csv"
-  @bnlc_path System.tmp_dir!() |> Path.join("bnlc.csv")
   # The S3 bucket to use to upload the consolidated file, sent to our team for review.
   # We use the `:on_demand_validation` one because this is a bucket holding temporary
   # files.
@@ -116,14 +115,16 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   def replace_file_on_datagouv do
     %{dataset_id: dataset_id, resource_id: resource_id} = consolidation_configuration()
 
+    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+
     Datagouvfr.Client.Resources.update(%{
       "dataset_id" => dataset_id,
       "resource_id" => resource_id,
-      "resource_file" => %{path: @bnlc_path, filename: "bnlc.csv"}
+      "resource_file" => %{path: bnlc_path, filename: "bnlc.csv"}
     })
 
     Logger.info("Updated file on data.gouv.fr")
-    File.rm!(@bnlc_path)
+    File.rm!(bnlc_path)
   end
 
   defp validator_unavailable?(validation_errors) do
@@ -133,9 +134,11 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   end
 
   defp upload_temporary_file do
+    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+
     now = DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_string() |> String.replace(" ", "_")
     filename = "bnlc-#{now}.csv"
-    Transport.S3.stream_to_s3!(@s3_bucket, @bnlc_path, filename, acl: :public_read)
+    Transport.S3.stream_to_s3!(@s3_bucket, bnlc_path, filename, acl: :public_read)
     filename
   end
 
@@ -296,12 +299,14 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
   @doc """
   Given a list of resources, previously prepared by `download_resources/1`,
-  creates the BNLC final file and write on the local disk at `@bnlc_path`.
+  creates the BNLC final file and write on the local disk at `System.tmp_dir!() |> Path.join("bnlc.csv")`.
 
   It downloads the BNLC from GitHub and reads other files from the disk.
   """
   def consolidate_resources(resources_details) do
-    file = File.open!(@bnlc_path, [:write, :utf8])
+    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+
+    file = File.open!(bnlc_path, [:write, :utf8])
     bnlc_headers = bnlc_csv_headers()
     final_headers = final_csv_headers(bnlc_headers)
 

--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -62,11 +62,13 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{id: job_id, args: %{"action" => "datagouv_update"}}) do
-    return_value = consolidate()
+  def perform(%Oban.Job{id: job_id, args: %{"action" => "datagouv_update"} = args}) do
+    bnlc_path = args["path"] || System.tmp_dir!() |> Path.join("bnlc.csv")
+
+    return_value = consolidate(bnlc_path)
 
     if return_value == :ok do
-      replace_file_on_datagouv()
+      replace_file_on_datagouv(bnlc_path)
     end
 
     Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
@@ -74,14 +76,18 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{id: job_id}) do
-    return_value = consolidate()
+  def perform(%Oban.Job{id: job_id, args: args}) do
+    bnlc_path = args["path"] || System.tmp_dir!() |> Path.join("bnlc.csv")
+
+    return_value = consolidate(bnlc_path)
     Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
     return_value
   end
 
-  @spec consolidate() :: :ok | {:discard, binary()}
-  def consolidate do
+  @spec consolidate(bnlc_path :: Path.t()) :: :ok | {:discard, binary()}
+  defp consolidate(bnlc_path) do
+    # bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+
     Logger.info("Starting consolidation…")
     Logger.info("Extracting configured datasets & retrieving data from data.gouv…")
     %{ok: datasets_details, errors: dataset_errors} = datagouv_dataset_slugs() |> extract_dataset_details()
@@ -95,11 +101,11 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
       Logger.info("Downloading resources…")
       %{ok: download_details, errors: download_or_decode_errors} = download_resources(resources_details)
       Logger.info("Creating a single file")
-      consolidate_resources(download_details)
+      consolidate_resources(download_details, bnlc_path)
 
       Logger.info("Sending the email recap")
 
-      upload_temporary_file()
+      upload_temporary_file(bnlc_path)
       |> schedule_deletion()
       |> send_email_recap(%{
         dataset_errors: dataset_errors,
@@ -112,10 +118,8 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
     end
   end
 
-  def replace_file_on_datagouv do
+  def replace_file_on_datagouv(bnlc_path) do
     %{dataset_id: dataset_id, resource_id: resource_id} = consolidation_configuration()
-
-    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
 
     Datagouvfr.Client.Resources.update(%{
       "dataset_id" => dataset_id,
@@ -133,9 +137,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
     |> Enum.any?()
   end
 
-  defp upload_temporary_file do
-    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
-
+  defp upload_temporary_file(bnlc_path) do
     now = DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_string() |> String.replace(" ", "_")
     filename = "bnlc-#{now}.csv"
     Transport.S3.stream_to_s3!(@s3_bucket, bnlc_path, filename, acl: :public_read)
@@ -303,9 +305,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
   It downloads the BNLC from GitHub and reads other files from the disk.
   """
-  def consolidate_resources(resources_details) do
-    bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
-
+  def consolidate_resources(resources_details, bnlc_path) do
     file = File.open!(bnlc_path, [:write, :utf8])
     bnlc_headers = bnlc_csv_headers()
     final_headers = final_csv_headers(bnlc_headers)
@@ -499,10 +499,11 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   @spec download_resources([map()]) :: %{ok: [], errors: [decode_error() | download_error()]}
   def download_resources(resources_details) do
     resources_details
-    |> Enum.map(fn {dataset_details, %{"url" => resource_url} = resource} ->
+    |> Enum.map(fn {dataset_details, %{"url" => resource_url, "id" => resource_id} = resource} ->
       case http_client().get(resource_url, [], follow_redirect: true) do
         {:ok, %HTTPoison.Response{status_code: 200} = response} ->
-          guess_csv_details_and_decode({dataset_details, resource}, response)
+          path = System.tmp_dir!() |> Path.join("consolidate_bnlc_#{resource_id}")
+          guess_csv_details_and_decode({dataset_details, resource}, response, path)
 
         _ ->
           {:errors, {:download, {dataset_details, resource}}}
@@ -517,11 +518,14 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
   - guess the file encoding
   - decode the CSV file with the guessed separator
   """
-  def guess_csv_details_and_decode({dataset_details, %{"id" => resource_id} = resource}, %HTTPoison.Response{
-        status_code: 200,
-        body: body
-      }) do
-    path = System.tmp_dir!() |> Path.join("consolidate_bnlc_#{resource_id}")
+  def guess_csv_details_and_decode(
+        {dataset_details, %{} = resource},
+        %HTTPoison.Response{
+          status_code: 200,
+          body: body
+        },
+        path
+      ) do
     File.write!(path, body)
 
     resource =

--- a/apps/transport/lib/jobs/consolidate_bnlc_job.ex
+++ b/apps/transport/lib/jobs/consolidate_bnlc_job.ex
@@ -63,7 +63,7 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
   @impl Oban.Worker
   def perform(%Oban.Job{id: job_id, args: %{"action" => "datagouv_update"} = args}) do
-    bnlc_path = args["path"] || System.tmp_dir!() |> Path.join("bnlc.csv")
+    bnlc_path = args["path"] || tmp_file!()
 
     return_value = consolidate(bnlc_path)
 
@@ -77,17 +77,19 @@ defmodule Transport.Jobs.ConsolidateBNLCJob do
 
   @impl Oban.Worker
   def perform(%Oban.Job{id: job_id, args: args}) do
-    bnlc_path = args["path"] || System.tmp_dir!() |> Path.join("bnlc.csv")
+    bnlc_path = args["path"] || tmp_file!()
 
     return_value = consolidate(bnlc_path)
     Oban.Notifier.notify(Oban, :gossip, %{complete: job_id})
     return_value
   end
 
+  defp tmp_file! do
+    System.tmp_dir!() |> Path.join("bnlc.csv")
+  end
+
   @spec consolidate(bnlc_path :: Path.t()) :: :ok | {:discard, binary()}
   defp consolidate(bnlc_path) do
-    # bnlc_path = System.tmp_dir!() |> Path.join("bnlc.csv")
-
     Logger.info("Starting consolidation…")
     Logger.info("Extracting configured datasets & retrieving data from data.gouv…")
     %{ok: datasets_details, errors: dataset_errors} = datagouv_dataset_slugs() |> extract_dataset_details()

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -390,7 +390,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
       end
     )
 
-    assert :ok == ConsolidateBNLCJob.consolidate_resources(res)
+    path = System.tmp_dir!() |> Path.join("consolidate_resources-bnlc.csv")
+
+    assert :ok == ConsolidateBNLCJob.consolidate_resources(res, path)
 
     assert [
              %{
@@ -454,8 +456,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                "resource_id" => other_resource_id
              }
            ] ==
-             System.tmp_dir!()
-             |> Path.join("bnlc.csv")
+             path
              |> File.stream!()
              |> CSV.decode!(headers: true)
              |> Enum.to_list()
@@ -472,7 +473,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
            21231-2,4,5,6,21231,2,#{dataset_id},#{resource_id}\r
            21231-3,a,b,c,21231,3,#{other_dataset_id},#{other_resource_id}\r
            21231-4,d,e,f,21231,4,#{other_dataset_id},#{other_resource_id}\r
-           """ == File.read!(System.tmp_dir!() |> Path.join("bnlc.csv"))
+           """ == File.read!(path)
 
     # Temporary files have been removed
     [{_, r1}, {_, r2}] = res
@@ -589,12 +590,12 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       expect_s3_stream_upload()
 
-      assert :ok == perform_job(ConsolidateBNLCJob, %{})
+      tmp_path = System.tmp_dir!() |> Path.join("job-success-bnlc.csv")
+
+      assert :ok == perform_job(ConsolidateBNLCJob, %{"path" => tmp_path})
 
       assert_ok_email_sent()
       expect_job_scheduled_to_remove_file()
-
-      tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
       # CSV content is fine
       assert """
              id_lieu,foo,bar,baz,insee,id_local,dataset_id,resource_id\r
@@ -755,13 +756,13 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       expect_s3_stream_upload()
 
-      assert :ok == perform_job(ConsolidateBNLCJob, %{})
+      tmp_path = System.tmp_dir!() |> Path.join("job-invalid-resource-bnlc.csv")
+
+      assert :ok == perform_job(ConsolidateBNLCJob, %{"path" => tmp_path})
 
       assert_ko_email_sent()
 
       expect_job_scheduled_to_remove_file()
-
-      tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
 
       assert """
              id_lieu,foo,bar,baz,insee,id_local,dataset_id,resource_id\r
@@ -774,11 +775,11 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   end
 
   test "replace_file_on_datagouv" do
-    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+    tmp_path = System.tmp_dir!() |> Path.join("replace_file_on_datagouv-bnlc.csv")
 
-    expect_datagouv_upload_file_http_call()
+    expect_datagouv_upload_file_http_call(tmp_path)
 
-    ConsolidateBNLCJob.replace_file_on_datagouv()
+    ConsolidateBNLCJob.replace_file_on_datagouv(tmp_path)
 
     refute File.exists?(tmp_path)
   end
@@ -808,16 +809,17 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
     )
 
     expect_s3_stream_upload()
-    expect_datagouv_upload_file_http_call()
 
-    assert :ok == perform_job(ConsolidateBNLCJob, %{"action" => "datagouv_update"})
+    path = System.tmp_dir!() |> Path.join("update_datagouv-bnlc.csv")
+
+    expect_datagouv_upload_file_http_call(path)
+
+    assert :ok == perform_job(ConsolidateBNLCJob, %{"action" => "datagouv_update", "path" => path})
 
     assert_ok_email_sent()
 
     expect_job_scheduled_to_remove_file()
-
-    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
-    refute File.exists?(tmp_path)
+    refute File.exists?(path)
   end
 
   describe "deleting a temporary file" do
@@ -858,9 +860,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
     end)
   end
 
-  defp expect_datagouv_upload_file_http_call do
-    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
-
+  defp expect_datagouv_upload_file_http_call(tmp_path) do
     expected_url =
       "https://demo.data.gouv.fr/api/1/datasets/bnlc_fake_dataset_id/resources/bnlc_fake_resource_id/upload/"
 
@@ -871,6 +871,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                            [{"content-type", "multipart/form-data"}, {"X-API-KEY", "fake-datagouv-api-key"}],
                            [follow_redirect: true] ->
       {:multipart, [{:file, ^tmp_path, {"form-data", [name: "file", filename: "bnlc.csv"]}, []}]} = args
+      File.touch!(tmp_path)
       {:ok, %HTTPoison.Response{body: "", status_code: 200}}
     end)
   end

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -7,7 +7,6 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   alias Transport.Jobs.ConsolidateBNLCJob
 
   @target_schema "etalab/schema-lieux-covoiturage"
-  @tmp_path System.tmp_dir!() |> Path.join("bnlc.csv")
   @csv_latin1_path "#{__DIR__}/../../fixture/files/csv_latin1.csv"
   @csv_utf8_path "#{__DIR__}/../../fixture/files/csv_utf8.csv"
 
@@ -454,7 +453,12 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
                "dataset_id" => other_dataset_id,
                "resource_id" => other_resource_id
              }
-           ] == @tmp_path |> File.stream!() |> CSV.decode!(headers: true) |> Enum.to_list()
+           ] ==
+             System.tmp_dir!()
+             |> Path.join("bnlc.csv")
+             |> File.stream!()
+             |> CSV.decode!(headers: true)
+             |> Enum.to_list()
 
     # From https://datatracker.ietf.org/doc/html/rfc4180#section-2
     # > Each record is located on a separate line, delimited by a line break (CRLF)
@@ -468,7 +472,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
            21231-2,4,5,6,21231,2,#{dataset_id},#{resource_id}\r
            21231-3,a,b,c,21231,3,#{other_dataset_id},#{other_resource_id}\r
            21231-4,d,e,f,21231,4,#{other_dataset_id},#{other_resource_id}\r
-           """ == File.read!(@tmp_path)
+           """ == File.read!(System.tmp_dir!() |> Path.join("bnlc.csv"))
 
     # Temporary files have been removed
     [{_, r1}, {_, r2}] = res
@@ -590,6 +594,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
       assert_ok_email_sent()
       expect_job_scheduled_to_remove_file()
 
+      tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
       # CSV content is fine
       assert """
              id_lieu,foo,bar,baz,insee,id_local,dataset_id,resource_id\r
@@ -598,7 +603,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
              21231-1,a,b,c,21231,1,#{foo_dataset_id},#{foo_resource_id}\r
              21231-2,d,e,f,21231,2,#{foo_dataset_id},#{foo_resource_id}\r
              21231-3,1,2,3,21231,3,#{bar_dataset_id},#{bar_resource_id}\r
-             """ == File.read!(@tmp_path)
+             """ == File.read!(tmp_path)
     end
 
     test "stops when the schema validator is down" do
@@ -756,24 +761,26 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       expect_job_scheduled_to_remove_file()
 
+      tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+
       assert """
              id_lieu,foo,bar,baz,insee,id_local,dataset_id,resource_id\r
              21231-3,I,Love,CSV,21231,3,bnlc_github,bnlc_github\r
              21231-4,Very,Much,So,21231,4,bnlc_github,bnlc_github\r
              21231-1,a,b,c,21231,1,#{foo_dataset_id},#{foo_resource_id}\r
              21231-2,d,e,f,21231,2,#{foo_dataset_id},#{foo_resource_id}\r
-             """ == File.read!(@tmp_path)
+             """ == File.read!(tmp_path)
     end
   end
 
   test "replace_file_on_datagouv" do
-    File.write!(@tmp_path, "fake_content")
+    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
 
     expect_datagouv_upload_file_http_call()
 
     ConsolidateBNLCJob.replace_file_on_datagouv()
 
-    refute File.exists?(@tmp_path)
+    refute File.exists?(tmp_path)
   end
 
   test "perform and update file on data.gouv.fr" do
@@ -809,7 +816,8 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
     expect_job_scheduled_to_remove_file()
 
-    refute File.exists?(@tmp_path)
+    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
+    refute File.exists?(tmp_path)
   end
 
   describe "deleting a temporary file" do
@@ -851,7 +859,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   end
 
   defp expect_datagouv_upload_file_http_call do
-    tmp_path = @tmp_path
+    tmp_path = System.tmp_dir!() |> Path.join("bnlc.csv")
 
     expected_url =
       "https://demo.data.gouv.fr/api/1/datasets/bnlc_fake_dataset_id/resources/bnlc_fake_resource_id/upload/"

--- a/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
+++ b/apps/transport/test/transport/jobs/consolidate_bnlc_job_test.exs
@@ -390,7 +390,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
       end
     )
 
-    path = System.tmp_dir!() |> Path.join("consolidate_resources-bnlc.csv")
+    path = tmp_file!()
 
     assert :ok == ConsolidateBNLCJob.consolidate_resources(res, path)
 
@@ -590,7 +590,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       expect_s3_stream_upload()
 
-      tmp_path = System.tmp_dir!() |> Path.join("job-success-bnlc.csv")
+      tmp_path = tmp_file!()
 
       assert :ok == perform_job(ConsolidateBNLCJob, %{"path" => tmp_path})
 
@@ -756,7 +756,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
       expect_s3_stream_upload()
 
-      tmp_path = System.tmp_dir!() |> Path.join("job-invalid-resource-bnlc.csv")
+      tmp_path = tmp_file!()
 
       assert :ok == perform_job(ConsolidateBNLCJob, %{"path" => tmp_path})
 
@@ -775,7 +775,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
   end
 
   test "replace_file_on_datagouv" do
-    tmp_path = System.tmp_dir!() |> Path.join("replace_file_on_datagouv-bnlc.csv")
+    tmp_path = tmp_file!()
 
     expect_datagouv_upload_file_http_call(tmp_path)
 
@@ -810,7 +810,7 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
 
     expect_s3_stream_upload()
 
-    path = System.tmp_dir!() |> Path.join("update_datagouv-bnlc.csv")
+    path = tmp_file!()
 
     expect_datagouv_upload_file_http_call(path)
 
@@ -917,5 +917,9 @@ defmodule Transport.Test.Transport.Jobs.ConsolidateBNLCJobTest do
       assert html_body =~
                ~r{🔗 <a href="https://transport-data-gouv-fr-on-demand-validation-test.cellar-c2.services.clever-cloud.com/bnlc-.*\.csv">Fichier consolidé</a>}
     end)
+  end
+
+  defp tmp_file! do
+    System.tmp_dir!() |> Path.join("#{Ecto.UUID.generate()}.csv")
   end
 end

--- a/apps/transport/test/unlock/dynamic_irve/feed_worker_test.exs
+++ b/apps/transport/test/unlock/dynamic_irve/feed_worker_test.exs
@@ -1,5 +1,6 @@
 defmodule Unlock.DynamicIRVE.FeedWorkerTest do
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
 
   import Mox
 
@@ -44,15 +45,20 @@ defmodule Unlock.DynamicIRVE.FeedWorkerTest do
       %Req.Response{status: 500, body: "oops"}
     end)
 
-    {:ok, pid} = FeedWorker.start_link({"parent", feed})
-    send(pid, :tick)
-    await_genserver_messages_processed(pid)
+    logs =
+      capture_log(fn ->
+        {:ok, pid} = FeedWorker.start_link({"parent", feed})
+        send(pid, :tick)
+        await_genserver_messages_processed(pid)
 
-    assert_received {:fetched, url}
-    assert url == feed.target_url
+        assert_received {:fetched, url}
+        assert url == feed.target_url
 
-    assert %{error: "HTTP 500", last_errored_at: %DateTime{}} = FeedStore.get_feed("parent", "slug-002")
-    assert Process.alive?(pid)
+        assert %{error: "HTTP 500", last_errored_at: %DateTime{}} = FeedStore.get_feed("parent", "slug-002")
+        assert Process.alive?(pid)
+      end)
+
+    assert logs =~ "[warning] [DynamicIRVE] parent/slug-002 => HTTP 500"
   end
 
   # Sync barrier: a GenServer handles one message at a time, in FIFO order from


### PR DESCRIPTION
- IRVE Dynamique : capture du log de warning sur la 500
- BNLC : le chemin temporaire n'est plus calculé à la compilation dans le cas (non conventionnel) où le dossier temporaire change entre la compilation des tests et la compilation de la lib. Le chemin est désormais aléatoire dans les tests.