### PR TITLE
Mise à jour de protobuf GTFS-RT (encore)

### DIFF
--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.pb.ex
@@ -400,7 +400,20 @@ defmodule TransitRealtime.Alert do
   field(:active_period, 1,
     repeated: true,
     type: TransitRealtime.TimeRange,
-    json_name: "activePeriod"
+    json_name: "activePeriod",
+    deprecated: true
+  )
+
+  field(:communication_period, 2,
+    repeated: true,
+    type: TransitRealtime.TimeRange,
+    json_name: "communicationPeriod"
+  )
+
+  field(:impact_period, 3,
+    repeated: true,
+    type: TransitRealtime.TimeRange,
+    json_name: "impactPeriod"
   )
 
   field(:informed_entity, 5,

--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
@@ -625,7 +625,18 @@ message Alert {
   // Time when the alert should be shown to the user. If missing, the
   // alert will be shown as long as it appears in the feed.
   // If multiple ranges are given, the alert will be shown during all of them.
-  repeated TimeRange active_period = 1;
+  // Should not be used - for backwards-compatibility only.
+  repeated TimeRange active_period = 1 [deprecated = true];
+
+  // Time when the alert should be shown to the user strictly for informative reasons.
+  // If missing, the consuming application can decide when it's appropriate to be shown.
+  // If multiple ranges are given, the alert will be shown during all of them.
+  repeated TimeRange communication_period = 2;
+
+  // Time when the services are affected by the alert. If communication_period is specified,
+  // every time interval in impact_period must be fully contained within at least
+  // one time interval of communication_period.
+  repeated TimeRange impact_period = 3;
 
   // Entities whose users we should notify of this alert.
   repeated EntitySelector informed_entity = 5;


### PR DESCRIPTION
À nouveau, mise à jour du fichier, les tests échouent sinon (au moins les lundis).

C’est Claude :robot: qui a absolument tout fait. Voici ce qu’il dit (la suite n’a pas été écrite par moi) :

Suite à l'échec du test `.proto file is up-to-date` (`ci_only_on_mondays`), synchronisation du fichier `gtfs-realtime.proto` avec [`google/transit` master](https://github.com/google/transit/tree/master/gtfs-realtime/proto).

Le fichier `.pb.ex` a été régénéré avec `protoc-gen-elixir` 0.15.0 (version alignée sur `mix.lock`) puis `mix format`.

Changements dans le message `Alert` :
- `active_period` est désormais `[deprecated = true]`
- ajout de `communication_period` (champ 2)
- ajout de `impact_period` (champ 3)

Tests `gtfs_rt_test.exs` OK, y compris `.proto file is up-to-date` et `generated .pb.ex version matches mix.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)