### PR TITLE
Chiffrement des cookies

### DIFF
--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -5,7 +5,9 @@ defmodule TransportWeb.Endpoint do
   @session_options [
     store: :cookie,
     key: "_transport_key",
+    # see https://plug.hexdocs.pm/Plug.Session.COOKIE.html
     signing_salt: "wqoqbzqj",
+    encryption_salt: "vr9k2xqm",
     same_site: "Lax",
     # 15 days
     max_age: 24 * 60 * 60 * 15

--- a/apps/transport/lib/transport_web/endpoint.ex
+++ b/apps/transport/lib/transport_web/endpoint.ex
@@ -7,7 +7,9 @@ defmodule TransportWeb.Endpoint do
     key: "_transport_key",
     # see https://plug.hexdocs.pm/Plug.Session.COOKIE.html
     signing_salt: "wqoqbzqj",
-    encryption_salt: "vr9k2xqm",
+    # reportedly does not have to be secret
+    # generated with `:crypto.strong_rand_bytes(8) |> Base.encode64(padding: false) |> binary_part(0, 8)`
+    encryption_salt: "mtPNrNTK",
     same_site: "Lax",
     # 15 days
     max_age: 24 * 60 * 60 * 15

--- a/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
+++ b/apps/transport/test/transport_web/routing/headers_and_cookies_test.exs
@@ -26,4 +26,14 @@ defmodule TransportWeb.HeadersAndCookiesTest do
     datetime = TimeWrapper.parse!(datetime, "{WDshort}, {D} {Mshort} {YYYY} {h24}:{m}:{s} GMT")
     assert_in_delta TimeWrapper.diff(datetime, TimeWrapper.now(), :hours), 15 * 24, 1
   end
+
+  test "the session cookie is encrypted", %{conn: conn} do
+    probe = "canary-value"
+    conn = conn |> Plug.Test.init_test_session(%{probe: probe}) |> get("/")
+    %{"_transport_key" => cookie} = get_resp_header(conn, "set-cookie") |> hd() |> Plug.Conn.Cookies.decode()
+
+    # signed-only, the base64-decoded payload holds the session verbatim (external term format)
+    raw = cookie |> String.split(".") |> Enum.map_join("", &Base.url_decode64!(&1, padding: false))
+    refute raw =~ probe
+  end
 end


### PR DESCRIPTION
Au prochain passage, les utilisateurs seront déloggés, et leur cookie écrasé (cela n'efface pas le cookie des gens qui ne viennent pas sur le site).