### PR TITLE
MAJ notification expiration des données 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check dependencies for security advisories
         # Bump Hex: advisory scanning (not just retirements) landed in 2.5.0.
+        # For now, continue on error, to avoid blocking each PR. We will move it to a separate worfklow.
+        continue-on-error: true
         run: |
           mix local.hex 2.5.1 --force
           mix hex.audit

--- a/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
+++ b/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
@@ -2,9 +2,11 @@ Bonjour,
 
 Les données GTFS <%= @resource_titles %> associées au jeu de données <%= link_for_dataset(@dataset) %> <%= @delay_str %>.
 
-Nous vous invitons à les mettre à jour en [remplaçant la ressource périmée par la nouvelle](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau) afin que vos données puissent être utilisées par les différents acteurs.
+Nous vous invitons à les mettre à jour dès maintenant en [remplaçant la ressource périmée par la nouvelle](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau).
 
-Afin de garantir une continuité dans l’utilisation de vos données, nous vous encourageons à anticiper les futures mises à jour au moins 1 mois avant la date d’expiration.
+Si vous êtes dans impossibilité d'effectuer cette mise à jour dans l'immédiat, nous vous suggérons de laisser un message dans l'espace discussions afin d'informer les différents acteurs de la prise en compte du problème et de la date prévisionnelle de mise à jour, le cas échéant.
+
+Afin de garantir une continuité de l’utilisation de vos données et de l'information voyageur diffusée par des acteurs tiers, nous vous encourageons à anticiper les futures mises à jour au moins 1 mois avant la date d’expiration.
 
 À bientôt,
 

--- a/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
+++ b/apps/transport/lib/transport_web/templates/email/expiration_producer.html.md
@@ -4,7 +4,7 @@ Les données GTFS <%= @resource_titles %> associées au jeu de données <%= link
 
 Nous vous invitons à les mettre à jour dès maintenant en [remplaçant la ressource périmée par la nouvelle](https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau).
 
-Si vous êtes dans impossibilité d'effectuer cette mise à jour dans l'immédiat, nous vous suggérons de laisser un message dans l'espace discussions afin d'informer les différents acteurs de la prise en compte du problème et de la date prévisionnelle de mise à jour, le cas échéant.
+Si vous êtes dans impossibilité d'effectuer cette mise à jour dans l'immédiat, nous vous suggérons de laisser un message dans <%= link_for_dataset_discussions(@dataset) %> afin d'informer les différents acteurs de la prise en compte du problème et de la date prévisionnelle de mise à jour, le cas échéant.
 
 Afin de garantir une continuité de l’utilisation de vos données et de l'information voyageur diffusée par des acteurs tiers, nous vous encourageons à anticiper les futures mises à jour au moins 1 mois avant la date d’expiration.
 

--- a/apps/transport/test/transport/jobs/expiration_notification_job_test.exs
+++ b/apps/transport/test/transport/jobs/expiration_notification_job_test.exs
@@ -169,6 +169,9 @@ defmodule Transport.Test.Transport.Jobs.ExpirationNotificationJobTest do
 
         assert html_body =~
                  ~s(<a href="https://doc.transport.data.gouv.fr/administration-des-donnees/procedures-de-publication/mettre-a-jour-des-donnees#remplacer-un-jeu-de-donnees-existant-plutot-quen-creer-un-nouveau">remplaçant la ressource périmée par la nouvelle</a>)
+
+        assert html_body =~
+                 ~s(laisser un message dans <a href="http://127.0.0.1:5100/datasets/#{dataset.slug}#dataset-discussions">l’espace de discussion du jeu de données</a>)
       end)
 
       # Notification logs


### PR DESCRIPTION
En lien avec l'issue #5585 et je profite aussi pour proposer un texte plus concis au début et une notre sur l'information voyageur à la fin pour que le producteur comprenne l'impact de l'absence de la mise à jour. A discuter.

Dans la mesure du possible, avez-vous la possibilité d'insérer automatiquement un lien sur les mots "espace discussions" vers la partie discussion ('#dataset-discussions' à la fin de l'url) du jeu de données en question ? Exemple : https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm#dataset-discussions pour le jeu [Citéa](https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm)