### PR TITLE
Refactor: moins de duplication de code

### DIFF
--- a/apps/shared/lib/data_visualization.ex
+++ b/apps/shared/lib/data_visualization.ex
@@ -4,10 +4,12 @@ defmodule Transport.DataVisualization do
   """
   @callback has_features(map() | nil) :: boolean()
   @callback validation_data_vis(any) :: nil | map
+  @callback encoded_data_vis(map() | nil, String.t()) :: nil | binary()
 
   defp impl, do: Application.get_env(:transport, :data_visualization)
   def has_features(validations), do: impl().has_features(validations)
   def validation_data_vis(validations), do: impl().validation_data_vis(validations)
+  def encoded_data_vis(validation, issue_type), do: impl().encoded_data_vis(validation, issue_type)
 end
 
 defmodule Transport.DataVisualization.Impl do
@@ -20,6 +22,21 @@ defmodule Transport.DataVisualization.Impl do
   @impl Transport.DataVisualization
   def has_features(nil), do: false
   def has_features(data_visualization), do: not Enum.empty?(data_visualization["features"])
+
+  @impl Transport.DataVisualization
+  @spec encoded_data_vis(map() | nil, String.t()) :: nil | binary()
+  def encoded_data_vis(nil, _issue_type), do: nil
+
+  def encoded_data_vis(validation, issue_type) do
+    issue_data_vis = validation.data_vis[issue_type]
+    has_features = has_features(issue_data_vis["geojson"])
+
+    case {has_features, Jason.encode(issue_data_vis, escape: :html_safe)} do
+      {false, _} -> nil
+      {true, {:ok, encoded}} -> encoded
+      _ -> nil
+    end
+  end
 
   @impl Transport.DataVisualization
   @spec validation_data_vis(any) :: nil | map

--- a/apps/transport/client/javascripts/validation-map.js
+++ b/apps/transport/client/javascripts/validation-map.js
@@ -21,7 +21,7 @@ function getColor(severity) {
 function createValidationMap(divId, dataVis) {
     const { map, fg } = initilizeMap(divId)
     const gs = L.geoJSON(dataVis.geojson, {
-        pointToLayer(feature, latlng) {
+        pointToLayer(_feature, latlng) {
             const marker = L.circleMarker(latlng, {
                 radius: 5,
                 fillColor: 'white',
@@ -40,7 +40,7 @@ function createValidationMap(divId, dataVis) {
                 }
             }
         },
-        onEachFeature(feature, layer) {
+        onEachFeature(_feature, layer) {
             layer.on('mouseover', () => {
                 layer.setStyle({ weight: 5, radius: 7 })
             })

--- a/apps/transport/lib/transport_web/controllers/resource_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/resource_controller.ex
@@ -178,7 +178,7 @@ defmodule TransportWeb.ResourceController do
     |> assign_base_resource_details(resource, validation_details)
     |> assign(:issues, Scrivener.paginate(issues, config))
     |> assign(:validator, Transport.Validators.GTFSTransport)
-    |> assign(:data_vis, encoded_data_vis(issue_type, validation))
+    |> assign(:data_vis, DataVisualization.encoded_data_vis(validation, issue_type))
     |> render("gtfs_details.html")
   end
 
@@ -285,19 +285,6 @@ defmodule TransportWeb.ResourceController do
     |> assign(:severities_count, severities_count)
     |> assign(:metadata, metadata)
     |> assign(:modes, modes)
-  end
-
-  def encoded_data_vis(_, nil), do: nil
-
-  def encoded_data_vis(issue_type, validation) do
-    issue_data_vis = validation.data_vis[issue_type]
-    has_features = DataVisualization.has_features(issue_data_vis["geojson"])
-
-    case {has_features, Jason.encode(issue_data_vis)} do
-      {false, _} -> nil
-      {true, {:ok, encoded_data_vis}} -> encoded_data_vis
-      _ -> nil
-    end
   end
 
   @doc """

--- a/apps/transport/lib/transport_web/controllers/validation_controller.ex
+++ b/apps/transport/lib/transport_web/controllers/validation_controller.ex
@@ -179,7 +179,7 @@ defmodule TransportWeb.ValidationController do
         |> assign(:validator, validator)
         |> assign(:metadata, validation.metadata.metadata)
         |> assign(:modes, validation.metadata.modes)
-        |> assign(:data_vis, data_vis(validation, issue_type))
+        |> assign(:data_vis, DataVisualization.encoded_data_vis(validation, issue_type))
         |> assign(:validation_summary, validator.summary(validation.result))
         |> assign(:severities_count, validator.count_by_severity(validation.result))
         |> render("show_gtfs.html")
@@ -321,17 +321,6 @@ defmodule TransportWeb.ValidationController do
     |> assign(:validation_id, params["id"])
     |> assign(:other_resources, [])
     |> assign(:token, params["token"])
-  end
-
-  defp data_vis(%MultiValidation{} = validation, issue_type) do
-    data_vis = validation.data_vis[issue_type]
-    has_features = DataVisualization.has_features(data_vis["geojson"])
-
-    case {has_features, Jason.encode(data_vis)} do
-      {false, _} -> nil
-      {true, {:ok, encoded_data_vis}} -> encoded_data_vis
-      _ -> nil
-    end
   end
 
   defp filepath(type) do

--- a/apps/transport/test/transport_web/controllers/validation_controller_test.exs
+++ b/apps/transport/test/transport_web/controllers/validation_controller_test.exs
@@ -223,7 +223,8 @@ defmodule TransportWeb.ValidationControllerTest do
       })
       |> DB.Repo.update!()
 
-      Transport.DataVisualization.Mock |> expect(:has_features, fn _ -> false end)
+      Transport.DataVisualization.Mock
+      |> expect(:encoded_data_vis, fn _, _ -> nil end)
 
       conn2 = conn |> get(validation_path(conn, :show, validation_id, token: token))
       assert conn2 |> html_response(200) =~ "bus, ferry"


### PR DESCRIPTION
Observé en travaillant sur l'affichage des résultats de validation NeTEx, fait en passant parce que fixe au passage un problème d'encodage potentiel (et 2 warnings eslint, c'est cadeau).