### PR TITLE
IRVE : affichage d’avertissements concernant les inversions de coordonnées dans le validateur à la demande

### DIFF
--- a/apps/transport/lib/irve/coordinate_correction.ex
+++ b/apps/transport/lib/irve/coordinate_correction.ex
@@ -62,6 +62,8 @@ defmodule Transport.IRVE.CoordinateCorrection do
       [false, true, false, true]
 
   """
+  def inverted?(%DF{} = df), do: inverted?(df["longitude"], df["latitude"])
+
   def inverted?(lon_series, lat_series) do
     lon_in_lat_range =
       Series.and(

--- a/apps/transport/lib/irve/data_frame.ex
+++ b/apps/transport/lib/irve/data_frame.ex
@@ -280,6 +280,14 @@ defmodule Transport.IRVE.DataFrame do
       longitude f64 [43.306241]
       latitude f64 [-0.332879]
     >
+
+  The function is resilient to weird values:
+  iex> Explorer.DataFrame.new([%{coordonneesXY: ""}, %{coordonneesXY: "[hello, 9]"}, %{coordonneesXY: "hello"}]) |> Transport.IRVE.DataFrame.preprocess_xy_coordinates()
+  #Explorer.DataFrame<
+    Polars[3 x 2]
+    longitude f64 [nil, nil, nil]
+    latitude f64 [nil, 9.0, nil]
+  >
   """
   def preprocess_xy_coordinates(df) do
     df

--- a/apps/transport/lib/irve/validator/data_frame_validation.ex
+++ b/apps/transport/lib/irve/validator/data_frame_validation.ex
@@ -81,4 +81,24 @@ defmodule Transport.IRVE.Validator.DataFrameValidation do
       %{"check_row_valid" => row_valid}
     end)
   end
+
+  @doc """
+  Adds custom warning columns.
+  We only apply warnings to valid values to avoid noise.
+  """
+  def setup_computed_warning_columns(%Explorer.DataFrame{} = df) do
+    df
+    |> setup_inverted_lon_lat_warning_column()
+  end
+
+  def setup_inverted_lon_lat_warning_column(%Explorer.DataFrame{} = df) do
+    warning =
+      Explorer.DataFrame.select(df, ["coordonneesXY"])
+      # The next line is safe and shouldn’t raise errors even with weird values.
+      |> Transport.IRVE.Processing.preprocess_coordinates()
+      |> Transport.IRVE.CoordinateCorrection.inverted?()
+      |> Explorer.Series.and(df["check_column_coordonneesXY_valid"])
+
+    Explorer.DataFrame.put(df, "warning_lon_lat_inverted", warning)
+  end
 end

--- a/apps/transport/lib/irve/validator/summary.ex
+++ b/apps/transport/lib/irve/validator/summary.ex
@@ -11,7 +11,8 @@ defmodule Transport.IRVE.Validator.Summary do
     :file_level_errors,
     :column_errors,
     :error_samples,
-    :warnings
+    :warnings,
+    :warning_samples
   ]
 
   defstruct [
@@ -22,7 +23,8 @@ defmodule Transport.IRVE.Validator.Summary do
     :file_level_errors,
     :column_errors,
     :error_samples,
-    :warnings
+    :warnings,
+    :warning_samples
   ]
 
   @doc """
@@ -34,7 +36,9 @@ defmodule Transport.IRVE.Validator.Summary do
     result
     |> atomize_keys()
     |> Map.put_new(:warnings, %{})
+    |> Map.put_new(:warning_samples, [])
     |> Map.update!(:error_samples, fn samples -> Enum.map(samples, &atomize_keys/1) end)
+    |> Map.update!(:warning_samples, fn samples -> Enum.map(samples, &atomize_keys/1) end)
     |> then(&struct!(__MODULE__, &1))
   end
 

--- a/apps/transport/lib/irve/validator/summary.ex
+++ b/apps/transport/lib/irve/validator/summary.ex
@@ -10,7 +10,8 @@ defmodule Transport.IRVE.Validator.Summary do
     :total_row_count,
     :file_level_errors,
     :column_errors,
-    :error_samples
+    :error_samples,
+    :warnings
   ]
 
   defstruct [
@@ -20,7 +21,8 @@ defmodule Transport.IRVE.Validator.Summary do
     :total_row_count,
     :file_level_errors,
     :column_errors,
-    :error_samples
+    :error_samples,
+    :warnings
   ]
 
   @doc """
