### PR TITLE
Mise à jour du fichier .proto GTFS-RT

### DIFF
--- a/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
+++ b/apps/transport/lib/transport/protobuf/gtfs-realtime.proto
@@ -708,12 +708,10 @@ message Alert {
 
   // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
   // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. 
-  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedImage image = 15;
 
   // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
   // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
-  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString image_alternative_text = 16;
 
 
@@ -1055,7 +1053,6 @@ message TranslatedString {
 //    translation, the first matching translation is picked.
 // 3. If some translation has an unspecified language code, that translation is
 //    picked.
-// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
 message TranslatedImage {
   message LocalizedImage {
     // String containing an URL linking to an image


### PR DESCRIPTION
Le test `.proto file is up-to-date` (tag `ci_only_on_mondays`) échoue à nouveau : le fichier `gtfs-realtime.proto` de [`google/transit`](https://github.com/google/transit/tree/master/gtfs-realtime/proto) a changé.

Seuls des commentaires ont bougé côté upstream. Du coup pas de diff sur le fichier `.pb.ex` (recompilé à tout hasard avec la bonne version de protobuf, mais quand même identique).