### PR TITLE
Validation NeTEx: tri par criticité décroissante

### DIFF
--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -102,12 +102,13 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
       # We can't call severity_level/1 here — this is a lazy Explorer expression tree,
       # not Elixir code executed per row. Inlining keeps it efficient and avoids
       # having to wrap it in apply_everywhere or similar machinery.
-      _severity: if(criticity == "error", do: 1, else: if(criticity == "warning", do: 2, else: 4))
+      _severity: if(criticity == "error", do: 1, else: if(criticity == "warning", do: 2, else: 4)),
+      _filename: cast(col("resource.filename"), :string)
     )
     |> DF.sort_with(
-      &[{:asc, &1["_severity"]}, {:asc, &1["resource.filename"]}, {:asc, &1["resource.line"]}, {:asc, &1["message"]}]
+      &[{:asc, &1["_severity"]}, {:asc, &1["_filename"]}, {:asc, &1["resource.line"]}, {:asc, &1["message"]}]
     )
-    |> DF.discard(:_severity)
+    |> DF.discard([:_severity, :_filename])
     |> DF.slice(page(config))
     |> DF.to_rows()
   end

--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -97,7 +97,13 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
   defp sorted_slice(df, %Scrivener.Config{} = config) do
     df
     |> DF.select(["code", "criticity", "message", "resource.filename", "resource.line"])
-    |> DF.mutate(_severity: if(criticity == "error", do: 1, else: if(criticity == "warning", do: 2, else: 3)))
+    |> DF.mutate(
+      # Aligns with severity_level/1: error=1, warning=2, information=3, unknown=4.
+      # We can't call severity_level/1 here — this is a lazy Explorer expression tree,
+      # not Elixir code executed per row. Inlining keeps it efficient and avoids
+      # having to wrap it in apply_everywhere or similar machinery.
+      _severity: if(criticity == "error", do: 1, else: if(criticity == "warning", do: 2, else: 4))
+    )
     |> DF.sort_with(
       &[{:asc, &1["_severity"]}, {:asc, &1["resource.filename"]}, {:asc, &1["resource.line"]}, {:asc, &1["message"]}]
     )
@@ -170,6 +176,9 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
     end
   end
 
+  # NOTE: any change to this function must be mirrored in sorted_slice/2 which
+  # uses the same mapping inline (see comment there). They are the only two
+  # consumers and must stay in sync.
   @doc false
   def severity_level(key) do
     case key do

--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -94,10 +94,15 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
     DF.load_parquet!(binary)
   end
 
-  defp slice(df, %Scrivener.Config{} = config) do
+  defp sorted_slice(df, %Scrivener.Config{} = config) do
     df
-    |> DF.slice(page(config))
     |> DF.select(["code", "criticity", "message", "resource.filename", "resource.line"])
+    |> DF.mutate(_severity: if(criticity == "error", do: 1, else: if(criticity == "warning", do: 2, else: 3)))
+    |> DF.sort_with(
+      &[{:asc, &1["_severity"]}, {:asc, &1["resource.filename"]}, {:asc, &1["resource.line"]}, {:asc, &1["message"]}]
+    )
+    |> DF.discard(:_severity)
+    |> DF.slice(page(config))
     |> DF.to_rows()
   end
 
@@ -142,7 +147,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
 
     issues =
       df
-      |> slice(pagination_config)
+      |> sorted_slice(pagination_config)
       |> to_issues()
 
     {total_count, issues}

--- a/apps/transport/lib/validators/netex/results_adapters/commons.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/commons.ex
@@ -27,7 +27,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.Commons do
     "resource.column": {:u, 8},
     "resource.filename": :category,
     "resource.id": :string,
-    "resource.line": {:u, 16}
+    "resource.line": {:u, 32}
   ]
 
   def to_dataframe(errors, extra_attributes_fun) do

--- a/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_1_0.ex
@@ -213,7 +213,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0 do
       if Commons.has_column?(df, "code") do
         df
         |> DF.filter(code == ^issue_type)
