### PR TITLE
fix: Reject nested archives during NeTEx validation

### DIFF
--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -30,6 +30,7 @@ defmodule Transport.Validators.NeTEx.Validator do
   def poll_interval(_), do: 20
 
   @validator_name "enroute-chouette-netex-validator"
+  @nested_archive_code "pan:french_profile:nested_archive"
 
   @impl Transport.Validators.Validator
   def validator_name, do: @validator_name
@@ -77,7 +78,7 @@ defmodule Transport.Validators.NeTEx.Validator do
         :ok
 
       {:error, %{details: {result_url, errors}, elapsed_seconds: elapsed_seconds, retries: retries}} ->
-        notify_success()
+        notify_success(result_url)
 
         insert_validation_results(
           resource_history_id,
@@ -155,9 +156,9 @@ defmodule Transport.Validators.NeTEx.Validator do
          }}
 
       {:error, %{details: {result_url, errors}, elapsed_seconds: elapsed_seconds, retries: retries}} ->
-        notify_success()
+        notify_success(result_url)
 
-        Logger.info("Result URL: #{result_url}")
+        log_result_url(result_url)
         # result_url in metadata?
         {:ok,
          %{
@@ -245,7 +246,53 @@ defmodule Transport.Validators.NeTEx.Validator do
   end
 
   defp validate_with_enroute(filepath, metadata) do
-    setup_validation(filepath) |> poll_validation_results(metadata, 0)
+    case nested_archive_errors(filepath) do
+      [] -> setup_validation(filepath) |> poll_validation_results(metadata, 0)
+      errors -> {:error, %{details: {nil, errors}, elapsed_seconds: 0, retries: 0}}
+    end
+  end
+
+  defp nested_archive_errors(filepath) do
+    zip_file = Unzip.LocalFile.open(filepath)
+
+    case Unzip.new(zip_file) do
+      {:ok, unzip} ->
+        unzip
+        |> Unzip.list_entries()
+        |> Enum.filter(&nested_archive?(unzip, &1.file_name))
+        |> Enum.map(&nested_archive_error(&1.file_name))
+
+      _ ->
+        []
+    end
+  after
+    Unzip.LocalFile.close(zip_file)
+  end
+
+  defp nested_archive?(unzip, file_name) do
+    unzip
+    |> Unzip.file_stream!(file_name, chunk_size: 4)
+    |> Enum.reduce_while(<<>>, fn chunk, prefix ->
+      prefix = prefix <> IO.iodata_to_binary(chunk)
+
+      if byte_size(prefix) >= 4 do
+        {:halt, binary_part(prefix, 0, 4)}
+      else
+        {:cont, prefix}
+      end
+    end)
+    |> Transport.ZipProbe.likely_zip_content?()
+  rescue
+    _ -> false
+  end
+
+  defp nested_archive_error(file_name) do
+    %{
+      "code" => @nested_archive_code,
+      "criticity" => "error",
+      "message" => "Nested archive #{file_name} is forbidden by the French NeTEx profile",
+      "resource" => %{"filename" => file_name}
+    }
   end
 
   defp setup_validation(filepath), do: client().create_a_validation(filepath, ResultsAdapter.french_profile().slug())
@@ -286,6 +333,12 @@ defmodule Transport.Validators.NeTEx.Validator do
   end
 
   defp notify_success, do: Appsignal.increment_counter("enroute_chouette_valid.success", 1)
+
+  defp notify_success(nil), do: :ok
+  defp notify_success(_result_url), do: notify_success()
+
+  defp log_result_url(nil), do: :ok
+  defp log_result_url(result_url), do: Logger.info("Result URL: #{result_url}")
 
   defp notify_invalid_api_call, do: Appsignal.increment_counter("enroute_chouette_valid.invalid_api_call", 1)
 

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -240,6 +240,22 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
       assert multi_validation.binary_result == ResultsAdapter.to_binary_result(result)
     end
 
+    test "nested archive" do
+      resource_history =
+        nested_archive_content()
+        |> mk_raw_netex_resource()
+        |> mk_netex_resource()
+
+      assert :ok == Validator.validate_and_save(resource_history)
+
+      multi_validation = load_multi_validation(resource_history.id)
+      result = %{"french-profile" => [nested_archive_error("payload.XML")]}
+
+      assert multi_validation.digest == ResultsAdapter.digest(result)
+      assert multi_validation.binary_result == ResultsAdapter.to_binary_result(result)
+      assert multi_validation.max_error == "error"
+    end
+
     defp load_multi_validation(resource_history_id) do
       DB.MultiValidation.base_query(include_binary_result: true)
       |> DB.Repo.get_by(resource_history_id: resource_history_id)
@@ -414,6 +430,28 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
 
       assert {:pending, {validation_id, metadata}} == Validator.validate(resource_url)
     end
+
+    test "rejects every ZIP content member without relying on a lowercase zip extension" do
+      nested_archive = nested_archive_content()
+
+      resource_url =
+        mk_raw_netex_resource([
+          {"payload.XML", nested_archive},
+          {"SECOND", nested_archive}
+        ])
+
+      assert {:ok,
+              %{
+                "validations" => %{"french-profile" => errors},
+                "metadata" => _metadata
+              }} = Validator.validate(resource_url)
+
+      assert MapSet.new(errors) ==
+               MapSet.new([
+                 nested_archive_error("payload.XML"),
+                 nested_archive_error("SECOND")
+               ])
+    end
   end
 
   defp mk_line(public_code, mode) do
@@ -430,13 +468,17 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
   end
 
   defp mk_netex_resource_with_calendar(start_date, end_date, network, lines) do
+    mk_netex(start_date, end_date, network, lines) |> mk_netex_resource()
+  end
+
+  defp mk_netex_resource(resource_url) do
     dataset = insert(:dataset)
 
     resource = insert(:resource, dataset_id: dataset.id, format: "NeTEx")
 
     insert(:resource_history,
       resource_id: resource.id,
-      payload: %{"permanent_url" => mk_netex(start_date, end_date, network, lines)}
+      payload: %{"permanent_url" => resource_url}
     )
   end
 
@@ -447,7 +489,11 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
         {"network.xml", network_content(network, lines)}
       ])
 
