### PR TITLE
Réutilisations : meilleur layout

### DIFF
--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -318,12 +318,18 @@
   background-color: var(--lighter-blue);
 }
 
+#dataset-reuses {
+  container-type: inline-size;
+}
+
 .reuses {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 16px;
+
+  @container (width < 800px) {
+    grid-template-columns: 1fr;
+  }
 
   .panel + * {
     margin-top: unset;

--- a/apps/transport/client/stylesheets/components/_dataset-details.scss
+++ b/apps/transport/client/stylesheets/components/_dataset-details.scss
@@ -323,42 +323,54 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: stretch;
-  margin: -12px;
+  gap: 16px;
+
+  .panel + * {
+    margin-top: unset;
+  }
 }
 
 .reuse {
-  margin: 12px;
   flex-basis: 450px;
-  // min-width: 450px;
   flex-grow: 1;
-  min-height: 300px;
-  max-height: 400px;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-areas:
+    "logo  details"
+    "owner details"
+    "links details";
+  grid-template-rows: min-content min-content 1fr;
+  grid-template-columns: 120px auto;
+  gap: 24px;
+
   img {
-    width: 25%;
-    height: 100px;
+    grid-area: logo;
+    max-width: 100%;
     object-fit: cover;
-    padding-right: 24px;
+  }
+
+  .reuse__owner {
+    grid-area: owner;
   }
 
   .reuse__links {
-    width: 25%;
-    height: 100px;
+    grid-area: links;
     display: flex;
     flex-direction: column;
+    gap: 12px;
 
     a {
       line-height: 1.1em;
-      padding-top: 1em;
     }
   }
+
   .reuse__details {
-    min-height: 200px;
-    width: 75%;
-    flex-basis: 100%;
+    grid-area: details;
     overflow: auto;
+    max-height: 40em;
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -14,7 +14,7 @@ defmodule TransportWeb.ReusesLive do
         <% @loading -> %>
           <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
         <% @fetch_reuses_error -> %>
-          <div :if={@fetch_reuses_error} class="panel reuses_not_available">
+          <div class="panel reuses_not_available">
             🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
           </div>
         <% @reuses != [] -> %>

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -8,44 +8,42 @@ defmodule TransportWeb.ReusesLive do
 
   def render(assigns) do
     ~H"""
-    <%= unless @loading do %>
-      <%= unless @reuses == [] and !@fetch_reuses_error do %>
-        <section class="white pt-48" id="dataset-reuses">
-          <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
-          <p>
-            {dgettext(
-              "page-dataset-details",
-              "You will find below reuses created by individuals or organizations based on this dataset."
-            )}
-          </p>
-          <%= if @fetch_reuses_error do %>
-            <div class="panel reuses_not_available">
-              🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
-            </div>
-          <% end %>
-          <div class="reuses">
-            <%= for reuse <- @reuses do %>
-              <div class="panel reuse">
-                <img src={reuse["image"]} alt={reuse["title"]} />
-                <div class="mt-12">{Phoenix.HTML.raw(owner(reuse))}</div>
-                <div class="reuse__links">
-                  <.link href={reuse["url"]}>{dgettext("page-dataset-details", "Website")}</.link>
-                  <.link href={reuse["page"]} target="_blank">
-                    {dgettext("page-dataset-details", "See on data.gouv.fr")}
-                  </.link>
-                </div>
-                <div class="reuse__details">
-                  <div>
-                    <h3>{reuse["title"]}</h3>
-                    <p>{MarkdownHandler.markdown_to_safe_html!(reuse["description"])}</p>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
+    <%= unless @loading and @reuses == [] and !@fetch_reuses_error do %>
+      <section class="white pt-48" id="dataset-reuses">
+        <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
+        <p>
+          {dgettext(
+            "page-dataset-details",
+            "You will find below reuses created by individuals or organizations based on this dataset."
+          )}
+        </p>
+        <div :if={@fetch_reuses_error} class="panel reuses_not_available">
+          🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
+        </div>
+        <div class="reuses">
+          <.reuse :for={reuse <- @reuses} reuse={reuse} />
+        </div>
+      </section>
     <% end %>
+    """
+  end
+
+  defp reuse(%{reuse: _} = assigns) do
+    ~H"""
+    <div class="panel reuse">
+      <img src={@reuse["image"]} alt={@reuse["title"]} />
+      <div class="reuse__owner">{Phoenix.HTML.raw(owner(@reuse))}</div>
+      <div class="reuse__links">
+        <.link href={@reuse["url"]}>{dgettext("page-dataset-details", "Website")}</.link>
+        <.link href={@reuse["page"]} target="_blank">
+          {dgettext("page-dataset-details", "See on data.gouv.fr")}
+        </.link>
+      </div>
+      <div class="reuse__details">
+        <h3>{@reuse["title"]}</h3>
+        {MarkdownHandler.markdown_to_safe_html!(@reuse["description"])}
+      </div>
+    </div>
     """
   end
 

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -106,7 +106,7 @@ defmodule TransportWeb.CountReusesLive do
   def render(assigns) do
     ~H"""
     <%= if assigns[:count] && @count > 0 do %>
-      <div class="menu-item"><a href="#dataset-reuses">{dgettext("page-dataset-details", "Reuses")}</a></div>
+      <div class="menu-item"><a href="#dataset-reuses">{dgettext("page-dataset-details", "Reuses")} ({@count})</a></div>
     <% end %>
     """
   end

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -10,21 +10,25 @@ defmodule TransportWeb.ReusesLive do
     ~H"""
     <section class="white pt-48" id="dataset-reuses">
       <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
-      <%= if @loading do %>
-        <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
-      <% else %>
-        <p>
-          {dgettext(
-            "page-dataset-details",
-            "You will find below reuses created by individuals or organizations based on this dataset."
-          )}
-        </p>
-        <div :if={@fetch_reuses_error} class="panel reuses_not_available">
-          🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
-        </div>
-        <div :if={@reuses != []} class="reuses">
-          <.reuse :for={reuse <- @reuses} reuse={reuse} />
-        </div>
+      <%= cond do %>
+        <% @loading -> %>
+          <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
+        <% @fetch_reuses_error -> %>
+          <div :if={@fetch_reuses_error} class="panel reuses_not_available">
+            🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
+          </div>
+        <% @reuses != [] -> %>
+          <p>
+            {dgettext(
+              "page-dataset-details",
+              "You will find below reuses created by individuals or organizations based on this dataset."
+            )}
+          </p>
+          <div class="reuses">
+            <.reuse :for={reuse <- @reuses} reuse={reuse} />
+          </div>
+        <% true -> %>
+          <p>{dgettext("page-dataset-details", "No known reuse on this dataset.")}</p>
       <% end %>
     </section>
     """
@@ -105,9 +109,14 @@ defmodule TransportWeb.CountReusesLive do
 
   def render(assigns) do
     ~H"""
-    <%= if assigns[:count] && @count > 0 do %>
-      <div class="menu-item"><a href="#dataset-reuses">{dgettext("page-dataset-details", "Reuses")} ({@count})</a></div>
-    <% end %>
+    <div class="menu-item">
+      <a href="#dataset-reuses">
+        {dgettext("page-dataset-details", "Reuses")}
+        <%= if assigns[:count] && @count > 0 do %>
+          ({@count})
+        <% end %>
+      </a>
+    </div>
     """
   end
 

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -8,9 +8,11 @@ defmodule TransportWeb.ReusesLive do
 
   def render(assigns) do
     ~H"""
-    <%= unless @loading and @reuses == [] and !@fetch_reuses_error do %>
-      <section class="white pt-48" id="dataset-reuses">
-        <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
+    <section class="white pt-48" id="dataset-reuses">
+      <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
+      <%= if @loading do %>
+        <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
+      <% else %>
         <p>
           {dgettext(
             "page-dataset-details",
@@ -20,11 +22,11 @@ defmodule TransportWeb.ReusesLive do
         <div :if={@fetch_reuses_error} class="panel reuses_not_available">
           🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}
         </div>
-        <div class="reuses">
+        <div :if={@reuses != []} class="reuses">
           <.reuse :for={reuse <- @reuses} reuse={reuse} />
         </div>
-      </section>
-    <% end %>
+      <% end %>
+    </section>
     """
   end
 

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -737,3 +737,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Loading reuses…"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No known reuse on this dataset."
+msgstr ""

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -733,3 +733,7 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Those resources are listed by the provider but are unreachable for now. <a href=\"%{url}\">Learn more</a>."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Loading reuses…"
+msgstr ""

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -733,3 +733,7 @@ msgstr "Télécharger au format GeoJSON"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Those resources are listed by the provider but are unreachable for now. <a href=\"%{url}\">Learn more</a>."
 msgstr "Ces ressources sont référencées, mais ne semblent pas accessibles pour le moment. <a href=\"%{url}\">En savoir plus</a>."
+
+#, elixir-autogen, elixir-format
+msgid "Loading reuses…"
+msgstr "Chargement des réutilisations…"

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -737,3 +737,7 @@ msgstr "Ces ressources sont référencées, mais ne semblent pas accessibles pou
 #, elixir-autogen, elixir-format
 msgid "Loading reuses…"
 msgstr "Chargement des réutilisations…"
+
+#, elixir-autogen, elixir-format
+msgid "No known reuse on this dataset."
+msgstr "Aucune réutilisation connue pour ce jeu de données."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -737,3 +737,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Loading reuses…"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "No known reuse on this dataset."
+msgstr ""

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -733,3 +733,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Those resources are listed by the provider but are unreachable for now. <a href=\"%{url}\">Learn more</a>."
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Loading reuses…"
+msgstr ""

--- a/apps/transport/test/transport_web/live_views/reuses_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/reuses_live_test.exs
@@ -56,7 +56,8 @@ defmodule Transport.TransportWeb.ReusesLiveTest do
         }
       )
 
-    refute render(view) =~ "Réutilisations"
+    assert render(view) =~ "Réutilisations"
+    refute render(view) =~ ~r/Réutilisations\s*\(10\)/
 
     Phoenix.PubSub.broadcast(
       TransportWeb.PubSub,
@@ -64,7 +65,8 @@ defmodule Transport.TransportWeb.ReusesLiveTest do
       {:count, 10}
     )
 
-    refute render(view) =~ "Réutilisations"
+    assert render(view) =~ "Réutilisations"
+    refute render(view) =~ ~r/Réutilisations\s*\(10\)/
 
     Phoenix.PubSub.broadcast(
       TransportWeb.PubSub,
@@ -72,7 +74,7 @@ defmodule Transport.TransportWeb.ReusesLiveTest do
       {:count, 10}
     )
 
-    assert render(view) =~ "Réutilisations"
+    assert render(view) =~ ~r/Réutilisations\s*\(10\)/
   end
 
   defp reuses do


### PR DESCRIPTION
- plus solide (moins d'overflow)
- plus lisible (logos et liens prennent la largeur disponible)
- moins de CSS, moins de margins et largeurs hardcodées
- meilleur rendu du markdown de la description (moins de marge inutile)
- décompte des réutilisations dans le menu
- affichage systèmatique de cette section avec un message quand aucune réutilisation (pour éviter les deep links absurdes le temps du chargement)

<img width="60%" alt="vue compacte" src="https://github.com/user-attachments/assets/29005706-cada-49e8-af41-affa2400525a" />

<img width="60%" alt="vue large" src="https://github.com/user-attachments/assets/cc8d35e0-edcd-4746-95b3-f158a0853dcc" />

* * *

Fixes #5370.