-        |> order_issues_by_location()
         |> Commons.count_and_slice(pagination_config)
       else
         {0, []}
@@ -235,11 +234,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_1_0 do
   end
 
   def get_codes(%Explorer.DataFrame{} = df), do: Commons.get_values(df, "code")
-
-  def order_issues_by_location(%Explorer.DataFrame{} = df) do
-    df
-    |> DF.sort_by(&[&1["resource.filename"], &1["resource.line"], &1["message"]])
-  end
 
   @impl Transport.Validators.NeTEx.ResultsAdapter
   def french_profile_compliance_check, do: :none

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_0.ex
@@ -123,7 +123,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
       if Commons.has_column?(df, "category") do
         df
         |> DF.filter(category == ^issues_category)
-        |> order_issues_by_location()
         |> Commons.count_and_slice(pagination_config)
       else
         {0, []}
@@ -153,8 +152,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_0 do
   end
 
   def get_categories(%Explorer.DataFrame{} = df), do: Commons.get_values(df, "category")
-
-  defdelegate order_issues_by_location(issues), to: V0_1_0
 
   # Delegation to V0_1_0 — these now accept DataFrames via the updated callbacks
   @impl Transport.Validators.NeTEx.ResultsAdapter

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_1.ex
@@ -102,7 +102,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
       if Commons.has_column?(df, "category") do
         df
         |> DF.filter(category == ^issues_category)
-        |> order_issues_by_location()
         |> Commons.count_and_slice(pagination_config)
       else
         {0, []}
@@ -126,8 +125,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_1 do
   end
 
   defdelegate pick_default_category(df, categories_preferred_order), to: V0_2_0
-
-  defdelegate order_issues_by_location(issues), to: V0_2_0
 
   @impl Transport.Validators.NeTEx.ResultsAdapter
   def french_profile_compliance_check, do: :partial

--- a/apps/transport/lib/validators/netex/results_adapters/v0_2_2.ex
+++ b/apps/transport/lib/validators/netex/results_adapters/v0_2_2.ex
@@ -47,8 +47,6 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.V0_2_2 do
 
   defdelegate pick_default_category(df, categories_preferred_order), to: Previous
 
-  defdelegate order_issues_by_location(issues), to: Previous
-
   @impl Transport.Validators.NeTEx.ResultsAdapter
   defdelegate digest(validation_result), to: Previous
 

--- a/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
@@ -67,22 +67,22 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
           "code" => "rule-a",
           "criticity" => "information",
           "message" => "Info A",
-          "resource.filename" => "b.xml",
-          "resource.line" => 10
+          "resource" => %{"filename" => "b.xml", "line" => 10},
+          "class" => nil
         },
         %{
           "code" => "rule-b",
           "criticity" => "warning",
           "message" => "Warning B",
-          "resource.filename" => "a.xml",
-          "resource.line" => 5
+          "resource" => %{"filename" => "a.xml", "line" => 5},
+          "class" => nil
         },
         %{
           "code" => "rule-c",
           "criticity" => "error",
           "message" => "Error C",
-          "resource.filename" => "c.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "c.xml", "line" => 1},
+          "class" => nil
         }
       ]
 
@@ -94,7 +94,80 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
       assert criticity_order == ["error", "warning", "information"]
     end
 