-  defp mk_raw_netex_resource(content) do
+  defp mk_raw_netex_resource(content) when is_binary(content) do
+    mk_raw_netex_resource([{"payload.XML", content}])
+  end
+
+  defp mk_raw_netex_resource(content) when is_list(content) do
     resource_url = generate_resource_url()
 
     expect(Transport.Req.Mock, :get!, 1, fn ^resource_url, [{:compressed, false}, {:into, into}] ->
@@ -457,6 +503,19 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
     end)
 
     resource_url
+  end
+
+  defp nested_archive_content do
+    ZipCreator.with_tmp_zip([{"resource.xml", "<PublicationDelivery />"}], &File.read!/1)
+  end
+
+  defp nested_archive_error(file_name) do
+    %{
+      "code" => "pan:french_profile:nested_archive",
+      "criticity" => "error",
+      "message" => "Nested archive #{file_name} is forbidden by the French NeTEx profile",
+      "resource" => %{"filename" => file_name}
+    }
   end
 
   defp zip_file(path, content) do


### PR DESCRIPTION
Add a preflight check in `Transport.Validators.NeTEx.Validator` after the outer archive has been downloaded and before it is submitted to enRoute. Inspect outer entries for ZIP content using the repository's existing ZIP-signature detection, and convert every detected nested archive into a local French-profile validation error that identifies the member; do not recursively validate prohibited content or call the remote validator for that archive. A NeTEx ZIP whose members are themselves ZIP archives currently reaches enRoute Chouette Valid and can be reported as having no errors even though the nested payloads were never inspected. The reporter demonstrated that a 32-archive aggregate is green while one of the same inner archives produces many XSD and base-rule errors when submitted alone.

A normal NeTEx archive containing XML files still calls enRoute and preserves the existing successful, failed, and pending result behavior; An outer ZIP containing an inner ZIP returns a French-profile error for on-demand validation and never invokes the enRoute client.

Fixes #5563
