### PR TITLE
ColorfulButton: plus de variantes

### DIFF
--- a/apps/transport/client/stylesheets/components/_colorful-button.scss
+++ b/apps/transport/client/stylesheets/components/_colorful-button.scss
@@ -5,8 +5,10 @@
  * Defaults to blue.
  *
  * Variant classes:
- * - `.valid`: green
- * - `.invalid`: red
+ * - `.variant-valid`: green
+ * - `.variant-error`: red
+ * - `.variant-warning`: orange
+ * - `.variant-information`: blue
  * - `.striped`: striped background, doesn't change the color
  * - `.selected`: highlighted button, white content and colored background, typically used for active page
  */
@@ -55,12 +57,20 @@ a.colorful, button.colorful {
     }
   }
 
-  &.valid {
+  &.variant-valid {
     --taint: var(--green);
   }
 
-  &.invalid {
+  &.variant-error {
     --taint: var(--red);
+  }
+
+  &.variant-warning {
+    --taint: var(--orange);
+  }
+
+  &.variant-information {
+    --taint: var(--dark-blue);
   }
 
   &.striped {

--- a/apps/transport/lib/transport_web/components/colorful_button.ex
+++ b/apps/transport/lib/transport_web/components/colorful_button.ex
@@ -7,7 +7,7 @@ defmodule TransportWeb.Components.ColorfulButton do
 
   use Phoenix.Component
 
-  attr(:valid, :boolean, default: true)
+  attr(:variant, :atom, default: :valid)
   attr(:striped, :boolean, default: false)
   attr(:selected, :boolean, default: false)
   attr(:href, :string, required: true)
@@ -17,7 +17,7 @@ defmodule TransportWeb.Components.ColorfulButton do
 
   def colorful_link(assigns) do
     ~H"""
-    <.link class={classnames(@valid, @striped, @selected)} href={@href}>
+    <.link class={classnames(@variant, @striped, @selected)} href={@href}>
       {render_slot(@icon)}
       <span>
         {render_slot(@label)}
@@ -26,28 +26,30 @@ defmodule TransportWeb.Components.ColorfulButton do
     """
   end
 
-  defp classnames(valid, striped, selected) do
-    validity =
-      if valid do
-        ["valid"]
-      else
-        ["invalid"]
+  def classnames(variant, striped, selected) do
+    variant_class =
+      case variant do
+        :valid -> ["variant-valid"]
+        :error -> ["variant-error"]
+        :warning -> ["variant-warning"]
+        :information -> ["variant-information"]
+        _ -> ["variant-valid"]
       end
 
-    variant =
+    striped_class =
       if striped do
         ["striped"]
       else
         []
       end
 
-    selected =
+    selected_class =
       if selected do
         ["selected"]
       else
         []
       end
 
-    Enum.join(["colorful"] ++ validity ++ variant ++ selected, " ")
+    Enum.join(["colorful"] ++ variant_class ++ striped_class ++ selected_class, " ")
   end
 end

--- a/apps/transport/lib/transport_web/views/netex_report_components.ex
+++ b/apps/transport/lib/transport_web/views/netex_report_components.ex
@@ -329,7 +329,13 @@ defmodule TransportWeb.NeTExReportComponents do
     ~H"""
     <.colorful_link
       href={netex_link_to_category(@conn, @category)}
-      valid={@stats["count"] == 0}
+      variant={
+        if @stats["count"] == 0 do
+          :valid
+        else
+          :error
+        end
+      }
       selected={@current_category == @category}
     >
       <:icon>

--- a/apps/transport/test/transport_web/components/colorful_button_test.exs
+++ b/apps/transport/test/transport_web/components/colorful_button_test.exs
@@ -1,0 +1,36 @@
+defmodule TransportWeb.Components.ColorfulButtonTest do
+  use ExUnit.Case, async: true
+
+  # Test the classnames function directly by importing it
+  import TransportWeb.Components.ColorfulButton, only: [classnames: 3]
+
+  describe "classnames" do
+    test "valid and not selected returns 'colorful valid'" do
+      assert classnames(nil, false, false) == "colorful variant-valid"
+    end
+
+    test "invalid and not selected returns 'colorful error'" do
+      assert classnames(:error, false, false) == "colorful variant-error"
+    end
+
+    test "invalid with variant warning includes 'variant-warning' class" do
+      assert classnames(:warning, false, false) == "colorful variant-warning"
+    end
+
+    test "invalid with variant information includes 'information' class" do
+      assert classnames(:information, false, false) == "colorful variant-information"
+    end
+
+    test "selected adds selected class" do
+      assert classnames(:error, false, true) == "colorful variant-error selected"
+    end
+
+    test "striped adds striped class" do
+      assert classnames(:error, true, false) == "colorful variant-error striped"
+    end
+
+    test "all classes can be combined" do
+      assert classnames(:warning, true, true) == "colorful variant-warning striped selected"
+    end
+  end
+end


### PR DESCRIPTION
- Ajoute les variantes warning et information au composant ColorfulButton.
- Met à jour netex_report_components pour utiliser l'attribut `variant` au lieu de `valid?`.

Contribue à #5568.