### PR TITLE
NeTEx: choix de la XSD selon la date de publication

### DIFF
--- a/apps/transport/lib/netex/schema_version_mapper.ex
+++ b/apps/transport/lib/netex/schema_version_mapper.ex
@@ -1,0 +1,19 @@
+defmodule Transport.NeTEx.SchemaVersionMapper do
+  @moduledoc """
+  Maps a publication date to the NeTEx XSD version to validate against.
+
+  French Profile 2.5 (→ NeTEx 2.0) is expected Dec 2026 with a 6-month grace
+  period until June 2027. Archives published during the grace period are
+  validated against the old XSD to avoid penalizing producers who haven't
+  upgraded yet.
+
+  Returns `"v1.3.2"` for dates before June 2027, `"v2.0.0"` otherwise.
+  """
+
+  @spec xsd_version_for_date(Date.t()) :: binary()
+  def xsd_version_for_date(%Date{year: year, month: month, day: day})
+      when {year, month, day} < {2027, 6, 1},
+      do: "v1.3.2"
+
+  def xsd_version_for_date(_), do: "v2.0.0"
+end

--- a/apps/transport/lib/validators/netex/validator.ex
+++ b/apps/transport/lib/validators/netex/validator.ex
@@ -6,6 +6,7 @@ defmodule Transport.Validators.NeTEx.Validator do
 
   require Logger
   alias Transport.Jobs.NeTExPollerJob, as: Poller
+  alias Transport.NeTEx.SchemaVersionMapper
   alias Transport.Validators.NeTEx.MetadataExtractor
   alias Transport.Validators.NeTEx.ResultsAdapters.V0_2_2, as: ResultsAdapter
 
@@ -46,7 +47,7 @@ defmodule Transport.Validators.NeTEx.Validator do
 
   def validate_resource_history(resource_history, filepath) do
     metadata = MetadataExtractor.extract(filepath)
-    xsd_version = "v1.3.2"
+    xsd_version = determine_xsd_version(metadata, resource_history)
     full_metadata = Map.put(metadata, "xsd_version", xsd_version)
 
     validate_with_enroute(filepath, metadata, xsd_version)
@@ -132,7 +133,7 @@ defmodule Transport.Validators.NeTEx.Validator do
   def validate(url) do
     with_url(url, fn filepath ->
       metadata = MetadataExtractor.extract(filepath)
-      xsd_version = "v1.3.2"
+      xsd_version = determine_xsd_version(metadata)
       full_metadata = Map.put(metadata, "xsd_version", xsd_version)
 
       validate_with_enroute(filepath, metadata, xsd_version)
@@ -257,6 +258,42 @@ defmodule Transport.Validators.NeTEx.Validator do
 
   defp setup_validation(filepath, xsd_version),
     do: client().create_a_validation(filepath, ResultsAdapter.french_profile().slug(), xsd_version)
+
+  @doc """
+  Determine the XSD version to use for validation based on a fallback chain:
+
+  1. Earliest `PublicationTimestamp` from XML files (in metadata[\"publication_date\"])
+  2. Fallback: `resource_history.inserted_at` (upload date)
+  3. Fallback: `Date.utc_today()` (on-demand validation, no resource history)
+  """
+  def determine_xsd_version(metadata, resource_history \\ nil) do
+    date =
+      case metadata["publication_date"] do
+        iso when is_binary(iso) ->
+          case Date.from_iso8601(iso) do
+            {:ok, date} -> date
+            _ -> fallback_date(resource_history)
+          end
+
+        _ ->
+          fallback_date(resource_history)
+      end
+
+    SchemaVersionMapper.xsd_version_for_date(date)
+  end
+
+  defp fallback_date(%DB.ResourceHistory{inserted_at: %DateTime{} = dt}) do
+    DateTime.to_date(dt)
+  end
+
+  defp fallback_date(%DB.ResourceHistory{inserted_at: inserted_at}) do
+    case Date.from_iso8601(inserted_at) do
+      {:ok, date} -> date
+      _ -> Date.utc_today()
+    end
+  end
+
+  defp fallback_date(_), do: Date.utc_today()
 
   def poll_validation_results(validation_id, metadata, retries) do
     case client().get_a_validation(validation_id) do

--- a/apps/transport/test/transport/netex/schema_version_mapper_test.exs
+++ b/apps/transport/test/transport/netex/schema_version_mapper_test.exs
@@ -1,0 +1,23 @@
+defmodule Transport.NeTEx.SchemaVersionMapperTest do
+  use ExUnit.Case, async: true
+
+  alias Transport.NeTEx.SchemaVersionMapper
+
+  describe "xsd_version_for_date/1" do
+    test "returns v1.3.2 for dates before June 2027" do
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2024-01-01]) == "v1.3.2"
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2025-06-15]) == "v1.3.2"
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2026-12-31]) == "v1.3.2"
+    end
+
+    test "returns v1.3.2 for the day before June 2027" do
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2027-05-31]) == "v1.3.2"
+    end
+
+    test "returns v2.0.0 for June 2027 and beyond" do
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2027-06-01]) == "v2.0.0"
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2027-12-31]) == "v2.0.0"
+      assert SchemaVersionMapper.xsd_version_for_date(~D[2030-01-01]) == "v2.0.0"
+    end
+  end
+end

