### PR TITLE
NeTEx: extrait la publication date dans les metadata

### DIFF
--- a/apps/transport/lib/netex/archive_parser.ex
+++ b/apps/transport/lib/netex/archive_parser.ex
@@ -163,6 +163,37 @@ defmodule Transport.NeTEx.ArchiveParser do
     read_all(zip_file_name, &read_description!/2)
   end
 
+  @doc """
+  Inside a zip archive opened with `Unzip`, parse a given file (pointed by
+  `file_name`) and extract the publication timestamp. The file is read in
+  streaming fashion.
+  """
+  def read_publication_timestamp(%Unzip{} = unzip, file_name) do
+    parse_stream(unzip, file_name, Transport.NeTEx.PublicationTimestampParser)
+  end
+
+  @doc """
+  Like read_publication_timestamp/2 but raises on errors.
+  """
+  def read_publication_timestamp!(%Unzip{} = unzip, file_name) do
+    parse_stream!(unzip, file_name, Transport.NeTEx.PublicationTimestampParser)
+  end
+
+  @doc """
+  A higher level method. Given a NeTEx zip archive stored on disk, return the
+  publication timestamp per XML file contained in the archive.
+  """
+  def read_all_publication_timestamps(zip_file_name) do
+    read_all(zip_file_name, &read_publication_timestamp/2)
+  end
+
+  @doc """
+  Like read_all_publication_timestamps/1 but raises on error.
+  """
+  def read_all_publication_timestamps!(zip_file_name) do
+    read_all(zip_file_name, &read_publication_timestamp!/2)
+  end
+
   defp parse_stream(unzip, file_name, parser) do
     extension = Path.extname(file_name)
 

--- a/apps/transport/lib/netex/publication_timestamp_parser.ex
+++ b/apps/transport/lib/netex/publication_timestamp_parser.ex
@@ -1,0 +1,46 @@
+defmodule Transport.NeTEx.PublicationTimestampParser do
+  @moduledoc """
+  SAX streaming parser to extract the `PublicationTimestamp` from a NeTEx XML file.
+
+  Returns a `Date.t() | nil`. If multiple timestamps exist across files, the
+  earliest one wins (determined by the caller).
+  """
+
+  @behaviour Saxy.Handler
+
+  import Transport.NeTEx.SaxyHelpers
+
+  def initial_state do
+    capturing_initial_state(%{timestamp: nil})
+  end
+
+  def unwrap_result(%{timestamp: timestamp}), do: timestamp
+
+  def handle_event(:start_element, {"PublicationTimestamp", _attributes}, state) do
+    {:ok, state |> push("PublicationTimestamp") |> start_capture()}
+  end
+
+  def handle_event(:end_element, "PublicationTimestamp", state) do
+    {:ok, state |> stop_capture() |> pop()}
+  end
+
+  def handle_event(:characters, chars, state) when state.capture and is_nil(state.timestamp) do
+    case parse_date(state, chars, fn date -> date end) do
+      {:ok, %Date{} = date} ->
+        {:ok, %{state | timestamp: date}}
+
+      _ ->
+        {:ok, state}
+    end
+  end
+
+  def handle_event(:start_element, {element, _attributes}, state) do
+    {:ok, state |> push(element)}
+  end
+
+  def handle_event(:end_element, _element, state) do
+    {:ok, pop(state)}
+  end
+
+  def handle_event(_, _, state), do: {:ok, state}
+end

--- a/apps/transport/lib/validators/netex/metadata_extractor.ex
+++ b/apps/transport/lib/validators/netex/metadata_extractor.ex
@@ -7,7 +7,10 @@ defmodule Transport.Validators.NeTEx.MetadataExtractor do
   alias Transport.NeTEx.ArchiveParser
 
   def extract(filepath) do
-    Map.merge(extract_validity_dates(filepath), describe_content(filepath))
+    Map.merge(
+      extract_validity_dates(filepath),
+      Map.merge(describe_content(filepath), extract_publication_info(filepath))
+    )
   end
 
   def extract_validity_dates(filepath) do
