### PR TITLE
NeTEx: Fix layout quand non valide

### DIFF
--- a/apps/transport/client/stylesheets/components/_validation.scss
+++ b/apps/transport/client/stylesheets/components/_validation.scss
@@ -217,7 +217,7 @@ details > code {
     container-type: inline-size;
     container-name: issues-list;
 
-    &:has(a.colorful.invalid) {
+    &:has(:not(a.colorful.variant-valid)) {
       min-height: 80vh;
     }
 


### PR DESCRIPTION
Le ColorfulButton a changé ses classes CSS and l'une d'elle leak dans un règle CSS de layout. C'est discutable j'en conviens.

Cette PR propose un fix minimal qui adapte aux changements de #5603.

A noter que cette régression est difficilement remarquable en tests manuels et cela portait sur du confort visuel donc mineur.

Voir https://github.com/etalab/transport-site/pull/5603#issuecomment-5450497944