### PR TITLE
Tentative de stabilisation de tests

### DIFF
--- a/apps/transport/test/transport/jobs/workflow_test.exs
+++ b/apps/transport/test/transport/jobs/workflow_test.exs
@@ -1,5 +1,5 @@
 defmodule Transport.Jobs.WorkflowTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Oban.Testing, repo: DB.Repo
   import Transport.Jobs.Workflow
   import Ecto.Adapters.SQL.Sandbox


### PR DESCRIPTION
Erreur fréquemment rencontrée sur ma machine :

```
1) test a workflow with custom job options (Transport.Jobs.WorkflowTest)
    apps/transport/test/transport/jobs/workflow_test.exs:83
    Expected a job matching:

    %{args: %{"some_id" => 1}, worker: Transport.Jobs.Dummy.JobA}

    to be enqueued within 200ms

    code: assert_enqueued(
    stacktrace:
      test/transport/jobs/workflow_test.exs:105: (test)
```