@@ -69,6 +72,25 @@ defmodule Transport.Validators.NeTEx.MetadataExtractor do
     end
   end
 
+  @doc """
+  Extract the earliest publication timestamp from all XML files in the archive.
+
+  Returns `%{"publication_date" => iso8601_string}` if any `PublicationTimestamp`
+  was found, or `%{}` otherwise. Fallbacks to upload date / today are handled
+  by `NeTEx.Validator.determine_xsd_version/2`.
+  """
+  def extract_publication_info(filepath) do
+    case earliest_publication_timestamp(filepath) do
+      %Date{} = date ->
+        %{"publication_date" => Date.to_iso8601(date)}
+
+      nil ->
+        %{}
+    end
+  rescue
+    _ -> %{}
+  end
+
   defp no_validity_dates, do: %{"no_validity_dates" => true}
 
   defp validity_dates(filepath) do
@@ -109,6 +131,20 @@ defmodule Transport.Validators.NeTEx.MetadataExtractor do
         _ -> acc
       end
     end)
+  end
+
+  defp earliest_publication_timestamp(filepath) do
+    timestamps =
+      filepath
+      |> ArchiveParser.read_all_publication_timestamps()
+      |> Enum.flat_map(fn {_filename, result} ->
+        case result do
+          {:ok, %Date{} = date} -> [date]
+          _ -> []
+        end
+      end)
+
+    if timestamps == [], do: nil, else: Enum.min(timestamps)
   end
 
   defp uniq(list), do: list |> MapSet.new() |> MapSet.to_list()

--- a/apps/transport/test/transport/netex/publication_timestamp_parser_test.exs
+++ b/apps/transport/test/transport/netex/publication_timestamp_parser_test.exs
@@ -1,0 +1,78 @@
+defmodule Transport.NeTEx.PublicationTimestampParserTest do
+  use ExUnit.Case, async: true
+
+  alias Transport.NeTEx.PublicationTimestampParser
+
+  describe "parsing PublicationTimestamp" do
+    test "extracts valid ISO 8601 date with Z suffix" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-07-29T09:34:55Z</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert %Date{year: 2025, month: 7, day: 29} = PublicationTimestampParser.unwrap_result(state)
+    end
+
+    test "extracts valid ISO 8601 date without Z suffix" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-07-29T09:34:55</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert %Date{year: 2025, month: 7, day: 29} = PublicationTimestampParser.unwrap_result(state)
+    end
+
+    test "extracts valid date with offset" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-07-29T11:34:55+02:00</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert %Date{year: 2025, month: 7, day: 29} = PublicationTimestampParser.unwrap_result(state)
+    end
+
+    test "returns nil when no PublicationTimestamp element" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <ParticipantRef>DIGO</ParticipantRef>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert nil == PublicationTimestampParser.unwrap_result(state)
+    end
+
+    test "returns nil when PublicationTimestamp contains invalid date" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>not-a-date</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert nil == PublicationTimestampParser.unwrap_result(state)
+    end
+
+    test "captures first timestamp when multiple exist" do
+      xml = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-01-15T00:00:00Z</PublicationTimestamp>
+          <dataObjects>
+            <GeneralFrame id="frame1">
+              <PublicationTimestamp>2025-06-01T00:00:00Z</PublicationTimestamp>
+            </GeneralFrame>
+          </dataObjects>
+        </PublicationDelivery>
+      """
+
+      {:ok, state} = Saxy.parse_string(xml, PublicationTimestampParser, PublicationTimestampParser.initial_state())
+      assert %Date{year: 2025, month: 1, day: 15} = PublicationTimestampParser.unwrap_result(state)
+    end
+  end
+end

--- a/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
+++ b/apps/transport/test/transport/validators/netex/metadata_extractor_test.exs
@@ -61,6 +61,67 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
     end
   end
 
+  describe "publication timestamp" do
+    test "extracts publication date from single file" do
+      content = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-07-29T09:34:55Z</PublicationTimestamp>
+          <ParticipantRef>DIGO</ParticipantRef>
+        </PublicationDelivery>
+      """
+
+      ZipCreator.with_tmp_zip([{"resource.xml", content}], fn filepath ->
+        result = MetadataExtractor.extract(filepath)
+        assert result["publication_date"] == "2025-07-29"
+      end)
+    end
+
+    test "extracts earliest publication date from multiple files" do
+      file1 = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-08-15T09:34:55Z</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      file2 = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>2025-07-01T09:34:55Z</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      ZipCreator.with_tmp_zip([{"file1.xml", file1}, {"file2.xml", file2}], fn filepath ->
+        result = MetadataExtractor.extract(filepath)
+        assert result["publication_date"] == "2025-07-01"
+      end)
+    end
+
+    test "returns no publication_date when no timestamp in archive" do
+      content = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <ParticipantRef>DIGO</ParticipantRef>
+        </PublicationDelivery>
+      """
+
+      ZipCreator.with_tmp_zip([{"resource.xml", content}], fn filepath ->
+        result = MetadataExtractor.extract(filepath)
+        refute Map.has_key?(result, "publication_date")
+      end)
+    end
+
+    test "ignores invalid publication timestamps" do
+      content = """
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+          <PublicationTimestamp>not-a-date</PublicationTimestamp>
+        </PublicationDelivery>
+      """
+
+      ZipCreator.with_tmp_zip([{"resource.xml", content}], fn filepath ->
+        result = MetadataExtractor.extract(filepath)
+        refute Map.has_key?(result, "publication_date")
+      end)
+    end
+  end
+
   describe "validity dates" do
     test "simple NeTEx archive" do
       calendar_content = """