--- a/apps/transport/test/transport/validators/netex/validator_test.exs
+++ b/apps/transport/test/transport/validators/netex/validator_test.exs
@@ -43,6 +43,58 @@ defmodule Transport.Validators.NeTEx.ValidatorTest do
     }
   ]
 
+  describe "determine_xsd_version/2" do
+    test "uses publication_date when present and valid" do
+      metadata = %{"publication_date" => "2025-07-29"}
+      assert Validator.determine_xsd_version(metadata) == "v1.3.2"
+    end
+
+    test "publication_date is parsed from ISO 8601 with time component" do
+      metadata = %{"publication_date" => "2025-07-29T09:34:55Z"}
+      assert Validator.determine_xsd_version(metadata) == "v1.3.2"
+    end
+
+    test "falls back to inserted_at when publication_date is invalid" do
+      metadata = %{"publication_date" => "not-a-date"}
+
+      resource_history =
+        insert(:resource_history,
+          inserted_at: "2026-11-15T10:00:00Z"
+        )
+
+      assert Validator.determine_xsd_version(metadata, resource_history) == "v1.3.2"
+    end
+
+    test "falls back to inserted_at when publication_date is missing" do
+      metadata = %{}
+
+      resource_history =
+        insert(:resource_history,
+          inserted_at: "2026-11-15T10:00:00Z"
+        )
+
+      assert Validator.determine_xsd_version(metadata, resource_history) == "v1.3.2"
+    end
+
+    test "falls back to today when no resource_history is provided" do
+      metadata = %{}
+
+      assert Validator.determine_xsd_version(metadata) ==
+               Transport.NeTEx.SchemaVersionMapper.xsd_version_for_date(Date.utc_today())
+    end
+
+    test "nil publication_date falls back to inserted_at, not today" do
+      metadata = %{"publication_date" => nil}
+
+      resource_history =
+        insert(:resource_history,
+          inserted_at: "2026-11-15T10:00:00Z"
+        )
+
+      assert Validator.determine_xsd_version(metadata, resource_history) == "v1.3.2"
+    end
+  end
+
   describe "existing resource" do
     test "valid NeTEx" do
       start_date = "2025-11-03"


### PR DESCRIPTION
Suit les releases du profil France et considère la `PublicationTimestamp` pour ainsi choisir la version de la XSD à appliquer :

- Profil France 2.4 => XSD NeTEx v1.3.2
- Profil France 2.5 => XSD NeTEx v2.0.0 - prévue pour décembre 2026

Une période de grâce de 6 mois est convenue avec l'ART, la version 2.0.0 de NeTEx sera donc validée à partir de juin 2027.

Contribue à #5594.