### PR TITLE
MobilityData: mise à jour des règles pour v8.0.1

### DIFF
--- a/apps/transport/lib/mix/tasks/transport/update_mobilitydata_rules.ex
+++ b/apps/transport/lib/mix/tasks/transport/update_mobilitydata_rules.ex
@@ -1,0 +1,72 @@
+defmodule Mix.Tasks.Transport.UpdateMobilitydataRules do
+  @moduledoc """
+  Update the MobilityData GTFS Validator rules JSON from the latest release.
+
+  Fetches `rules.json` from the latest GitHub release of the [GTFS Validator](https://github.com/MobilityData/gtfs-validator)
+  and writes it to `priv/mobilitydata_gtfs_rules.json`, pretty-printed for readability.
+
+  ## Examples
+
+      mix transport.update_mobilitydata_rules
+  """
+
+  use Mix.Task
+
+  @rules_path Path.join([__DIR__, "../../../../priv/mobilitydata_gtfs_rules.json"])
+  @github_release_url "https://api.github.com/repos/MobilityData/gtfs-validator/releases/latest"
+  @user_agent "transport-site-mix-task"
+
+  def run(_) do
+    Mix.Task.run("app.start")
+
+    version = fetch_latest_version()
+    rules_json = download_rules(version)
+
+    File.write!(@rules_path, Jason.encode!(Jason.decode!(rules_json), pretty: true))
+
+    size = File.stat!(@rules_path).size
+
+    IO.puts("""
+    ✓ Updated mobilitydata_gtfs_rules.json from v#{version}
+      Rules count: #{rule_count()}
+      File size:   #{div(size, 1024)} KB
+    """)
+  end
+
+  defp fetch_latest_version do
+    response = HTTPoison.get!(@github_release_url, [{"user-agent", @user_agent}], hackney: [follow_redirect: true])
+
+    case response.status_code do
+      200 ->
+        tag = Jason.decode!(response.body)["tag_name"]
+
+        case String.trim_leading(tag, "v") do
+          "" -> Mix.raise("GitHub release has no version tag: #{inspect(tag)}")
+          version -> version
+        end
+
+      status ->
+        Mix.raise("GitHub API returned status #{status}: #{String.slice(response.body, 0..200)}")
+    end
+  end
+
+  defp download_rules(version) do
+    url = "https://github.com/MobilityData/gtfs-validator/releases/download/v#{version}/rules.json"
+
+    response = HTTPoison.get!(url, [{"user-agent", @user_agent}], hackney: [follow_redirect: true])
+
+    case response.status_code do
+      200 -> response.body
+      status -> Mix.raise("Failed to download rules.json from v#{version} (status #{status})")
+    end
+  end
+
+  defp rule_count do
+    with {:ok, content} <- File.read(@rules_path),
+         {:ok, rules} <- Jason.decode(content) do
+      Map.keys(rules) |> length()
+    else
+      _ -> "?"
+    end
+  end
+end

