### PR TITLE
Désactivation du poll IRVE dynamique en staging, dev, et sur le worker de prod

### DIFF
--- a/apps/transport/lib/unlock/dynamic_irve_supervisor.ex
+++ b/apps/transport/lib/unlock/dynamic_irve_supervisor.ex
@@ -26,8 +26,9 @@ defmodule Unlock.DynamicIRVESupervisor do
       # Calls `sync_feeds/0` once at boot in a separate short-lived process: fetches
       # the config (HTTP to GitHub) and (re)starts one poller per feed in the
       # DynamicSupervisor above.
-      # `:temporary` → a failure is not restarted and does not affect sibling boot.
-      {Task, &initial_sync/0}
+      # `sync_feeds/0` may raise (HTTP to GitHub) — let it crash: `:temporary` → a failure
+      # is not restarted and does not affect sibling boot, and the stack trace bubbles up to Sentry.
+      {Task, &sync_feeds/0}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -36,20 +37,25 @@ defmodule Unlock.DynamicIRVESupervisor do
   @doc """
   Fetches the current proxy config, terminates all running feed workers, then
   starts one per feed across all `DynamicIRVEAggregate` items. Called at boot
-  and on backoffice reload.
+  and on backoffice reload. No-op when polling is disabled (everywhere but
+  production, see `config/runtime.exs`).
 
   The brute-force approach avoids edge cases (renamed slug, changed URL, partial
   drift) at the cost of a short data gap — acceptable for now.
   """
   def sync_feeds do
-    config = Application.fetch_env!(:transport, :unlock_config_fetcher).fetch_config!()
+    if Application.fetch_env!(:transport, :dynamic_irve_polling_enabled) do
+      config = Application.fetch_env!(:transport, :unlock_config_fetcher).fetch_config!()
 
-    stop_all(Unlock.DynamicIRVE.FeedSupervisor)
+      stop_all(Unlock.DynamicIRVE.FeedSupervisor)
 