-    test "sorts by message as tiebreaker when severity, filename and line are equal" do
+    test "sorts filenames alphabetically, not by insertion order" do
+      # All same severity → tiebreaker is filename. Must sort alphabetically,
+      # not by the category column's internal code (insertion) order.
+      pagination_config = make_pagination_config(%{"page_size" => "10"})
+
+      errors = [
+        %{
+          "code" => "r0",
+          "criticity" => "error",
+          "message" => "m",
+          "resource" => %{"filename" => "zebra.xml", "line" => 1},
+          "class" => nil
+        },
+        %{
+          "code" => "r1",
+          "criticity" => "error",
+          "message" => "m",
+          "resource" => %{"filename" => "alpha.xml", "line" => 1},
+          "class" => nil
+        },
+        %{
+          "code" => "r2",
+          "criticity" => "error",
+          "message" => "m",
+          "resource" => %{"filename" => "mid.xml", "line" => 1},
+          "class" => nil
+        }
+      ]
+
+      df = errors |> Commons.to_dataframe(fn _ -> %{} end)
+
+      assert {3, issues} = Commons.count_and_slice(df, pagination_config)
+
+      filenames = Enum.map(issues, & &1["resource"]["filename"])
+      assert filenames == ["alpha.xml", "mid.xml", "zebra.xml"]
+    end
+
+    test "sorts by line number as secondary tiebreaker after filename" do
+      # Same severity + same filename → sort by line number ascending
+      pagination_config = make_pagination_config(%{"page_size" => "10"})
+
+      errors = [
+        %{
+          "code" => "r3",
+          "criticity" => "error",
+          "message" => "Line 3",
+          "resource" => %{"filename" => "a.xml", "line" => 30},
+          "class" => nil
+        },
+        %{
+          "code" => "r1",
+          "criticity" => "error",
+          "message" => "Line 1",
+          "resource" => %{"filename" => "a.xml", "line" => 10},
+          "class" => nil
+        },
+        %{
+          "code" => "r2",
+          "criticity" => "error",
+          "message" => "Line 2",
+          "resource" => %{"filename" => "a.xml", "line" => 20},
+          "class" => nil
+        }
+      ]
+
+      df = errors |> Commons.to_dataframe(fn _ -> %{} end)
+
+      assert {3, issues} = Commons.count_and_slice(df, pagination_config)
+
+      lines = Enum.map(issues, & &1["resource"]["line"])
+      assert lines == [10, 20, 30]
+    end
+
+    test "sorts by message as final tiebreaker when severity, filename and line are equal" do
       pagination_config = make_pagination_config(%{"page_size" => "10"})
 
       errors = [
@@ -102,22 +175,22 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
           "code" => "rule-3",
           "criticity" => "error",
           "message" => "Third message",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "rule-1",
           "criticity" => "error",
           "message" => "Alpha message",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "rule-2",
           "criticity" => "error",
           "message" => "Middle message",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         }
       ]
 
@@ -138,36 +211,36 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
           "code" => "r1",
           "criticity" => "error",
           "message" => "E1",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "r2",
           "criticity" => "warning",
           "message" => "W1",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "r3",
           "criticity" => "error",
           "message" => "E2",
-          "resource.filename" => "b.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "b.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "r4",
           "criticity" => "information",
           "message" => "I1",
-          "resource.filename" => "a.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "a.xml", "line" => 1},
+          "class" => nil
         },
         %{
           "code" => "r5",
           "criticity" => "error",
           "message" => "E3",
-          "resource.filename" => "c.xml",
-          "resource.line" => 1
+          "resource" => %{"filename" => "c.xml", "line" => 1},
+          "class" => nil
         }
       ]
 

--- a/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
@@ -58,8 +58,8 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
 
   describe "count_and_slice/2" do
     test "sorts by criticity severity (error > warning > information), not lexicographically" do
