### PR TITLE
Ajout de Yelo VLS (la Rochelle) à la liste des opérateurs VLS connus

### DIFF
--- a/apps/transport/priv/gbfs_operators.csv
+++ b/apps/transport/priv/gbfs_operators.csv
@@ -1,5 +1,6 @@
 url;operator
 example.com;Example
+_ecovelo/gbfs;Ecovélo
 api.cyclocity.fr;JC Decaux
 api.saint-etienne-metropole.fr;Fifteen
 backend.citiz.fr;Citiz
@@ -9,6 +10,7 @@ clermontferrand.publicbikesystem.net;Citybike
 data.grandlyon.com/files/rdata/lpa_mobilite.donnees;Citiz
 data.metropolegrenoble.fr/sites/default/files/dataset/2023/08/10/75c1054c-e602-445c-9852-0fc7abddf592/velos_gbfs.json;Dott
 data.mobilites-m.fr/api/gbfs/dott_grenoble;Dott
+data.mulhouse-alsace.fr;nextbike
 data.optymo.fr;SMTC 90
 donkey.bike;Donkey Republic
 download.data.grandlyon.com;JC Decaux
@@ -16,25 +18,23 @@ ecovelo.mobi;Ecovélo
 eu.ftp.opendatasoft.com/star;Cykleo
 fifteen.eu;Fifteen
 fifteen.site;Fifteen
+fr.getaround.com/gbfs;Getaround
 gbfs.api.ridedott.com;Dott
+gbfs.clem.mobi;Clem
 getapony.com;Pony
+grandestprod.data4citizen.com;Fifteen
 lime.bike;Lime
 media.ilevia.fr/opendata;Cykleo
 nextbike.net;nextbike
 opendata.agglo-larochelle.fr;Yélo VLS
+proxy.transport.data.gouv.fr/resource/pony-;Pony
+services.rideyego.com;Yego
 smovengo.cloud;Smovengo
 stce.transdev-hdf.fr;Transdev
 urbansharing.com/lovelolibreservice.fr;Citybike
 valence.publicbikesystem.net;Fifteen
 voiapp.io;Voi
+www.mobility-parc.net/gbfs;Green On
 zoov.eu;Fifteen
 zoov.io;Fifteen
 zoov.site;Fifteen
-_ecovelo/gbfs;Ecovélo
-gbfs.clem.mobi;Clem
-grandestprod.data4citizen.com;Fifteen
-fr.getaround.com/gbfs;Getaround
-www.mobility-parc.net/gbfs;Green On
-data.mulhouse-alsace.fr;nextbike
-proxy.transport.data.gouv.fr/resource/pony-;Pony
-services.rideyego.com;Yego

--- a/apps/transport/priv/gbfs_operators.csv
+++ b/apps/transport/priv/gbfs_operators.csv
@@ -21,6 +21,7 @@ getapony.com;Pony
 lime.bike;Lime
 media.ilevia.fr/opendata;Cykleo
 nextbike.net;nextbike
+opendata.agglo-larochelle.fr;Yélo VLS
 smovengo.cloud;Smovengo
 stce.transdev-hdf.fr;Transdev
 urbansharing.com/lovelolibreservice.fr;Citybike


### PR DESCRIPTION
Fixes #5534 

Deux commits :
- Pour rajouter Yelo VLS
- Pour réordonner le fichier par ordre alphabétique, les derniers rajouts ne l’étaient plus, du coup ça faisait deux logiques contradictoires d’ordonnancement dans le même fichier (alphabétique et par ordre de rajout), ça m’a démangé.