@@ -82,6 +143,7 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
         assert %{
                  "start_date" => "2025-07-05",
                  "end_date" => "2025-08-31",
+                 "publication_date" => "2025-07-29",
                  "networks" => [],
                  "modes" => [],
                  "stats" => %{
@@ -187,6 +249,7 @@ defmodule Transport.Validators.NeTEx.MetadataExtractorTest do
       ZipCreator.with_tmp_zip([{"network.xml", multiple_networks}] |> in_sub_directory(), fn filepath ->
         assert %{
                  "no_validity_dates" => true,
+                 "publication_date" => "2026-02-02",
                  "networks" => ["Réseau Urbain", "Réseau Régional"],
                  "modes" => ["bus", "ferry"],
                  "stats" => %{

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -77,6 +77,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
       assert multi_validation.metadata.metadata == %{
                "retries" => 0,
                "elapsed_seconds" => 12,
+               "publication_date" => "2025-07-29",
                "start_date" => start_date,
                "end_date" => end_date,
                "networks" => [network],
@@ -181,6 +182,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
       assert multi_validation.metadata.metadata == %{
                "retries" => 0,
                "elapsed_seconds" => 31,
+               "publication_date" => "2025-07-29",
                "start_date" => start_date,
                "end_date" => end_date,
                "networks" => [network],
@@ -245,6 +247,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                 "metadata" => %{
                   :retries => 0,
                   :elapsed_seconds => 9,
+                  "publication_date" => "2025-07-29",
                   "start_date" => start_date,
                   "end_date" => end_date,
                   "networks" => [network],
@@ -293,6 +296,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
                 "metadata" => %{
                   :retries => 0,
                   :elapsed_seconds => 25,
+                  "publication_date" => "2025-07-29",
                   "start_date" => start_date,
                   "end_date" => end_date,
                   "networks" => [network],
@@ -332,6 +336,7 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
       metadata = %{
         "start_date" => start_date,
         "end_date" => end_date,
+        "publication_date" => "2025-07-29",
         "networks" => [network],
         "modes" => modes,
         "stats" => %{


### PR DESCRIPTION
Contribue à #5594. Cette date aidera à choisir la version de la XSD à valider sans dépendre de la date du jour ou d'autres dates moins fiables.