@@ -31,6 +33,7 @@ defmodule Transport.IRVE.Validator.Summary do
   def from_result(result) when is_map(result) do
     result
     |> atomize_keys()
+    |> Map.put_new(:warnings, %{})
     |> Map.update!(:error_samples, fn samples -> Enum.map(samples, &atomize_keys/1) end)
     |> then(&struct!(__MODULE__, &1))
   end

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -101,6 +101,7 @@ defmodule Transport.IRVE.Validator do
       }
   end
 
+  # Maps each warning to the raw input column (not immediately constructed from the warning name)
   @warning_value_columns %{"lon_lat_inverted" => "coordonneesXY"}
 
   defp summarize_warnings(df) do

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -56,6 +56,7 @@ defmodule Transport.IRVE.Validator do
     {valid_count, invalid_count} = summarize_total_counts(df)
     column_errors = summarize_column_errors(df)
     error_samples = error_samples(df, column_errors)
+    warnings = summarize_warnings(df)
 
     %Transport.IRVE.Validator.Summary{
       valid: invalid_count == 0,
@@ -65,7 +66,8 @@ defmodule Transport.IRVE.Validator do
       file_level_errors: [],
       column_errors: column_errors,
       error_samples: error_samples,
-      warnings: summarize_warnings(df)
+      warnings: warnings,
+      warning_samples: warning_samples(df, warnings)
     }
   end
 
@@ -94,9 +96,12 @@ defmodule Transport.IRVE.Validator do
         file_level_errors: [Exception.message(error)],
         column_errors: %{},
         error_samples: [],
-        warnings: %{}
+        warnings: %{},
+        warning_samples: []
       }
   end
+
+  @warning_value_columns %{"lon_lat_inverted" => "coordonneesXY"}
 
   defp summarize_warnings(df) do
     df
@@ -107,6 +112,22 @@ defmodule Transport.IRVE.Validator do
       if count > 0, do: [{String.replace_prefix(col, "warning_", ""), count}], else: []
     end)
     |> Map.new()
+  end
+
+  defp warning_samples(df, warnings) do
+    warnings
+    |> Enum.flat_map(fn {warning_name, _count} ->
+      value_col = Map.fetch!(@warning_value_columns, warning_name)
+
+      df
+      |> Explorer.DataFrame.filter_with(& &1["warning_#{warning_name}"])
+      |> Explorer.DataFrame.select(["id_pdc_itinerance", value_col])
+      |> Explorer.DataFrame.head(5)
+      |> Explorer.DataFrame.to_rows()
+      |> Enum.map(fn row ->
+        %{id_pdc_itinerance: row["id_pdc_itinerance"], warning: warning_name, value: row[value_col]}
+      end)
+    end)
   end
 
   defp summarize_total_counts(df) do

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -9,6 +9,7 @@ defmodule Transport.IRVE.Validator do
     df
     |> Transport.IRVE.Validator.DataFrameValidation.setup_computed_field_validation_columns(schema)
     |> Transport.IRVE.Validator.DataFrameValidation.setup_computed_row_validation_column()