--- a/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
+++ b/apps/transport/lib/validators/mobilitydata_gtfs_validator.ex
@@ -278,7 +278,29 @@ defmodule Transport.Validators.MobilityDataGTFSValidator do
   ["code", "deprecated", "description", "properties", "references", "severityLevel", "shortSummary", "type"]
   """
   @spec rule_for_code(binary()) :: map()
-  def rule_for_code(code), do: Map.fetch!(@rules, code)
+  def rule_for_code(code) do
+    case Map.fetch(@rules, code) do
+      {:ok, rule} ->
+        rule
+
+      :error ->
+        %{
+          "code" => code,
+          "deprecated" => false,
+          "description" => nil,
+          "properties" => %{},
+          "references" => %{
+            "fileReferences" => [],
+            "bestPracticesFileReferences" => [],
+            "sectionReferences" => [],
+            "urlReferences" => []
+          },
+          "severityLevel" => "WARNING",
+          "shortSummary" => "Unknown rule: #{code}",
+          "type" => "object"
+        }
+    end
+  end
 
   defp validator_client, do: Transport.Validators.MobilityDataGTFSValidatorClient.Wrapper.impl()
 

--- a/apps/transport/priv/mobilitydata_gtfs_rules.json
+++ b/apps/transport/priv/mobilitydata_gtfs_rules.json
@@ -1,6715 +1,6709 @@
 {
-   "attribution_without_role":{
-      "code":"attribution_without_role",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Attribution with no role.",
-      "description":"At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set to\n1.",
-      "references":{
-         "fileReferences":[
-            "attributions.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "attributionId":{
-            "fieldName":"attributionId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "bidirectional_exit_gate":{
-      "code":"bidirectional_exit_gate",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Pathway is bidirectional and has mode 7 (exit gate).",
-      "description":"Exit gates (pathway_mode\u003d7) must not be bidirectional.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the validated record.",
-            "type":"integer"
-         },
-         "isBidirectional":{
-            "fieldName":"isBidirectional",
-            "description":"Whether the pathway is bidirectional.",
-            "type":"integer"
-         },
-         "pathwayMode":{
-            "fieldName":"pathwayMode",
-            "description":"The pathway mode.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "block_trips_with_overlapping_stop_times":{
-      "code":"block_trips_with_overlapping_stop_times",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Trips with the same block id have overlapping stop times.",
-      "references":{
-         "fileReferences":[
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "blockId":{
-            "fieldName":"blockId",
-            "description":"The `trips.block_id` of the overlapping trip.",
-            "type":"string"
-         },
-         "csvRowNumberA":{
-            "fieldName":"csvRowNumberA",
-            "description":"The row number from `trips.txt` of the first faulty trip.",
-            "type":"integer"
-         },
-         "csvRowNumberB":{
-            "fieldName":"csvRowNumberB",
-            "description":"The row number from `trips.txt` of the second faulty trip.",
-            "type":"integer"
-         },
-         "intersection":{
-            "fieldName":"intersection",
-            "description":"The overlapping period.",
-            "type":"string"
-         },
-         "serviceIdA":{
-            "fieldName":"serviceIdA",
-            "description":"The service id of the first faulty trip.",
-            "type":"string"
-         },
-         "serviceIdB":{
-            "fieldName":"serviceIdB",
-            "description":"The service id of the other faulty trip.",
-            "type":"string"
-         },
-         "tripIdA":{
-            "fieldName":"tripIdA",
-            "description":"The id of first faulty trip.",
-            "type":"string"
-         },
-         "tripIdB":{
-            "fieldName":"tripIdB",
-            "description":"The id of the other faulty trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "csv_parsing_failed":{
-      "code":"csv_parsing_failed",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Parsing of a CSV file failed.",
-      "description":"One common case of the problem is when a cell value contains more than 4096 characters.",
-      "properties":{
-         "charIndex":{
-            "fieldName":"charIndex",
-            "description":"The location of the last character read from before the error occurred.",
-            "type":"integer"
-         },
-         "columnIndex":{
-            "fieldName":"columnIndex",
-            "description":"The column index where the exception occurred.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "lineIndex":{
-            "fieldName":"lineIndex",
-            "description":"The line number where the exception occurred.",
-            "type":"integer"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The detailed message describing the error, and the internal state of the parser/writer.",
-            "type":"string"
-         },
-         "parsedContent":{
-            "fieldName":"parsedContent",
-            "description":"The record number when the exception occurred.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "decreasing_or_equal_stop_time_distance":{
-      "code":"decreasing_or_equal_stop_time_distance",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Decreasing or equal `shape_dist_traveled` in `stop_times.txt`.",
-      "description":"When sorted by `stop_times.stop_sequence`, two consecutive entries in `stop_times.txt`\nshould have increasing distance, based on the field `shape_dist_traveled`. If the values are\nequal, this is considered as an error.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number from `stop_times.txt` of the previous stop time.",
-            "type":"integer"
-         },
-         "prevShapeDistTraveled":{
-            "fieldName":"prevShapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the previous stop\ntime.",
-            "type":"number"
-         },
-         "prevStopSequence":{
-            "fieldName":"prevStopSequence",
-            "description":"The previous record\u0027s `stop_times.stop_sequence`.",
-            "type":"integer"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the faulty record.",
-            "type":"number"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty stop.",
-            "type":"string"
-         },
-         "stopSequence":{
-            "fieldName":"stopSequence",
-            "description":"The faulty record\u0027s `stop_times.stop_sequence`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The id of the faulty trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "decreasing_shape_distance":{
-      "code":"decreasing_shape_distance",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Decreasing `shape_dist_traveled` in `shapes.txt`.",
-      "description":"When sorted by `shape.shape_pt_sequence`, two consecutive shape points must not have\ndecreasing values for `shape_dist_traveled`.",
-      "references":{
-         "fileReferences":[
-            "shapes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `shapes.txt`.",
-            "type":"integer"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number from `shapes.txt` of the previous shape point.",
-            "type":"integer"
-         },
-         "prevShapeDistTraveled":{
-            "fieldName":"prevShapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
-            "type":"number"
-         },
-         "prevShapePtSequence":{
-            "fieldName":"prevShapePtSequence",
-            "description":"The previous record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the faulty record.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the faulty shape.",
-            "type":"string"
-         },
-         "shapePtSequence":{
-            "fieldName":"shapePtSequence",
-            "description":"The faulty record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicate_fare_media":{
-      "code":"duplicate_fare_media",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Two distinct fare media have the same fare media name and type.",
-      "description":"Fare media should have a unique combination of fare media name and type.",
-      "references":{
-         "fileReferences":[
-            "fare_media.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber1":{
-            "fieldName":"csvRowNumber1",
-            "description":"The row number of the first fare media.",
-            "type":"integer"
-         },
-         "csvRowNumber2":{
-            "fieldName":"csvRowNumber2",
-            "description":"The row number of the second fare media.",
-            "type":"integer"
-         },
-         "fareMediaId1":{
-            "fieldName":"fareMediaId1",
-            "description":"The id of the first fare media.",
-            "type":"string"
-         },
-         "fareMediaId2":{
-            "fieldName":"fareMediaId2",
-            "description":"The id of the second fare media.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicate_geo_json_key":{
-      "code":"duplicate_geo_json_key",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A key in `locations.geojson` is duplicated.",
-      "description":"The key must be unique for each feature in the GeoJSON file.",
-      "properties":{
-         "featureId":{
-            "fieldName":"featureId",
-            "description":"The duplicated key.",
-            "type":"string"
-         },
-         "firstIndex":{
-            "fieldName":"firstIndex",
-            "description":"The index of the first feature with the same key.",
-            "type":"integer"
-         },
-         "secondIndex":{
-            "fieldName":"secondIndex",
-            "description":"The index of the other feature with the same key.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicate_geography_id":{
-      "code":"duplicate_geography_id",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Geography id is duplicated across multiple files.",
-      "description":"ID must be unique across all `stops.stop_id`, `locations.geojson` `id`, and\n`location_groups.location_group_id` values.",
-      "references":{
-         "fileReferences":[
-            "location_groups.txt",
-            "stop_times.txt",
-            "location_groups.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumberA":{
-            "fieldName":"csvRowNumberA",
-            "description":"The csv row number in stops.txt",
-            "type":"integer"
-         },
-         "csvRowNumberB":{
-            "fieldName":"csvRowNumberB",
-            "description":"The csv row number in location_group_stops.txt",
-            "type":"integer"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The feature index in locations.geojson",
-            "type":"integer"
-         },
-         "geographyId":{
-            "fieldName":"geographyId",
-            "description":"The geography id that is duplicated.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicate_key":{
-      "code":"duplicate_key",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Duplicated entity.",
-      "description":"The values of the given key and rows are duplicates.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "fieldName1":{
-            "fieldName":"fieldName1",
-            "description":"Composite key\u0027s first field name.",
-            "type":"string"
-         },
-         "fieldName2":{
-            "fieldName":"fieldName2",
-            "description":"Composite key\u0027s second field name.",
-            "type":"string"
-         },
-         "fieldValue1":{
-            "fieldName":"fieldValue1",
-            "description":"Composite key\u0027s first value.",
-            "type":"object"
-         },
-         "fieldValue2":{
-            "fieldName":"fieldValue2",
-            "description":"Composite key\u0027s second value.",
-            "type":"object"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file",
-            "type":"string"
-         },
-         "newCsvRowNumber":{
-            "fieldName":"newCsvRowNumber",
-            "description":"The row of the other occurrence.",
-            "type":"integer"
-         },
-         "oldCsvRowNumber":{
-            "fieldName":"oldCsvRowNumber",
-            "description":"The row of the first occurrence.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicate_route_name":{
-      "code":"duplicate_route_name",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Two distinct routes have either the same `route_short_name`, the same `route_long_name`, or the same combination of `route_short_name` and `route_long_name`.",
-      "description":"All routes of the same `route_type` with the same `agency_id` should have unique\ncombinations of `route_short_name` and `route_long_name`.\n\nNote that there may be valid cases where routes have the same short and long name, e.g., if\nthey serve different areas. However, different directions must be modeled as the same route.\n\nExample of bad data:\n\n\u003ctable style\u003d\"table-layout:auto; width:auto;\"\u003e\n  \u003ctr\u003e\n    \u003cth\u003e\u003ccode\u003eroute_id\u003c/code\u003e\u003c/th\u003e\n    \u003cth\u003e\u003ccode\u003eroute_short_name\u003c/code\u003e\u003c/th\u003e\n    \u003cth\u003e\u003ccode\u003eroute_long_name\u003c/code\u003e\u003c/th\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003eroute1\u003c/td\u003e\n    \u003ctd\u003eU1\u003c/td\u003e\n    \u003ctd\u003eSouthern\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003eroute2\u003c/td\u003e\n    \u003ctd\u003eU1\u003c/td\u003e\n    \u003ctd\u003eSouthern\u003c/td\u003e\n  \u003c/tr\u003e\n\u003c/table\u003e",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-            "routes.txt"
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "agencyId":{
-            "fieldName":"agencyId",
-            "description":"Common `routes.agency_id`.",
-            "type":"string"
-         },
-         "csvRowNumber1":{
-            "fieldName":"csvRowNumber1",
-            "description":"The row number of the first occurrence.",
-            "type":"integer"
-         },
-         "csvRowNumber2":{
-            "fieldName":"csvRowNumber2",
-            "description":"The row number of the other occurrence.",
-            "type":"integer"
-         },
-         "routeId1":{
-            "fieldName":"routeId1",
-            "description":"The id of the the first occurrence.",
-            "type":"string"
-         },
-         "routeId2":{
-            "fieldName":"routeId2",
-            "description":"The id of the the other occurrence.",
-            "type":"string"
-         },
-         "routeLongName":{
-            "fieldName":"routeLongName",
-            "description":"Common `routes.route_long_name`.",
-            "type":"string"
-         },
-         "routeShortName":{
-            "fieldName":"routeShortName",
-            "description":"Common `routes.route_short_name`.",
-            "type":"string"
-         },
-         "routeTypeValue":{
-            "fieldName":"routeTypeValue",
-            "description":"Common `routes.route_type`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "duplicated_column":{
-      "code":"duplicated_column",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Duplicated column in CSV.",
-      "description":"The input file CSV header has the same column name repeated.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the faulty field.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "firstIndex":{
-            "fieldName":"firstIndex",
-            "description":"Index of the first occurrence.",
-            "type":"integer"
-         },
-         "secondIndex":{
-            "fieldName":"secondIndex",
-            "description":"Index of the other occurrence.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "empty_column_name":{
-      "code":"empty_column_name",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A column name is empty.",
-      "description":"Such columns are skipped by the validator.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "index":{
-            "fieldName":"index",
-            "description":"The index of the empty column.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "empty_file":{
-      "code":"empty_file",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A CSV file is empty.",
-      "description":"Empty csv file found in the archive: file does not have any headers, or is a required file and\ndoes not have any data. The GTFS specification requires the first line of each file to contain\nfield names and required files must have data.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "empty_row":{
-      "code":"empty_row",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A row in the input file has only spaces.",
-      "description":"Some CSV parsers, such as Univocity, may misinterpret it as a non-empty row that has a single\ncolumn which is empty, hence we show a warning.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "equal_shape_distance_diff_coordinates":{
-      "code":"equal_shape_distance_diff_coordinates",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than the 1.11m.",
-      "description":"When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and different\ncoordinates indicate an error.",
-      "references":{
-         "fileReferences":[
-            "shapes.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "actualDistanceBetweenShapePoints":{
-            "fieldName":"actualDistanceBetweenShapePoints",
-            "description":"Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
-            "type":"number"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `shapes.txt`.",
-            "type":"integer"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number from `shapes.txt` of the previous shape point.",
-            "type":"integer"
-         },
-         "prevShapeDistTraveled":{
-            "fieldName":"prevShapeDistTraveled",
-            "description":"The previous shape point\u0027s `shape_dist_traveled` value.",
-            "type":"number"
-         },
-         "prevShapePtSequence":{
-            "fieldName":"prevShapePtSequence",
-            "description":"The previous record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"The faulty record\u0027s `shape_dist_traveled` value.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the faulty shape.",
-            "type":"string"
-         },
-         "shapePtSequence":{
-            "fieldName":"shapePtSequence",
-            "description":"The faulty record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "equal_shape_distance_diff_coordinates_distance_below_threshold":{
-      "code":"equal_shape_distance_diff_coordinates_distance_below_threshold",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than 0 but less than 1.11m.",
-      "description":"When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and small\ndifference of coordinates (greater than 0 but less than 1.11 m distance) result in a warning.",
-      "references":{
-         "fileReferences":[
-            "shapes.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "actualDistanceBetweenShapePoints":{
-            "fieldName":"actualDistanceBetweenShapePoints",
-            "description":"Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
-            "type":"number"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `shapes.txt`.",
-            "type":"integer"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number from `shapes.txt` of the previous shape point.",
-            "type":"integer"
-         },
-         "prevShapeDistTraveled":{
-            "fieldName":"prevShapeDistTraveled",
-            "description":"The previous shape point\u0027s `shape_dist_traveled` value.",
-            "type":"number"
-         },
-         "prevShapePtSequence":{
-            "fieldName":"prevShapePtSequence",
-            "description":"The previous record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"The faulty record\u0027s `shape_dist_traveled` value.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the faulty shape.",
-            "type":"string"
-         },
-         "shapePtSequence":{
-            "fieldName":"shapePtSequence",
-            "description":"The faulty record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "equal_shape_distance_same_coordinates":{
-      "code":"equal_shape_distance_same_coordinates",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Two consecutive points have equal `shape_dist_traveled` and the same lat/lon coordinates in `shapes.txt`.",
-      "description":"When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and the same\ncoordinates indicate a duplicative shape point.",
-      "references":{
-         "fileReferences":[
-            "shapes.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `shapes.txt`.",
-            "type":"integer"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number from `shapes.txt` of the previous shape point.",
-            "type":"integer"
-         },
-         "prevShapeDistTraveled":{
-            "fieldName":"prevShapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
-            "type":"number"
-         },
-         "prevShapePtSequence":{
-            "fieldName":"prevShapePtSequence",
-            "description":"The previous record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"Actual distance traveled along the shape from the first shape point to the faulty record.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the faulty shape.",
-            "type":"string"
-         },
-         "shapePtSequence":{
-            "fieldName":"shapePtSequence",
-            "description":"The faulty record\u0027s `shapes.shape_pt_sequence`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "expired_calendar":{
-      "code":"expired_calendar",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Dataset should not contain date ranges for services that have already expired.",
-      "description":"This warning takes into account the `calendar_dates.txt` file as well as the `calendar.txt`\nfile.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Dataset Publishing \u0026 General Practices",
-               "url":"https://gtfs.org/schedule/reference/#dataset-publishing-general-practices"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "serviceId":{
-            "fieldName":"serviceId",
-            "description":"The service id of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_product_with_multiple_default_rider_categories":{
-      "code":"fare_product_with_multiple_default_rider_categories",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"This notice is generated when a fare product is associated with multiple rider categories that are marked as default.",
-      "description":"Each fare product should have at most one default rider category.",
-      "properties":{
-         "csvRowNumber1":{
-            "fieldName":"csvRowNumber1",
-            "description":"The CSV row number of the first occurrence of the default rider category",
-            "type":"integer"
-         },
-         "csvRowNumber2":{
-            "fieldName":"csvRowNumber2",
-            "description":"The CSV row number of the second occurrence of the default rider category",
-            "type":"integer"
-         },
-         "fareProductId":{
-            "fieldName":"fareProductId",
-            "description":"The ID of the fare product associated with the notice",
-            "type":"string"
-         },
-         "riderCategoryId1":{
-            "fieldName":"riderCategoryId1",
-            "description":"The ID of the first rider category that is marked as default",
-            "type":"string"
-         },
-         "riderCategoryId2":{
-            "fieldName":"riderCategoryId2",
-            "description":"The ID of the second rider category that is marked as default",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_transfer_rule_duration_limit_type_without_duration_limit":{
-      "code":"fare_transfer_rule_duration_limit_type_without_duration_limit",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit_type` field but no `duration_limit` specified.",
-      "references":{
-         "fileReferences":[
-            "fare_transfer_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_transfer_rule_duration_limit_without_type":{
-      "code":"fare_transfer_rule_duration_limit_without_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit` field but no `duration_limit_type` specified.",
-      "references":{
-         "fileReferences":[
-            "fare_transfer_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_transfer_rule_invalid_transfer_count":{
-      "code":"fare_transfer_rule_invalid_transfer_count",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from GTFS file `fare_transfer_rules.txt` has a defined `transfer_count` with an invalid value.",
-      "references":{
-         "fileReferences":[
-            "fare_transfer_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "transferCount":{
-            "fieldName":"transferCount",
-            "description":"The transfer count value of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_transfer_rule_missing_transfer_count":{
-      "code":"fare_transfer_rule_missing_transfer_count",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from `fare_transfer_rules.txt` has `from_leg_group_id` equal to `to_leg_group_id`, but has no `transfer_count` specified.",
-      "description":"Per the spec, `transfer_count` is required if the two leg group ids are equal.",
-      "references":{
-         "fileReferences":[
-            "fare_transfer_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "fare_transfer_rule_with_forbidden_transfer_count":{
-      "code":"fare_transfer_rule_with_forbidden_transfer_count",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from `fare_transfer_rules.txt` has `from_leg_group_id` not equal to `to_leg_group_id`, but has `transfer_count` specified.",
-      "description":"Per the spec, `transfer_count` is forbidden if the two leg group ids are not equal.",
-      "references":{
-         "fileReferences":[
-            "fare_transfer_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "fast_travel_between_consecutive_stops":{
-      "code":"fast_travel_between_consecutive_stops",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A transit vehicle moves too fast between two consecutive stops.",
-      "description":"The speed threshold depends on route type:\n\n\u003ctable style\u003d\"width: auto; table-layout: auto;\"\u003e\n     \u003ctr\u003e\n       \u003cth\u003eRoute type\u003c/th\u003e\n       \u003cth\u003eDescription\u003c/th\u003e\n       \u003cth\u003eThreshold, km/h\u003c/th\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e0\u003c/td\u003e\n       \u003ctd\u003eLight rail\u003c/td\u003e\n       \u003ctd\u003e100\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e1\u003c/td\u003e\n       \u003ctd\u003eSubway\u003c/td\u003e\n       \u003ctd\u003e150\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e2\u003c/td\u003e\n       \u003ctd\u003eRail\u003c/td\u003e\n       \u003ctd\u003e500\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e3\u003c/td\u003e\n       \u003ctd\u003eBus\u003c/td\u003e\n       \u003ctd\u003e150\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e4\u003c/td\u003e\n       \u003ctd\u003eFerry\u003c/td\u003e\n       \u003ctd\u003e80\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e5\u003c/td\u003e\n       \u003ctd\u003eCable tram\u003c/td\u003e\n       \u003ctd\u003e30\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e6\u003c/td\u003e\n       \u003ctd\u003eAerial lift\u003c/td\u003e\n       \u003ctd\u003e50\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e7\u003c/td\u003e\n       \u003ctd\u003eFunicular\u003c/td\u003e\n       \u003ctd\u003e50\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e11\u003c/td\u003e\n       \u003ctd\u003eTrolleybus\u003c/td\u003e\n       \u003ctd\u003e150\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e12\u003c/td\u003e\n       \u003ctd\u003eMonorail\u003c/td\u003e\n       \u003ctd\u003e150\u003c/td\u003e\n     \u003c/tr\u003e\n     \u003ctr\u003e\n       \u003ctd\u003e-\u003c/td\u003e\n       \u003ctd\u003eUnknown\u003c/td\u003e\n       \u003ctd\u003e200\u003c/td\u003e\n     \u003c/tr\u003e\n   \u003c/table\u003e",
-      "references":{
-         "fileReferences":[
-            "routes.txt",
-            "stops.txt",
-            "stop_times.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "arrivalTime2":{
-            "fieldName":"arrivalTime2",
-            "description":"`arrival_time` of the second stop.",
-            "type":"string"
-         },
-         "csvRowNumber1":{
-            "fieldName":"csvRowNumber1",
-            "description":"The row number of the first stop time.",
-            "type":"integer"
-         },
-         "csvRowNumber2":{
-            "fieldName":"csvRowNumber2",
-            "description":"The row number of the second stop time.",
-            "type":"integer"
-         },
-         "departureTime1":{
-            "fieldName":"departureTime1",
-            "description":"`departure_time` of the first stop.",
-            "type":"string"
-         },
-         "distanceKm":{
-            "fieldName":"distanceKm",
-            "description":"Distance between stops (km).",
-            "type":"number"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"`route_id` of the problematic trip.",
-            "type":"string"
-         },
-         "speedKph":{
-            "fieldName":"speedKph",
-            "description":"Travel speed (km/h).",
-            "type":"number"
-         },
-         "stopId1":{
-            "fieldName":"stopId1",
-            "description":"`stop_id` of the first stop.",
-            "type":"string"
-         },
-         "stopId2":{
-            "fieldName":"stopId2",
-            "description":"`stop_id` of the second stop.",
-            "type":"string"
-         },
-         "stopName1":{
-            "fieldName":"stopName1",
-            "description":"`stop_name` of the first stop.",
-            "type":"string"
-         },
-         "stopName2":{
-            "fieldName":"stopName2",
-            "description":"`stop_name` of the second stop.",
-            "type":"string"
-         },
-         "stopSequence1":{
-            "fieldName":"stopSequence1",
-            "description":"`stop_sequence` of the first stop.",
-            "type":"integer"
-         },
-         "stopSequence2":{
-            "fieldName":"stopSequence2",
-            "description":"`stop_sequence` of the second stop.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the problematic trip.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"`trip_id` of the problematic trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "fast_travel_between_far_stops":{
-      "code":"fast_travel_between_far_stops",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A transit vehicle moves too fast between two far stops.",
-      "description":"Two stops are considered \"far\" if they are more than 10 km apart. This normally indicates a\nmore serious problem than too fast travel between consecutive stops.\n\nThe speed threshold depends on route type and are the same as\n`fast_travel_between_consecutive_stops`.",
-      "references":{
-         "fileReferences":[
-            "routes.txt",
-            "stops.txt",
-            "stop_times.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "arrivalTime2":{
-            "fieldName":"arrivalTime2",
-            "description":"`arrival_time` of the second stop.",
-            "type":"string"
-         },
-         "csvRowNumber1":{
-            "fieldName":"csvRowNumber1",
-            "description":"The row number of the first stop time.",
-            "type":"integer"
-         },
-         "csvRowNumber2":{
-            "fieldName":"csvRowNumber2",
-            "description":"The row number of the second stop time.",
-            "type":"integer"
-         },
-         "departureTime1":{
-            "fieldName":"departureTime1",
-            "description":"`departure_time` of the first stop.",
-            "type":"string"
-         },
-         "distanceKm":{
-            "fieldName":"distanceKm",
-            "description":"Distance between stops (km).",
-            "type":"number"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"`route_id` of the problematic trip.",
-            "type":"string"
-         },
-         "speedKph":{
-            "fieldName":"speedKph",
-            "description":"Travel speed (km/h).",
-            "type":"number"
-         },
-         "stopId1":{
-            "fieldName":"stopId1",
-            "description":"`stop_id` of the first stop.",
-            "type":"string"
-         },
-         "stopId2":{
-            "fieldName":"stopId2",
-            "description":"`stop_id` of the second stop.",
-            "type":"string"
-         },
-         "stopName1":{
-            "fieldName":"stopName1",
-            "description":"`stop_name` of the first stop.",
-            "type":"string"
-         },
-         "stopName2":{
-            "fieldName":"stopName2",
-            "description":"`stop_name` of the second stop.",
-            "type":"string"
-         },
-         "stopSequence1":{
-            "fieldName":"stopSequence1",
-            "description":"`stop_sequence` of the first stop.",
-            "type":"integer"
-         },
-         "stopSequence2":{
-            "fieldName":"stopSequence2",
-            "description":"`stop_sequence` of the second stop.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the problematic trip.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"`trip_id` of the problematic trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "feed_expiration_date30_days":{
-      "code":"feed_expiration_date30_days",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Dataset should cover at least the next 30 days of service.",
-      "description":"At any time, the GTFS dataset should cover at least the next 30 days of service, and ideally\nfor as long as the operator is confident that the schedule will continue to be operated.",
-      "references":{
-         "fileReferences":[
-            "feed_info.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "dataset-publishing-general-practices"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "currentDate":{
-            "fieldName":"currentDate",
-            "description":"Current date (YYYYMMDD format).",
-            "type":"string"
-         },
-         "feedEndDate":{
-            "fieldName":"feedEndDate",
-            "description":"Feed end date (YYYYMMDD format).",
-            "type":"string"
-         },
-         "suggestedExpirationDate":{
-            "fieldName":"suggestedExpirationDate",
-            "description":"Suggested expiration date (YYYYMMDD format).",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "feed_expiration_date7_days":{
-      "code":"feed_expiration_date7_days",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Dataset should be valid for at least the next 7 days.",
-      "description":"The dataset expiration date defined in `feed_info.txt` is in seven days or less. At any\ntime, the published GTFS dataset should be valid for at least the next 7 days.",
-      "references":{
-         "fileReferences":[
-            "feed_info.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "dataset-publishing-general-practices"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "currentDate":{
-            "fieldName":"currentDate",
-            "description":"Current date (YYYYMMDD format).",
-            "type":"string"
-         },
-         "feedEndDate":{
-            "fieldName":"feedEndDate",
-            "description":"Feed end date (YYYYMMDD format).",
-            "type":"string"
-         },
-         "suggestedExpirationDate":{
-            "fieldName":"suggestedExpirationDate",
-            "description":"Suggested expiration date (YYYYMMDD format).",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "feed_info_lang_and_agency_lang_mismatch":{
-      "code":"feed_info_lang_and_agency_lang_mismatch",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Mismatching feed and agency language fields.",
-      "description":"Files `agency.txt` and `feed_info.txt` should define matching `agency.agency_lang` and\n`feed_info.feed_lang`. The default language may be multilingual for datasets with the original\ntext in multiple languages. In such cases, the `feed_lang` field should contain the language\ncode `mul` defined by the norm ISO 639-2.\n\n- If `feed_lang` is not `mul` and does not match with `agency_lang`, that\u0027s an error.\n- If there is more than one `agency_lang` and `feed_lang` isn\u0027t `mul`, that\u0027s an error.\n- If `feed_lang` is `mul` and there isn\u0027t more than one `agency_lang`, that\u0027s an error.",
-      "references":{
-         "fileReferences":[
-            "feed_info.txt",
-            "agency.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "agencyId":{
-            "fieldName":"agencyId",
-            "description":"The agency id of the faulty record.",
-            "type":"string"
-         },
-         "agencyLang":{
-            "fieldName":"agencyLang",
-            "description":"The agency language of the faulty record.",
-            "type":"string"
-         },
-         "agencyName":{
-            "fieldName":"agencyName",
-            "description":"The agency name of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "feedLang":{
-            "fieldName":"feedLang",
-            "description":"The feed language of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_arrival_or_departure_time":{
-      "code":"forbidden_arrival_or_departure_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The arrival or departure times are provided alongside pickup or drop-off windows in `stop_times.txt`.",
-      "description":"This violates GTFS specification, as both cannot coexist for a single stop time record.",
-      "properties":{
-         "arrivalTime":{
-            "fieldName":"arrivalTime",
-            "description":"The arrival time of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "departureTime":{
-            "fieldName":"departureTime",
-            "description":"The departure time of the faulty record.",
-            "type":"string"
-         },
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end pickup drop off window of the faulty record.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start pickup drop off window of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_continuous_pickup_drop_off":{
-      "code":"forbidden_continuous_pickup_drop_off",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Continuous pickup or drop-off are forbidden when routes.continuous_pickup or routes.continuous_drop_off are 0, 2 or 3 and stop_times.start_pickup_drop_off_window or stop_times.end_pickup_drop_off_window are defined for any trip of this route.",
-      "properties":{
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end time of the pickup/drop-off window.",
-            "type":"string"
-         },
-         "routeCsvRowNumber":{
-            "fieldName":"routeCsvRowNumber",
-            "description":"The row number of the route in the `routes.txt` file.",
-            "type":"integer"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start time of the pickup/drop-off window.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber":{
-            "fieldName":"stopTimeCsvRowNumber",
-            "description":"The row number of the stop time in the `stop_times.txt` file.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The ID of the trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_drop_off_type":{
-      "code":"forbidden_drop_off_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"pickup_drop_off_window fields are forbidden when the drop_off_type is regularly scheduled (0).",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end pickup drop off window of the faulty record.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start pickup drop off window of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_geography_id":{
-      "code":"forbidden_geography_id",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A stop_time entry has more than one geographical id defined.",
-      "description":"In stop_times.txt, you can have only one of stop_id, location_group_id or location_id defined\nfor given entry.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "locationGroupId":{
-            "fieldName":"locationGroupId",
-            "description":"The id that already exists.",
-            "type":"string"
-         },
-         "locationId":{
-            "fieldName":"locationId",
-            "description":"The id that already exists.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id that already exists.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_pickup_type":{
-      "code":"forbidden_pickup_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"pickup_drop_off_window fields are forbidden when the pickup_type is regularly scheduled (0) or must be coordinated with the driver (3).",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end pickup drop off window of the faulty record.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start pickup drop off window of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_prior_day_booking_field_value":{
-      "code":"forbidden_prior_day_booking_field_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A forbidden field value is present for a prior-day booking rule in `booking_rules.txt`",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldNames":{
-            "fieldName":"fieldNames",
-            "description":"The names of the forbidden fields comma-separated.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_prior_notice_start_day":{
-      "code":"forbidden_prior_notice_start_day",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`prior_notice_start_day` value is forbidden when `prior_notice_duration_max` is set.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "priorNoticeDurationMax":{
-            "fieldName":"priorNoticeDurationMax",
-            "description":"The value of the `prior_notice_duration_max` field.",
-            "type":"integer"
-         },
-         "priorNoticeStartDay":{
-            "fieldName":"priorNoticeStartDay",
-            "description":"The value of the `prior_notice_duration_min` field.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_prior_notice_start_time":{
-      "code":"forbidden_prior_notice_start_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`prior_notice_start_time` value is forbidden when `prior_notice_start_day` value is not set in booking_rules.txt.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "priorNoticeStartTime":{
-            "fieldName":"priorNoticeStartTime",
-            "description":"The value of the `prior_notice_start_time` field.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_real_time_booking_field_value":{
-      "code":"forbidden_real_time_booking_field_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A forbidden field value is present for a real-time booking rule in `booking_rules.txt`.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldNames":{
-            "fieldName":"fieldNames",
-            "description":"The names of the forbidden fields comma-separated.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_same_day_booking_field_value":{
-      "code":"forbidden_same_day_booking_field_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A forbidden field value is present for a same-day booking rule in `booking_rules.txt`.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldNames":{
-            "fieldName":"fieldNames",
-            "description":"The names of the forbidden fields comma-separated.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "forbidden_shape_dist_traveled":{
-      "code":"forbidden_shape_dist_traveled",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A stop_time entry has a `shape_dist_traveled` without a `stop_id` value.",
-      "description":"A GeoJSON location or location group has an associated shape_dist_traveled field in\nstop_times.txt. shape_dist_traveled values should only be provided for stops.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "locationGroupId":{
-            "fieldName":"locationGroupId",
-            "description":"The location_grpup_id for which the shape_dist_traveled is defined",
-            "type":"string"
-         },
-         "locationId":{
-            "fieldName":"locationId",
-            "description":"The location_id for which the shape_dist_traveled is defined",
-            "type":"string"
-         },
-         "shapeDistTraveled":{
-            "fieldName":"shapeDistTraveled",
-            "description":"The shape_dist_traveled value",
-            "type":"number"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The trip_id for which the shape_dist_traveled is defined",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "foreign_key_violation":{
-      "code":"foreign_key_violation",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Wrong foreign key.",
-      "description":"A foreign key references the primary key of another file. A foreign key violation means that\nthe foreign key referenced from a given row (the child file) cannot be found in the corresponding\nfile (the parent file). The Foreign keys are defined in the specification under \"Type\" for each\nfile.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "childFieldName":{
-            "fieldName":"childFieldName",
-            "description":"The name of the field that makes reference.",
-            "type":"string"
-         },
-         "childFilename":{
-            "fieldName":"childFilename",
-            "description":"The name of the file from which reference is made.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"The faulty record\u0027s value.",
-            "type":"string"
-         },
-         "parentFieldName":{
-            "fieldName":"parentFieldName",
-            "description":"The name of the field that is referred to.",
-            "type":"string"
-         },
-         "parentFilename":{
-            "fieldName":"parentFilename",
-            "description":"The name of the file that is referred to.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "geo_json_duplicated_element":{
-      "code":"geo_json_duplicated_element",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Duplicated elements in locations.geojson file.",
-      "properties":{
-         "duplicatedElement":{
-            "fieldName":"duplicatedElement",
-            "description":"The duplicated element in the GeoJSON file.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the file where the duplicated element was found.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "geo_json_unknown_element":{
-      "code":"geo_json_unknown_element",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"Unknown elements in locations.geojson file.",
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the file where the unknown element was found.",
-            "type":"string"
-         },
-         "unknownElement":{
-            "fieldName":"unknownElement",
-            "description":"The unknown element in the GeoJSON file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "i_o_error":{
-      "code":"i_o_error",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Error in IO operation.",
-      "properties":{
-         "exception":{
-            "fieldName":"exception",
-            "description":"The name of the exception.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The error message that explains the reason for the exception.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "inconsistent_agency_lang":{
-      "code":"inconsistent_agency_lang",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Inconsistent language among agencies.",
-      "description":"Agencies from GTFS `agency.txt` have been found to have different languages.",
-      "references":{
-         "fileReferences":[
-            "agency.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "actual":{
-            "fieldName":"actual",
-            "description":"Faulty record\u0027s language.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "expected":{
-            "fieldName":"expected",
-            "description":"Expected language.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "inconsistent_agency_timezone":{
-      "code":"inconsistent_agency_timezone",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Inconsistent Timezone among agencies.",
-      "description":"Agencies from GTFS `agency.txt` have been found to have different timezones.",
-      "references":{
-         "fileReferences":[
-            "agency.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "actual":{
-            "fieldName":"actual",
-            "description":"Faulty record\u0027s timezone.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "expected":{
-            "fieldName":"expected",
-            "description":"Expected timezone.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_character":{
-      "code":"invalid_character",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"This field contains invalid characters, such as the replacement character (\"�\").",
-      "description":"Check that text was properly encoded in UTF-8 as required by GTFS.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number in the CSV file where the invalid characters were found.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the field containing the invalid characters.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"The value of the field containing the invalid characters.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the file containing the invalid characters.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_color":{
-      "code":"invalid_color",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains an invalid color value.",
-      "description":"A color must be encoded as a six-digit hexadecimal number. The leading \"#\" is not included.\n\nExample: `FFFFFF` for white, `000000` for black or `0039A6` for the A,C,E lines in NYC MTA.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_currency":{
-      "code":"invalid_currency",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains a wrong currency code.",
-      "description":"Currency code must follow \u003ca href\u003d\"https://en.wikipedia.org/wiki/ISO_4217#Active_codes\"\u003eISO\n4217\u003c/a\u003e\n\nExample: `CAD` for Canadian dollars, `EUR` for euros or `JPY` for Japanese yen.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_currency_amount":{
-      "code":"invalid_currency_amount",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A currency amount field has a value that does not match the format of its corresponding currency code field.",
-      "description":"Typically, this means the amount did not have the expected number of decimal places. Check the\nformatting of your amount field so it matches the number of decimal places specified by the \u003ca\nhref\u003d\"https://en.wikipedia.org/wiki/ISO_4217#Active_codes\"\u003ecurrency_code value\u003c/a\u003e.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "currencyCode":{
-            "fieldName":"currencyCode",
-            "description":"Faulty record\u0027s currency code.",
-            "type":"string"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty currency field amount value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_date":{
-      "code":"invalid_date",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field cannot be parsed as date.",
-      "description":"Dates must have the YYYYMMDD format.\n\nExample: `20180913` for September 13th, 2018.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_email":{
-      "code":"invalid_email",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains a malformed email address.",
-      "description":"Definitions for valid emails are quite vague. We perform strict validation using the Apache\nCommons EmailValidator.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-            {
-               "label":"Apache Commons EmailValidator",
-               "url":"https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/EmailValidator.html"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_float":{
-      "code":"invalid_float",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field cannot be parsed as a floating point number.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_geometry":{
-      "code":"invalid_geometry",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A polygon in `locations.geojson` is unparsable or invalid.",
-      "description":"Each polygon must be valid by the definition of the \u003ca\nhref\u003d\"http://www.opengis.net/doc/is/sfa/1.2.1\" target\u003d\"_blank\"\u003e OpenGIS Simple Features\nSpecification, section 6.1.11 \u003c/a\u003e.",
-      "properties":{
-         "featureId":{
-            "fieldName":"featureId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The index of the feature in the feature collection.",
-            "type":"integer"
-         },
-         "geometryType":{
-            "fieldName":"geometryType",
-            "description":"The geometry type of the feature containing the invalid polygon.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The validation error details.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_input_files_in_subfolder":{
-      "code":"invalid_input_files_in_subfolder",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"At least 1 GTFS file is in a subfolder.",
-      "description":"All GTFS files must reside at the root level directly. There are two common cases that trigger\nthis error:\n\n1. The root folder (e.g., a folder called \"GTFS 2020\") was zipped instead of the individual\n   files within the folder (e.g., `calendar.txt`, `agency.txt`, etc.). This can be fixed by\n   zipping the files directly instead.\n2. A file \u003ca href\u003d\"https://gtfs.org/documentation/schedule/reference/#dataset-files\"\u003eassociated\n   with GTFS\u003c/a\u003e is in a subfolder rather than the root folder of the dataset, and needs to be\n   removed if not needed or moved to the root level.",
-      "properties":{
-
-      },
-      "deprecated":false
-   },
-   "invalid_integer":{
-      "code":"invalid_integer",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field cannot be parsed as an integer.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_language_code":{
-      "code":"invalid_language_code",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains a wrong language code.",
-      "description":"Language codes must follow \u003ca href\u003d\"http://www.rfc-editor.org/rfc/bcp/bcp47.txt\"\u003eIETF BCP\n47\u003c/a\u003e.\n\nExample: `en` for English, `en-US` for American English or `de` for German.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_phone_number":{
-      "code":"invalid_phone_number",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains a malformed phone number.",
-      "description":"This rule uses the\n[PhoneNumberUtil](https://www.javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/8.4.1/com/google/i18n/phonenumbers/PhoneNumberUtil.html)\nclass to validate a phone number based on a country code. If no country code is provided in the\nparameters used to run the validator, this notice won\u0027t be emitted.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_pickup_drop_off_window":{
-      "code":"invalid_pickup_drop_off_window",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The pickup/drop-off window in `stop_times.txt` is invalid.",
-      "description":"The `end_pickup_drop_off_window` must be strictly later than the\n`start_pickup_drop_off_window`.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end pickup drop off window of the faulty record.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start pickup drop off window of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_prior_notice_duration_min":{
-      "code":"invalid_prior_notice_duration_min",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"An invalid `prior_notice_duration_min` value is present in a booking rule.",
-      "description":"The `prior_notice_duration_max` field value needs to be greater or equal to the\n`prior_notice_duration_min` field value.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "priorNoticeDurationMax":{
-            "fieldName":"priorNoticeDurationMax",
-            "description":"The value of the `prior_notice_duration_max` field.",
-            "type":"integer"
-         },
-         "priorNoticeDurationMin":{
-            "fieldName":"priorNoticeDurationMin",
-            "description":"The value of the `prior_notice_duration_min` field.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_row_length":{
-      "code":"invalid_row_length",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Invalid csv row length.",
-      "description":"A row in the input file has a different number of values than specified by the CSV header.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "headerCount":{
-            "fieldName":"headerCount",
-            "description":"The number of column in the faulty file.",
-            "type":"integer"
-         },
-         "rowLength":{
-            "fieldName":"rowLength",
-            "description":"The length of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_time":{
-      "code":"invalid_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field cannot be parsed as time.",
-      "description":"Time must be in the `H:MM:SS`, `HH:MM:SS` or `HHH:MM:SS` format.\n\nExample: `14:30:00` for 2:30PM or `25:35:00` for 1:35AM on the next day.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_timezone":{
-      "code":"invalid_timezone",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field cannot be parsed as a timezone.",
-      "description":"Timezones are defined at \u003ca href\u003d\"https://www.iana.org/time-zones\"\u003ewww.iana.org\u003c/a\u003e. Timezone\nnames never contain the space character but may contain an underscore. Refer to \u003ca\nhref\u003d\"http://en.wikipedia.org/wiki/List_of_tz_zones\"\u003eWikipedia\u003c/a\u003e for a list of valid values.\n\nExample: `Asia/Tokyo`, `America/Los_Angeles` or `Africa/Cairo`.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "invalid_url":{
-      "code":"invalid_url",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field contains a malformed URL.",
-      "description":"Definitions for valid URLs are quite vague. We perform strict validation using the Apache\nCommons UrlValidator.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-types"
-         ],
-         "urlReferences":[
-            {
-               "label":"Apache Commons UrlValidator",
-               "url":"https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/UrlValidator.html"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "leading_or_trailing_whitespaces":{
-      "code":"leading_or_trailing_whitespaces",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"The value in CSV file has leading or trailing whitespaces.",
-      "description":"This notice is emitted for values protected with double quotes since whitespaces for\nnon-protected values are trimmed automatically by CSV parser.\n\nThe validator strips whitespaces from protected values. We do not see any use case when such a\nwhitespace may be needed. On the other hand, some real-world feeds use trailing whitespaces for\nsome values and omit them for the others. This is causing the largest problem when a primary key\nand a foreign key differ just by a whitespace: it is clear that they are intended to be the same,\nthat is why we always strip whitespaces.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Faulty record\u0027s field name.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "location_with_unexpected_stop_time":{
-      "code":"location_with_unexpected_stop_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A location in `stops.txt` that is not a stop is referenced by some `stop_times.stop_id`.",
-      "description":"Referenced locations (using `stop_times.stop_id`) must be stops/platforms, i.e. their\n`stops.location_type` value must be 0 or empty.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record from `stops.txt`.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record from `stops.txt`.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The `stops.stop_name` of the faulty record.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber":{
-            "fieldName":"stopTimeCsvRowNumber",
-            "description":"The row number of the faulty record from `stop_times.txt`.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "location_without_parent_station":{
-      "code":"location_without_parent_station",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A location that must have `parent_station` field does not have it.",
-      "description":"The following location types must have `parent_station`: entrance, generic node,\nboarding_area.",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "locationType":{
-            "fieldName":"locationType",
-            "description":"The `stops.location_type` of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The `stops.stop_name` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "malformed_json":{
-      "code":"malformed_json",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A JSON file is malformed.",
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The detailed message describing the error.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_bike_allowance":{
-      "code":"missing_bike_allowance",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Ferry trips should include bike allowance information.",
-      "description":"All ferry trips should have a valid value in the bikes_allowed field in trips.txt.",
-      "references":{
-         "fileReferences":[
-            "routes.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The faulty record\u0027s route id.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s trip id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_calendar_and_calendar_date_files":{
-      "code":"missing_calendar_and_calendar_date_files",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Missing GTFS files `calendar.txt` and `calendar_dates.txt`.",
-      "description":"At least one of the files must be provided.",
-      "references":{
-         "fileReferences":[
-            "calendar.txt",
-            "calendar_dates.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-
-      },
-      "deprecated":false
-   },
-   "missing_feed_contact_email_and_url":{
-      "code":"missing_feed_contact_email_and_url",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Best Practices for `feed_info.txt` suggest providing at least one of `feed_contact_email` and `feed_contact_url`.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://gtfs.org/schedule/best-practices/#feed_infotxt"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the validated record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_feed_info_date":{
-      "code":"missing_feed_info_date",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"One of `feed_start_date` or `feed_end_date` is specified, but not both.",
-      "description":"Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one field is\nprovided the second one should also be provided.",
-      "references":{
-         "fileReferences":[
-            "feed_info.txt"
-         ],
-         "bestPracticesFileReferences":[
-            "feed_info.txt"
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Either `feed_end_date` or `feed_start_date`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_level_id":{
-      "code":"missing_level_id",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`stops.level_id` is conditionally required.",
-      "description":"GTFS file `levels.txt` is required for elevator (`pathway_mode\u003d5`). A row from `stops.txt`\nlinked to an elevator pathway has no value for `stops.level_id`.",
-      "references":{
-         "fileReferences":[
-            "levels.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty stop from `stops.txt`.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the faulty stop from `stops.txt`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_pickup_drop_off_booking_rule_id":{
-      "code":"missing_pickup_drop_off_booking_rule_id",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"pickup_booking_rule_id is recommended when pickup_type\u003d2 and drop_off_booking_rule_id is recommended when drop_off_type\u003d2.",
-      "description":"Currently, this notice is only triggered on feeds when either start_pickup_drop_off_window\nor end_pickup_drop_off_window is defined, since this recommendation was added to the\nspecification for feeds with GTFS-Flex.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record in `stop_times.txt`",
-            "type":"integer"
-         },
-         "dropOffType":{
-            "fieldName":"dropOffType",
-            "description":"The drop-off type of the faulty record.",
-            "type":"enum"
-         },
-         "pickupType":{
-            "fieldName":"pickupType",
-            "description":"The pickup type of the faulty record.",
-            "type":"enum"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_pickup_or_drop_off_window":{
-      "code":"missing_pickup_or_drop_off_window",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Either the start or end pickup/drop-off window is missing in `stop_times.txt`.",
-      "description":"GTFS specification requires both the start and end pickup/drop-off windows to be provided\ntogether, if used.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "endPickupDropOffWindow":{
-            "fieldName":"endPickupDropOffWindow",
-            "description":"The end pickup drop off window of the faulty record.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow":{
-            "fieldName":"startPickupDropOffWindow",
-            "description":"The start pickup drop off window of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_prior_day_booking_field_value":{
-      "code":"missing_prior_day_booking_field_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The `prior_notice_last_day` and the `prior_notice_last_time` values are required for prior day `booking_type` in booking_rules.txt.",
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":true,
-      "deprecationReason":"Separated into `missing_prior_notice_last_day` and `missing_prior_notice_last_time` notices",
-      "deprecationVersion":"7.0.0",
-      "replacementNoticeCodes":[
-         "missing_prior_notice_last_day",
-         "missing_prior_notice_last_time"
+  "equal_shape_distance_diff_coordinates_distance_below_threshold": {
+    "code": "equal_shape_distance_diff_coordinates_distance_below_threshold",
+    "deprecated": false,
+    "description": "When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and small\ndifference of coordinates (greater than 0 but less than 1.11 m distance) result in a warning.",
+    "properties": {
+      "actualDistanceBetweenShapePoints": {
+        "description": "Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
+        "fieldName": "actualDistanceBetweenShapePoints",
+        "type": "number"
+      },
+      "csvRowNumber": {
+        "description": "The row number from `shapes.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number from `shapes.txt` of the previous shape point.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevShapeDistTraveled": {
+        "description": "The previous shape point's `shape_dist_traveled` value.",
+        "fieldName": "prevShapeDistTraveled",
+        "type": "number"
+      },
+      "prevShapePtSequence": {
+        "description": "The previous record's `shapes.shape_pt_sequence`.",
+        "fieldName": "prevShapePtSequence",
+        "type": "integer"
+      },
+      "shapeDistTraveled": {
+        "description": "The faulty record's `shape_dist_traveled` value.",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "shapeId": {
+        "description": "The id of the faulty shape.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "shapePtSequence": {
+        "description": "The faulty record's `shapes.shape_pt_sequence`.",
+        "fieldName": "shapePtSequence",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
       ]
-   },
-   "missing_prior_notice_duration_min":{
-      "code":"missing_prior_notice_duration_min",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`prior_notice_duration_min` value is required for same day `booking_type` in booking_rules.txt.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_prior_notice_last_day":{
-      "code":"missing_prior_notice_last_day",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The `prior_notice_last_day` is required when booking_type\u003d2 (prior day booking) is specified in booking_rules.txt.",
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_prior_notice_last_time":{
-      "code":"missing_prior_notice_last_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The `prior_notice_last_time` is required when booking_type\u003d2 (prior day booking) is specified in booking_rules.txt.",
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_prior_notice_start_time":{
-      "code":"missing_prior_notice_start_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`prior_notice_start_time` value is required when `prior_notice_start_day` value is set in booking_rules.txt.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "bookingRuleId":{
-            "fieldName":"bookingRuleId",
-            "description":"The `booking_rules.booking_rule_id` of the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "priorNoticeStartDay":{
-            "fieldName":"priorNoticeStartDay",
-            "description":"The value of the `prior_notice_start_day` field.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_recommended_column":{
-      "code":"missing_recommended_column",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A recommended column is missing in the input file.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "term-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the missing column.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":true,
-      "deprecationReason":"Unused validation notice",
-      "deprecationVersion":"7.0.0"
-   },
-   "missing_recommended_field":{
-      "code":"missing_recommended_field",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A recommended field is missing.",
-      "description":"The given field has no value in some input row, even though values are recommended.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the missing field.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_recommended_file":{
-      "code":"missing_recommended_file",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A recommended file is missing.",
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_required_column":{
-      "code":"missing_required_column",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A required column is missing in the input file.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "term-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the missing column.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_required_element":{
-      "code":"missing_required_element",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A required element is missing in `locations.geojson`.",
-      "properties":{
-         "featureId":{
-            "fieldName":"featureId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"Index of the feature in the feature collection.",
-            "type":"integer"
-         },
-         "missingElement":{
-            "fieldName":"missingElement",
-            "description":"The missing required element.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_required_field":{
-      "code":"missing_required_field",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A required field is missing.",
-      "description":"The given field has no value in some input row, even though values are required.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "term-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the missing field.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_required_file":{
-      "code":"missing_required_file",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A required file is missing.",
-      "description":"If this notice is triggered for every core file, it might be a problem with the input. To\ncreate a zip file from the GTFS `.txt` files: select all the `.txt` files, right-click, and\ncompress. Do not compress the folder containing the files.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "term-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_stop_name":{
-      "code":"missing_stop_name",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`stops.stop_name` is required for `location_type` equal to `0`, `1`, or `2`.",
-      "description":"`stops.stop_name` is required for locations that are stops (`location_type\u003d0`), stations\n(`location_type\u003d1`) or entrances/exits (`location_type\u003d2`).",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "locationType":{
-            "fieldName":"locationType",
-            "description":"`stops.location_type` of the faulty record.",
-            "type":"enum"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The `stops.stop_id` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_stop_times_record":{
-      "code":"missing_stop_times_record",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Only one stop_times record is found where two are required.",
-      "description":"Travel within the same location group or GeoJSON location requires two records in\nstop_times.txt with the same location_group_id or location_id.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "locationGroupId":{
-            "fieldName":"locationGroupId",
-            "description":"The `locationGroupId` of the faulty record.",
-            "type":"string"
-         },
-         "locationId":{
-            "fieldName":"locationId",
-            "description":"The `locationId` of the faulty record.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The `tripId` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_timepoint_value":{
-      "code":"missing_timepoint_value",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"`stop_times.timepoint` value is missing for a record.",
-      "description":"When at least one of `stop_times.arrival_time` or `stop_times.departure_time` are provided,\n`stop_times.timepoint` should be defined",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopSequence":{
-            "fieldName":"stopSequence",
-            "description":"The faulty record\u0027s `stop_times.stop_sequence`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s `stop_times.trip_id`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "missing_trip_edge":{
-      "code":"missing_trip_edge",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Missing trip edge `arrival_time` or `departure_time`.",
-      "description":"First and last stop of a trip must define both `arrival_time` and `departure_time` fields.\nPer [stop_times.txt](http://gtfs.org/reference/static/#stop_timestxt), \"If there are not\nseparate times for arrival and departure at a stop, enter the same value for arrival_time and\ndeparture_time.\"",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "specifiedField":{
-            "fieldName":"specifiedField",
-            "description":"Name of the missing field.",
-            "type":"string"
-         },
-         "stopSequence":{
-            "fieldName":"stopSequence",
-            "description":"`stops.stop_sequence` of the faulty record.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The `trips.trip_id` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "mixed_case_recommended_field":{
-      "code":"mixed_case_recommended_field",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"This field has customer-facing text and should use Mixed Case (should contain upper and lower case letters).",
-      "description":"This field contains customer-facing text and should use Mixed Case (upper and lower case\nletters) to ensure good readability when displayed to riders. Avoid the use of abbreviations\nthroughout the feed (e.g. St. for Street) unless a location is called by its abbreviated name\n(e.g. “JFK Airport”). Abbreviations may be problematic for accessibility by screen reader\nsoftware and voice user interfaces.\n\n\u003ctable style\u003d\"table-layout:auto; width:auto;\"\u003e\n  \u003ccaption\u003eGood examples:\u003c/caption\u003e\n  \u003ctr\u003e\n    \u003cth\u003e\u003ccode\u003eField Text\u003c/code\u003e\u003c/th\u003e\n    \u003cth\u003e\u003ccode\u003eDataset\u003c/code\u003e\u003c/th\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"Schwerin, Hauptbahnhof\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"http://vbb.de/vbbgtfs\"\u003eVerkehrsverbund Berlin-Brandenburg\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n   \u003ctr\u003e\n    \u003ctd\u003e\"Red Hook/Atlantic Basin\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"http://nycferry.connexionz.net/rtt/public/utility/gtfs.aspx\"\u003eNYC Ferry\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"Campo Grande Norte\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"https://gateway.carris.pt/gateway/gtfs/api/v2.8/GTFS\"\u003eCarris\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n\u003c/table\u003e\n\n\u003ctable style\u003d\"table-layout:auto; width:auto;\"\u003e\n  \u003ccaption\u003eBad examples:\u003c/caption\u003e\n  \u003ctr\u003e\n    \u003cth\u003e\u003ccode\u003eField Text\u003c/code\u003e\u003c/th\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"GALLERIA MALL\"\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"3427 GG 17\"\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"21 Clark Rd Est\"\u003c/td\u003e\n  \u003c/tr\u003e\n\u003c/table\u003e",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Best Practices for All Files",
-               "url":"https://gtfs.org/schedule/reference/#file-requirements"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Name of the faulty field.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"Name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "more_than_one_entity":{
-      "code":"more_than_one_entity",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"More than one row in CSV.",
-      "description":"The file is expected to have a single entity but has more (e.g., \"feed_info.txt\").",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "entityCount":{
-            "fieldName":"entityCount",
-            "description":"Number of occurrences.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"Name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "new_line_in_value":{
-      "code":"new_line_in_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"New line or carriage return in a value in CSV file.",
-      "description":"This error is usually found when the CSV file does not close double quotes properly, so the\nnext line is considered as a continuation of the previous line.\n\nExample: the following file was intended to have fields \"f11\", \"f12\", \"f21\", \"f22\", but it\nactually parses as two fields: \"f11\", \"f12\\nf21,\\\"f22\\\"\".\n\n```\nf11,\"f12\nf21,\"f22\"\n```",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the faulty field.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "non_ascii_or_non_printable_char":{
-      "code":"non_ascii_or_non_printable_char",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Non ascii or non printable char in ID field.",
-      "description":"A value of a field with type ID contains non ASCII or non printable characters. This is not\nrecommended.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "columnName":{
-            "fieldName":"columnName",
-            "description":"Name of the column where the error occurred.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"Row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"Name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "number_out_of_range":{
-      "code":"number_out_of_range",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Out of range value.",
-      "description":"The values in the given column of the input rows are out of range.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "file-requirements",
-            "field-types",
-            "dataset-files"
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the faulty field.",
-            "type":"string"
-         },
-         "fieldType":{
-            "fieldName":"fieldType",
-            "description":"The type of the faulty field.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"object"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "overlapping_frequency":{
-      "code":"overlapping_frequency",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Trip frequencies overlap.",
-      "description":"Trip frequencies must not overlap in time. Two entries X and Y are considered to directly\noverlap if `X.start_time \u0026lt;\u003d Y.start_time` and `Y.start_time \u0026lt; X.end_time`.",
-      "references":{
-         "fileReferences":[
-            "frequencies.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "currCsvRowNumber":{
-            "fieldName":"currCsvRowNumber",
-            "description":"The overlapping frequency\u0027s row number.",
-            "type":"integer"
-         },
-         "currStartTime":{
-            "fieldName":"currStartTime",
-            "description":"The overlapping frequency\u0027s start time.",
-            "type":"string"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number of the first frequency.",
-            "type":"integer"
-         },
-         "prevEndTime":{
-            "fieldName":"prevEndTime",
-            "description":"The first frequency end time.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The trip id associated to the first frequency.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "overlapping_zone_and_pickup_drop_off_window":{
-      "code":"overlapping_zone_and_pickup_drop_off_window",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Two entities have overlapping pickup/drop-off windows and zones.",
-      "description":"Two entities in `stop_times.txt` with the same `trip_id` have the same `pickup_type` or\n`drop_off_type`, overlapping pickup/drop-off windows and overlapping zones in\n`locations.geojson`.",
-      "properties":{
-         "endPickupDropOffWindow1":{
-            "fieldName":"endPickupDropOffWindow1",
-            "description":"The `end_pickup_drop_off_window` of the first entity in `stop_times.txt`.",
-            "type":"string"
-         },
-         "endPickupDropOffWindow2":{
-            "fieldName":"endPickupDropOffWindow2",
-            "description":"The `end_pickup_drop_off_window` of the second entity in `stop_times.txt`.",
-            "type":"string"
-         },
-         "locationId1":{
-            "fieldName":"locationId1",
-            "description":"The `location_id` of the first entity.",
-            "type":"string"
-         },
-         "locationId2":{
-            "fieldName":"locationId2",
-            "description":"The `location_id` of the second entity.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow1":{
-            "fieldName":"startPickupDropOffWindow1",
-            "description":"The `start_pickup_drop_off_window` of the first entity in `stop_times.txt`.",
-            "type":"string"
-         },
-         "startPickupDropOffWindow2":{
-            "fieldName":"startPickupDropOffWindow2",
-            "description":"The `start_pickup_drop_off_window` of the second entity in `stop_times.txt`.",
-            "type":"string"
-         },
-         "stopSequence1":{
-            "fieldName":"stopSequence1",
-            "description":"The `stop_sequence` of the first entity in `stop_times.txt`.",
-            "type":"integer"
-         },
-         "stopSequence2":{
-            "fieldName":"stopSequence2",
-            "description":"The `stop_sequence` of the second entity in `stop_times.txt`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The `trip_id` of the entities.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "pathway_dangling_generic_node":{
-      "code":"pathway_dangling_generic_node",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A generic node has only one incident location in a pathway graph.",
-      "description":"Such generic node is useless because there is no benefit in visiting it.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"Row number of the dangling generic node.",
-            "type":"integer"
-         },
-         "parentStation":{
-            "fieldName":"parentStation",
-            "description":"The parent station of the dangling generic node.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the dangling generic node.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The stop name of the dangling generic node.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "pathway_loop":{
-      "code":"pathway_loop",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A pathway starts and ends at the same location.",
-      "description":"A pathway should not have same values for `from_stop_id` and `to_stop_id`.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"Row number of the faulty row from `pathways.txt`.",
-            "type":"integer"
-         },
-         "pathwayId":{
-            "fieldName":"pathwayId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The `pathway.stop_id` that is repeated in `pathways.from_stop_id` and `pathways.to_stop_id`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "pathway_to_platform_with_boarding_areas":{
-      "code":"pathway_to_platform_with_boarding_areas",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A pathway has an endpoint that is a platform which has boarding areas.",
-      "description":"A platform that has boarding areas is treated as a parent object, not a point. In such\ncases, the platform must not have pathways assigned - instead, pathways must be assigned to its\nboarding areas.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty row.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The platform id field name.",
-            "type":"string"
-         },
-         "pathwayId":{
-            "fieldName":"pathwayId",
-            "description":"The id of the faulty pathway.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the endpoint platform.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "pathway_to_wrong_location_type":{
-      "code":"pathway_to_wrong_location_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A pathway has an endpoint that is a station.",
-      "description":"Pathways endpoints must be platforms (stops), entrances/exits, generic nodes or boarding\nareas.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty row.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The station id field name.",
-            "type":"string"
-         },
-         "pathwayId":{
-            "fieldName":"pathwayId",
-            "description":"The id of the faulty pathway.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the endpoint station.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "pathway_unreachable_location":{
-      "code":"pathway_unreachable_location",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A location is not reachable at least in one direction: from the entrances or to the exits.",
-      "description":"Notices are reported for platforms, boarding areas and generic nodes but not for entrances\nor stations.\n\nNotices are not reported for platforms that have boarding areas since such platforms may not\nhave incident pathways. Instead, notices are reported for the boarding areas.",
-      "references":{
-         "fileReferences":[
-            "pathways.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"Row number of the unreachable location.",
-            "type":"integer"
-         },
-         "hasEntrance":{
-            "fieldName":"hasEntrance",
-            "description":"Whether the location is reachable from entrances.",
-            "type":"boolean"
-         },
-         "hasExit":{
-            "fieldName":"hasExit",
-            "description":"Whether some exit can be reached from the location.",
-            "type":"boolean"
-         },
-         "locationType":{
-            "fieldName":"locationType",
-            "description":"The type of the unreachable location.",
-            "type":"integer"
-         },
-         "parentStation":{
-            "fieldName":"parentStation",
-            "description":"The parent of the unreachable location.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the unreachable location.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The stop name of the unreachable location.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "platform_without_parent_station":{
-      "code":"platform_without_parent_station",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"A platform has no `parent_station` field set.",
-      "description":"This is different from `location_without_parent_station` since it is less severe.",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"Row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The stop name of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "point_near_origin":{
-      "code":"point_near_origin",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A point is too close to origin `(0, 0)`.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty row.",
-            "type":"integer"
-         },
-         "entityId":{
-            "fieldName":"entityId",
-            "description":"The id of the faulty entity.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The index of the feature in the feature collection.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the affected GTFS file.",
-            "type":"string"
-         },
-         "latFieldName":{
-            "fieldName":"latFieldName",
-            "description":"The name of the field that uses latitude value.",
-            "type":"string"
-         },
-         "latFieldValue":{
-            "fieldName":"latFieldValue",
-            "description":"The latitude of the faulty row.",
-            "type":"number"
-         },
-         "lonFieldName":{
-            "fieldName":"lonFieldName",
-            "description":"The name of the field that uses longitude value.",
-            "type":"string"
-         },
-         "lonFieldValue":{
-            "fieldName":"lonFieldValue",
-            "description":"The longitude of the faulty row",
-            "type":"number"
-         }
-      },
-      "deprecated":false
-   },
-   "point_near_pole":{
-      "code":"point_near_pole",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A point is too close to the North or South Pole.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row of the faulty row.",
-            "type":"integer"
-         },
-         "entityId":{
-            "fieldName":"entityId",
-            "description":"The id of the faulty entity.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The index of the feature in the feature collection.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the affected GTFS file.",
-            "type":"string"
-         },
-         "latFieldName":{
-            "fieldName":"latFieldName",
-            "description":"The name of the field that uses latitude value.",
-            "type":"string"
-         },
-         "latFieldValue":{
-            "fieldName":"latFieldValue",
-            "description":"The latitude of the faulty row.",
-            "type":"number"
-         },
-         "lonFieldName":{
-            "fieldName":"lonFieldName",
-            "description":"The name of the field that uses longitude value.",
-            "type":"string"
-         },
-         "lonFieldValue":{
-            "fieldName":"lonFieldValue",
-            "description":"The longitude of the faulty row",
-            "type":"number"
-         }
-      },
-      "deprecated":false
-   },
-   "prior_notice_last_day_after_start_day":{
-      "code":"prior_notice_last_day_after_start_day",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Prior notice last day should not be greater than the prior notice start day in booking_rules.txt.",
-      "references":{
-         "fileReferences":[
-            "booking_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "priorNoticeLastDay":{
-            "fieldName":"priorNoticeLastDay",
-            "description":"The value of the `prior_notice_last_day` of the faulty field.",
-            "type":"integer"
-         },
-         "priorNoticeStartDay":{
-            "fieldName":"priorNoticeStartDay",
-            "description":"The value of the `prior_notice_start_day` of the faulty field.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "route_both_short_and_long_name_missing":{
-      "code":"route_both_short_and_long_name_missing",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Both `route_short_name` and `route_long_name` are missing for a route.",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "route_color_contrast":{
-      "code":"route_color_contrast",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Insufficient route color contrast.",
-      "description":"A route\u0027s color and `route_text_color` should be contrasting.",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeColor":{
-            "fieldName":"routeColor",
-            "description":"The faulty record\u0027s HTML route color.",
-            "type":"string"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "routeTextColor":{
-            "fieldName":"routeTextColor",
-            "description":"The faulty record\u0027s HTML route text color.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "route_long_name_contains_short_name":{
-      "code":"route_long_name_contains_short_name",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Long name should not contain short name for a single route.",
-      "description":"In routes.txt, `route_long_name` should not contain the value for `route_short_name`,\nbecause when both are provided, they are often combined by transit applications. Note that only\none of the two fields is required. If there is no short name used for a route, use\n`route_long_name` only.\n\nGood examples:\n\n\u003ctable\u003e\n  \u003ctr\u003e\n    \u003cth\u003eroute_short_name/route_long_name\u003c/th\u003e\n    \u003cth\u003eDataset\u003c/th\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"N\"/\"Judah\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"https://www.sfmta.com/getting-around/transit/routes-stops/n-judah\"\u003eMuni San Fransisco\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"6\"/\"ML King Jr Blvd\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"https://trimet.org/schedules/r006.htm\"\u003eTrimet Portland Streetcar\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"55\"/\"Boulevard Saint Laurent\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"https://www.stm.info/en/info/networks/bus/local/line-55-north\"\u003eSTM Montreal\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"1\"/\"Rangiora/Cashmere\"\u003c/td\u003e\n    \u003ctd\u003e\u003ca href\u003d\"https://www.metroinfo.co.nz/timetables/1-rangiora-cashmere/\"\u003eMetro Christchurch\u003c/a\u003e\u003c/td\u003e\n  \u003c/tr\u003e\n\u003c/table\u003e\n\nBad examples:\n\n\u003ctable\u003e\n  \u003ctr\u003e\n    \u003cth\u003eroute_short_name/route_long_name\u003c/th\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"604\"/\"604\"\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"14\"/\"Route 14\"\u003c/td\u003e\n  \u003c/tr\u003e\n  \u003ctr\u003e\n    \u003ctd\u003e\"2\"/\"Route 2: Bellows Falls In-Town\"\u003c/td\u003e\n  \u003c/tr\u003e\n\u003c/table\u003e",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-            "routes.txt"
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "routeLongName":{
-            "fieldName":"routeLongName",
-            "description":"The faulty record\u0027s `route_long_name`.",
-            "type":"string"
-         },
-         "routeShortName":{
-            "fieldName":"routeShortName",
-            "description":"The faulty record\u0027s `route_short_name`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "route_networks_specified_in_more_than_one_file":{
-      "code":"route_networks_specified_in_more_than_one_file",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Indicates that route network identifiers are specified across multiple files.",
-      "description":"This notice highlights a data integrity issue where route network specifications are\nredundantly defined in more than one file. According to specifications, a route network\nidentifier should be uniquely defined in a single file. Any additional definitions of route\nnetwork specifications in other files are considered conditionally forbidden.",
-      "references":{
-         "fileReferences":[
-            "routes.txt",
-            "route_networks.txt",
-            "networks.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"Name of the field in fileNameA",
-            "type":"string"
-         },
-         "fileNameA":{
-            "fieldName":"fileNameA",
-            "description":"The name of the first file.",
-            "type":"string"
-         },
-         "fileNameB":{
-            "fieldName":"fileNameB",
-            "description":"The name of the second file which presence duplicates route networks specification.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "route_short_name_too_long":{
-      "code":"route_short_name_too_long",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Short name of a route is too long (more than 12 characters).",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-            "routes.txt"
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "routeShortName":{
-            "fieldName":"routeShortName",
-            "description":"The faulty record\u0027s `route_short_name`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "runtime_exception_in_loader_error":{
-      "code":"runtime_exception_in_loader_error",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"RuntimeException while loading GTFS dataset in memory.",
-      "description":"A\n[RuntimeException](https://docs.oracle.com/javase/8/docs/api/java/lang/RuntimeException.html)\noccurred while loading a table. This normally indicates a bug in validator.",
-      "properties":{
-         "exception":{
-            "fieldName":"exception",
-            "description":"The name of the exception.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the file that caused the exception.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The error message that explains the reason for the exception.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "runtime_exception_in_validator_error":{
-      "code":"runtime_exception_in_validator_error",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"RuntimeException while validating GTFS archive.",
-      "description":"A\n[RuntimeException](https://docs.oracle.com/javase/8/docs/api/java/lang/RuntimeException.html)\noccurred during validation. This normally indicates a bug in validator code, e.g., in a custom\nvalidator class.",
-      "properties":{
-         "exception":{
-            "fieldName":"exception",
-            "description":"The name of the exception.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The error message that explains the reason for the exception.",
-            "type":"string"
-         },
-         "validator":{
-            "fieldName":"validator",
-            "description":"The name of the validator that caused the exception.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "same_name_and_description_for_route":{
-      "code":"same_name_and_description_for_route",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Same name and description for route.",
-      "description":"The GTFS spec defines `routes.txt`\n[route_desc](https://gtfs.org/reference/static/#routestxt) as:\n\nDescription of a route that provides useful, quality information. Do not simply duplicate\nthe name of the route.\n\nSee the GTFS and GTFS Best Practices links below for more examples of how to populate the\n`route_short_name`, `route_long_name`, and `route_desc` fields.",
-      "references":{
-         "fileReferences":[
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "routeDesc":{
-            "fieldName":"routeDesc",
-            "description":"The `routes.routes_desc` of the faulty record.",
-            "type":"string"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "specifiedField":{
-            "fieldName":"specifiedField",
-            "description":"Either `route_short_name` or `route_long_name`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "same_name_and_description_for_stop":{
-      "code":"same_name_and_description_for_stop",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Same name and description for stop.",
-      "description":"The GTFS spec defines `stops.txt`\n[stop_description](https://gtfs.org/reference/static/#stopstxt) as:\n\nDescription of the location that provides useful, quality information. Do not simply\nduplicate the name of the location.",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopDesc":{
-            "fieldName":"stopDesc",
-            "description":"The faulty record\u0027s `stop_desc`.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "same_route_and_agency_url":{
-      "code":"same_route_and_agency_url",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Same `routes.route_url` and `agency.agency_url`.",
-      "description":"A route should not have the same `routes.route_url` as a record from `agency.txt`.",
-      "references":{
-         "fileReferences":[
-            "routes.txt",
-            "agency.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "agencyCsvRowNumber":{
-            "fieldName":"agencyCsvRowNumber",
-            "description":"The row number of the faulty record from `agency.txt`.",
-            "type":"integer"
-         },
-         "agencyName":{
-            "fieldName":"agencyName",
-            "description":"The faulty record\u0027s referenced agency name.",
-            "type":"string"
-         },
-         "routeCsvRowNumber":{
-            "fieldName":"routeCsvRowNumber",
-            "description":"The row number of the faulty record from `routes.txt`.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         },
-         "routeUrl":{
-            "fieldName":"routeUrl",
-            "description":"The duplicate URL value",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "same_stop_and_agency_url":{
-      "code":"same_stop_and_agency_url",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Same `stops.stop_url` and `agency.agency_url`.",
-      "description":"A stop should not have the same `stops.stop_url` as a record from `agency.txt`.",
-      "references":{
-         "fileReferences":[
-            "stops.txt",
-            "agency.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "agencyCsvRowNumber":{
-            "fieldName":"agencyCsvRowNumber",
-            "description":"The row number of the faulty record from `agency.txt`.",
-            "type":"integer"
-         },
-         "agencyName":{
-            "fieldName":"agencyName",
-            "description":"The faulty record\u0027s `agency.agency_name`.",
-            "type":"string"
-         },
-         "stopCsvRowNumber":{
-            "fieldName":"stopCsvRowNumber",
-            "description":"The row number of the faulty record from `stops.txt`.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         },
-         "stopUrl":{
-            "fieldName":"stopUrl",
-            "description":"The duplicate URL value.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "same_stop_and_route_url":{
-      "code":"same_stop_and_route_url",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Same `stops.stop_url` and `routes.route_url`.",
-      "description":"A stop should not have the same `stop.stop_url` as a record from `routes.txt`.",
-      "references":{
-         "fileReferences":[
-            "stops.txt",
-            "routes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "routeCsvRowNumber":{
-            "fieldName":"routeCsvRowNumber",
-            "description":"The row number of the faulty record from `routes.txt`.",
-            "type":"integer"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The faulty record\u0027s id from `routes.txt.",
-            "type":"string"
-         },
-         "stopCsvRowNumber":{
-            "fieldName":"stopCsvRowNumber",
-            "description":"The row number of the faulty record from `stops.txt`.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         },
-         "stopUrl":{
-            "fieldName":"stopUrl",
-            "description":"The duplicate URL value.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "single_shape_point":{
-      "code":"single_shape_point",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"The shape within `shapes.txt` contains a single shape point.",
-      "description":"A shape should contain more than one shape point to visualize the route",
-      "references":{
-         "fileReferences":[
-            "shapes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "start_and_end_range_equal":{
-      "code":"start_and_end_range_equal",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Two date or time fields are equal.",
-      "description":"The fields `frequencies.start_date` and `frequencies.end_date` have been found equal in\n`frequencies.txt`. The GTFS spec is currently unclear how this case should be handled (e.g., is\nit a trip that circulates once?). It is recommended to use a trip not defined via frequencies.txt\nfor this case.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "endFieldName":{
-            "fieldName":"endFieldName",
-            "description":"The end value\u0027s field name.",
-            "type":"string"
-         },
-         "entityId":{
-            "fieldName":"entityId",
-            "description":"The id of the faulty entity.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "startFieldName":{
-            "fieldName":"startFieldName",
-            "description":"The start value\u0027s field name.",
-            "type":"string"
-         },
-         "value":{
-            "fieldName":"value",
-            "description":"The faulty value.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "start_and_end_range_out_of_order":{
-      "code":"start_and_end_range_out_of_order",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Two date or time fields are out of order.",
-      "description":"Date or time fields have been found out of order in `calendar.txt`, `feed_info.txt` and\n`stop_times.txt`.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "endFieldName":{
-            "fieldName":"endFieldName",
-            "description":"The end value\u0027s field name.",
-            "type":"string"
-         },
-         "endValue":{
-            "fieldName":"endValue",
-            "description":"The end value.",
-            "type":"string"
-         },
-         "entityId":{
-            "fieldName":"entityId",
-            "description":"The faulty service id.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "startFieldName":{
-            "fieldName":"startFieldName",
-            "description":"The start value\u0027s field name.",
-            "type":"string"
-         },
-         "startValue":{
-            "fieldName":"startValue",
-            "description":"The start value.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "station_with_parent_station":{
-      "code":"station_with_parent_station",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A station has `parent_station` field set.",
-      "description":"Field `parent_station` must be empty when `location_type` is 1.",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "parentStation":{
-            "fieldName":"parentStation",
-            "description":"Parent station\u0027s id.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The stops.stop_name of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_has_too_many_matches_for_shape":{
-      "code":"stop_has_too_many_matches_for_shape",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Stop entry that has many potential matches to the trip\u0027s path of travel, as defined by the shape entry in `shapes.txt`.",
-      "description":"This potentially indicates a problem with the location of the stop or the path of the shape.",
-      "references":{
-         "fileReferences":[
-            "trips.txt",
-            "stop_times.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "match":{
-            "fieldName":"match",
-            "description":"Latitude and longitude pair of the location.",
-            "type":"array",
-            "contains":{
-               "type":"number"
-            },
-            "minItems":2,
-            "maxItems":2
-         },
-         "matchCount":{
-            "fieldName":"matchCount",
-            "description":"The number of matches for the stop that is referred to.",
-            "type":"integer"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the shape that is referred to.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber":{
-            "fieldName":"stopTimeCsvRowNumber",
-            "description":"The row number of the faulty record from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the faulty record from `trips.txt`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The id of the trip that is referred to.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_time_timepoint_without_times":{
-      "code":"stop_time_timepoint_without_times",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`arrival_time` or `departure_time` not specified for timepoint.",
-      "description":"Any records with `stop_times.timepoint` set to 1 must define a value for\n`stop_times.arrival_time` and `stop_times.departure_time` fields.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt",
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "specifiedField":{
-            "fieldName":"specifiedField",
-            "description":"Either `departure_time` or `arrival_time`.",
-            "type":"string"
-         },
-         "stopSequence":{
-            "fieldName":"stopSequence",
-            "description":"The faulty record\u0027s `stops.stop_sequence`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_time_with_arrival_before_previous_departure_time":{
-      "code":"stop_time_with_arrival_before_previous_departure_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Backwards time travel between stops in `stop_times.txt`",
-      "description":"For a given `trip_id`, the `arrival_time` of (n+1)-th stoptime in sequence must not precede\nthe `departure_time` of n-th stoptime in sequence in `stop_times.txt`.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "arrivalTime":{
-            "fieldName":"arrivalTime",
-            "description":"Arrival time at the faulty record.",
-            "type":"string"
-         },
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "departureTime":{
-            "fieldName":"departureTime",
-            "description":"Departure time at the previous stop time.",
-            "type":"string"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row of the previous stop time.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The trip_id associated to the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_time_with_only_arrival_or_departure_time":{
-      "code":"stop_time_with_only_arrival_or_departure_time",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Missing `stop_times.arrival_time` or `stop_times.departure_time`.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "specifiedField":{
-            "fieldName":"specifiedField",
-            "description":"Either `arrival_time` or `departure_time`",
-            "type":"string"
-         },
-         "stopSequence":{
-            "fieldName":"stopSequence",
-            "description":"The sequence of the faulty stop.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The trip_id associated to the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_too_far_from_shape":{
-      "code":"stop_too_far_from_shape",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Stop too far from trip shape.",
-      "description":"Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100 meters of\nstop locations which a trip serves. This potentially indicates a problem with the location of\nthe stop or the path of the shape.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt",
-            "stops.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-            "shapes.txt"
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "geoDistanceToShape":{
-            "fieldName":"geoDistanceToShape",
-            "description":"Distance from stop to shape.",
-            "type":"number"
-         },
-         "match":{
-            "fieldName":"match",
-            "description":"Latitude and longitude pair of the location.",
-            "type":"array",
-            "contains":{
-               "type":"number"
-            },
-            "minItems":2,
-            "maxItems":2
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the shape that is referred to.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber":{
-            "fieldName":"stopTimeCsvRowNumber",
-            "description":"The row number of the faulty record from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the faulty record from `trips.txt`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The id of the trip that is referred to.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_too_far_from_shape_using_user_distance":{
-      "code":"stop_too_far_from_shape_using_user_distance",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Stop time too far from shape.",
-      "description":"A stop time entry that is a large distance away from the location of the shape in\n`shapes.txt` as defined by `shape_dist_traveled` values.",
-      "references":{
-         "fileReferences":[
-            "trips.txt",
-            "stop_times.txt",
-            "stops.txt",
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "geoDistanceToShape":{
-            "fieldName":"geoDistanceToShape",
-            "description":"Distance from stop to shape.",
-            "type":"number"
-         },
-         "match":{
-            "fieldName":"match",
-            "description":"Latitude and longitude pair of the location.",
-            "type":"array",
-            "contains":{
-               "type":"number"
-            },
-            "minItems":2,
-            "maxItems":2
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the shape that is referred to.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the stop that is referred to.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber":{
-            "fieldName":"stopTimeCsvRowNumber",
-            "description":"The row number of the faulty record from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the faulty record from `trips.txt`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The id of the trip that is referred to.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_without_location":{
-      "code":"stop_without_location",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"`stop_lat` and/or `stop_lon` is missing for stop with `location_type` equal to`0`, `1`, or `2`",
-      "description":"`stop_lat` and/or `stop_lon` are required for locations that are stops (`location_type\u003d0`),\nstations (`location_type\u003d1`) or entrances/exits (`location_type\u003d2`).",
-      "references":{
-         "fileReferences":[
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "locationType":{
-            "fieldName":"locationType",
-            "description":"The faulty record\u0027s `stops.location_type`.",
-            "type":"enum"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_without_stop_time":{
-      "code":"stop_without_stop_time",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.",
-      "description":"Such stops are not used by any trip and normally do not provide user value. This notice may\nindicate a typo in `stop_times.txt`.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty stop.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the faulty stop.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stop_without_zone_id":{
-      "code":"stop_without_zone_id",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"Stop without value for `stops.zone_id` contained in a route with a zone-dependent fare rule.",
-      "description":"If `fare_rules.txt` is provided, and `fare_rules.txt` uses at least one column among\n`origin_id`, `destination_id`, and `contains_id`, then all stops and platforms (location_type \u003d\n0) must have `stops.zone_id` assigned if they are defined in a trip defined in a route defined\nin a fare rule which also defines at least one of `origin_id`, `destination_id`, or\n`contains_id`.",
-      "references":{
-         "fileReferences":[
-            "stops.txt",
-            "stop_times.txt",
-            "trips.txt",
-            "routes.txt",
-            "fare_rules.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The faulty record\u0027s `stops.stop_name`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "stops_match_shape_out_of_order":{
-      "code":"stops_match_shape_out_of_order",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Two stop entries are different than their arrival-departure order defined by `shapes.txt`.",
-      "description":"This could indicate a problem with the location of the stops, the path of the shape, or the\nsequence of the stops for their trip.",
-      "references":{
-         "fileReferences":[
-            "trips.txt",
-            "stop_times.txt",
-            "stops.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "match1":{
-            "fieldName":"match1",
-            "description":"Latitude and longitude pair of the first matching location.",
-            "type":"array",
-            "contains":{
-               "type":"number"
-            },
-            "minItems":2,
-            "maxItems":2
-         },
-         "match2":{
-            "fieldName":"match2",
-            "description":"Latitude and longitude pair of the second matching location.",
-            "type":"array",
-            "contains":{
-               "type":"number"
-            },
-            "minItems":2,
-            "maxItems":2
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The id of the shape that is referred to.",
-            "type":"string"
-         },
-         "stopId1":{
-            "fieldName":"stopId1",
-            "description":"The id of the first stop that is referred to.",
-            "type":"string"
-         },
-         "stopId2":{
-            "fieldName":"stopId2",
-            "description":"The id of the second stop that is referred to.",
-            "type":"string"
-         },
-         "stopName1":{
-            "fieldName":"stopName1",
-            "description":"The name of the first stop that is referred to.",
-            "type":"string"
-         },
-         "stopName2":{
-            "fieldName":"stopName2",
-            "description":"The name of the second stop that is referred to.",
-            "type":"string"
-         },
-         "stopTimeCsvRowNumber1":{
-            "fieldName":"stopTimeCsvRowNumber1",
-            "description":"The row number of the first faulty record from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "stopTimeCsvRowNumber2":{
-            "fieldName":"stopTimeCsvRowNumber2",
-            "description":"The row number of the second faulty record from `stop_times.txt`.",
-            "type":"integer"
-         },
-         "tripCsvRowNumber":{
-            "fieldName":"tripCsvRowNumber",
-            "description":"The row number of the faulty record from `trips.txt`.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The id of the trip that is referred to.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "thread_execution_error":{
-      "code":"thread_execution_error",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"ExecutionException during multithreaded validation",
-      "description":"An\n[ExecutionException](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutionException.html)\noccurred during multithreaded validation.",
-      "properties":{
-         "exception":{
-            "fieldName":"exception",
-            "description":"The name of the exception.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The error message that explains the reason for the exception.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "timeframe_only_start_or_end_time_specified":{
-      "code":"timeframe_only_start_or_end_time_specified",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A row from `timeframes.txt` was found with only one of `start_time` and `end_time` specified.",
-      "description":"Either both must be specified or neither must be specified.",
-      "references":{
-         "fileReferences":[
-            "timeframes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number for the faulty record.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "timeframe_overlap":{
-      "code":"timeframe_overlap",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Two entries in `timeframes.txt` with the same `timeframe_group_id` and `service_id` have overlapping time intervals.",
-      "description":"Timeframes with the same group and service dates must not overlap in time. Two entries X and\nY are considered to directly overlap if `X.start_time \u0026lt;\u003d Y.start_time` and `Y.start_time\n\u0026lt; X.end_time`.",
-      "references":{
-         "fileReferences":[
-            "frequencies.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "currCsvRowNumber":{
-            "fieldName":"currCsvRowNumber",
-            "description":"The row number of the second timeframe entry.",
-            "type":"integer"
-         },
-         "currStartTime":{
-            "fieldName":"currStartTime",
-            "description":"The start time of the second timeframe entry.",
-            "type":"string"
-         },
-         "prevCsvRowNumber":{
-            "fieldName":"prevCsvRowNumber",
-            "description":"The row number of the first timeframe entry.",
-            "type":"integer"
-         },
-         "prevEndTime":{
-            "fieldName":"prevEndTime",
-            "description":"The first timeframe end time.",
-            "type":"string"
-         },
-         "serviceId":{
-            "fieldName":"serviceId",
-            "description":"The service id associated with the two entries.",
-            "type":"string"
-         },
-         "timeframeGroupId":{
-            "fieldName":"timeframeGroupId",
-            "description":"The timeframe group id associated with the two entries.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "timeframe_start_or_end_time_greater_than_twenty_four_hours":{
-      "code":"timeframe_start_or_end_time_greater_than_twenty_four_hours",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A time in `timeframes.txt` is greater than `24:00:00`.",
-      "references":{
-         "fileReferences":[
-            "timeframes.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number for the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The time field name for the faulty record.",
-            "type":"string"
-         },
-         "time":{
-            "fieldName":"time",
-            "description":"The invalid time value.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "too_many_rows":{
-      "code":"too_many_rows",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A CSV file has too many rows.",
-      "description":"Feeds with too large files cannot be processed in a reasonable time by GTFS consumers.",
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"Name of the CSV file that has too many rows.",
-            "type":"string"
-         },
-         "rowNumber":{
-            "fieldName":"rowNumber",
-            "description":"Number of the row when reading was stopped.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_distance_above_2_km":{
-      "code":"transfer_distance_above_2_km",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"The transfer distance from stop to stop in `transfers.txt` is larger than 2 km.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "distanceKm":{
-            "fieldName":"distanceKm",
-            "description":"The distance between the two stops in km.",
-            "type":"number"
-         },
-         "fromStopId":{
-            "fieldName":"fromStopId",
-            "description":"The ID of the stop in `from_stop_id`.",
-            "type":"string"
-         },
-         "toStopId":{
-            "fieldName":"toStopId",
-            "description":"The ID of the stop in `to_stop_id`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_distance_too_large":{
-      "code":"transfer_distance_too_large",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"The transfer distance from stop to stop in `transfers.txt` is larger than 10 km.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "distanceKm":{
-            "fieldName":"distanceKm",
-            "description":"The distance between the two stops in km.",
-            "type":"number"
-         },
-         "fromStopId":{
-            "fieldName":"fromStopId",
-            "description":"The ID of the stop in `from_stop_id`.",
-            "type":"string"
-         },
-         "toStopId":{
-            "fieldName":"toStopId",
-            "description":"The ID of the stop in `to_stop_id`.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_with_invalid_stop_location_type":{
-      "code":"transfer_with_invalid_stop_location_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A stop id field from GTFS file `transfers.txt` references a stop that has a `location_type` other than 0 or 1 (aka Stop/Platform or Station).",
-      "references":{
-         "fileReferences":[
-            "transfers.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "locationTypeName":{
-            "fieldName":"locationTypeName",
-            "description":"The name of the invalid location type.",
-            "type":"string"
-         },
-         "locationTypeValue":{
-            "fieldName":"locationTypeValue",
-            "description":"The numeric value of the invalid location type.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The referenced stop id.",
-            "type":"string"
-         },
-         "stopIdFieldName":{
-            "fieldName":"stopIdFieldName",
-            "description":"The name of the stop id field (e.g. `from_stop_id`) referencing the stop.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_with_invalid_trip_and_route":{
-      "code":"transfer_with_invalid_trip_and_route",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A trip id field from GTFS file `transfers.txt` references a route that does not match its `trips.txt` `route_id`.",
-      "references":{
-         "fileReferences":[
-            "transfers.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "expectedRouteId":{
-            "fieldName":"expectedRouteId",
-            "description":"The expected route id from `trips.txt`.",
-            "type":"string"
-         },
-         "routeFieldName":{
-            "fieldName":"routeFieldName",
-            "description":"The name of the route id field (e.g. `from_route_id`) referencing the route.",
-            "type":"string"
-         },
-         "routeId":{
-            "fieldName":"routeId",
-            "description":"The referenced route id.",
-            "type":"string"
-         },
-         "tripFieldName":{
-            "fieldName":"tripFieldName",
-            "description":"The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The referenced trip id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_with_invalid_trip_and_stop":{
-      "code":"transfer_with_invalid_trip_and_stop",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A trip id field from GTFS file `transfers.txt` references a stop that is not included in the referenced trip\u0027s stop-times.",
-      "references":{
-         "fileReferences":[
-            "transfers.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "stopFieldName":{
-            "fieldName":"stopFieldName",
-            "description":"The name of the stop id field (e.g. `stop_route_id`) referencing the stop.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The referenced stop id.",
-            "type":"string"
-         },
-         "tripFieldName":{
-            "fieldName":"tripFieldName",
-            "description":"The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The referenced trip id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "transfer_with_suspicious_mid_trip_in_seat":{
-      "code":"transfer_with_suspicious_mid_trip_in_seat",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A trip id field from GTFS file `transfers.txt` with an in-seat transfer type references a stop that is not in the expected position in the trip\u0027s stop-times.",
-      "description":"For in-seat transfers, we expect the stop to be the last stop-time in the trip sequence for\n`from_stop_id` and the first stop-time for `to_stop_id`. If you are intentionally using this\nfeature to model mid-trip transfers, you can ignore this warning, but be aware that this\nfunctionality is still considered to be partially experimental in some interpretations of the\nspec.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number from `transfers.txt` for the faulty entry.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The referenced stop id.",
-            "type":"string"
-         },
-         "stopIdFieldName":{
-            "fieldName":"stopIdFieldName",
-            "description":"The name of the stop id field (e.g. `from_stop_id`) referencing the stop.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The referenced trip id.",
-            "type":"string"
-         },
-         "tripIdFieldName":{
-            "fieldName":"tripIdFieldName",
-            "description":"The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "translation_foreign_key_violation":{
-      "code":"translation_foreign_key_violation",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.",
-      "references":{
-         "fileReferences":[
-            "translations.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "recordId":{
-            "fieldName":"recordId",
-            "description":"`record_id` of the faulty record.",
-            "type":"string"
-         },
-         "recordSubId":{
-            "fieldName":"recordSubId",
-            "description":"`record_sub_id` of the faulty record.",
-            "type":"string"
-         },
-         "tableName":{
-            "fieldName":"tableName",
-            "description":"`table_name` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "translation_unexpected_value":{
-      "code":"translation_unexpected_value",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A field in a translations row has value but must be empty.",
-      "references":{
-         "fileReferences":[
-            "translations.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the field that was expected to be empty.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Actual value of the field that was expected to be empty.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "translation_unknown_table_name":{
-      "code":"translation_unknown_table_name",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"A translation references an unknown or missing GTFS table.",
-      "references":{
-         "fileReferences":[
-            "translations.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "tableName":{
-            "fieldName":"tableName",
-            "description":"`table_name` of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "trip_coverage_not_active_for_next7_days":{
-      "code":"trip_coverage_not_active_for_next7_days",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Trips data should be valid for at least the next seven days.",
-      "description":"This notice is triggered if the date range where a significant number of trips are running\nends in less than 7 days.",
-      "properties":{
-         "currentDate":{
-            "fieldName":"currentDate",
-            "description":"Current date (YYYYMMDD format).",
-            "type":"string"
-         },
-         "serviceWindowEndDate":{
-            "fieldName":"serviceWindowEndDate",
-            "description":"The end date of the majority service window.",
-            "type":"string"
-         },
-         "serviceWindowStartDate":{
-            "fieldName":"serviceWindowStartDate",
-            "description":"The start date of the majority service window.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "trip_distance_exceeds_shape_distance":{
-      "code":"trip_distance_exceeds_shape_distance",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"The distance between the last shape point and last stop point is greater than or equal to the 11.1m threshold.",
-      "properties":{
-         "geoDistanceToShape":{
-            "fieldName":"geoDistanceToShape",
-            "description":"The distance in meters between the shape and the stop.",
-            "type":"number"
-         },
-         "maxShapeDistanceTraveled":{
-            "fieldName":"maxShapeDistanceTraveled",
-            "description":"The faulty record\u0027s shape max distance traveled.",
-            "type":"number"
-         },
-         "maxTripDistanceTraveled":{
-            "fieldName":"maxTripDistanceTraveled",
-            "description":"The faulty record\u0027s trip max distance traveled.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The faulty record\u0027s shape id.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s trip id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "trip_distance_exceeds_shape_distance_below_threshold":{
-      "code":"trip_distance_exceeds_shape_distance_below_threshold",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"The distance between the last shape point and last stop point is greater than 0 but less than the 11.1m threshold.",
-      "properties":{
-         "geoDistanceToShape":{
-            "fieldName":"geoDistanceToShape",
-            "description":"The distance in meters between the shape and the stop.",
-            "type":"number"
-         },
-         "maxShapeDistanceTraveled":{
-            "fieldName":"maxShapeDistanceTraveled",
-            "description":"The faulty record\u0027s shape max distance traveled.",
-            "type":"number"
-         },
-         "maxTripDistanceTraveled":{
-            "fieldName":"maxTripDistanceTraveled",
-            "description":"The faulty record\u0027s trip max distance traveled.",
-            "type":"number"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The faulty record\u0027s shape id.",
-            "type":"string"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s trip id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "u_r_i_syntax_error":{
-      "code":"u_r_i_syntax_error",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A string could not be parsed as a URI reference.",
-      "properties":{
-         "exception":{
-            "fieldName":"exception",
-            "description":"The name of the exception.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The error message that explains the reason for the exception.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unexpected_enum_value":{
-      "code":"unexpected_enum_value",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"An enum has an unexpected value.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-            "field-definitions"
-         ],
-         "urlReferences":[
-
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the field where the error occurred.",
-            "type":"string"
-         },
-         "fieldValue":{
-            "fieldName":"fieldValue",
-            "description":"Faulty value.",
-            "type":"integer"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unknown_column":{
-      "code":"unknown_column",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"A column name is unknown.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "fieldName":{
-            "fieldName":"fieldName",
-            "description":"The name of the unknown column.",
-            "type":"string"
-         },
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the faulty file.",
-            "type":"string"
-         },
-         "index":{
-            "fieldName":"index",
-            "description":"The index of the faulty column.",
-            "type":"integer"
-         }
-      },
-      "deprecated":false
-   },
-   "unknown_file":{
-      "code":"unknown_file",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"A file is unknown.",
-      "references":{
-         "fileReferences":[
-
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "filename":{
-            "fieldName":"filename",
-            "description":"The name of the unknown file.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unsupported_feature_type":{
-      "code":"unsupported_feature_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"An unsupported feature type is used in the `locations.geojson` file.",
-      "description":"Use `Feature` instead to comply with the spec.",
-      "properties":{
-         "featureId":{
-            "fieldName":"featureId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The value of the unsupported GeoJSON type.",
-            "type":"integer"
-         },
-         "featureType":{
-            "fieldName":"featureType",
-            "description":"The feature type of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unsupported_geo_json_type":{
-      "code":"unsupported_geo_json_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"An unsupported GeoJSON type is used in the `locations.geojson` file.",
-      "description":"Use `FeatureCollection` instead to comply with the spec.",
-      "properties":{
-         "geoJsonType":{
-            "fieldName":"geoJsonType",
-            "description":"The value of the unsupported GeoJSON type.",
-            "type":"string"
-         },
-         "message":{
-            "fieldName":"message",
-            "description":"The detailed message describing the error.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unsupported_geometry_type":{
-      "code":"unsupported_geometry_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"A GeoJSON feature has an unsupported geometry type in `locations.geojson`.",
-      "description":"Each feature must have a geometry type that is supported by the GTFS spec. The supported\ngeometry types `Polygon` and `MultiPolygon`.",
-      "properties":{
-         "featureId":{
-            "fieldName":"featureId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "featureIndex":{
-            "fieldName":"featureIndex",
-            "description":"The index of the feature in the feature collection.",
-            "type":"integer"
-         },
-         "geometryType":{
-            "fieldName":"geometryType",
-            "description":"The geometry type of the faulty record.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unusable_trip":{
-      "code":"unusable_trip",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Trips must have more than one stop to be usable.",
-      "description":"A trip must visit more than one stop in stop_times.txt to be usable by passengers for\nboarding and alighting.",
-      "references":{
-         "fileReferences":[
-            "stop_times.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
-      },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
-      },
-      "deprecated":false
-   },
-   "unused_parent_station":{
-      "code":"unused_parent_station",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"Unused parent station.",
-      "description":"A stop has `location_type` STATION (1) but does not appear in any stop\u0027s `parent_station`.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty stop.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the faulty stop.",
-            "type":"string"
-         }
-      },
-      "deprecated":true,
-      "deprecationReason":"Renamed to `unused_station`",
-      "deprecationVersion":"7.0.0",
-      "replacementNoticeCodes":[
-         "unused_station"
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than 0 but less than 1.11m.",
+    "type": "object"
+  },
+  "feed_expiration_date30_days": {
+    "code": "feed_expiration_date30_days",
+    "deprecated": false,
+    "description": "At any time, the GTFS dataset should cover at least the next 30 days of service, and ideally\nfor as long as the operator is confident that the schedule will continue to be operated.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "currentDate": {
+        "description": "Current date (YYYYMMDD format).",
+        "fieldName": "currentDate",
+        "type": "string"
+      },
+      "feedEndDate": {
+        "description": "Feed end date (YYYYMMDD format).",
+        "fieldName": "feedEndDate",
+        "type": "string"
+      },
+      "suggestedExpirationDate": {
+        "description": "Suggested expiration date (YYYYMMDD format).",
+        "fieldName": "suggestedExpirationDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "feed_info.txt"
+      ],
+      "sectionReferences": [
+        "dataset-publishing-general-practices"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Dataset should cover at least the next 30 days of service.",
+    "type": "object"
+  },
+  "equal_shape_distance_diff_coordinates": {
+    "code": "equal_shape_distance_diff_coordinates",
+    "deprecated": false,
+    "description": "When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and different\ncoordinates indicate an error.",
+    "properties": {
+      "actualDistanceBetweenShapePoints": {
+        "description": "Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
+        "fieldName": "actualDistanceBetweenShapePoints",
+        "type": "number"
+      },
+      "csvRowNumber": {
+        "description": "The row number from `shapes.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number from `shapes.txt` of the previous shape point.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevShapeDistTraveled": {
+        "description": "The previous shape point's `shape_dist_traveled` value.",
+        "fieldName": "prevShapeDistTraveled",
+        "type": "number"
+      },
+      "prevShapePtSequence": {
+        "description": "The previous record's `shapes.shape_pt_sequence`.",
+        "fieldName": "prevShapePtSequence",
+        "type": "integer"
+      },
+      "shapeDistTraveled": {
+        "description": "The faulty record's `shape_dist_traveled` value.",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "shapeId": {
+        "description": "The id of the faulty shape.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "shapePtSequence": {
+        "description": "The faulty record's `shapes.shape_pt_sequence`.",
+        "fieldName": "shapePtSequence",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
       ]
-   },
-   "unused_shape":{
-      "code":"unused_shape",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Shape is not used in GTFS file `trips.txt`.",
-      "description":"All records defined by GTFS `shapes.txt` should be used in `trips.txt`.",
-      "references":{
-         "fileReferences":[
-            "shapes.txt",
-            "trips.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than the 1.11m.",
+    "type": "object"
+  },
+  "invalid_phone_number": {
+    "code": "invalid_phone_number",
+    "deprecated": false,
+    "description": "This rule uses the\n[PhoneNumberUtil](https://www.javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/8.4.1/com/google/i18n/phonenumbers/PhoneNumberUtil.html)\nclass to validate a phone number based on a country code. If no country code is provided in the\nparameters used to run the validator, this notice won't be emitted.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
       },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "shapeId":{
-            "fieldName":"shapeId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
       },
-      "deprecated":false
-   },
-   "unused_station":{
-      "code":"unused_station",
-      "severityLevel":"INFO",
-      "type":"object",
-      "shortSummary":"Unused station.",
-      "description":"A stop has `location_type` STATION (1) but does not appear in any stop\u0027s `parent_station`.",
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty stop.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The name of the faulty stop.",
-            "type":"string"
-         }
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
       },
-      "deprecated":false
-   },
-   "unused_trip":{
-      "code":"unused_trip",
-      "severityLevel":"WARNING",
-      "type":"object",
-      "shortSummary":"Trip is not be used in `stop_times.txt`",
-      "description":"Trips should be referred to at least once in `stop_times.txt`.",
-      "references":{
-         "fileReferences":[
-            "trips.txt",
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-            {
-               "label":"Original Python validator implementation",
-               "url":"https://github.com/google/transitfeed"
-            }
-         ]
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains a malformed phone number.",
+    "type": "object"
+  },
+  "trip_distance_exceeds_shape_distance": {
+    "code": "trip_distance_exceeds_shape_distance",
+    "deprecated": false,
+    "properties": {
+      "geoDistanceToShape": {
+        "description": "The distance in meters between the shape and the stop.",
+        "fieldName": "geoDistanceToShape",
+        "type": "number"
       },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "tripId":{
-            "fieldName":"tripId",
-            "description":"The faulty record\u0027s id.",
-            "type":"string"
-         }
+      "maxShapeDistanceTraveled": {
+        "description": "The faulty record's shape max distance traveled.",
+        "fieldName": "maxShapeDistanceTraveled",
+        "type": "number"
       },
-      "deprecated":false
-   },
-   "wrong_parent_location_type":{
-      "code":"wrong_parent_location_type",
-      "severityLevel":"ERROR",
-      "type":"object",
-      "shortSummary":"Incorrect type of the parent location.",
-      "description":"Value of field `location_type` of parent found in field `parent_station` is invalid.\n\nAccording to spec\n\n- _Stop/platform_ can only have _Station_ as parent\n- _Station_ can NOT have a parent\n- _Entrance/exit_ or _generic node_ can only have _Station_ as parent\n- _Boarding Area_ can only have _Platform_ as parent\n\nAny other combination raise this error.",
-      "references":{
-         "fileReferences":[
-            "stops.txt",
-            "stop_times.txt"
-         ],
-         "bestPracticesFileReferences":[
-
-         ],
-         "sectionReferences":[
-
-         ],
-         "urlReferences":[
-
-         ]
+      "maxTripDistanceTraveled": {
+        "description": "The faulty record's trip max distance traveled.",
+        "fieldName": "maxTripDistanceTraveled",
+        "type": "number"
       },
-      "properties":{
-         "csvRowNumber":{
-            "fieldName":"csvRowNumber",
-            "description":"The row number of the faulty record.",
-            "type":"integer"
-         },
-         "expectedLocationType":{
-            "fieldName":"expectedLocationType",
-            "description":"The expected location type of the faulty record.",
-            "type":"integer"
-         },
-         "locationType":{
-            "fieldName":"locationType",
-            "description":"The faulty record\u0027s `stops.location_type`.",
-            "type":"integer"
-         },
-         "parentCsvRowNumber":{
-            "fieldName":"parentCsvRowNumber",
-            "description":"The row number of the faulty record\u0027s parent.",
-            "type":"integer"
-         },
-         "parentLocationType":{
-            "fieldName":"parentLocationType",
-            "description":"The location type of the faulty record\u0027s parent.",
-            "type":"integer"
-         },
-         "parentStation":{
-            "fieldName":"parentStation",
-            "description":"The id of the faulty record\u0027s parent station.",
-            "type":"string"
-         },
-         "parentStopName":{
-            "fieldName":"parentStopName",
-            "description":"The stop name of the faulty record\u0027s parent.",
-            "type":"string"
-         },
-         "stopId":{
-            "fieldName":"stopId",
-            "description":"The id of the faulty record.",
-            "type":"string"
-         },
-         "stopName":{
-            "fieldName":"stopName",
-            "description":"The faulty record\u0027s `stops.stop_name`.",
-            "type":"string"
-         }
+      "shapeId": {
+        "description": "The faulty record's shape id.",
+        "fieldName": "shapeId",
+        "type": "string"
       },
-      "deprecated":false
-   }
+      "tripId": {
+        "description": "The faulty record's trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "shapes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "The distance between the last shape point and last stop point is greater than or equal to the 11.1m threshold.",
+    "type": "object"
+  },
+  "empty_column_name": {
+    "code": "empty_column_name",
+    "deprecated": false,
+    "description": "Such columns are skipped by the validator.",
+    "properties": {
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "index": {
+        "description": "The index of the empty column.",
+        "fieldName": "index",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A column name is empty.",
+    "type": "object"
+  },
+  "attribution_without_role": {
+    "code": "attribution_without_role",
+    "deprecated": false,
+    "description": "At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set to\n1.",
+    "properties": {
+      "attributionId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "attributionId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "attributions.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Attribution with no role.",
+    "type": "object"
+  },
+  "start_and_end_range_out_of_order": {
+    "code": "start_and_end_range_out_of_order",
+    "deprecated": false,
+    "description": "Date or time fields have been found out of order in `calendar.txt`, `feed_info.txt` and\n`stop_times.txt`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endFieldName": {
+        "description": "The end value's field name.",
+        "fieldName": "endFieldName",
+        "type": "string"
+      },
+      "endValue": {
+        "description": "The end value.",
+        "fieldName": "endValue",
+        "type": "string"
+      },
+      "entityId": {
+        "description": "The faulty service id.",
+        "fieldName": "entityId",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "startFieldName": {
+        "description": "The start value's field name.",
+        "fieldName": "startFieldName",
+        "type": "string"
+      },
+      "startValue": {
+        "description": "The start value.",
+        "fieldName": "startValue",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Two date or time fields are out of order.",
+    "type": "object"
+  },
+  "missing_calendar_and_calendar_date_files": {
+    "code": "missing_calendar_and_calendar_date_files",
+    "deprecated": false,
+    "description": "At least one of the files must be provided.",
+    "properties": {},
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Missing GTFS files `calendar.txt` and `calendar_dates.txt`.",
+    "type": "object"
+  },
+  "forbidden_drop_off_type": {
+    "code": "forbidden_drop_off_type",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endPickupDropOffWindow": {
+        "description": "The end pickup drop off window of the faulty record.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start pickup drop off window of the faulty record.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "pickup_drop_off_window fields are forbidden when the drop_off_type is regularly scheduled (0).",
+    "type": "object"
+  },
+  "invalid_pickup_drop_off_window": {
+    "code": "invalid_pickup_drop_off_window",
+    "deprecated": false,
+    "description": "The `end_pickup_drop_off_window` must be strictly later than the\n`start_pickup_drop_off_window`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endPickupDropOffWindow": {
+        "description": "The end pickup drop off window of the faulty record.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start pickup drop off window of the faulty record.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "The pickup/drop-off window in `stop_times.txt` is invalid.",
+    "type": "object"
+  },
+  "translation_foreign_key_violation": {
+    "code": "translation_foreign_key_violation",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "recordId": {
+        "description": "`record_id` of the faulty record.",
+        "fieldName": "recordId",
+        "type": "string"
+      },
+      "recordSubId": {
+        "description": "`record_sub_id` of the faulty record.",
+        "fieldName": "recordSubId",
+        "type": "string"
+      },
+      "tableName": {
+        "description": "`table_name` of the faulty record.",
+        "fieldName": "tableName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "translations.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.",
+    "type": "object"
+  },
+  "pathway_to_platform_with_boarding_areas": {
+    "code": "pathway_to_platform_with_boarding_areas",
+    "deprecated": false,
+    "description": "A platform that has boarding areas is treated as a parent object, not a point. In such\ncases, the platform must not have pathways assigned - instead, pathways must be assigned to its\nboarding areas.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty row.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The platform id field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "pathwayId": {
+        "description": "The id of the faulty pathway.",
+        "fieldName": "pathwayId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the endpoint platform.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A pathway has an endpoint that is a platform which has boarding areas.",
+    "type": "object"
+  },
+  "duplicate_geography_id": {
+    "code": "duplicate_geography_id",
+    "deprecated": false,
+    "description": "ID must be unique across all `stops.stop_id`, `locations.geojson` `id`, and\n`location_groups.location_group_id` values.",
+    "properties": {
+      "csvRowNumberA": {
+        "description": "The csv row number in stops.txt",
+        "fieldName": "csvRowNumberA",
+        "type": "integer"
+      },
+      "csvRowNumberB": {
+        "description": "The csv row number in location_group_stops.txt",
+        "fieldName": "csvRowNumberB",
+        "type": "integer"
+      },
+      "featureIndex": {
+        "description": "The feature index in locations.geojson",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "geographyId": {
+        "description": "The geography id that is duplicated.",
+        "fieldName": "geographyId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "location_groups.txt",
+        "stop_times.txt",
+        "location_groups.txt"
+      ],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Geography id is duplicated across multiple files.",
+    "type": "object"
+  },
+  "thread_execution_error": {
+    "code": "thread_execution_error",
+    "deprecated": false,
+    "description": "An\n[ExecutionException](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutionException.html)\noccurred during multithreaded validation.",
+    "properties": {
+      "exception": {
+        "description": "The name of the exception.",
+        "fieldName": "exception",
+        "type": "string"
+      },
+      "message": {
+        "description": "The error message that explains the reason for the exception.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "ExecutionException during multithreaded validation",
+    "type": "object"
+  },
+  "unsupported_geo_json_type": {
+    "code": "unsupported_geo_json_type",
+    "deprecated": false,
+    "description": "Use `FeatureCollection` instead to comply with the spec.",
+    "properties": {
+      "geoJsonType": {
+        "description": "The value of the unsupported GeoJSON type.",
+        "fieldName": "geoJsonType",
+        "type": "string"
+      },
+      "message": {
+        "description": "The detailed message describing the error.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "An unsupported GeoJSON type is used in the `locations.geojson` file.",
+    "type": "object"
+  },
+  "forbidden_continuous_pickup_drop_off": {
+    "code": "forbidden_continuous_pickup_drop_off",
+    "deprecated": false,
+    "properties": {
+      "endPickupDropOffWindow": {
+        "description": "The end time of the pickup/drop-off window.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "routeCsvRowNumber": {
+        "description": "The row number of the route in the `routes.txt` file.",
+        "fieldName": "routeCsvRowNumber",
+        "type": "integer"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start time of the pickup/drop-off window.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the stop time in the `stop_times.txt` file.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The ID of the trip.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "stop_times.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Continuous pickup or drop-off are forbidden when routes.continuous_pickup or routes.continuous_drop_off are 0, 2 or 3 and stop_times.start_pickup_drop_off_window or stop_times.end_pickup_drop_off_window are defined for any trip of this route.",
+    "type": "object"
+  },
+  "missing_prior_notice_duration_min": {
+    "code": "missing_prior_notice_duration_min",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`prior_notice_duration_min` value is required for same day `booking_type` in booking_rules.txt.",
+    "type": "object"
+  },
+  "fare_transfer_rule_duration_limit_without_type": {
+    "code": "fare_transfer_rule_duration_limit_without_type",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit` field but no `duration_limit_type` specified.",
+    "type": "object"
+  },
+  "missing_trip_edge": {
+    "code": "missing_trip_edge",
+    "deprecated": false,
+    "description": "First and last stop of a trip must define both `arrival_time` and `departure_time` fields.\nPer [stop_times.txt](http://gtfs.org/reference/static/#stop_timestxt), \"If there are not\nseparate times for arrival and departure at a stop, enter the same value for arrival_time and\ndeparture_time.\"",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "specifiedField": {
+        "description": "Name of the missing field.",
+        "fieldName": "specifiedField",
+        "type": "string"
+      },
+      "stopSequence": {
+        "description": "`stops.stop_sequence` of the faulty record.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The `trips.trip_id` of the faulty record.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Missing trip edge `arrival_time` or `departure_time`.",
+    "type": "object"
+  },
+  "duplicate_fare_media": {
+    "code": "duplicate_fare_media",
+    "deprecated": false,
+    "description": "Fare media should have a unique combination of fare media name and type.",
+    "properties": {
+      "csvRowNumber1": {
+        "description": "The row number of the first fare media.",
+        "fieldName": "csvRowNumber1",
+        "type": "integer"
+      },
+      "csvRowNumber2": {
+        "description": "The row number of the second fare media.",
+        "fieldName": "csvRowNumber2",
+        "type": "integer"
+      },
+      "fareMediaId1": {
+        "description": "The id of the first fare media.",
+        "fieldName": "fareMediaId1",
+        "type": "string"
+      },
+      "fareMediaId2": {
+        "description": "The id of the second fare media.",
+        "fieldName": "fareMediaId2",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_media.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Two distinct fare media have the same fare media name and type.",
+    "type": "object"
+  },
+  "missing_required_agency_id": {
+    "code": "missing_required_agency_id",
+    "deprecated": false,
+    "description": "`agency.agency_id`, `routes.agency_id` or `fare_attributes.agency_id` is required when there\nare multiple agencies.",
+    "properties": {
+      "agencyName": {
+        "description": "The agency name if it can be obtained.",
+        "fieldName": "agencyName",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number in the source file where the error occurs.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the file where the error occurs.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "agency.txt",
+        "routes.txt",
+        "fare_attributes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Agency id is required when there are multiple agencies.",
+    "type": "object"
+  },
+  "unexpected_enum_value": {
+    "code": "unexpected_enum_value",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the field where the error occurred.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "An enum has an unexpected value.",
+    "type": "object"
+  },
+  "station_with_parent_station": {
+    "code": "station_with_parent_station",
+    "deprecated": false,
+    "description": "Field `parent_station` must be empty when `location_type` is 1.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "parentStation": {
+        "description": "Parent station's id.",
+        "fieldName": "parentStation",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The stops.stop_name of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A station has `parent_station` field set.",
+    "type": "object"
+  },
+  "same_name_and_description_for_stop": {
+    "code": "same_name_and_description_for_stop",
+    "deprecated": false,
+    "description": "The GTFS spec defines `stops.txt`\n[stop_description](https://gtfs.org/reference/static/#stopstxt) as:\n\nDescription of the location that provides useful, quality information. Do not simply\nduplicate the name of the location.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopDesc": {
+        "description": "The faulty record's `stop_desc`.",
+        "fieldName": "stopDesc",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Same name and description for stop.",
+    "type": "object"
+  },
+  "empty_row": {
+    "code": "empty_row",
+    "deprecated": false,
+    "description": "Some CSV parsers, such as Univocity, may misinterpret it as a non-empty row that has a single\ncolumn which is empty, hence we show a warning.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A row in the input file has only spaces.",
+    "type": "object"
+  },
+  "missing_required_column": {
+    "code": "missing_required_column",
+    "deprecated": false,
+    "properties": {
+      "fieldName": {
+        "description": "The name of the missing column.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "term-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A required column is missing in the input file.",
+    "type": "object"
+  },
+  "same_route_and_agency_url": {
+    "code": "same_route_and_agency_url",
+    "deprecated": false,
+    "description": "A route should not have the same `routes.route_url` as a record from `agency.txt`.",
+    "properties": {
+      "agencyCsvRowNumber": {
+        "description": "The row number of the faulty record from `agency.txt`.",
+        "fieldName": "agencyCsvRowNumber",
+        "type": "integer"
+      },
+      "agencyName": {
+        "description": "The faulty record's referenced agency name.",
+        "fieldName": "agencyName",
+        "type": "string"
+      },
+      "routeCsvRowNumber": {
+        "description": "The row number of the faulty record from `routes.txt`.",
+        "fieldName": "routeCsvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The faulty record's id.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "routeUrl": {
+        "description": "The duplicate URL value",
+        "fieldName": "routeUrl",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "agency.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Same `routes.route_url` and `agency.agency_url`.",
+    "type": "object"
+  },
+  "runtime_exception_in_validator_error": {
+    "code": "runtime_exception_in_validator_error",
+    "deprecated": false,
+    "description": "A\n[RuntimeException](https://docs.oracle.com/javase/8/docs/api/java/lang/RuntimeException.html)\noccurred during validation. This normally indicates a bug in validator code, e.g., in a custom\nvalidator class.",
+    "properties": {
+      "exception": {
+        "description": "The name of the exception.",
+        "fieldName": "exception",
+        "type": "string"
+      },
+      "message": {
+        "description": "The error message that explains the reason for the exception.",
+        "fieldName": "message",
+        "type": "string"
+      },
+      "validator": {
+        "description": "The name of the validator that caused the exception.",
+        "fieldName": "validator",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "RuntimeException while validating GTFS archive.",
+    "type": "object"
+  },
+  "transfer_distance_too_large": {
+    "code": "transfer_distance_too_large",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "distanceKm": {
+        "description": "The distance between the two stops in km.",
+        "fieldName": "distanceKm",
+        "type": "number"
+      },
+      "fromStopId": {
+        "description": "The ID of the stop in `from_stop_id`.",
+        "fieldName": "fromStopId",
+        "type": "string"
+      },
+      "toStopId": {
+        "description": "The ID of the stop in `to_stop_id`.",
+        "fieldName": "toStopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "The transfer distance from stop to stop in `transfers.txt` is larger than 10 km.",
+    "type": "object"
+  },
+  "missing_required_element": {
+    "code": "missing_required_element",
+    "deprecated": false,
+    "properties": {
+      "featureId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "featureId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "Index of the feature in the feature collection.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "missingElement": {
+        "description": "The missing required element.",
+        "fieldName": "missingElement",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A required element is missing in `locations.geojson`.",
+    "type": "object"
+  },
+  "invalid_date": {
+    "code": "invalid_date",
+    "deprecated": false,
+    "description": "Dates must have the YYYYMMDD format.\n\nExample: `20180913` for September 13th, 2018.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field cannot be parsed as date.",
+    "type": "object"
+  },
+  "invalid_geometry": {
+    "code": "invalid_geometry",
+    "deprecated": false,
+    "description": "Each polygon must be valid by the definition of the <a\nhref=\"http://www.opengis.net/doc/is/sfa/1.2.1\" target=\"_blank\"> OpenGIS Simple Features\nSpecification, section 6.1.11 </a>.",
+    "properties": {
+      "featureId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "featureId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "The index of the feature in the feature collection.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "geometryType": {
+        "description": "The geometry type of the feature containing the invalid polygon.",
+        "fieldName": "geometryType",
+        "type": "string"
+      },
+      "message": {
+        "description": "The validation error details.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A polygon in `locations.geojson` is unparsable or invalid.",
+    "type": "object"
+  },
+  "inconsistent_route_type_for_block_id": {
+    "code": "inconsistent_route_type_for_block_id",
+    "deprecated": false,
+    "properties": {
+      "blockId": {
+        "description": "The block_id value of the faulty trip.",
+        "fieldName": "blockId",
+        "type": "string"
+      },
+      "routeIds": {
+        "description": "The route_id values associated with the block_id comma separated.",
+        "fieldName": "routeIds",
+        "type": "string"
+      },
+      "routeTypes": {
+        "description": "The route_type values associated with the block_id comma separated.",
+        "fieldName": "routeTypes",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A block should have the same route mode.",
+    "type": "object"
+  },
+  "trip_coverage_not_active_for_next7_days": {
+    "code": "trip_coverage_not_active_for_next7_days",
+    "deprecated": false,
+    "description": "This notice is triggered if the date range where a significant number of trips are running\nends in less than 7 days.",
+    "properties": {
+      "currentDate": {
+        "description": "Current date (YYYYMMDD format).",
+        "fieldName": "currentDate",
+        "type": "string"
+      },
+      "serviceWindowEndDate": {
+        "description": "The end date of the majority service window.",
+        "fieldName": "serviceWindowEndDate",
+        "type": "string"
+      },
+      "serviceWindowStartDate": {
+        "description": "The start date of the majority service window.",
+        "fieldName": "serviceWindowStartDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt",
+        "frequencies.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Trips data should be valid for at least the next seven days.",
+    "type": "object"
+  },
+  "non_ascii_or_non_printable_char": {
+    "code": "non_ascii_or_non_printable_char",
+    "deprecated": false,
+    "description": "A value of a field with type ID contains non ASCII or non printable characters. This is not\nrecommended.",
+    "properties": {
+      "columnName": {
+        "description": "Name of the column where the error occurred.",
+        "fieldName": "columnName",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "Row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "Name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Non ascii or non printable char in ID field.",
+    "type": "object"
+  },
+  "equal_shape_distance_same_coordinates": {
+    "code": "equal_shape_distance_same_coordinates",
+    "deprecated": false,
+    "description": "When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase\nalong a shape. Two consecutive points with equal values for `shape_dist_traveled` and the same\ncoordinates indicate a duplicative shape point.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `shapes.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number from `shapes.txt` of the previous shape point.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevShapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
+        "fieldName": "prevShapeDistTraveled",
+        "type": "number"
+      },
+      "prevShapePtSequence": {
+        "description": "The previous record's `shapes.shape_pt_sequence`.",
+        "fieldName": "prevShapePtSequence",
+        "type": "integer"
+      },
+      "shapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the faulty record.",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "shapeId": {
+        "description": "The id of the faulty shape.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "shapePtSequence": {
+        "description": "The faulty record's `shapes.shape_pt_sequence`.",
+        "fieldName": "shapePtSequence",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Two consecutive points have equal `shape_dist_traveled` and the same lat/lon coordinates in `shapes.txt`.",
+    "type": "object"
+  },
+  "invalid_color": {
+    "code": "invalid_color",
+    "deprecated": false,
+    "description": "A color must be encoded as a six-digit hexadecimal number. The leading \"#\" is not included.\n\nExample: `FFFFFF` for white, `000000` for black or `0039A6` for the A,C,E lines in NYC MTA.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains an invalid color value.",
+    "type": "object"
+  },
+  "more_than_one_entity": {
+    "code": "more_than_one_entity",
+    "deprecated": false,
+    "description": "The file is expected to have a single entity but has more (e.g., \"feed_info.txt\").",
+    "properties": {
+      "entityCount": {
+        "description": "Number of occurrences.",
+        "fieldName": "entityCount",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "Name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "More than one row in CSV.",
+    "type": "object"
+  },
+  "forbidden_prior_notice_start_time": {
+    "code": "forbidden_prior_notice_start_time",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "priorNoticeStartTime": {
+        "description": "The value of the `prior_notice_start_time` field.",
+        "fieldName": "priorNoticeStartTime",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`prior_notice_start_time` value is forbidden when `prior_notice_start_day` value is not set in booking_rules.txt.",
+    "type": "object"
+  },
+  "too_many_rows": {
+    "code": "too_many_rows",
+    "deprecated": false,
+    "description": "Feeds with too large files cannot be processed in a reasonable time by GTFS consumers.",
+    "properties": {
+      "filename": {
+        "description": "Name of the CSV file that has too many rows.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "rowNumber": {
+        "description": "Number of the row when reading was stopped.",
+        "fieldName": "rowNumber",
+        "type": "integer"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A CSV file has too many rows.",
+    "type": "object"
+  },
+  "missing_timepoint_value": {
+    "code": "missing_timepoint_value",
+    "deprecated": false,
+    "description": "When at least one of `stop_times.arrival_time` or `stop_times.departure_time` are provided,\n`stop_times.timepoint` should be defined",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopSequence": {
+        "description": "The faulty record's `stop_times.stop_sequence`.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The faulty record's `stop_times.trip_id`.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "`stop_times.timepoint` value is missing for a record.",
+    "type": "object"
+  },
+  "missing_feed_contact_email_and_url": {
+    "code": "missing_feed_contact_email_and_url",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the validated record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Best Practices for `feed_info.txt` suggest providing at least one of `feed_contact_email` and `feed_contact_url`.",
+    "type": "object"
+  },
+  "mixed_case_recommended_field": {
+    "code": "mixed_case_recommended_field",
+    "deprecated": false,
+    "description": "This field contains customer-facing text and should use Mixed Case (upper and lower case\nletters) to ensure good readability when displayed to riders. Avoid the use of abbreviations\nthroughout the feed (e.g. St. for Street) unless a location is called by its abbreviated name\n(e.g. “JFK Airport”). Abbreviations may be problematic for accessibility by screen reader\nsoftware and voice user interfaces.\n\n<table style=\"table-layout:auto; width:auto;\">\n  <caption>Good examples:</caption>\n  <tr>\n    <th><code>Field Text</code></th>\n    <th><code>Dataset</code></th>\n  </tr>\n  <tr>\n    <td>\"Schwerin, Hauptbahnhof\"</td>\n    <td><a href=\"http://vbb.de/vbbgtfs\">Verkehrsverbund Berlin-Brandenburg</a></td>\n  </tr>\n   <tr>\n    <td>\"Red Hook/Atlantic Basin\"</td>\n    <td><a href=\"http://nycferry.connexionz.net/rtt/public/utility/gtfs.aspx\">NYC Ferry</a></td>\n  </tr>\n  <tr>\n    <td>\"Campo Grande Norte\"</td>\n    <td><a href=\"https://gateway.carris.pt/gateway/gtfs/api/v2.8/GTFS\">Carris</a></td>\n  </tr>\n</table>\n\n<table style=\"table-layout:auto; width:auto;\">\n  <caption>Bad examples:</caption>\n  <tr>\n    <th><code>Field Text</code></th>\n  </tr>\n  <tr>\n    <td>\"GALLERIA MALL\"</td>\n  </tr>\n  <tr>\n    <td>\"3427 GG 17\"</td>\n  </tr>\n  <tr>\n    <td>\"21 Clark Rd Est\"</td>\n  </tr>\n</table>",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Name of the faulty field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "Name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Best Practices for All Files",
+          "url": "https://gtfs.org/schedule/reference/#file-requirements"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "This field has customer-facing text and should use Mixed Case (should contain upper and lower case letters).",
+    "type": "object"
+  },
+  "missing_prior_notice_last_time": {
+    "code": "missing_prior_notice_last_time",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "The `prior_notice_last_time` is required when booking_type=2 (prior day booking) is specified in booking_rules.txt.",
+    "type": "object"
+  },
+  "invalid_integer": {
+    "code": "invalid_integer",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field cannot be parsed as an integer.",
+    "type": "object"
+  },
+  "point_near_origin": {
+    "code": "point_near_origin",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty row.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "entityId": {
+        "description": "The id of the faulty entity.",
+        "fieldName": "entityId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "The index of the feature in the feature collection.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the affected GTFS file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "latFieldName": {
+        "description": "The name of the field that uses latitude value.",
+        "fieldName": "latFieldName",
+        "type": "string"
+      },
+      "latFieldValue": {
+        "description": "The latitude of the faulty row.",
+        "fieldName": "latFieldValue",
+        "type": "number"
+      },
+      "lonFieldName": {
+        "description": "The name of the field that uses longitude value.",
+        "fieldName": "lonFieldName",
+        "type": "string"
+      },
+      "lonFieldValue": {
+        "description": "The longitude of the faulty row",
+        "fieldName": "lonFieldValue",
+        "type": "number"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A point is too close to origin `(0, 0)`.",
+    "type": "object"
+  },
+  "feed_info_lang_and_agency_lang_mismatch": {
+    "code": "feed_info_lang_and_agency_lang_mismatch",
+    "deprecated": false,
+    "description": "Files `agency.txt` and `feed_info.txt` should define matching `agency.agency_lang` and\n`feed_info.feed_lang`. The default language may be multilingual for datasets with the original\ntext in multiple languages. In such cases, the `feed_lang` field should contain the language\ncode `mul` defined by the norm ISO 639-2.\n\n- If `feed_lang` is not `mul` and does not match with `agency_lang`, that's an error.\n- If there is more than one `agency_lang` and `feed_lang` isn't `mul`, that's an error.\n- If `feed_lang` is `mul` and there isn't more than one `agency_lang`, that's an error.",
+    "properties": {
+      "agencyId": {
+        "description": "The agency id of the faulty record.",
+        "fieldName": "agencyId",
+        "type": "string"
+      },
+      "agencyLang": {
+        "description": "The agency language of the faulty record.",
+        "fieldName": "agencyLang",
+        "type": "string"
+      },
+      "agencyName": {
+        "description": "The agency name of the faulty record.",
+        "fieldName": "agencyName",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "feedLang": {
+        "description": "The feed language of the faulty record.",
+        "fieldName": "feedLang",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "feed_info.txt",
+        "agency.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Mismatching feed and agency language fields.",
+    "type": "object"
+  },
+  "decreasing_or_equal_stop_time_distance": {
+    "code": "decreasing_or_equal_stop_time_distance",
+    "deprecated": false,
+    "description": "When sorted by `stop_times.stop_sequence`, two consecutive entries in `stop_times.txt`\nshould have increasing distance, based on the field `shape_dist_traveled`. If the values are\nequal, this is considered as an error.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `stop_times.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number from `stop_times.txt` of the previous stop time.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevShapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the previous stop\ntime.",
+        "fieldName": "prevShapeDistTraveled",
+        "type": "number"
+      },
+      "prevStopSequence": {
+        "description": "The previous record's `stop_times.stop_sequence`.",
+        "fieldName": "prevStopSequence",
+        "type": "integer"
+      },
+      "shapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the faulty record.",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "stopId": {
+        "description": "The id of the faulty stop.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopSequence": {
+        "description": "The faulty record's `stop_times.stop_sequence`.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The id of the faulty trip.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Decreasing or equal `shape_dist_traveled` in `stop_times.txt`.",
+    "type": "object"
+  },
+  "duplicate_route_name": {
+    "code": "duplicate_route_name",
+    "deprecated": false,
+    "description": "All routes of the same `route_type` with the same `agency_id` should have unique\ncombinations of `route_short_name` and `route_long_name`.\n\nNote that there may be valid cases where routes have the same short and long name, e.g., if\nthey serve different areas. However, different directions must be modeled as the same route.\n\nExample of bad data:\n\n<table style=\"table-layout:auto; width:auto;\">\n  <tr>\n    <th><code>route_id</code></th>\n    <th><code>route_short_name</code></th>\n    <th><code>route_long_name</code></th>\n  </tr>\n  <tr>\n    <td>route1</td>\n    <td>U1</td>\n    <td>Southern</td>\n  </tr>\n  <tr>\n    <td>route2</td>\n    <td>U1</td>\n    <td>Southern</td>\n  </tr>\n</table>",
+    "properties": {
+      "agencyId": {
+        "description": "Common `routes.agency_id`.",
+        "fieldName": "agencyId",
+        "type": "string"
+      },
+      "csvRowNumber1": {
+        "description": "The row number of the first occurrence.",
+        "fieldName": "csvRowNumber1",
+        "type": "integer"
+      },
+      "csvRowNumber2": {
+        "description": "The row number of the other occurrence.",
+        "fieldName": "csvRowNumber2",
+        "type": "integer"
+      },
+      "routeId1": {
+        "description": "The id of the the first occurrence.",
+        "fieldName": "routeId1",
+        "type": "string"
+      },
+      "routeId2": {
+        "description": "The id of the the other occurrence.",
+        "fieldName": "routeId2",
+        "type": "string"
+      },
+      "routeLongName": {
+        "description": "Common `routes.route_long_name`.",
+        "fieldName": "routeLongName",
+        "type": "string"
+      },
+      "routeShortName": {
+        "description": "Common `routes.route_short_name`.",
+        "fieldName": "routeShortName",
+        "type": "string"
+      },
+      "routeTypeValue": {
+        "description": "Common `routes.route_type`.",
+        "fieldName": "routeTypeValue",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [
+        "routes.txt"
+      ],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Two distinct routes have either the same `route_short_name`, the same `route_long_name`, or the same combination of `route_short_name` and `route_long_name`.",
+    "type": "object"
+  },
+  "forbidden_same_day_booking_field_value": {
+    "code": "forbidden_same_day_booking_field_value",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldNames": {
+        "description": "The names of the forbidden fields comma-separated.",
+        "fieldName": "fieldNames",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A forbidden field value is present for a same-day booking rule in `booking_rules.txt`.",
+    "type": "object"
+  },
+  "trip_distance_exceeds_shape_distance_below_threshold": {
+    "code": "trip_distance_exceeds_shape_distance_below_threshold",
+    "deprecated": false,
+    "properties": {
+      "geoDistanceToShape": {
+        "description": "The distance in meters between the shape and the stop.",
+        "fieldName": "geoDistanceToShape",
+        "type": "number"
+      },
+      "maxShapeDistanceTraveled": {
+        "description": "The faulty record's shape max distance traveled.",
+        "fieldName": "maxShapeDistanceTraveled",
+        "type": "number"
+      },
+      "maxTripDistanceTraveled": {
+        "description": "The faulty record's trip max distance traveled.",
+        "fieldName": "maxTripDistanceTraveled",
+        "type": "number"
+      },
+      "shapeId": {
+        "description": "The faulty record's shape id.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The faulty record's trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "shapes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "The distance between the last shape point and last stop point is greater than 0 but less than the 11.1m threshold.",
+    "type": "object"
+  },
+  "stop_time_timepoint_without_times": {
+    "code": "stop_time_timepoint_without_times",
+    "deprecated": false,
+    "description": "Any records with `stop_times.timepoint` set to 1 must define a value for\n`stop_times.arrival_time` and `stop_times.departure_time` fields.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "specifiedField": {
+        "description": "Either `departure_time` or `arrival_time`.",
+        "fieldName": "specifiedField",
+        "type": "string"
+      },
+      "stopSequence": {
+        "description": "The faulty record's `stops.stop_sequence`.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The faulty record's id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt",
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`arrival_time` or `departure_time` not specified for timepoint.",
+    "type": "object"
+  },
+  "transfer_with_invalid_stop_location_type": {
+    "code": "transfer_with_invalid_stop_location_type",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationTypeName": {
+        "description": "The name of the invalid location type.",
+        "fieldName": "locationTypeName",
+        "type": "string"
+      },
+      "locationTypeValue": {
+        "description": "The numeric value of the invalid location type.",
+        "fieldName": "locationTypeValue",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The referenced stop id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopIdFieldName": {
+        "description": "The name of the stop id field (e.g. `from_stop_id`) referencing the stop.",
+        "fieldName": "stopIdFieldName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A stop id field from GTFS file `transfers.txt` references a stop that has a `location_type` other than 0 or 1 (aka Stop/Platform or Station).",
+    "type": "object"
+  },
+  "future_calendar": {
+    "code": "future_calendar",
+    "deprecated": false,
+    "properties": {
+      "currentDate": {
+        "description": "Today's date at validation time.",
+        "fieldName": "currentDate",
+        "type": "string"
+      },
+      "minServiceStartDate": {
+        "description": "The earliest service start date across all services in the feed.",
+        "fieldName": "minServiceStartDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "All services in the feed start in the future; no service covers today's date.",
+    "type": "object"
+  },
+  "point_near_pole": {
+    "code": "point_near_pole",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty row.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "entityId": {
+        "description": "The id of the faulty entity.",
+        "fieldName": "entityId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "The index of the feature in the feature collection.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the affected GTFS file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "latFieldName": {
+        "description": "The name of the field that uses latitude value.",
+        "fieldName": "latFieldName",
+        "type": "string"
+      },
+      "latFieldValue": {
+        "description": "The latitude of the faulty row.",
+        "fieldName": "latFieldValue",
+        "type": "number"
+      },
+      "lonFieldName": {
+        "description": "The name of the field that uses longitude value.",
+        "fieldName": "lonFieldName",
+        "type": "string"
+      },
+      "lonFieldValue": {
+        "description": "The longitude of the faulty row",
+        "fieldName": "lonFieldValue",
+        "type": "number"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A point is too close to the North or South Pole.",
+    "type": "object"
+  },
+  "transfer_with_invalid_trip_and_route": {
+    "code": "transfer_with_invalid_trip_and_route",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "expectedRouteId": {
+        "description": "The expected route id from `trips.txt`.",
+        "fieldName": "expectedRouteId",
+        "type": "string"
+      },
+      "routeFieldName": {
+        "description": "The name of the route id field (e.g. `from_route_id`) referencing the route.",
+        "fieldName": "routeFieldName",
+        "type": "string"
+      },
+      "routeId": {
+        "description": "The referenced route id.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "tripFieldName": {
+        "description": "The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
+        "fieldName": "tripFieldName",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The referenced trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A trip id field from GTFS file `transfers.txt` references a route that does not match its `trips.txt` `route_id`.",
+    "type": "object"
+  },
+  "empty_file": {
+    "code": "empty_file",
+    "deprecated": false,
+    "description": "Empty csv file found in the archive: file does not have any headers, or is a required file and\ndoes not have any data. The GTFS specification requires the first line of each file to contain\nfield names and required files must have data.",
+    "properties": {
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A CSV file is empty.",
+    "type": "object"
+  },
+  "malformed_json": {
+    "code": "malformed_json",
+    "deprecated": false,
+    "properties": {
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "message": {
+        "description": "The detailed message describing the error.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A JSON file is malformed.",
+    "type": "object"
+  },
+  "timeframe_start_or_end_time_greater_than_twenty_four_hours": {
+    "code": "timeframe_start_or_end_time_greater_than_twenty_four_hours",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number for the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The time field name for the faulty record.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "time": {
+        "description": "The invalid time value.",
+        "fieldName": "time",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "timeframes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A time in `timeframes.txt` is greater than `24:00:00`.",
+    "type": "object"
+  },
+  "missing_required_field": {
+    "code": "missing_required_field",
+    "deprecated": false,
+    "description": "The given field has no value in some input row, even though values are required.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the missing field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "term-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A required field is missing.",
+    "type": "object"
+  },
+  "missing_feed_info_date": {
+    "code": "missing_feed_info_date",
+    "deprecated": false,
+    "description": "Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one field is\nprovided the second one should also be provided.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Either `feed_end_date` or `feed_start_date`.",
+        "fieldName": "fieldName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [
+        "feed_info.txt"
+      ],
+      "fileReferences": [
+        "feed_info.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "One of `feed_start_date` or `feed_end_date` is specified, but not both.",
+    "type": "object"
+  },
+  "same_stop_and_route_url": {
+    "code": "same_stop_and_route_url",
+    "deprecated": false,
+    "description": "A stop should not have the same `stop.stop_url` as a record from `routes.txt`.",
+    "properties": {
+      "routeCsvRowNumber": {
+        "description": "The row number of the faulty record from `routes.txt`.",
+        "fieldName": "routeCsvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The faulty record's id from `routes.txt.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "stopCsvRowNumber": {
+        "description": "The row number of the faulty record from `stops.txt`.",
+        "fieldName": "stopCsvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The faulty record's id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopUrl": {
+        "description": "The duplicate URL value.",
+        "fieldName": "stopUrl",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt",
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Same `stops.stop_url` and `routes.route_url`.",
+    "type": "object"
+  },
+  "same_stop_and_agency_url": {
+    "code": "same_stop_and_agency_url",
+    "deprecated": false,
+    "description": "A stop should not have the same `stops.stop_url` as a record from `agency.txt`.",
+    "properties": {
+      "agencyCsvRowNumber": {
+        "description": "The row number of the faulty record from `agency.txt`.",
+        "fieldName": "agencyCsvRowNumber",
+        "type": "integer"
+      },
+      "agencyName": {
+        "description": "The faulty record's `agency.agency_name`.",
+        "fieldName": "agencyName",
+        "type": "string"
+      },
+      "stopCsvRowNumber": {
+        "description": "The row number of the faulty record from `stops.txt`.",
+        "fieldName": "stopCsvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The faulty record's id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopUrl": {
+        "description": "The duplicate URL value.",
+        "fieldName": "stopUrl",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt",
+        "agency.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Same `stops.stop_url` and `agency.agency_url`.",
+    "type": "object"
+  },
+  "missing_pickup_or_drop_off_window": {
+    "code": "missing_pickup_or_drop_off_window",
+    "deprecated": false,
+    "description": "GTFS specification requires both the start and end pickup/drop-off windows to be provided\ntogether, if used.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endPickupDropOffWindow": {
+        "description": "The end pickup drop off window of the faulty record.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start pickup drop off window of the faulty record.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Either the start or end pickup/drop-off window is missing in `stop_times.txt`.",
+    "type": "object"
+  },
+  "invalid_language_code": {
+    "code": "invalid_language_code",
+    "deprecated": false,
+    "description": "Language codes must follow <a href=\"http://www.rfc-editor.org/rfc/bcp/bcp47.txt\">IETF BCP\n47</a>.\n\nExample: `en` for English, `en-US` for American English or `de` for German.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains a wrong language code.",
+    "type": "object"
+  },
+  "stop_access_specified_for_stop_with_no_parent_station": {
+    "code": "stop_access_specified_for_stop_with_no_parent_station",
+    "deprecated": false,
+    "description": "stops.stop_access is forbidden for stops that are not associated with a parent station.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "`stops.location_type` of the faulty record.",
+        "fieldName": "locationType",
+        "type": "enum"
+      },
+      "stopAccess": {
+        "description": "The `stops.stop_access` of the faulty record.",
+        "fieldName": "stopAccess",
+        "type": "enum"
+      },
+      "stopId": {
+        "description": "The `stops.stop_id` of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The 'stops.stop_name' of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A stop without a value for parent station has stop_access specified.",
+    "type": "object"
+  },
+  "inconsistent_agency_timezone": {
+    "code": "inconsistent_agency_timezone",
+    "deprecated": false,
+    "description": "Agencies from GTFS `agency.txt` have been found to have different timezones.",
+    "properties": {
+      "actual": {
+        "description": "Faulty record's timezone.",
+        "fieldName": "actual",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "expected": {
+        "description": "Expected timezone.",
+        "fieldName": "expected",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "agency.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Inconsistent Timezone among agencies.",
+    "type": "object"
+  },
+  "unused_station": {
+    "code": "unused_station",
+    "deprecated": false,
+    "description": "A stop has `location_type` STATION (1) but does not appear in any stop's `parent_station`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty stop.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the faulty stop.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "Unused station.",
+    "type": "object"
+  },
+  "forbidden_geography_id": {
+    "code": "forbidden_geography_id",
+    "deprecated": false,
+    "description": "In stop_times.txt, you can have only one of stop_id, location_group_id or location_id\ndefined for given entry.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationGroupId": {
+        "description": "The id that already exists.",
+        "fieldName": "locationGroupId",
+        "type": "string"
+      },
+      "locationId": {
+        "description": "The id that already exists.",
+        "fieldName": "locationId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id that already exists.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A stop_time entry has more than one geographical id defined.",
+    "type": "object"
+  },
+  "forbidden_prior_day_booking_field_value": {
+    "code": "forbidden_prior_day_booking_field_value",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldNames": {
+        "description": "The names of the forbidden fields comma-separated.",
+        "fieldName": "fieldNames",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A forbidden field value is present for a prior-day booking rule in `booking_rules.txt`",
+    "type": "object"
+  },
+  "invalid_row_length": {
+    "code": "invalid_row_length",
+    "deprecated": false,
+    "description": "A row in the input file has a different number of values than specified by the CSV header.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "headerCount": {
+        "description": "The number of column in the faulty file.",
+        "fieldName": "headerCount",
+        "type": "integer"
+      },
+      "rowLength": {
+        "description": "The length of the faulty record.",
+        "fieldName": "rowLength",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Invalid csv row length.",
+    "type": "object"
+  },
+  "leading_or_trailing_whitespaces": {
+    "code": "leading_or_trailing_whitespaces",
+    "deprecated": false,
+    "description": "This notice is emitted for values protected with double quotes since whitespaces for\nnon-protected values are trimmed automatically by CSV parser.\n\nThe validator strips whitespaces from protected values. We do not see any use case when such a\nwhitespace may be needed. On the other hand, some real-world feeds use trailing whitespaces for\nsome values and omit them for the others. This is causing the largest problem when a primary key\nand a foreign key differ just by a whitespace: it is clear that they are intended to be the same,\nthat is why we always strip whitespaces.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "The value in CSV file has leading or trailing whitespaces.",
+    "type": "object"
+  },
+  "block_trips_with_overlapping_stop_times": {
+    "code": "block_trips_with_overlapping_stop_times",
+    "deprecated": false,
+    "properties": {
+      "blockId": {
+        "description": "The `trips.block_id` of the overlapping trip.",
+        "fieldName": "blockId",
+        "type": "string"
+      },
+      "csvRowNumberA": {
+        "description": "The row number from `trips.txt` of the first faulty trip.",
+        "fieldName": "csvRowNumberA",
+        "type": "integer"
+      },
+      "csvRowNumberB": {
+        "description": "The row number from `trips.txt` of the second faulty trip.",
+        "fieldName": "csvRowNumberB",
+        "type": "integer"
+      },
+      "intersection": {
+        "description": "The overlapping period.",
+        "fieldName": "intersection",
+        "type": "string"
+      },
+      "serviceIdA": {
+        "description": "The service id of the first faulty trip.",
+        "fieldName": "serviceIdA",
+        "type": "string"
+      },
+      "serviceIdB": {
+        "description": "The service id of the other faulty trip.",
+        "fieldName": "serviceIdB",
+        "type": "string"
+      },
+      "tripIdA": {
+        "description": "The id of first faulty trip.",
+        "fieldName": "tripIdA",
+        "type": "string"
+      },
+      "tripIdB": {
+        "description": "The id of the other faulty trip.",
+        "fieldName": "tripIdB",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Trips with the same block id have overlapping stop times.",
+    "type": "object"
+  },
+  "invalid_currency_amount": {
+    "code": "invalid_currency_amount",
+    "deprecated": false,
+    "description": "Typically, this means the amount did not have the expected number of decimal places. Check the\nformatting of your amount field so it matches the number of decimal places specified by the <a\nhref=\"https://en.wikipedia.org/wiki/ISO_4217#Active_codes\">currency_code value</a>.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "currencyCode": {
+        "description": "Faulty record's currency code.",
+        "fieldName": "currencyCode",
+        "type": "string"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty currency field amount value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A currency amount field has a value that does not match the format of its corresponding currency code field.",
+    "type": "object"
+  },
+  "u_r_i_syntax_error": {
+    "code": "u_r_i_syntax_error",
+    "deprecated": false,
+    "properties": {
+      "exception": {
+        "description": "The name of the exception.",
+        "fieldName": "exception",
+        "type": "string"
+      },
+      "message": {
+        "description": "The error message that explains the reason for the exception.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A string could not be parsed as a URI reference.",
+    "type": "object"
+  },
+  "location_without_parent_station": {
+    "code": "location_without_parent_station",
+    "deprecated": false,
+    "description": "The following location types must have `parent_station`: entrance, generic node,\nboarding_area.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "The `stops.location_type` of the faulty record.",
+        "fieldName": "locationType",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The `stops.stop_name` of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A location that must have `parent_station` field does not have it.",
+    "type": "object"
+  },
+  "missing_prior_day_booking_field_value": {
+    "code": "missing_prior_day_booking_field_value",
+    "deprecated": true,
+    "deprecationReason": "Separated into `missing_prior_notice_last_day` and `missing_prior_notice_last_time` notices",
+    "deprecationVersion": "7.0.0",
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "replacementNoticeCodes": [
+      "missing_prior_notice_last_day",
+      "missing_prior_notice_last_time"
+    ],
+    "severityLevel": "ERROR",
+    "shortSummary": "The `prior_notice_last_day` and the `prior_notice_last_time` values are required for prior day `booking_type` in booking_rules.txt.",
+    "type": "object"
+  },
+  "stop_too_far_from_shape": {
+    "code": "stop_too_far_from_shape",
+    "deprecated": false,
+    "description": "Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100 meters of\nstop locations which a trip serves. This potentially indicates a problem with the location of\nthe stop or the path of the shape.",
+    "properties": {
+      "geoDistanceToShape": {
+        "description": "Distance from stop to shape.",
+        "fieldName": "geoDistanceToShape",
+        "type": "number"
+      },
+      "match": {
+        "contains": {
+          "type": "number"
+        },
+        "description": "Latitude and longitude pair of the location.",
+        "fieldName": "match",
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "shapeId": {
+        "description": "The id of the shape that is referred to.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the stop that is referred to.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the stop that is referred to.",
+        "fieldName": "stopName",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the faulty record from `trips.txt`.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The id of the trip that is referred to.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [
+        "shapes.txt"
+      ],
+      "fileReferences": [
+        "stop_times.txt",
+        "stops.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Stop too far from trip shape.",
+    "type": "object"
+  },
+  "trip_headsign_matches_intermediate_stop": {
+    "code": "trip_headsign_matches_intermediate_stop",
+    "deprecated": false,
+    "description": "The `trip_headsign` matches the `stop_name` of a stop that is not the last stop of the trip.\nThis may confuse passengers boarding after that stop, since the headsign suggests the vehicle\nis heading to a stop it has already passed.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record in `trips.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId1": {
+        "description": "The id of the intermediate stop whose name matches the headsign.",
+        "fieldName": "stopId1",
+        "type": "string"
+      },
+      "stopId2": {
+        "description": "The id of the actual last stop of the trip.",
+        "fieldName": "stopId2",
+        "type": "string"
+      },
+      "stopSequence": {
+        "description": "The stop_sequence value of the intermediate stop that matches the headsign.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripHeadsign": {
+        "description": "The headsign value that matches an intermediate stop name.",
+        "fieldName": "tripHeadsign",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The id of the trip with the problematic headsign.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "Trip headsign matches the name of an intermediate stop, not the last stop.",
+    "type": "object"
+  },
+  "missing_required_file": {
+    "code": "missing_required_file",
+    "deprecated": false,
+    "description": "If this notice is triggered for every core file, it might be a problem with the input. To\ncreate a zip file from the GTFS `.txt` files: select all the `.txt` files, right-click, and\ncompress. Do not compress the folder containing the files.",
+    "properties": {
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "term-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A required file is missing.",
+    "type": "object"
+  },
+  "overlapping_frequency": {
+    "code": "overlapping_frequency",
+    "deprecated": false,
+    "description": "Trip frequencies must not overlap in time. Two entries X and Y are considered to directly\noverlap if X.start_time is less than or equal to Y.start_time and Y.start_time is less than\nX.end_time.",
+    "properties": {
+      "currCsvRowNumber": {
+        "description": "The overlapping frequency's row number.",
+        "fieldName": "currCsvRowNumber",
+        "type": "integer"
+      },
+      "currStartTime": {
+        "description": "The overlapping frequency's start time.",
+        "fieldName": "currStartTime",
+        "type": "string"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number of the first frequency.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevEndTime": {
+        "description": "The first frequency end time.",
+        "fieldName": "prevEndTime",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The trip id associated to the first frequency.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "frequencies.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Trip frequencies overlap.",
+    "type": "object"
+  },
+  "geo_json_unknown_element": {
+    "code": "geo_json_unknown_element",
+    "deprecated": false,
+    "properties": {
+      "filename": {
+        "description": "The name of the file where the unknown element was found.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "unknownElement": {
+        "description": "The unknown element in the GeoJSON file.",
+        "fieldName": "unknownElement",
+        "type": "string"
+      }
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "Unknown elements in locations.geojson file.",
+    "type": "object"
+  },
+  "location_with_unexpected_stop_time": {
+    "code": "location_with_unexpected_stop_time",
+    "deprecated": false,
+    "description": "Referenced locations (using `stop_times.stop_id`) must be stops/platforms, i.e. their\n`stops.location_type` value must be 0 or empty.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record from `stops.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty record from `stops.txt`.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The `stops.stop_name` of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A location in `stops.txt` that is not a stop is referenced by some `stop_times.stop_id`.",
+    "type": "object"
+  },
+  "invalid_email": {
+    "code": "invalid_email",
+    "deprecated": false,
+    "description": "Definitions for valid emails are quite vague. We perform strict validation using the Apache\nCommons EmailValidator.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": [
+        {
+          "label": "Apache Commons EmailValidator",
+          "url": "https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/EmailValidator.html"
+        }
+      ]
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains a malformed email address.",
+    "type": "object"
+  },
+  "missing_stop_name": {
+    "code": "missing_stop_name",
+    "deprecated": false,
+    "description": "`stops.stop_name` is required for locations that are stops (`location_type=0`), stations\n(`location_type=1`) or entrances/exits (`location_type=2`).",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "`stops.location_type` of the faulty record.",
+        "fieldName": "locationType",
+        "type": "enum"
+      },
+      "stopId": {
+        "description": "The `stops.stop_id` of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`stops.stop_name` is required for `location_type` equal to `0`, `1`, or `2`.",
+    "type": "object"
+  },
+  "route_long_name_contains_short_name": {
+    "code": "route_long_name_contains_short_name",
+    "deprecated": false,
+    "description": "In routes.txt, `route_long_name` should not contain the value for `route_short_name`,\nbecause when both are provided, they are often combined by transit applications. Note that only\none of the two fields is required. If there is no short name used for a route, use\n`route_long_name` only.\n\nGood examples:\n\n<table>\n  <tr>\n    <th>route_short_name/route_long_name</th>\n    <th>Dataset</th>\n  </tr>\n  <tr>\n    <td>\"N\"/\"Judah\"</td>\n    <td><a href=\"https://www.sfmta.com/getting-around/transit/routes-stops/n-judah\">Muni San Fransisco</a></td>\n  </tr>\n  <tr>\n    <td>\"6\"/\"ML King Jr Blvd\"</td>\n    <td><a href=\"https://trimet.org/schedules/r006.htm\">Trimet Portland Streetcar</a></td>\n  </tr>\n  <tr>\n    <td>\"55\"/\"Boulevard Saint Laurent\"</td>\n    <td><a href=\"https://www.stm.info/en/info/networks/bus/local/line-55-north\">STM Montreal</a></td>\n  </tr>\n  <tr>\n    <td>\"1\"/\"Rangiora/Cashmere\"</td>\n    <td><a href=\"https://www.metroinfo.co.nz/timetables/1-rangiora-cashmere/\">Metro Christchurch</a></td>\n  </tr>\n</table>\n\nBad examples:\n\n<table>\n  <tr>\n    <th>route_short_name/route_long_name</th>\n  </tr>\n  <tr>\n    <td>\"604\"/\"604\"</td>\n  </tr>\n  <tr>\n    <td>\"14\"/\"Route 14\"</td>\n  </tr>\n  <tr>\n    <td>\"2\"/\"Route 2: Bellows Falls In-Town\"</td>\n  </tr>\n</table>",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "routeLongName": {
+        "description": "The faulty record's `route_long_name`.",
+        "fieldName": "routeLongName",
+        "type": "string"
+      },
+      "routeShortName": {
+        "description": "The faulty record's `route_short_name`.",
+        "fieldName": "routeShortName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [
+        "routes.txt"
+      ],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Long name should not contain short name for a single route.",
+    "type": "object"
+  },
+  "prior_notice_last_day_after_start_day": {
+    "code": "prior_notice_last_day_after_start_day",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "priorNoticeLastDay": {
+        "description": "The value of the `prior_notice_last_day` of the faulty field.",
+        "fieldName": "priorNoticeLastDay",
+        "type": "integer"
+      },
+      "priorNoticeStartDay": {
+        "description": "The value of the `prior_notice_start_day` of the faulty field.",
+        "fieldName": "priorNoticeStartDay",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Prior notice last day should not be greater than the prior notice start day in booking_rules.txt.",
+    "type": "object"
+  },
+  "decreasing_shape_distance": {
+    "code": "decreasing_shape_distance",
+    "deprecated": false,
+    "description": "When sorted by `shape.shape_pt_sequence`, two consecutive shape points must not have\ndecreasing values for `shape_dist_traveled`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `shapes.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number from `shapes.txt` of the previous shape point.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevShapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the previous shape\npoint.",
+        "fieldName": "prevShapeDistTraveled",
+        "type": "number"
+      },
+      "prevShapePtSequence": {
+        "description": "The previous record's `shapes.shape_pt_sequence`.",
+        "fieldName": "prevShapePtSequence",
+        "type": "integer"
+      },
+      "shapeDistTraveled": {
+        "description": "Actual distance traveled along the shape from the first shape point to the faulty record.",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "shapeId": {
+        "description": "The id of the faulty shape.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "shapePtSequence": {
+        "description": "The faulty record's `shapes.shape_pt_sequence`.",
+        "fieldName": "shapePtSequence",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Decreasing `shape_dist_traveled` in `shapes.txt`.",
+    "type": "object"
+  },
+  "pathway_loop": {
+    "code": "pathway_loop",
+    "deprecated": false,
+    "description": "A pathway should not have same values for `from_stop_id` and `to_stop_id`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "Row number of the faulty row from `pathways.txt`.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "pathwayId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "pathwayId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The `pathway.stop_id` that is repeated in `pathways.from_stop_id` and `pathways.to_stop_id`.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A pathway starts and ends at the same location.",
+    "type": "object"
+  },
+  "new_line_in_value": {
+    "code": "new_line_in_value",
+    "deprecated": false,
+    "description": "This error is usually found when the CSV file does not close double quotes properly, so the\nnext line is considered as a continuation of the previous line.\n\nExample: the following file was intended to have fields \"f11\", \"f12\", \"f21\", \"f22\", but it\nactually parses as two fields: \"f11\", \"f12\\nf21,\\\"f22\\\"\".\n\n```\nf11,\"f12\nf21,\"f22\"\n```",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the faulty field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "New line or carriage return in a value in CSV file.",
+    "type": "object"
+  },
+  "missing_bike_allowance": {
+    "code": "missing_bike_allowance",
+    "deprecated": false,
+    "description": "All ferry trips should have a valid value in the bikes_allowed field in trips.txt.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The faulty record's route id.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The faulty record's trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Ferry trips should include bike allowance information.",
+    "type": "object"
+  },
+  "number_out_of_range": {
+    "code": "number_out_of_range",
+    "deprecated": false,
+    "description": "The values in the given column of the input rows are out of range.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the faulty field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldType": {
+        "description": "The type of the faulty field.",
+        "fieldName": "fieldType",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "object"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements",
+        "field-types",
+        "dataset-files"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Out of range value.",
+    "type": "object"
+  },
+  "invalid_timezone": {
+    "code": "invalid_timezone",
+    "deprecated": false,
+    "description": "Timezones are defined at <a href=\"https://www.iana.org/time-zones\">www.iana.org</a>. Timezone\nnames never contain the space character but may contain an underscore. Refer to <a\nhref=\"http://en.wikipedia.org/wiki/List_of_tz_zones\">Wikipedia</a> for a list of valid values.\n\nExample: `Asia/Tokyo`, `America/Los_Angeles` or `Africa/Cairo`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field cannot be parsed as a timezone.",
+    "type": "object"
+  },
+  "forbidden_pickup_type": {
+    "code": "forbidden_pickup_type",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endPickupDropOffWindow": {
+        "description": "The end pickup drop off window of the faulty record.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start pickup drop off window of the faulty record.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "pickup_drop_off_window fields are forbidden when the pickup_type is regularly scheduled (0) or must be coordinated with the driver (3).",
+    "type": "object"
+  },
+  "duplicate_geo_json_key": {
+    "code": "duplicate_geo_json_key",
+    "deprecated": false,
+    "description": "The key must be unique for each feature in the GeoJSON file.",
+    "properties": {
+      "featureId": {
+        "description": "The duplicated key.",
+        "fieldName": "featureId",
+        "type": "string"
+      },
+      "firstIndex": {
+        "description": "The index of the first feature with the same key.",
+        "fieldName": "firstIndex",
+        "type": "integer"
+      },
+      "secondIndex": {
+        "description": "The index of the other feature with the same key.",
+        "fieldName": "secondIndex",
+        "type": "integer"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A key in `locations.geojson` is duplicated.",
+    "type": "object"
+  },
+  "stop_without_stop_time": {
+    "code": "stop_without_stop_time",
+    "deprecated": false,
+    "description": "Such stops are not used by any trip and normally do not provide user value. This notice may\nindicate a typo in `stop_times.txt`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty stop.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the faulty stop.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.",
+    "type": "object"
+  },
+  "big_gap_in_service": {
+    "code": "big_gap_in_service",
+    "deprecated": false,
+    "properties": {
+      "gapDurationDays": {
+        "description": "The number of days in the gap.",
+        "fieldName": "gapDurationDays",
+        "type": "integer"
+      },
+      "gapEndDate": {
+        "description": "The last day of the gap.",
+        "fieldName": "gapEndDate",
+        "type": "string"
+      },
+      "gapStartDate": {
+        "description": "The first day of the gap.",
+        "fieldName": "gapStartDate",
+        "type": "string"
+      },
+      "serviceId": {
+        "description": "The service_id that has the gap.",
+        "fieldName": "serviceId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A service has a gap of more than 13 days between active service dates.",
+    "type": "object"
+  },
+  "stop_without_location": {
+    "code": "stop_without_location",
+    "deprecated": false,
+    "description": "`stop_lat` and/or `stop_lon` are required for locations that are stops (`location_type=0`),\nstations (`location_type=1`) or entrances/exits (`location_type=2`).",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "The faulty record's `stops.location_type`.",
+        "fieldName": "locationType",
+        "type": "enum"
+      },
+      "stopId": {
+        "description": "The faulty record's id.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`stop_lat` and/or `stop_lon` is missing for stop with `location_type` equal to`0`, `1`, or `2`",
+    "type": "object"
+  },
+  "transfer_distance_above_2_km": {
+    "code": "transfer_distance_above_2_km",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "distanceKm": {
+        "description": "The distance between the two stops in km.",
+        "fieldName": "distanceKm",
+        "type": "number"
+      },
+      "fromStopId": {
+        "description": "The ID of the stop in `from_stop_id`.",
+        "fieldName": "fromStopId",
+        "type": "string"
+      },
+      "toStopId": {
+        "description": "The ID of the stop in `to_stop_id`.",
+        "fieldName": "toStopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "The transfer distance from stop to stop in `transfers.txt` is larger than 2 km.",
+    "type": "object"
+  },
+  "start_and_end_range_equal": {
+    "code": "start_and_end_range_equal",
+    "deprecated": false,
+    "description": "The fields `frequencies.start_date` and `frequencies.end_date` have been found equal in\n`frequencies.txt`. The GTFS spec is currently unclear how this case should be handled (e.g., is\nit a trip that circulates once?). It is recommended to use a trip not defined via frequencies.txt\nfor this case.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "endFieldName": {
+        "description": "The end value's field name.",
+        "fieldName": "endFieldName",
+        "type": "string"
+      },
+      "entityId": {
+        "description": "The id of the faulty entity.",
+        "fieldName": "entityId",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "startFieldName": {
+        "description": "The start value's field name.",
+        "fieldName": "startFieldName",
+        "type": "string"
+      },
+      "value": {
+        "description": "The faulty value.",
+        "fieldName": "value",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Two date or time fields are equal.",
+    "type": "object"
+  },
+  "feed_expiration_date7_days": {
+    "code": "feed_expiration_date7_days",
+    "deprecated": false,
+    "description": "The dataset expiration date defined in `feed_info.txt` is in seven days or less. At any\ntime, the published GTFS dataset should be valid for at least the next 7 days.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "currentDate": {
+        "description": "Current date (YYYYMMDD format).",
+        "fieldName": "currentDate",
+        "type": "string"
+      },
+      "feedEndDate": {
+        "description": "Feed end date (YYYYMMDD format).",
+        "fieldName": "feedEndDate",
+        "type": "string"
+      },
+      "suggestedExpirationDate": {
+        "description": "Suggested expiration date (YYYYMMDD format).",
+        "fieldName": "suggestedExpirationDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "feed_info.txt"
+      ],
+      "sectionReferences": [
+        "dataset-publishing-general-practices"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Dataset should be valid for at least the next 7 days.",
+    "type": "object"
+  },
+  "unused_trip": {
+    "code": "unused_trip",
+    "deprecated": false,
+    "description": "Trips should be referred to at least once in `stop_times.txt`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The faulty record's id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Trip is not be used in `stop_times.txt`",
+    "type": "object"
+  },
+  "bidirectional_exit_gate": {
+    "code": "bidirectional_exit_gate",
+    "deprecated": false,
+    "description": "Exit gates (pathway_mode=7) must not be bidirectional.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the validated record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "isBidirectional": {
+        "description": "Whether the pathway is bidirectional.",
+        "fieldName": "isBidirectional",
+        "type": "integer"
+      },
+      "pathwayMode": {
+        "description": "The pathway mode.",
+        "fieldName": "pathwayMode",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Pathway is bidirectional and has mode 7 (exit gate).",
+    "type": "object"
+  },
+  "duplicate_key": {
+    "code": "duplicate_key",
+    "deprecated": false,
+    "description": "The values of the given key and rows are duplicates.",
+    "properties": {
+      "fieldName1": {
+        "description": "Composite key's first field name.",
+        "fieldName": "fieldName1",
+        "type": "string"
+      },
+      "fieldName2": {
+        "description": "Composite key's second field name.",
+        "fieldName": "fieldName2",
+        "type": "string"
+      },
+      "fieldValue1": {
+        "description": "Composite key's first value.",
+        "fieldName": "fieldValue1",
+        "type": "object"
+      },
+      "fieldValue2": {
+        "description": "Composite key's second value.",
+        "fieldName": "fieldValue2",
+        "type": "object"
+      },
+      "filename": {
+        "description": "The name of the faulty file",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "newCsvRowNumber": {
+        "description": "The row of the other occurrence.",
+        "fieldName": "newCsvRowNumber",
+        "type": "integer"
+      },
+      "oldCsvRowNumber": {
+        "description": "The row of the first occurrence.",
+        "fieldName": "oldCsvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Duplicated entity.",
+    "type": "object"
+  },
+  "stop_has_too_many_matches_for_shape": {
+    "code": "stop_has_too_many_matches_for_shape",
+    "deprecated": false,
+    "description": "This potentially indicates a problem with the location of the stop or the path of the shape.",
+    "properties": {
+      "match": {
+        "contains": {
+          "type": "number"
+        },
+        "description": "Latitude and longitude pair of the location.",
+        "fieldName": "match",
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "matchCount": {
+        "description": "The number of matches for the stop that is referred to.",
+        "fieldName": "matchCount",
+        "type": "integer"
+      },
+      "shapeId": {
+        "description": "The id of the shape that is referred to.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the stop that is referred to.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the stop that is referred to.",
+        "fieldName": "stopName",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the faulty record from `trips.txt`.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The id of the trip that is referred to.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Stop entry that has many potential matches to the trip's path of travel, as defined by the shape entry in `shapes.txt`.",
+    "type": "object"
+  },
+  "inconsistent_agency_lang": {
+    "code": "inconsistent_agency_lang",
+    "deprecated": false,
+    "description": "Agencies from GTFS `agency.txt` have been found to have different languages.",
+    "properties": {
+      "actual": {
+        "description": "Faulty record's language.",
+        "fieldName": "actual",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "expected": {
+        "description": "Expected language.",
+        "fieldName": "expected",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "agency.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Inconsistent language among agencies.",
+    "type": "object"
+  },
+  "unsorted_stop_times": {
+    "code": "unsorted_stop_times",
+    "deprecated": false,
+    "description": "'stop_times.txt' entries for a given trip are not sorted by stop_sequence, or are not\ncontiguous in the file.",
+    "properties": {
+      "endCsvRowNumber": {
+        "description": "CSV row number of the last stop_times entry for this trip.",
+        "fieldName": "endCsvRowNumber",
+        "type": "integer"
+      },
+      "startCsvRowNumber": {
+        "description": "CSV row number of the first stop_times entry for this trip.",
+        "fieldName": "startCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The faulty record's trip_id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "Stop times are not sorted by trip_id and stop_sequence.",
+    "type": "object"
+  },
+  "missing_recommended_column": {
+    "code": "missing_recommended_column",
+    "deprecated": true,
+    "deprecationReason": "Unused validation notice",
+    "deprecationVersion": "7.0.0",
+    "properties": {
+      "fieldName": {
+        "description": "The name of the missing column.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "term-definitions"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A recommended column is missing in the input file.",
+    "type": "object"
+  },
+  "geo_json_duplicated_element": {
+    "code": "geo_json_duplicated_element",
+    "deprecated": false,
+    "properties": {
+      "duplicatedElement": {
+        "description": "The duplicated element in the GeoJSON file.",
+        "fieldName": "duplicatedElement",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the file where the duplicated element was found.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Duplicated elements in locations.geojson file.",
+    "type": "object"
+  },
+  "fare_transfer_rule_without_transfer_count": {
+    "code": "fare_transfer_rule_without_transfer_count",
+    "deprecated": false,
+    "description": "Per the spec, `transfer_count` is required if the two leg group ids are equal.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from `fare_transfer_rules.txt` has `from_leg_group_id` equal to `to_leg_group_id`, but has no `transfer_count` specified.",
+    "type": "object"
+  },
+  "platform_without_parent_station": {
+    "code": "platform_without_parent_station",
+    "deprecated": false,
+    "description": "This is different from `location_without_parent_station` since it is less severe.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "Row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The stop name of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A platform has no `parent_station` field set.",
+    "type": "object"
+  },
+  "trip_with_shape_dist_traveled_but_no_shape_distances": {
+    "code": "trip_with_shape_dist_traveled_but_no_shape_distances",
+    "deprecated": false,
+    "description": "When stop times define distance values but the shape does not carry matching distances on\nevery point, consumers cannot use those distances to align stops to the shape geometry\nreliably. This inconsistency may cause incorrect routing or display behaviour.\n\n<b>Note:</b> Only the first stop time carrying a shape_dist_traveled value is referenced in\nthe notice; this is a representative row rather than an exhaustive list.",
+    "properties": {
+      "shapeId": {
+        "description": "The shape_id referenced by the trip.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the first stop_times.txt record for this trip that contains a\nshape_dist_traveled value. Provided as a representative location; other stop times for the\nsame trip may also carry distance values.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the faulty record in trips.txt.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The trip_id of the faulty trip.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "shapes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A trip has shape_dist_traveled values in stop_times.txt but the shape referenced by the trip's shape_id does not have shape_dist_traveled values on all of its points in shapes.txt.",
+    "type": "object"
+  },
+  "service_extends_far_in_the_future": {
+    "code": "service_extends_far_in_the_future",
+    "deprecated": false,
+    "properties": {
+      "serviceId": {
+        "description": "The service_id that ends far in the future.",
+        "fieldName": "serviceId",
+        "type": "string"
+      },
+      "serviceWindowEndDate": {
+        "description": "The end date of the service (YYYY-MM-DD format).",
+        "fieldName": "serviceWindowEndDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A service end date is more than 2 years in the future.",
+    "type": "object"
+  },
+  "unknown_file": {
+    "code": "unknown_file",
+    "deprecated": false,
+    "properties": {
+      "filename": {
+        "description": "The name of the unknown file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A file is unknown.",
+    "type": "object"
+  },
+  "unknown_column": {
+    "code": "unknown_column",
+    "deprecated": false,
+    "properties": {
+      "fieldName": {
+        "description": "The name of the unknown column.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "index": {
+        "description": "The index of the faulty column.",
+        "fieldName": "index",
+        "type": "integer"
+      }
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A column name is unknown.",
+    "type": "object"
+  },
+  "same_name_and_description_for_route": {
+    "code": "same_name_and_description_for_route",
+    "deprecated": false,
+    "description": "The GTFS spec defines `routes.txt`\n[route_desc](https://gtfs.org/reference/static/#routestxt) as:\n\nDescription of a route that provides useful, quality information. Do not simply duplicate\nthe name of the route.\n\nSee the GTFS and GTFS Best Practices links below for more examples of how to populate the\n`route_short_name`, `route_long_name`, and `route_desc` fields.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeDesc": {
+        "description": "The `routes.routes_desc` of the faulty record.",
+        "fieldName": "routeDesc",
+        "type": "string"
+      },
+      "routeId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "specifiedField": {
+        "description": "Either `route_short_name` or `route_long_name`.",
+        "fieldName": "specifiedField",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Same name and description for route.",
+    "type": "object"
+  },
+  "stops_match_shape_out_of_order": {
+    "code": "stops_match_shape_out_of_order",
+    "deprecated": false,
+    "description": "This could indicate a problem with the location of the stops, the path of the shape, or the\nsequence of the stops for their trip.",
+    "properties": {
+      "match1": {
+        "contains": {
+          "type": "number"
+        },
+        "description": "Latitude and longitude pair of the first matching location.",
+        "fieldName": "match1",
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "match2": {
+        "contains": {
+          "type": "number"
+        },
+        "description": "Latitude and longitude pair of the second matching location.",
+        "fieldName": "match2",
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "shapeId": {
+        "description": "The id of the shape that is referred to.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "stopId1": {
+        "description": "The id of the first stop that is referred to.",
+        "fieldName": "stopId1",
+        "type": "string"
+      },
+      "stopId2": {
+        "description": "The id of the second stop that is referred to.",
+        "fieldName": "stopId2",
+        "type": "string"
+      },
+      "stopName1": {
+        "description": "The name of the first stop that is referred to.",
+        "fieldName": "stopName1",
+        "type": "string"
+      },
+      "stopName2": {
+        "description": "The name of the second stop that is referred to.",
+        "fieldName": "stopName2",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber1": {
+        "description": "The row number of the first faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber1",
+        "type": "integer"
+      },
+      "stopTimeCsvRowNumber2": {
+        "description": "The row number of the second faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber2",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the faulty record from `trips.txt`.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The id of the trip that is referred to.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Two stop entries are different than their arrival-departure order defined by `shapes.txt`.",
+    "type": "object"
+  },
+  "forbidden_real_time_booking_field_value": {
+    "code": "forbidden_real_time_booking_field_value",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldNames": {
+        "description": "The names of the forbidden fields comma-separated.",
+        "fieldName": "fieldNames",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A forbidden field value is present for a real-time booking rule in `booking_rules.txt`.",
+    "type": "object"
+  },
+  "invalid_character": {
+    "code": "invalid_character",
+    "deprecated": false,
+    "description": "Check that text was properly encoded in UTF-8 as required by GTFS.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number in the CSV file where the invalid characters were found.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the field containing the invalid characters.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "The value of the field containing the invalid characters.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the file containing the invalid characters.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "This field contains invalid characters, such as the replacement character (\"�\").",
+    "type": "object"
+  },
+  "invalid_url": {
+    "code": "invalid_url",
+    "deprecated": false,
+    "description": "Definitions for valid URLs are quite vague. We perform strict validation using the Apache\nCommons UrlValidator.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": [
+        {
+          "label": "Apache Commons UrlValidator",
+          "url": "https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/UrlValidator.html"
+        }
+      ]
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains a malformed URL.",
+    "type": "object"
+  },
+  "invalid_time": {
+    "code": "invalid_time",
+    "deprecated": false,
+    "description": "Time must be in the `H:MM:SS`, `HH:MM:SS` or `HHH:MM:SS` format.\n\nExample: `14:30:00` for 2:30PM or `25:35:00` for 1:35AM on the next day.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field cannot be parsed as time.",
+    "type": "object"
+  },
+  "pathway_unreachable_location": {
+    "code": "pathway_unreachable_location",
+    "deprecated": false,
+    "description": "Notices are reported for platforms, boarding areas and generic nodes but not for entrances\nor stations.\n\nNotices are not reported for platforms that have boarding areas since such platforms may not\nhave incident pathways. Instead, notices are reported for the boarding areas.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "Row number of the unreachable location.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "hasEntrance": {
+        "description": "Whether the location is reachable from entrances.",
+        "fieldName": "hasEntrance",
+        "type": "boolean"
+      },
+      "hasExit": {
+        "description": "Whether some exit can be reached from the location.",
+        "fieldName": "hasExit",
+        "type": "boolean"
+      },
+      "locationType": {
+        "description": "The type of the unreachable location.",
+        "fieldName": "locationType",
+        "type": "integer"
+      },
+      "parentStation": {
+        "description": "The parent of the unreachable location.",
+        "fieldName": "parentStation",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the unreachable location.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The stop name of the unreachable location.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A location is not reachable at least in one direction: from the entrances or to the exits.",
+    "type": "object"
+  },
+  "expired_calendar": {
+    "code": "expired_calendar",
+    "deprecated": false,
+    "description": "This warning takes into account the `calendar_dates.txt` file as well as the `calendar.txt`\nfile.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "serviceId": {
+        "description": "The service id of the faulty record.",
+        "fieldName": "serviceId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Dataset Publishing & General Practices",
+          "url": "https://gtfs.org/schedule/reference/#dataset-publishing-general-practices"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Dataset should not contain date ranges for services that have already expired.",
+    "type": "object"
+  },
+  "missing_recommended_field": {
+    "code": "missing_recommended_field",
+    "deprecated": false,
+    "description": "The given field has no value in some input row, even though values are recommended.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the missing field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A recommended field is missing.",
+    "type": "object"
+  },
+  "stop_time_with_arrival_before_previous_departure_time": {
+    "code": "stop_time_with_arrival_before_previous_departure_time",
+    "deprecated": false,
+    "description": "For a given `trip_id`, the `arrival_time` of (n+1)-th stoptime in sequence must not precede\nthe `departure_time` of n-th stoptime in sequence in `stop_times.txt`.",
+    "properties": {
+      "arrivalTime": {
+        "description": "Arrival time at the faulty record.",
+        "fieldName": "arrivalTime",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "departureTime": {
+        "description": "Departure time at the previous stop time.",
+        "fieldName": "departureTime",
+        "type": "string"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row of the previous stop time.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The trip_id associated to the faulty record.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Backwards time travel between stops in `stop_times.txt`",
+    "type": "object"
+  },
+  "fare_transfer_rule_invalid_transfer_count": {
+    "code": "fare_transfer_rule_invalid_transfer_count",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "transferCount": {
+        "description": "The transfer count value of the faulty record.",
+        "fieldName": "transferCount",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from GTFS file `fare_transfer_rules.txt` has a defined `transfer_count` with an invalid value.",
+    "type": "object"
+  },
+  "stop_too_far_from_shape_using_user_distance": {
+    "code": "stop_too_far_from_shape_using_user_distance",
+    "deprecated": false,
+    "description": "A stop time entry that is a large distance away from the location of the shape in\n`shapes.txt` as defined by `shape_dist_traveled` values.",
+    "properties": {
+      "geoDistanceToShape": {
+        "description": "Distance from stop to shape.",
+        "fieldName": "geoDistanceToShape",
+        "type": "number"
+      },
+      "match": {
+        "contains": {
+          "type": "number"
+        },
+        "description": "Latitude and longitude pair of the location.",
+        "fieldName": "match",
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "shapeId": {
+        "description": "The id of the shape that is referred to.",
+        "fieldName": "shapeId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the stop that is referred to.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the stop that is referred to.",
+        "fieldName": "stopName",
+        "type": "string"
+      },
+      "stopTimeCsvRowNumber": {
+        "description": "The row number of the faulty record from `stop_times.txt`.",
+        "fieldName": "stopTimeCsvRowNumber",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the faulty record from `trips.txt`.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The id of the trip that is referred to.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "trips.txt",
+        "stop_times.txt",
+        "stops.txt",
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Stop time too far from shape.",
+    "type": "object"
+  },
+  "single_shape_point": {
+    "code": "single_shape_point",
+    "deprecated": false,
+    "description": "A shape should contain more than one shape point to visualize the route",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "shapeId": {
+        "description": "The faulty record's id.",
+        "fieldName": "shapeId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "The shape within `shapes.txt` contains a single shape point.",
+    "type": "object"
+  },
+  "missing_prior_notice_last_day": {
+    "code": "missing_prior_notice_last_day",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "The `prior_notice_last_day` is required when booking_type=2 (prior day booking) is specified in booking_rules.txt.",
+    "type": "object"
+  },
+  "csv_parsing_failed": {
+    "code": "csv_parsing_failed",
+    "deprecated": false,
+    "description": "One common case of the problem is when a cell value contains more than 4096 characters.",
+    "properties": {
+      "charIndex": {
+        "description": "The location of the last character read from before the error occurred.",
+        "fieldName": "charIndex",
+        "type": "integer"
+      },
+      "columnIndex": {
+        "description": "The column index where the exception occurred.",
+        "fieldName": "columnIndex",
+        "type": "integer"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "lineIndex": {
+        "description": "The line number where the exception occurred.",
+        "fieldName": "lineIndex",
+        "type": "integer"
+      },
+      "message": {
+        "description": "The detailed message describing the error, and the internal state of the parser/writer.",
+        "fieldName": "message",
+        "type": "string"
+      },
+      "parsedContent": {
+        "description": "The record number when the exception occurred.",
+        "fieldName": "parsedContent",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Parsing of a CSV file failed.",
+    "type": "object"
+  },
+  "stop_access_specified_for_incorrect_location": {
+    "code": "stop_access_specified_for_incorrect_location",
+    "deprecated": false,
+    "description": "Stops.stop_access is forbidden for locations that are stations, entrances, generic nodes or\nboarding areas. It can only be specific when a stop is associated with a parent station.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "`stops.location_type` of the faulty record.",
+        "fieldName": "locationType",
+        "type": "enum"
+      },
+      "stopAccess": {
+        "description": "The `stops.stop_access` of the faulty record.",
+        "fieldName": "stopAccess",
+        "type": "enum"
+      },
+      "stopId": {
+        "description": "The `stops.stop_id` of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The 'stops.stop_name' of the faulty record.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A location that is not a stop has stop_access specified.",
+    "type": "object"
+  },
+  "unused_parent_station": {
+    "code": "unused_parent_station",
+    "deprecated": true,
+    "deprecationReason": "Renamed to `unused_station`",
+    "deprecationVersion": "7.0.0",
+    "description": "A stop has `location_type` STATION (1) but does not appear in any stop's `parent_station`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty stop.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the faulty stop.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "replacementNoticeCodes": [
+      "unused_station"
+    ],
+    "severityLevel": "INFO",
+    "shortSummary": "Unused parent station.",
+    "type": "object"
+  },
+  "stop_without_zone_id": {
+    "code": "stop_without_zone_id",
+    "deprecated": false,
+    "description": "If `fare_rules.txt` is provided, and `fare_rules.txt` uses at least one column among\n`origin_id`, `destination_id`, and `contains_id`, then all stops and platforms (location_type =\n0) must have `stops.zone_id` assigned if they are defined in a trip defined in a route defined\nin a fare rule which also defines at least one of `origin_id`, `destination_id`, or\n`contains_id`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The faulty record's id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The faulty record's `stops.stop_name`.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt",
+        "stop_times.txt",
+        "trips.txt",
+        "routes.txt",
+        "fare_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "Stop without value for `stops.zone_id` contained in a route with a zone-dependent fare rule.",
+    "type": "object"
+  },
+  "fare_transfer_rule_with_forbidden_transfer_count": {
+    "code": "fare_transfer_rule_with_forbidden_transfer_count",
+    "deprecated": false,
+    "description": "Per the spec, `transfer_count` is forbidden if the two leg group ids are not equal.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from `fare_transfer_rules.txt` has `from_leg_group_id` not equal to `to_leg_group_id`, but has `transfer_count` specified.",
+    "type": "object"
+  },
+  "route_color_contrast": {
+    "code": "route_color_contrast",
+    "deprecated": false,
+    "description": "A route's color and `route_text_color` should be contrasting.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeColor": {
+        "description": "The faulty record's HTML route color.",
+        "fieldName": "routeColor",
+        "type": "string"
+      },
+      "routeId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "routeTextColor": {
+        "description": "The faulty record's HTML route text color.",
+        "fieldName": "routeTextColor",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Insufficient route color contrast.",
+    "type": "object"
+  },
+  "fare_product_with_multiple_default_rider_categories": {
+    "code": "fare_product_with_multiple_default_rider_categories",
+    "deprecated": false,
+    "description": "Each fare product should have at most one default rider category.",
+    "properties": {
+      "csvRowNumber1": {
+        "description": "The CSV row number of the first occurrence of the default rider category",
+        "fieldName": "csvRowNumber1",
+        "type": "integer"
+      },
+      "csvRowNumber2": {
+        "description": "The CSV row number of the second occurrence of the default rider category",
+        "fieldName": "csvRowNumber2",
+        "type": "integer"
+      },
+      "fareProductId": {
+        "description": "The ID of the fare product associated with the notice",
+        "fieldName": "fareProductId",
+        "type": "string"
+      },
+      "riderCategoryId1": {
+        "description": "The ID of the first rider category that is marked as default",
+        "fieldName": "riderCategoryId1",
+        "type": "string"
+      },
+      "riderCategoryId2": {
+        "description": "The ID of the second rider category that is marked as default",
+        "fieldName": "riderCategoryId2",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_products.txt",
+        "rider_categories.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "This notice is generated when a fare product is associated with multiple rider categories that are marked as default.",
+    "type": "object"
+  },
+  "timeframe_overlap": {
+    "code": "timeframe_overlap",
+    "deprecated": false,
+    "description": "Timeframes with the same group and service dates must not overlap in time. Two entries X and\nY are considered to directly overlap if X.start_time is less than or equal to Y.start_time and\nY.start_time is less than X.end_time.",
+    "properties": {
+      "currCsvRowNumber": {
+        "description": "The row number of the second timeframe entry.",
+        "fieldName": "currCsvRowNumber",
+        "type": "integer"
+      },
+      "currStartTime": {
+        "description": "The start time of the second timeframe entry.",
+        "fieldName": "currStartTime",
+        "type": "string"
+      },
+      "prevCsvRowNumber": {
+        "description": "The row number of the first timeframe entry.",
+        "fieldName": "prevCsvRowNumber",
+        "type": "integer"
+      },
+      "prevEndTime": {
+        "description": "The first timeframe end time.",
+        "fieldName": "prevEndTime",
+        "type": "string"
+      },
+      "serviceId": {
+        "description": "The service id associated with the two entries.",
+        "fieldName": "serviceId",
+        "type": "string"
+      },
+      "timeframeGroupId": {
+        "description": "The timeframe group id associated with the two entries.",
+        "fieldName": "timeframeGroupId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "frequencies.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Two entries in `timeframes.txt` with the same `timeframe_group_id` and `service_id` have overlapping time intervals.",
+    "type": "object"
+  },
+  "wrong_parent_location_type": {
+    "code": "wrong_parent_location_type",
+    "deprecated": false,
+    "description": "Value of field `location_type` of parent found in field `parent_station` is invalid.\n\nAccording to spec\n\n- _Stop/platform_ can only have _Station_ as parent\n- _Station_ can NOT have a parent\n- _Entrance/exit_ or _generic node_ can only have _Station_ as parent\n- _Boarding Area_ can only have _Platform_ as parent\n\nAny other combination raise this error.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "expectedLocationType": {
+        "description": "The expected location type of the faulty record.",
+        "fieldName": "expectedLocationType",
+        "type": "integer"
+      },
+      "locationType": {
+        "description": "The faulty record's `stops.location_type`.",
+        "fieldName": "locationType",
+        "type": "integer"
+      },
+      "parentCsvRowNumber": {
+        "description": "The row number of the faulty record's parent.",
+        "fieldName": "parentCsvRowNumber",
+        "type": "integer"
+      },
+      "parentLocationType": {
+        "description": "The location type of the faulty record's parent.",
+        "fieldName": "parentLocationType",
+        "type": "integer"
+      },
+      "parentStation": {
+        "description": "The id of the faulty record's parent station.",
+        "fieldName": "parentStation",
+        "type": "string"
+      },
+      "parentStopName": {
+        "description": "The stop name of the faulty record's parent.",
+        "fieldName": "parentStopName",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The faulty record's `stops.stop_name`.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stops.txt",
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Incorrect type of the parent location.",
+    "type": "object"
+  },
+  "invalid_prior_notice_duration_min": {
+    "code": "invalid_prior_notice_duration_min",
+    "deprecated": false,
+    "description": "The `prior_notice_duration_max` field value needs to be greater or equal to the\n`prior_notice_duration_min` field value.",
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "priorNoticeDurationMax": {
+        "description": "The value of the `prior_notice_duration_max` field.",
+        "fieldName": "priorNoticeDurationMax",
+        "type": "integer"
+      },
+      "priorNoticeDurationMin": {
+        "description": "The value of the `prior_notice_duration_min` field.",
+        "fieldName": "priorNoticeDurationMin",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "An invalid `prior_notice_duration_min` value is present in a booking rule.",
+    "type": "object"
+  },
+  "pathway_dangling_generic_node": {
+    "code": "pathway_dangling_generic_node",
+    "deprecated": false,
+    "description": "Such generic node is useless because there is no benefit in visiting it.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "Row number of the dangling generic node.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "parentStation": {
+        "description": "The parent station of the dangling generic node.",
+        "fieldName": "parentStation",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the dangling generic node.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The stop name of the dangling generic node.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A generic node has only one incident location in a pathway graph.",
+    "type": "object"
+  },
+  "duplicated_column": {
+    "code": "duplicated_column",
+    "deprecated": false,
+    "description": "The input file CSV header has the same column name repeated.",
+    "properties": {
+      "fieldName": {
+        "description": "The name of the faulty field.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "firstIndex": {
+        "description": "Index of the first occurrence.",
+        "fieldName": "firstIndex",
+        "type": "integer"
+      },
+      "secondIndex": {
+        "description": "Index of the other occurrence.",
+        "fieldName": "secondIndex",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Duplicated column in CSV.",
+    "type": "object"
+  },
+  "fast_travel_between_far_stops": {
+    "code": "fast_travel_between_far_stops",
+    "deprecated": false,
+    "description": "Two stops are considered \"far\" if they are more than 10 km apart. This normally indicates a\nmore serious problem than too fast travel between consecutive stops.\n\nThe speed threshold depends on route type and are the same as\n`fast_travel_between_consecutive_stops`.",
+    "properties": {
+      "arrivalTime2": {
+        "description": "`arrival_time` of the second stop.",
+        "fieldName": "arrivalTime2",
+        "type": "string"
+      },
+      "csvRowNumber1": {
+        "description": "The row number of the first stop time.",
+        "fieldName": "csvRowNumber1",
+        "type": "integer"
+      },
+      "csvRowNumber2": {
+        "description": "The row number of the second stop time.",
+        "fieldName": "csvRowNumber2",
+        "type": "integer"
+      },
+      "departureTime1": {
+        "description": "`departure_time` of the first stop.",
+        "fieldName": "departureTime1",
+        "type": "string"
+      },
+      "distanceKm": {
+        "description": "Distance between stops (km).",
+        "fieldName": "distanceKm",
+        "type": "number"
+      },
+      "routeId": {
+        "description": "`route_id` of the problematic trip.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "speedKph": {
+        "description": "Travel speed (km/h).",
+        "fieldName": "speedKph",
+        "type": "number"
+      },
+      "stopId1": {
+        "description": "`stop_id` of the first stop.",
+        "fieldName": "stopId1",
+        "type": "string"
+      },
+      "stopId2": {
+        "description": "`stop_id` of the second stop.",
+        "fieldName": "stopId2",
+        "type": "string"
+      },
+      "stopName1": {
+        "description": "`stop_name` of the first stop.",
+        "fieldName": "stopName1",
+        "type": "string"
+      },
+      "stopName2": {
+        "description": "`stop_name` of the second stop.",
+        "fieldName": "stopName2",
+        "type": "string"
+      },
+      "stopSequence1": {
+        "description": "`stop_sequence` of the first stop.",
+        "fieldName": "stopSequence1",
+        "type": "integer"
+      },
+      "stopSequence2": {
+        "description": "`stop_sequence` of the second stop.",
+        "fieldName": "stopSequence2",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the problematic trip.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "`trip_id` of the problematic trip.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "stops.txt",
+        "stop_times.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A transit vehicle moves too fast between two far stops.",
+    "type": "object"
+  },
+  "invalid_currency": {
+    "code": "invalid_currency",
+    "deprecated": false,
+    "description": "Currency code must follow <a href=\"https://en.wikipedia.org/wiki/ISO_4217#Active_codes\">ISO\n4217</a>\n\nExample: `CAD` for Canadian dollars, `EUR` for euros or `JPY` for Japanese yen.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field contains a wrong currency code.",
+    "type": "object"
+  },
+  "transfer_with_invalid_trip_and_stop": {
+    "code": "transfer_with_invalid_trip_and_stop",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopFieldName": {
+        "description": "The name of the stop id field (e.g. `stop_route_id`) referencing the stop.",
+        "fieldName": "stopFieldName",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The referenced stop id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "tripFieldName": {
+        "description": "The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
+        "fieldName": "tripFieldName",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The referenced trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A trip id field from GTFS file `transfers.txt` references a stop that is not included in the referenced trip's stop-times.",
+    "type": "object"
+  },
+  "inconsistent_route_type_for_in_seat_transfer": {
+    "code": "inconsistent_route_type_for_in_seat_transfer",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The csv row number of the faulty transfer in tranfers.txt.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fromRouteId": {
+        "description": "The from_route_id value of the faulty transfer.",
+        "fieldName": "fromRouteId",
+        "type": "string"
+      },
+      "fromRouteType": {
+        "description": "The route_type value of the from_route_id.",
+        "fieldName": "fromRouteType",
+        "type": "enum"
+      },
+      "toRouteId": {
+        "description": "The to_route_id value of the faulty transfer.",
+        "fieldName": "toRouteId",
+        "type": "string"
+      },
+      "toRouteType": {
+        "description": "The route_type value of the to_route_id.",
+        "fieldName": "toRouteType",
+        "type": "enum"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt",
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "An in-seat transfer should occur in the same route mode.",
+    "type": "object"
+  },
+  "pathway_to_wrong_location_type": {
+    "code": "pathway_to_wrong_location_type",
+    "deprecated": false,
+    "description": "Pathways endpoints must be platforms (stops), entrances/exits, generic nodes or boarding\nareas.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty row.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The station id field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "pathwayId": {
+        "description": "The id of the faulty pathway.",
+        "fieldName": "pathwayId",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The id of the endpoint station.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A pathway has an endpoint that is a station.",
+    "type": "object"
+  },
+  "foreign_key_violation": {
+    "code": "foreign_key_violation",
+    "deprecated": false,
+    "description": "A foreign key references the primary key of another file. A foreign key violation means that\nthe foreign key referenced from a given row (the child file) cannot be found in the corresponding\nfile (the parent file). The Foreign keys are defined in the specification under \"Type\" for each\nfile.",
+    "properties": {
+      "childFieldName": {
+        "description": "The name of the field that makes reference.",
+        "fieldName": "childFieldName",
+        "type": "string"
+      },
+      "childFilename": {
+        "description": "The name of the file from which reference is made.",
+        "fieldName": "childFilename",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldValue": {
+        "description": "The faulty record's value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "parentFieldName": {
+        "description": "The name of the field that is referred to.",
+        "fieldName": "parentFieldName",
+        "type": "string"
+      },
+      "parentFilename": {
+        "description": "The name of the file that is referred to.",
+        "fieldName": "parentFilename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Wrong foreign key.",
+    "type": "object"
+  },
+  "missing_stop_times_record": {
+    "code": "missing_stop_times_record",
+    "deprecated": false,
+    "description": "Travel within the same location group or GeoJSON location requires two records in\nstop_times.txt with the same location_group_id or location_id.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationGroupId": {
+        "description": "The `locationGroupId` of the faulty record.",
+        "fieldName": "locationGroupId",
+        "type": "string"
+      },
+      "locationId": {
+        "description": "The `locationId` of the faulty record.",
+        "fieldName": "locationId",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The `tripId` of the faulty record.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Only one stop_times record is found where two are required.",
+    "type": "object"
+  },
+  "invalid_input_files_in_subfolder": {
+    "code": "invalid_input_files_in_subfolder",
+    "deprecated": false,
+    "description": "All GTFS files must reside at the root level directly. There are two common cases that trigger\nthis error:\n\n1. The root folder (e.g., a folder called \"GTFS 2020\") was zipped instead of the individual\n   files within the folder (e.g., `calendar.txt`, `agency.txt`, etc.). This can be fixed by\n   zipping the files directly instead.\n2. A file <a href=\"https://gtfs.org/documentation/schedule/reference/#dataset-files\">associated\n   with GTFS</a> is in a subfolder rather than the root folder of the dataset, and needs to be\n   removed if not needed or moved to the root level.",
+    "properties": {},
+    "severityLevel": "ERROR",
+    "shortSummary": "At least 1 GTFS file is in a subfolder.",
+    "type": "object"
+  },
+  "unsupported_feature_type": {
+    "code": "unsupported_feature_type",
+    "deprecated": false,
+    "description": "Use `Feature` instead to comply with the spec.",
+    "properties": {
+      "featureId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "featureId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "The value of the unsupported GeoJSON type.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "featureType": {
+        "description": "The feature type of the faulty record.",
+        "fieldName": "featureType",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "An unsupported feature type is used in the `locations.geojson` file.",
+    "type": "object"
+  },
+  "missing_pickup_drop_off_booking_rule_id": {
+    "code": "missing_pickup_drop_off_booking_rule_id",
+    "deprecated": false,
+    "description": "Currently, this notice is only triggered on feeds when either start_pickup_drop_off_window\nor end_pickup_drop_off_window is defined, since this recommendation was added to the\nspecification for feeds with GTFS-Flex.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record in `stop_times.txt`",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "dropOffType": {
+        "description": "The drop-off type of the faulty record.",
+        "fieldName": "dropOffType",
+        "type": "enum"
+      },
+      "pickupType": {
+        "description": "The pickup type of the faulty record.",
+        "fieldName": "pickupType",
+        "type": "enum"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "pickup_booking_rule_id is recommended when pickup_type=2 and drop_off_booking_rule_id is recommended when drop_off_type=2.",
+    "type": "object"
+  },
+  "missing_prior_notice_start_time": {
+    "code": "missing_prior_notice_start_time",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "priorNoticeStartDay": {
+        "description": "The value of the `prior_notice_start_day` field.",
+        "fieldName": "priorNoticeStartDay",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`prior_notice_start_time` value is required when `prior_notice_start_day` value is set in booking_rules.txt.",
+    "type": "object"
+  },
+  "missing_level_id": {
+    "code": "missing_level_id",
+    "deprecated": false,
+    "description": "GTFS file `levels.txt` is required for elevator (`pathway_mode=5`). A row from `stops.txt`\nlinked to an elevator pathway has no value for `stops.level_id`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The id of the faulty stop from `stops.txt`.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopName": {
+        "description": "The name of the faulty stop from `stops.txt`.",
+        "fieldName": "stopName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "levels.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`stops.level_id` is conditionally required.",
+    "type": "object"
+  },
+  "feed_valid_beyond_total_service_window": {
+    "code": "feed_valid_beyond_total_service_window",
+    "deprecated": false,
+    "properties": {
+      "feedEndDate": {
+        "description": "The feed end date from feed_info.txt.",
+        "fieldName": "feedEndDate",
+        "type": "string"
+      },
+      "feedStartDate": {
+        "description": "The feed start date from feed_info.txt.",
+        "fieldName": "feedStartDate",
+        "type": "string"
+      },
+      "serviceWindowEndDate": {
+        "description": "The latest active service date across all services.",
+        "fieldName": "serviceWindowEndDate",
+        "type": "string"
+      },
+      "serviceWindowStartDate": {
+        "description": "The earliest active service date across all services.",
+        "fieldName": "serviceWindowStartDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt",
+        "feed_info.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "The feed is valid 14 days beyond its total service window.",
+    "type": "object"
+  },
+  "translation_unknown_table_name": {
+    "code": "translation_unknown_table_name",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "tableName": {
+        "description": "`table_name` of the faulty record.",
+        "fieldName": "tableName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "translations.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A translation references an unknown or missing GTFS table.",
+    "type": "object"
+  },
+  "route_both_short_and_long_name_missing": {
+    "code": "route_both_short_and_long_name_missing",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "routeId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Both `route_short_name` and `route_long_name` are missing for a route.",
+    "type": "object"
+  },
+  "fast_travel_between_consecutive_stops": {
+    "code": "fast_travel_between_consecutive_stops",
+    "deprecated": false,
+    "description": "The speed threshold depends on route type:\n\n<table style=\"width: auto; table-layout: auto;\">\n     <tr>\n       <th>Route type</th>\n       <th>Description</th>\n       <th>Threshold, km/h</th>\n     </tr>\n     <tr>\n       <td>0</td>\n       <td>Light rail</td>\n       <td>100</td>\n     </tr>\n     <tr>\n       <td>1</td>\n       <td>Subway</td>\n       <td>150</td>\n     </tr>\n     <tr>\n       <td>2</td>\n       <td>Rail</td>\n       <td>500</td>\n     </tr>\n     <tr>\n       <td>3</td>\n       <td>Bus</td>\n       <td>150</td>\n     </tr>\n     <tr>\n       <td>4</td>\n       <td>Ferry</td>\n       <td>80</td>\n     </tr>\n     <tr>\n       <td>5</td>\n       <td>Cable tram</td>\n       <td>30</td>\n     </tr>\n     <tr>\n       <td>6</td>\n       <td>Aerial lift</td>\n       <td>50</td>\n     </tr>\n     <tr>\n       <td>7</td>\n       <td>Funicular</td>\n       <td>50</td>\n     </tr>\n     <tr>\n       <td>11</td>\n       <td>Trolleybus</td>\n       <td>150</td>\n     </tr>\n     <tr>\n       <td>12</td>\n       <td>Monorail</td>\n       <td>150</td>\n     </tr>\n     <tr>\n       <td>-</td>\n       <td>Unknown</td>\n       <td>200</td>\n     </tr>\n   </table>",
+    "properties": {
+      "arrivalTime2": {
+        "description": "`arrival_time` of the second stop.",
+        "fieldName": "arrivalTime2",
+        "type": "string"
+      },
+      "csvRowNumber1": {
+        "description": "The row number of the first stop time.",
+        "fieldName": "csvRowNumber1",
+        "type": "integer"
+      },
+      "csvRowNumber2": {
+        "description": "The row number of the second stop time.",
+        "fieldName": "csvRowNumber2",
+        "type": "integer"
+      },
+      "departureTime1": {
+        "description": "`departure_time` of the first stop.",
+        "fieldName": "departureTime1",
+        "type": "string"
+      },
+      "distanceKm": {
+        "description": "Distance between stops (km).",
+        "fieldName": "distanceKm",
+        "type": "number"
+      },
+      "routeId": {
+        "description": "`route_id` of the problematic trip.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "speedKph": {
+        "description": "Travel speed (km/h).",
+        "fieldName": "speedKph",
+        "type": "number"
+      },
+      "stopId1": {
+        "description": "`stop_id` of the first stop.",
+        "fieldName": "stopId1",
+        "type": "string"
+      },
+      "stopId2": {
+        "description": "`stop_id` of the second stop.",
+        "fieldName": "stopId2",
+        "type": "string"
+      },
+      "stopName1": {
+        "description": "`stop_name` of the first stop.",
+        "fieldName": "stopName1",
+        "type": "string"
+      },
+      "stopName2": {
+        "description": "`stop_name` of the second stop.",
+        "fieldName": "stopName2",
+        "type": "string"
+      },
+      "stopSequence1": {
+        "description": "`stop_sequence` of the first stop.",
+        "fieldName": "stopSequence1",
+        "type": "integer"
+      },
+      "stopSequence2": {
+        "description": "`stop_sequence` of the second stop.",
+        "fieldName": "stopSequence2",
+        "type": "integer"
+      },
+      "tripCsvRowNumber": {
+        "description": "The row number of the problematic trip.",
+        "fieldName": "tripCsvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "`trip_id` of the problematic trip.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "stops.txt",
+        "stop_times.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A transit vehicle moves too fast between two consecutive stops.",
+    "type": "object"
+  },
+  "forbidden_shape_dist_traveled": {
+    "code": "forbidden_shape_dist_traveled",
+    "deprecated": false,
+    "description": "A GeoJSON location or location group has an associated shape_dist_traveled field in\nstop_times.txt. shape_dist_traveled values should only be provided for stops.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "locationGroupId": {
+        "description": "The location_grpup_id for which the shape_dist_traveled is defined",
+        "fieldName": "locationGroupId",
+        "type": "string"
+      },
+      "locationId": {
+        "description": "The location_id for which the shape_dist_traveled is defined",
+        "fieldName": "locationId",
+        "type": "string"
+      },
+      "shapeDistTraveled": {
+        "description": "The shape_dist_traveled value",
+        "fieldName": "shapeDistTraveled",
+        "type": "number"
+      },
+      "tripId": {
+        "description": "The trip_id for which the shape_dist_traveled is defined",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [
+        "file-requirements"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A stop_time entry has a `shape_dist_traveled` without a `stop_id` value.",
+    "type": "object"
+  },
+  "service_window_outside_feed_period": {
+    "code": "service_window_outside_feed_period",
+    "deprecated": false,
+    "properties": {
+      "daysAfterFeedEnd": {
+        "description": "Number of days the service window extends after feed_end_date (0 if none).",
+        "fieldName": "daysAfterFeedEnd",
+        "type": "integer"
+      },
+      "daysBeforeFeedStart": {
+        "description": "Number of days the service window extends before feed_start_date (0 if none).",
+        "fieldName": "daysBeforeFeedStart",
+        "type": "integer"
+      },
+      "serviceId": {
+        "description": "The service_id whose active window extends outside the feed validity period.",
+        "fieldName": "serviceId",
+        "type": "string"
+      },
+      "serviceWindowEndDate": {
+        "description": "The last active date of the service window.",
+        "fieldName": "serviceWindowEndDate",
+        "type": "string"
+      },
+      "serviceWindowStartDate": {
+        "description": "The first active date of the service window.",
+        "fieldName": "serviceWindowStartDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt",
+        "calendar_dates.txt",
+        "feed_info.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "A service window is not covered by the feed's validity period.",
+    "type": "object"
+  },
+  "invalid_float": {
+    "code": "invalid_float",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "Faulty record's field name.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Faulty value.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [],
+      "sectionReferences": [
+        "field-types"
+      ],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field cannot be parsed as a floating point number.",
+    "type": "object"
+  },
+  "route_short_name_too_long": {
+    "code": "route_short_name_too_long",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "routeId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "routeId",
+        "type": "string"
+      },
+      "routeShortName": {
+        "description": "The faulty record's `route_short_name`.",
+        "fieldName": "routeShortName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [
+        "routes.txt"
+      ],
+      "fileReferences": [
+        "routes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Short name of a route is too long (more than 12 characters).",
+    "type": "object"
+  },
+  "timeframe_only_start_or_end_time_specified": {
+    "code": "timeframe_only_start_or_end_time_specified",
+    "deprecated": false,
+    "description": "Either both must be specified or neither must be specified.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number for the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "timeframes.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from `timeframes.txt` was found with only one of `start_time` and `end_time` specified.",
+    "type": "object"
+  },
+  "forbidden_arrival_or_departure_time": {
+    "code": "forbidden_arrival_or_departure_time",
+    "deprecated": false,
+    "description": "This violates GTFS specification, as both cannot coexist for a single stop time record.",
+    "properties": {
+      "arrivalTime": {
+        "description": "The arrival time of the faulty record.",
+        "fieldName": "arrivalTime",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "departureTime": {
+        "description": "The departure time of the faulty record.",
+        "fieldName": "departureTime",
+        "type": "string"
+      },
+      "endPickupDropOffWindow": {
+        "description": "The end pickup drop off window of the faulty record.",
+        "fieldName": "endPickupDropOffWindow",
+        "type": "string"
+      },
+      "startPickupDropOffWindow": {
+        "description": "The start pickup drop off window of the faulty record.",
+        "fieldName": "startPickupDropOffWindow",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "The arrival or departure times are provided alongside pickup or drop-off windows in `stop_times.txt`.",
+    "type": "object"
+  },
+  "unused_shape": {
+    "code": "unused_shape",
+    "deprecated": false,
+    "description": "All records defined by GTFS `shapes.txt` should be used in `trips.txt`.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "shapeId": {
+        "description": "The faulty record's id.",
+        "fieldName": "shapeId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "shapes.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": [
+        {
+          "label": "Shapes Data Guidance",
+          "url": "https://gtfs.org/resources/gtfs-schedule-feature-guides/shapes/#shapes-data-guidance"
+        }
+      ]
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Shape is not used in GTFS file `trips.txt`.",
+    "type": "object"
+  },
+  "stop_time_with_only_arrival_or_departure_time": {
+    "code": "stop_time_with_only_arrival_or_departure_time",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "specifiedField": {
+        "description": "Either `arrival_time` or `departure_time`",
+        "fieldName": "specifiedField",
+        "type": "string"
+      },
+      "stopSequence": {
+        "description": "The sequence of the faulty stop.",
+        "fieldName": "stopSequence",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The trip_id associated to the faulty record.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Missing `stop_times.arrival_time` or `stop_times.departure_time`.",
+    "type": "object"
+  },
+  "forbidden_prior_notice_start_day": {
+    "code": "forbidden_prior_notice_start_day",
+    "deprecated": false,
+    "properties": {
+      "bookingRuleId": {
+        "description": "The `booking_rules.booking_rule_id` of the faulty record.",
+        "fieldName": "bookingRuleId",
+        "type": "string"
+      },
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "priorNoticeDurationMax": {
+        "description": "The value of the `prior_notice_duration_max` field.",
+        "fieldName": "priorNoticeDurationMax",
+        "type": "integer"
+      },
+      "priorNoticeStartDay": {
+        "description": "The value of the `prior_notice_duration_min` field.",
+        "fieldName": "priorNoticeStartDay",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "booking_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "`prior_notice_start_day` value is forbidden when `prior_notice_duration_max` is set.",
+    "type": "object"
+  },
+  "i_o_error": {
+    "code": "i_o_error",
+    "deprecated": false,
+    "properties": {
+      "exception": {
+        "description": "The name of the exception.",
+        "fieldName": "exception",
+        "type": "string"
+      },
+      "message": {
+        "description": "The error message that explains the reason for the exception.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Error in IO operation.",
+    "type": "object"
+  },
+  "future_feed": {
+    "code": "future_feed",
+    "deprecated": false,
+    "description": "The minimum `start_date` in `feed_info.txt` is greater than today's date, indicating the\nfeed covers the future only.",
+    "properties": {
+      "currentDate": {
+        "description": "Current date.",
+        "fieldName": "currentDate",
+        "type": "string"
+      },
+      "feedStartDate": {
+        "description": "Feed start date.",
+        "fieldName": "feedStartDate",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "feed_info.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "INFO",
+    "shortSummary": "The feed covers the future only.",
+    "type": "object"
+  },
+  "translation_unexpected_value": {
+    "code": "translation_unexpected_value",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "fieldName": {
+        "description": "The name of the field that was expected to be empty.",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fieldValue": {
+        "description": "Actual value of the field that was expected to be empty.",
+        "fieldName": "fieldValue",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "translations.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A field in a translations row has value but must be empty.",
+    "type": "object"
+  },
+  "pathway_to_stop_with_access_outside_of_station_pathways": {
+    "code": "pathway_to_stop_with_access_outside_of_station_pathways",
+    "deprecated": false,
+    "description": "Stops with stop_access=1 should not have pathways that link to them since they can be\naccessed from the street and are independent of the pathways inside the station.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "pathwayId": {
+        "description": "The pathway_id of the pathway record that triggered this notice.",
+        "fieldName": "pathwayId",
+        "type": "string"
+      },
+      "platformCode": {
+        "description": "The platform code (if available) associated with the stop referenced by this pathway.",
+        "fieldName": "platformCode",
+        "type": "string"
+      },
+      "stopId": {
+        "description": "The stop_id (either from_stop_id or to_stop_id) that has stop_access == 1.",
+        "fieldName": "stopId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "pathways.txt",
+        "stops.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A pathway has an endpoint that is a stop with stop_access=1, which should be accessible outside of the station’s pathways.",
+    "type": "object"
+  },
+  "route_networks_specified_in_more_than_one_file": {
+    "code": "route_networks_specified_in_more_than_one_file",
+    "deprecated": false,
+    "description": "This notice highlights a data integrity issue where route network specifications are\nredundantly defined in more than one file. According to specifications, a route network\nidentifier should be uniquely defined in a single file. Any additional definitions of route\nnetwork specifications in other files are considered conditionally forbidden.",
+    "properties": {
+      "fieldName": {
+        "description": "Name of the field in fileNameA",
+        "fieldName": "fieldName",
+        "type": "string"
+      },
+      "fileNameA": {
+        "description": "The name of the first file.",
+        "fieldName": "fileNameA",
+        "type": "string"
+      },
+      "fileNameB": {
+        "description": "The name of the second file which presence duplicates route networks specification.",
+        "fieldName": "fileNameB",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "routes.txt",
+        "route_networks.txt",
+        "networks.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Indicates that route network identifiers are specified across multiple files.",
+    "type": "object"
+  },
+  "transfer_with_suspicious_mid_trip_in_seat": {
+    "code": "transfer_with_suspicious_mid_trip_in_seat",
+    "deprecated": false,
+    "description": "For in-seat transfers, we expect the stop to be the last stop-time in the trip sequence for\n`from_stop_id` and the first stop-time for `to_stop_id`. If you are intentionally using this\nfeature to model mid-trip transfers, you can ignore this warning, but be aware that this\nfunctionality is still considered to be partially experimental in some interpretations of the\nspec.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number from `transfers.txt` for the faulty entry.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "stopId": {
+        "description": "The referenced stop id.",
+        "fieldName": "stopId",
+        "type": "string"
+      },
+      "stopIdFieldName": {
+        "description": "The name of the stop id field (e.g. `from_stop_id`) referencing the stop.",
+        "fieldName": "stopIdFieldName",
+        "type": "string"
+      },
+      "tripId": {
+        "description": "The referenced trip id.",
+        "fieldName": "tripId",
+        "type": "string"
+      },
+      "tripIdFieldName": {
+        "description": "The name of the trip id field (e.g. `from_trip_id`) referencing a trip.",
+        "fieldName": "tripIdFieldName",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "transfers.txt",
+        "stops.txt",
+        "stop_times.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A trip id field from GTFS file `transfers.txt` with an in-seat transfer type references a stop that is not in the expected position in the trip's stop-times.",
+    "type": "object"
+  },
+  "service_has_no_active_day_of_the_week": {
+    "code": "service_has_no_active_day_of_the_week",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number in calendar.txt where the error occurs.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "serviceId": {
+        "description": "The service_id field value.",
+        "fieldName": "serviceId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "calendar.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A service is not valid for any day of the week.",
+    "type": "object"
+  },
+  "fare_transfer_rule_duration_limit_type_without_duration_limit": {
+    "code": "fare_transfer_rule_duration_limit_type_without_duration_limit",
+    "deprecated": false,
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit_type` field but no `duration_limit` specified.",
+    "type": "object"
+  },
+  "unusable_trip": {
+    "code": "unusable_trip",
+    "deprecated": false,
+    "description": "A trip must visit more than one stop in stop_times.txt to be usable by passengers for\nboarding and alighting.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row number of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The faulty record's id.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "stop_times.txt",
+        "trips.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "Trips must have more than one stop to be usable.",
+    "type": "object"
+  },
+  "fare_transfer_rule_missing_transfer_count": {
+    "code": "fare_transfer_rule_missing_transfer_count",
+    "deprecated": true,
+    "deprecationReason": "Renamed to `fare_transfer_rule_without_transfer_count`.",
+    "deprecationVersion": "8.0",
+    "description": "Per the spec, `transfer_count` is required if the two leg group ids are equal.",
+    "properties": {
+      "csvRowNumber": {
+        "description": "The row of the faulty record.",
+        "fieldName": "csvRowNumber",
+        "type": "integer"
+      }
+    },
+    "references": {
+      "bestPracticesFileReferences": [],
+      "fileReferences": [
+        "fare_transfer_rules.txt"
+      ],
+      "sectionReferences": [],
+      "urlReferences": []
+    },
+    "replacementNoticeCodes": [
+      "fare_transfer_rule_without_transfer_count"
+    ],
+    "severityLevel": "ERROR",
+    "shortSummary": "A row from `fare_transfer_rules.txt` has `from_leg_group_id` equal to `to_leg_group_id`, but has no `transfer_count` specified.",
+    "type": "object"
+  },
+  "overlapping_zone_and_pickup_drop_off_window": {
+    "code": "overlapping_zone_and_pickup_drop_off_window",
+    "deprecated": false,
+    "description": "Two entities in `stop_times.txt` with the same `trip_id` have the same `pickup_type` or\n`drop_off_type`, overlapping pickup/drop-off windows and overlapping zones in\n`locations.geojson`.",
+    "properties": {
+      "endPickupDropOffWindow1": {
+        "description": "The `end_pickup_drop_off_window` of the first entity in `stop_times.txt`.",
+        "fieldName": "endPickupDropOffWindow1",
+        "type": "string"
+      },
+      "endPickupDropOffWindow2": {
+        "description": "The `end_pickup_drop_off_window` of the second entity in `stop_times.txt`.",
+        "fieldName": "endPickupDropOffWindow2",
+        "type": "string"
+      },
+      "locationId1": {
+        "description": "The `location_id` of the first entity.",
+        "fieldName": "locationId1",
+        "type": "string"
+      },
+      "locationId2": {
+        "description": "The `location_id` of the second entity.",
+        "fieldName": "locationId2",
+        "type": "string"
+      },
+      "startPickupDropOffWindow1": {
+        "description": "The `start_pickup_drop_off_window` of the first entity in `stop_times.txt`.",
+        "fieldName": "startPickupDropOffWindow1",
+        "type": "string"
+      },
+      "startPickupDropOffWindow2": {
+        "description": "The `start_pickup_drop_off_window` of the second entity in `stop_times.txt`.",
+        "fieldName": "startPickupDropOffWindow2",
+        "type": "string"
+      },
+      "stopSequence1": {
+        "description": "The `stop_sequence` of the first entity in `stop_times.txt`.",
+        "fieldName": "stopSequence1",
+        "type": "integer"
+      },
+      "stopSequence2": {
+        "description": "The `stop_sequence` of the second entity in `stop_times.txt`.",
+        "fieldName": "stopSequence2",
+        "type": "integer"
+      },
+      "tripId": {
+        "description": "The `trip_id` of the entities.",
+        "fieldName": "tripId",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "Two entities have overlapping pickup/drop-off windows and zones.",
+    "type": "object"
+  },
+  "unsupported_geometry_type": {
+    "code": "unsupported_geometry_type",
+    "deprecated": false,
+    "description": "Each feature must have a geometry type that is supported by the GTFS spec. The supported\ngeometry types `Polygon` and `MultiPolygon`.",
+    "properties": {
+      "featureId": {
+        "description": "The id of the faulty record.",
+        "fieldName": "featureId",
+        "type": "string"
+      },
+      "featureIndex": {
+        "description": "The index of the feature in the feature collection.",
+        "fieldName": "featureIndex",
+        "type": "integer"
+      },
+      "geometryType": {
+        "description": "The geometry type of the faulty record.",
+        "fieldName": "geometryType",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "A GeoJSON feature has an unsupported geometry type in `locations.geojson`.",
+    "type": "object"
+  },
+  "runtime_exception_in_loader_error": {
+    "code": "runtime_exception_in_loader_error",
+    "deprecated": false,
+    "description": "A\n[RuntimeException](https://docs.oracle.com/javase/8/docs/api/java/lang/RuntimeException.html)\noccurred while loading a table. This normally indicates a bug in validator.",
+    "properties": {
+      "exception": {
+        "description": "The name of the exception.",
+        "fieldName": "exception",
+        "type": "string"
+      },
+      "filename": {
+        "description": "The name of the file that caused the exception.",
+        "fieldName": "filename",
+        "type": "string"
+      },
+      "message": {
+        "description": "The error message that explains the reason for the exception.",
+        "fieldName": "message",
+        "type": "string"
+      }
+    },
+    "severityLevel": "ERROR",
+    "shortSummary": "RuntimeException while loading GTFS dataset in memory.",
+    "type": "object"
+  },
+  "missing_recommended_file": {
+    "code": "missing_recommended_file",
+    "deprecated": false,
+    "properties": {
+      "filename": {
+        "description": "The name of the faulty file.",
+        "fieldName": "filename",
+        "type": "string"
+      }
+    },
+    "severityLevel": "WARNING",
+    "shortSummary": "A recommended file is missing.",
+    "type": "object"
+  }
 }

--- a/apps/transport/test/transport/validators/mobilitydata_gtfs_validator_test.exs
+++ b/apps/transport/test/transport/validators/mobilitydata_gtfs_validator_test.exs
@@ -180,6 +180,35 @@ defmodule Transport.Validators.MobilityDataGTFSValidatorTest do
     refute TransportWeb.DatasetView.multi_validation_performed?(mv)
   end
 
+  describe "rule_for_code/1" do
+    test "returns the rule for a known code" do
+      rule = MobilityDataGTFSValidator.rule_for_code("attribution_without_role")
+
+      assert rule["code"] == "attribution_without_role"
+      assert rule["severityLevel"] == "WARNING"
+      assert rule["shortSummary"] == "Attribution with no role."
+      assert rule["deprecated"] == false
+    end
+
+    test "returns a safe fallback for an unknown code instead of crashing" do
+      rule = MobilityDataGTFSValidator.rule_for_code("totally_new_rule_that_does_not_exist")
+
+      assert rule["code"] == "totally_new_rule_that_does_not_exist"
+      assert rule["shortSummary"] == "Unknown rule: totally_new_rule_that_does_not_exist"
+      assert rule["description"] == nil
+      assert rule["properties"] == %{}
+      assert rule["severityLevel"] == "WARNING"
+      assert rule["deprecated"] == false
+
+      assert rule["references"] == %{
+               "fileReferences" => [],
+               "bestPracticesFileReferences" => [],
+               "sectionReferences" => [],
+               "urlReferences" => []
+             }
+    end
+  end
+
   test "validate_and_save when unexpected_validation_status" do
     gtfs_url = "https://example.com/gtfs"
     job_id = Ecto.UUID.generate()


### PR DESCRIPTION
- fournit également une tâche pour télécharger les-dites règles depuis la dernière version
- protège des futures nouvelles règles inconnues avec un message générique en fallback

Fixes #5573