-      # Lexicographic order would give: error < information < warning
-      # Severity order should be: error > warning > information
+      # Severity order: error(1) > warning(2) > information(3)
+      # Input is interleaved to ensure the sort actually reorders them
       pagination_config = make_pagination_config(%{"page_size" => "10"})
 
       errors = [

--- a/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
+++ b/apps/transport/test/transport/validators/netex/results_adapters/commons_test.exs
@@ -2,6 +2,7 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
   use ExUnit.Case, async: true
   alias Transport.Validators.NeTEx.ResultsAdapters.Commons
   require Explorer.DataFrame, as: DF
+  import TransportWeb.PaginationHelpers, only: [make_pagination_config: 1, make_pagination_config: 2]
 
   @xsd %{
     "code" => "xsd-123",
@@ -53,5 +54,134 @@ defmodule Transport.Validators.NeTEx.ResultsAdapters.CommonsTest do
 
   def example do
     Commons.to_dataframe(@errors, fn _ -> %{} end)
+  end
+
+  describe "count_and_slice/2" do
+    test "sorts by criticity severity (error > warning > information), not lexicographically" do
+      # Lexicographic order would give: error < information < warning
+      # Severity order should be: error > warning > information
+      pagination_config = make_pagination_config(%{"page_size" => "10"})
+
+      errors = [
+        %{
+          "code" => "rule-a",
+          "criticity" => "information",
+          "message" => "Info A",
+          "resource.filename" => "b.xml",
+          "resource.line" => 10
+        },
+        %{
+          "code" => "rule-b",
+          "criticity" => "warning",
+          "message" => "Warning B",
+          "resource.filename" => "a.xml",
+          "resource.line" => 5
+        },
+        %{
+          "code" => "rule-c",
+          "criticity" => "error",
+          "message" => "Error C",
+          "resource.filename" => "c.xml",
+          "resource.line" => 1
+        }
+      ]
+
+      df = errors |> Commons.to_dataframe(fn _ -> %{} end)
+
+      assert {3, issues} = Commons.count_and_slice(df, pagination_config)
+
+      criticity_order = Enum.map(issues, & &1["criticity"])
+      assert criticity_order == ["error", "warning", "information"]
+    end
+
+    test "sorts by message as tiebreaker when severity, filename and line are equal" do
+      pagination_config = make_pagination_config(%{"page_size" => "10"})
+
+      errors = [
+        %{
+          "code" => "rule-3",
+          "criticity" => "error",
+          "message" => "Third message",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "rule-1",
+          "criticity" => "error",
+          "message" => "Alpha message",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "rule-2",
+          "criticity" => "error",
+          "message" => "Middle message",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        }
+      ]
+
+      df = errors |> Commons.to_dataframe(fn _ -> %{} end)
+
+      assert {3, issues} = Commons.count_and_slice(df, pagination_config)
+
+      message_order = Enum.map(issues, & &1["message"])
+      assert message_order == ["Alpha message", "Middle message", "Third message"]
+    end
+
+    test "pagination returns the correct page after sorting" do
+      # 5 errors total, page_size=2 → page 2 should return items 3-4 (0-indexed: 2-3)
+      pagination_config = make_pagination_config(%{"page" => "2"}, 2)
+
+      errors = [
+        %{
+          "code" => "r1",
+          "criticity" => "error",
+          "message" => "E1",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "r2",
+          "criticity" => "warning",
+          "message" => "W1",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "r3",
+          "criticity" => "error",
+          "message" => "E2",
+          "resource.filename" => "b.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "r4",
+          "criticity" => "information",
+          "message" => "I1",
+          "resource.filename" => "a.xml",
+          "resource.line" => 1
+        },
+        %{
+          "code" => "r5",
+          "criticity" => "error",
+          "message" => "E3",
+          "resource.filename" => "c.xml",
+          "resource.line" => 1
+        }
+      ]
+
+      df = errors |> Commons.to_dataframe(fn _ -> %{} end)
+
+      assert {5, issues} = Commons.count_and_slice(df, pagination_config)
+      assert length(issues) == 2
+
+      # Sorted order: error(a.xml/E1), error(b.xml/E2), error(c.xml/E3), warning(W1), information(I1)
+      # Page 2 (1-indexed) = items at index 2-3 = E3, W1
+      codes = Enum.map(issues, & &1["code"])
+      criticities = Enum.map(issues, & &1["criticity"])
+      assert codes == ["r5", "r2"]
+      assert criticities == ["error", "warning"]
+    end
   end
 end


### PR DESCRIPTION
Exploite Explorer pour faire le tri sur le DataFrame avant la pagination

Contribue à #5568.
Extrait de #5578 puis retravaillé suite à relectures précédentes et tests complémentaires.