+    |> Transport.IRVE.Validator.DataFrameValidation.setup_computed_warning_columns()
   end
 
   @doc """

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -105,14 +105,12 @@ defmodule Transport.IRVE.Validator do
   @warning_value_columns %{"lon_lat_inverted" => "coordonneesXY"}
 
   defp summarize_warnings(df) do
-    df
+    warnings = Explorer.DataFrame.select(df, &String.starts_with?(&1, "warning_"))
+
+    warnings
     |> Explorer.DataFrame.names()
-    |> Enum.filter(&String.starts_with?(&1, "warning_"))
-    |> Enum.flat_map(fn col ->
-      count = df[col] |> Explorer.Series.sum()
-      if count > 0, do: [{String.replace_prefix(col, "warning_", ""), count}], else: []
-    end)
-    |> Map.new()
+    |> Map.new(fn col -> {String.replace_prefix(col, "warning_", ""), Explorer.Series.sum(warnings[col])} end)
+    |> Map.reject(fn {_name, count} -> count == 0 end)
   end
 
   defp warning_samples(df, warnings) do

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -101,6 +101,8 @@ defmodule Transport.IRVE.Validator do
       }
   end
 
+  @max_samples_per_group 5
+
   # Maps each warning to the raw input column (not immediately constructed from the warning name)
   @warning_value_columns %{"lon_lat_inverted" => "coordonneesXY"}
 
@@ -120,12 +122,7 @@ defmodule Transport.IRVE.Validator do
 
       df
       |> Explorer.DataFrame.filter_with(& &1["warning_#{warning_name}"])
-      |> Explorer.DataFrame.select(["id_pdc_itinerance", value_col])
-      |> Explorer.DataFrame.head(5)
-      |> Explorer.DataFrame.to_rows()
-      |> Enum.map(fn row ->
-        %{id_pdc_itinerance: row["id_pdc_itinerance"], warning: warning_name, value: row[value_col]}
-      end)
+      |> take_samples(value_col, :warning, warning_name)
     end)
   end
 
@@ -148,17 +145,19 @@ defmodule Transport.IRVE.Validator do
   defp error_samples(df, column_errors) do
     column_errors
     |> Enum.flat_map(fn {field_name, _error_count} ->
-      check_col = "check_column_#{field_name}_valid"
-
       df
-      |> Explorer.DataFrame.filter_with(&(&1[check_col] |> Explorer.Series.not()))
-      |> Explorer.DataFrame.select(["id_pdc_itinerance", field_name])
-      # Limit to 5 samples per error column
-      |> Explorer.DataFrame.head(5)
-      |> Explorer.DataFrame.to_rows()
-      |> Enum.map(fn row ->
-        %{id_pdc_itinerance: row["id_pdc_itinerance"], column: field_name, value: row[field_name]}
-      end)
+      |> Explorer.DataFrame.filter_with(&Explorer.Series.not(&1["check_column_#{field_name}_valid"]))
+      |> take_samples(field_name, :column, field_name)
+    end)
+  end
+
+  defp take_samples(df, value_col, tag_key, name) do
+    df
+    |> Explorer.DataFrame.select(["id_pdc_itinerance", value_col])
+    |> Explorer.DataFrame.head(@max_samples_per_group)
+    |> Explorer.DataFrame.to_rows()
+    |> Enum.map(fn row ->
+      %{:id_pdc_itinerance => row["id_pdc_itinerance"], tag_key => name, :value => row[value_col]}
     end)
   end
 end

--- a/apps/transport/lib/irve/validator/validator.ex
+++ b/apps/transport/lib/irve/validator/validator.ex
@@ -64,7 +64,8 @@ defmodule Transport.IRVE.Validator do
       total_row_count: valid_count + invalid_count,
       file_level_errors: [],
       column_errors: column_errors,
-      error_samples: error_samples
+      error_samples: error_samples,
+      warnings: summarize_warnings(df)
     }
   end
 
@@ -92,8 +93,20 @@ defmodule Transport.IRVE.Validator do
         total_row_count: nil,
         file_level_errors: [Exception.message(error)],
         column_errors: %{},
-        error_samples: []
+        error_samples: [],
+        warnings: %{}
       }
+  end
+
+  defp summarize_warnings(df) do
+    df
+    |> Explorer.DataFrame.names()
+    |> Enum.filter(&String.starts_with?(&1, "warning_"))
+    |> Enum.flat_map(fn col ->
+      count = df[col] |> Explorer.Series.sum()
+      if count > 0, do: [{String.replace_prefix(col, "warning_", ""), count}], else: []
+    end)
+    |> Map.new()
   end
 
   defp summarize_total_counts(df) do

--- a/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
+++ b/apps/transport/lib/transport_web/templates/validation/show_irve_statique.html.heex
@@ -55,6 +55,18 @@
           </ul>
         <% end %>
 
+        <%= unless Enum.empty?(@summary.warnings) do %>
+          <p>
+            <span class="icon--validation">⚠️</span>
+            {dngettext(
+              "validations",
+              "%{count} warning detected.",
+              "%{count} warnings detected.",
+              Enum.sum(Map.values(@summary.warnings))
+            )}
+          </p>
+        <% end %>
+
         <%= unless Enum.empty?(@summary.file_level_errors) do %>
           <h4>{dgettext("validations", "File-level errors")}</h4>
           <ul>
@@ -94,6 +106,44 @@
               <tr :for={sample <- @summary.error_samples}>
                 <td>{sample.id_pdc_itinerance}</td>
                 <td>{sample.column}</td>
+                <td>{sample.value}</td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+
+        <%= unless Enum.empty?(@summary.warnings) do %>
+          <h4>{dgettext("validations", "Warnings")}</h4>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{dgettext("validations", "Warning")}</th>
+                <th>{dgettext("validations", "Rows")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={{warning, count} <- Enum.sort_by(@summary.warnings, &elem(&1, 0))}>
+                <td>{warning_label(warning)}</td>
+                <td>{count}</td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+
+        <%= unless Enum.empty?(@summary.warning_samples) do %>
+          <h4>{dgettext("validations", "Warning samples")}</h4>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>id_pdc_itinerance</th>
+                <th>{dgettext("validations", "Warning")}</th>
+                <th>{dgettext("validations", "Value")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={sample <- @summary.warning_samples}>
+                <td>{sample.id_pdc_itinerance}</td>
+                <td>{warning_label(sample.warning)}</td>
                 <td>{sample.value}</td>
               </tr>
             </tbody>

--- a/apps/transport/lib/transport_web/views/validation_view.ex
+++ b/apps/transport/lib/transport_web/views/validation_view.ex
@@ -24,6 +24,11 @@ defmodule TransportWeb.ValidationView do
   def has_errors?([]), do: false
   def has_errors?(summary) when is_list(summary), do: true
 
+  def warning_label("lon_lat_inverted"),
+    do: dgettext("validations", "Longitude and latitude coordinates inverted")
+
+  def warning_label(warning) when is_binary(warning), do: warning
+
   def netex_pagination_links(conn, issues, validation_id, current_category) do
     pagination_links(conn, issues, [validation_id],
       issues_category: current_category,

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/validations.po
@@ -513,3 +513,25 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large, must be <%{max_file_size}."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "%{count} warning detected."
+msgid_plural "%{count} warnings detected."
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Longitude and latitude coordinates inverted"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Warning"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Warning samples"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/validations.po
@@ -513,3 +513,25 @@ msgstr "Vous pouvez toujours utiliser l'ancien <a href=\"%{url}\" target=\"_blan
 #, elixir-autogen, elixir-format
 msgid "File is too large, must be <%{max_file_size}."
 msgstr "Fichier trop gros, doit peser moins de %{max_file_size}."
+
+#, elixir-autogen, elixir-format
+msgid "%{count} warning detected."
+msgid_plural "%{count} warnings detected."
+msgstr[0] "%{count} avertissement détecté."
+msgstr[1] "%{count} avertissements détectés."
+
+#, elixir-autogen, elixir-format
+msgid "Longitude and latitude coordinates inverted"
+msgstr "Coordonnées de longitude et latitude inversées"
+
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr "Lignes"
+
+#, elixir-autogen, elixir-format
+msgid "Warning"
+msgstr "Avertissement"
+
+#, elixir-autogen, elixir-format
+msgid "Warning samples"
+msgstr "Exemples d'avertissements"

--- a/apps/transport/priv/gettext/validations.pot
+++ b/apps/transport/priv/gettext/validations.pot
@@ -511,3 +511,25 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "File is too large, must be <%{max_file_size}."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "%{count} warning detected."
+msgid_plural "%{count} warnings detected."
+msgstr[0] ""
+msgstr[1] ""
+
+#, elixir-autogen, elixir-format
+msgid "Longitude and latitude coordinates inverted"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Warning"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Warning samples"
+msgstr ""

--- a/apps/transport/test/transport/irve/validation/data_frame_validation_test.exs
+++ b/apps/transport/test/transport/irve/validation/data_frame_validation_test.exs
@@ -252,9 +252,41 @@ defmodule Transport.IRVE.Validator.DataFrameValidationTest do
   defp to_boolean(:valid), do: true
   defp to_boolean(:invalid), do: false
 
-  defp stringify_row(row), do: row |> Enum.map(fn {a, b} -> {a, b |> to_string} end)
+  def stringify_row(row), do: row |> Enum.map(fn {a, b} -> {a, b |> to_string} end)
 
   defp run_dataframe_validators(rows) do
     Transport.IRVE.Validator.compute_validation(rows |> Explorer.DataFrame.new())
+  end
+end
+
+defmodule Transport.IRVE.Validator.DataFrameValidation.WarningsTest do
+  use ExUnit.Case, async: true
+
+  alias Transport.IRVE.Validator.DataFrameValidationTest, as: Parent
+
+  test "warning_lon_lat_inverted is false for correct mainland France coordinates" do
+    result = run_with_xy("[2.35, 48.85]")
+    assert Explorer.Series.to_list(result["warning_lon_lat_inverted"]) == [false]
+  end
+
+  test "warning_lon_lat_inverted is true for inverted mainland France coordinates" do
+    result = run_with_xy("[48.85, 2.35]")
+    assert Explorer.Series.to_list(result["warning_lon_lat_inverted"]) == [true]
+  end
+
+  test "warning_lon_lat_inverted is false when coordonneesXY is invalid (not a warning)" do
+    result = run_with_xy("[invalid, 9]")
+    assert Explorer.Series.to_list(result["warning_lon_lat_inverted"]) == [false]
+  end
+
+  test "warning_lon_lat_inverted is false for Réunion correct coordinates" do
+    result = run_with_xy("[55.4, -21.1]")
+    assert Explorer.Series.to_list(result["warning_lon_lat_inverted"]) == [false]
+  end
+
+  defp run_with_xy(xy) do
+    [DB.Factory.IRVE.generate_row(%{"coordonneesXY" => xy}) |> Parent.stringify_row()]
+    |> Explorer.DataFrame.new()
+    |> Transport.IRVE.Validator.compute_validation()
   end
 end

--- a/apps/transport/test/transport/irve/validation/validator_test.exs
+++ b/apps/transport/test/transport/irve/validation/validator_test.exs
@@ -152,7 +152,8 @@ defmodule Transport.IRVE.ValidatorTest do
                total_row_count: 1,
                file_level_errors: [],
                column_errors: %{},
-               error_samples: []
+               error_samples: [],
+               warnings: %{}
              } == summary
     end)
   end
@@ -180,6 +181,20 @@ defmodule Transport.IRVE.ValidatorTest do
 
       assert [%{column: "nbre_pdc", value: "not-a-number", id_pdc_itinerance: _}] =
                Enum.filter(summary.error_samples, &(&1.column == "nbre_pdc"))
+    end)
+  end
+
+  test "summarize/1 reports inverted lon/lat coordinates as a warning" do
+    inverted_row = DB.Factory.IRVE.generate_row(%{"coordonneesXY" => "[45.91914, -0.799141]"})
+    valid_row = DB.Factory.IRVE.generate_row()
+    csv_content = [inverted_row, valid_row] |> DB.Factory.IRVE.to_csv_body()
+
+    with_tmp_file(csv_content, fn path ->
+      summary = Transport.IRVE.Validator.validate(path) |> Transport.IRVE.Validator.summarize()
+
+      assert summary.valid == true
+      assert summary.column_errors == %{}
+      assert summary.warnings == %{"lon_lat_inverted" => 1}
     end)
   end
 

--- a/apps/transport/test/transport/irve/validation/validator_test.exs
+++ b/apps/transport/test/transport/irve/validation/validator_test.exs
@@ -153,7 +153,8 @@ defmodule Transport.IRVE.ValidatorTest do
                file_level_errors: [],
                column_errors: %{},
                error_samples: [],
-               warnings: %{}
+               warnings: %{},
+               warning_samples: []
              } == summary
     end)
   end
@@ -185,7 +186,12 @@ defmodule Transport.IRVE.ValidatorTest do
   end
 
   test "summarize/1 reports inverted lon/lat coordinates as a warning" do
-    inverted_row = DB.Factory.IRVE.generate_row(%{"coordonneesXY" => "[45.91914, -0.799141]"})
+    inverted_row =
+      DB.Factory.IRVE.generate_row(%{
+        "id_pdc_itinerance" => "FRPAN99E00000001",
+        "coordonneesXY" => "[45.91914, -0.799141]"
+      })
+
     valid_row = DB.Factory.IRVE.generate_row()
     csv_content = [inverted_row, valid_row] |> DB.Factory.IRVE.to_csv_body()
 
@@ -195,6 +201,10 @@ defmodule Transport.IRVE.ValidatorTest do
       assert summary.valid == true
       assert summary.column_errors == %{}
       assert summary.warnings == %{"lon_lat_inverted" => 1}
+
+      assert summary.warning_samples == [
+               %{id_pdc_itinerance: "FRPAN99E00000001", warning: "lon_lat_inverted", value: "[45.91914, -0.799141]"}
+             ]
     end)
   end
 

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -879,7 +879,7 @@ defmodule TransportWeb.ValidationControllerTest do
         )
 
       response = conn |> get(validation_path(conn, :show, mv.id, token: token)) |> html_response(200)
-      assert response =~ "Longitude and latitude coordinates inverted"
+      assert response =~ "Coordonnées de longitude et latitude inversées"
       assert response =~ "FRPAN99E00000001"
       assert response =~ "[45.91914, -0.799141]"
     end

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -848,6 +848,42 @@ defmodule TransportWeb.ValidationControllerTest do
       assert response =~ "irve.csv"
     end
 
+    test "with a completed IRVE Statique validation reporting a warning", %{conn: conn} do
+      token = Ecto.UUID.generate()
+
+      mv =
+        insert(:multi_validation,
+          oban_args: %{
+            "state" => "completed",
+            "type" => "irve-statique",
+            "secret_url_token" => token
+          },
+          result: %{
+            "valid" => true,
+            "valid_row_count" => 1,
+            "invalid_row_count" => 0,
+            "total_row_count" => 1,
+            "file_level_errors" => [],
+            "column_errors" => %{},
+            "error_samples" => [],
+            "warnings" => %{"lon_lat_inverted" => 1},
+            "warning_samples" => [
+              %{
+                "id_pdc_itinerance" => "FRPAN99E00000001",
+                "warning" => "lon_lat_inverted",
+                "value" => "[45.91914, -0.799141]"
+              }
+            ]
+          },
+          validated_data_name: "irve.csv"
+        )
+
+      response = conn |> get(validation_path(conn, :show, mv.id, token: token)) |> html_response(200)
+      assert response =~ "Longitude and latitude coordinates inverted"
+      assert response =~ "FRPAN99E00000001"
+      assert response =~ "[45.91914, -0.799141]"
+    end
+
     test "with a GTFS-RT validation", %{conn: conn} do
       gtfs_rt_url = "https://example.com/gtfs-rt"
 


### PR DESCRIPTION
Suite de [#5535](https://github.com/etalab/transport-site/pull/5535) sur lequel s’appuie cette PR.

Une image valant mieux qu’un discours :

<img width="1862" height="1274" alt="image" src="https://github.com/user-attachments/assets/ee2c1242-7116-43f2-8f26-9f80708c4cfd" />

J’ai réutilisé le module utilisé pour la rectification pré-insertion en base (qui a lieu après la validation).

Remarque : cet embranchement du validateur ne fonctionne que lors de la validation à la demande, les checks de warnings (enfin, l’unique check pour l’instant) ne sont pas effectués lors de la validation de la consolidation.

Écrit avec la précieuse collaboration de Claude (« Claude, voyez-cela »).