-    for item <- Map.values(config),
-        match?(%Unlock.Config.Item.DynamicIRVEAggregate{}, item),
-        feed <- item.feeds,
-        do: start_feed(item.identifier, feed)
+      for item <- Map.values(config),
+          match?(%Unlock.Config.Item.DynamicIRVEAggregate{}, item),
+          feed <- item.feeds,
+          do: start_feed(item.identifier, feed)
+    else
+      Logger.info("[DynamicIRVE] Polling disabled, not starting feed workers")
+    end
   end
 
   @doc """
@@ -64,13 +70,6 @@ defmodule Unlock.DynamicIRVESupervisor do
     # inside ETS without copying the table.
     # See https://hexdocs.pm/elixir/Registry.html#select/2
     Registry.select(Unlock.DynamicIRVE.Registry, [{{:"$1", :_, :_}, [], [:"$1"]}])
-  end
-
-  # `sync_feeds/0` may raise (HTTP to GitHub) — let it crash: the `:temporary` Task
-  # isolates the failure (boot is unaffected) and the stack trace bubbles up to Sentry.
-  # Disabled in test so the config fetcher Mox mock needs no default expectation.
-  defp initial_sync do
-    if Application.fetch_env!(:transport, :dynamic_irve_initial_sync), do: sync_feeds()
   end
 
   defp stop_all(supervisor) do

--- a/apps/transport/lib/unlock/dynamic_irve_supervisor.ex
+++ b/apps/transport/lib/unlock/dynamic_irve_supervisor.ex
@@ -38,7 +38,7 @@ defmodule Unlock.DynamicIRVESupervisor do
   Fetches the current proxy config, terminates all running feed workers, then
   starts one per feed across all `DynamicIRVEAggregate` items. Called at boot
   and on backoffice reload. No-op when polling is disabled (everywhere but
-  production, see `config/runtime.exs`).
+  production webserver nodes, see `config/runtime.exs`).
 
   The brute-force approach avoids edge cases (renamed slug, changed URL, partial
   drift) at the cost of a short data gap — acceptable for now.

--- a/apps/transport/test/unlock/dynamic_irve_integration_test.exs
+++ b/apps/transport/test/unlock/dynamic_irve_integration_test.exs
@@ -10,8 +10,11 @@ defmodule Unlock.DynamicIRVE.IntegrationTest do
 
   setup do
     setup_telemetry_handler()
+    Application.put_env(:transport, :dynamic_irve_polling_enabled, true)
 
     on_exit(fn ->
+      Application.put_env(:transport, :dynamic_irve_polling_enabled, false)
+
       for {_, pid, _, _} <- DynamicSupervisor.which_children(Unlock.DynamicIRVE.FeedSupervisor),
           is_pid(pid),
           do: DynamicSupervisor.terminate_child(Unlock.DynamicIRVE.FeedSupervisor, pid)
@@ -63,6 +66,14 @@ defmodule Unlock.DynamicIRVE.IntegrationTest do
 
     # :external event must be emitted so the request counts in the proxy metrics
     assert_received {:telemetry_event, [:proxy, :request, :external], %{}, %{target: "proxy:test-agg"}}
+  end
+
+  test "sync_feeds is a no-op when polling is disabled" do
+    Application.put_env(:transport, :dynamic_irve_polling_enabled, false)
+
+    Unlock.DynamicIRVESupervisor.sync_feeds()
+
+    assert Unlock.DynamicIRVESupervisor.running_feed_pollers() == []
   end
 
   defp build_df(marker) do

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,10 @@ config :transport,
     "https://raw.githubusercontent.com/transportdatagouvfr/proxy-config/refs/heads/master/proxy-config.yml",
   unlock_github_auth_token: System.get_env("TRANSPORT_PROXY_CONFIG_GITHUB_TOKEN"),
   unlock_event_incrementer: Unlock.BatchMetrics,
-  unlock_token_auth_enabled: false
+  unlock_token_auth_enabled: false,
+  dynamic_irve_tick_interval: :timer.seconds(30),
+  # Turned on for production webserver nodes only in `runtime.exs`. For local work, see `dev.secret.template.exs`.
+  dynamic_irve_polling_enabled: false
 
 config :transport, Unlock.Endpoint, []
 

--- a/config/dev.secret.template.exs
+++ b/config/dev.secret.template.exs
@@ -28,6 +28,11 @@ config :transport, TransportWeb.Endpoint,
 # if you need to work on IRVE dashboard, turn this on
 config :transport, :irve_consolidation_caching, true
 
+# Uncomment if you need to work on the dynamic IRVE concentrator: polls the feeds of the
+# `dynamic-irve-aggregate` items of your `config/proxy-config.yml` (off outside production,
+# so avoid pointing at real producers' feeds unless needed)
+# config :transport, dynamic_irve_polling_enabled: true
+
 # for minio local S3 support. See `.miniorc`
 config :ex_aws,
   access_key_id: System.fetch_env!("MINIO_ROOT_USER"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -98,12 +98,13 @@ config :transport,
   app_env: app_env,
   mix_env: config_env()
 
-config :transport,
-  unlock_enforce_ttl: webserver,
-  dynamic_irve_tick_interval: :timer.seconds(30),
-  # Only production webserver nodes poll the third-party IRVE feeds: staging and dev would add to the load
-  # on producers, and worker-only nodes never serve the proxy so their feed store would go unread.
-  dynamic_irve_polling_enabled: webserver and app_env == :production
+config :transport, unlock_enforce_ttl: webserver
+
+# Only production webserver nodes poll the third-party IRVE feeds: staging and dev would add to the load
+# on producers, and worker-only nodes never serve the proxy so their feed store would go unread.
+if webserver and app_env == :production do
+  config :transport, dynamic_irve_polling_enabled: true
+end
 
 # Override configuration specific to staging
 if app_env == :staging do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,8 +101,9 @@ config :transport,
 config :transport,
   unlock_enforce_ttl: webserver,
   dynamic_irve_tick_interval: :timer.seconds(30),
-  # Only production polls the third-party IRVE feeds: staging and dev nodes would add to the load on producers
-  dynamic_irve_polling_enabled: app_env == :production
+  # Only production webserver nodes poll the third-party IRVE feeds: staging and dev would add to the load
+  # on producers, and worker-only nodes never serve the proxy so their feed store would go unread.
+  dynamic_irve_polling_enabled: webserver and app_env == :production
 
 # Override configuration specific to staging
 if app_env == :staging do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -42,11 +42,6 @@ config :transport,
   disable_netex_validator: System.get_env("DISABLE_NETEX_VALIDATOR") in ["1", "true"]
 
 config :transport,
-  unlock_enforce_ttl: webserver,
-  dynamic_irve_tick_interval: :timer.seconds(if(config_env() == :dev, do: 10, else: 30)),
-  dynamic_irve_initial_sync: config_env() != :test
-
-config :transport,
   # This endpoint is not really public but we can use it for now
   # See https://github.com/MobilityData/gbfs-validator/issues/53#issuecomment-957917240
   gbfs_validator_url:
@@ -102,6 +97,12 @@ config :transport, domain_name: domain_name
 config :transport,
   app_env: app_env,
   mix_env: config_env()
+
+config :transport,
+  unlock_enforce_ttl: webserver,
+  dynamic_irve_tick_interval: :timer.seconds(30),
+  # Only production polls the third-party IRVE feeds: staging and dev nodes would add to the load on producers
+  dynamic_irve_polling_enabled: app_env == :production
 
 # Override configuration specific to staging
 if app_env == :staging do


### PR DESCRIPTION
Cette PR ne laisse activé le polling des flux IRVE dynamiques que sur le serveur _web_ de production (c’est le serveur web qui sert le flux, donc c’est lui qui a besoin de poller).

Est désactivé à présent le polling sur :
- Le serveur _worker_ de production (qui pollait également, mais ça ne servait à rien)
- Les deux serveurs _web_ et _worker_ d’intégration
- Les machines de développement, avec une option documentée dans `.dev.secret.template`

Du coup à minima une fois déployé sur prochainement (ce que je vais faire de suite) et en production, ça va diviser le volume de poll par 4 sur les producteurs.

Comme d’hab co-créé avec :robot: Claude.