### PR TITLE
Corrige les niveaux de titres HTML pour les réutilisations

### DIFF
--- a/apps/transport/lib/transport_web/live/discussions_live.ex
+++ b/apps/transport/lib/transport_web/live/discussions_live.ex
@@ -50,7 +50,7 @@ defmodule TransportWeb.DiscussionsLive do
       </div>
     <% else %>
       <div>
-        {dgettext("page-dataset-details", "loading discussions...")}
+        {dgettext("page-dataset-details", "Loading discussions…")}
       </div>
     <% end %>
     """

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -47,10 +47,34 @@ defmodule TransportWeb.ReusesLive do
       </div>
       <div class="reuse__details">
         <h3>{@reuse["title"]}</h3>
-        {MarkdownHandler.markdown_to_safe_html!(@reuse["description"])}
+        {MarkdownHandler.markdown_to_safe_html!(@reuse["description"], &shift_headings/1)}
       </div>
     </div>
     """
+  end
+
+  # Shift headings to fit inside a reuse card (titled with <h3>).
+  # h1→h4, h2→h5, h3→h6 so they don't clash with the page heading hierarchy.
+  defp shift_headings(html) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.traverse_and_update(&shift_headings_tag/1)
+    |> Floki.raw_html()
+  end
+
+  defp shift_headings_tag({tag, attrs, children}) do
+    tag =
+      case tag do
+        "h1" -> "h4"
+        "h2" -> "h5"
+        "h3" -> "h6"
+        "h4" -> "h6"
+        "h5" -> "h6"
+        "h6" -> "h6"
+        unaltered -> unaltered
+      end
+
+    {tag, attrs, children}
   end
 
   def mount(

--- a/apps/transport/lib/transport_web/live/reuses_live.ex
+++ b/apps/transport/lib/transport_web/live/reuses_live.ex
@@ -12,7 +12,9 @@ defmodule TransportWeb.ReusesLive do
       <h2>{dgettext("page-dataset-details", "Reuses")}</h2>
       <%= cond do %>
         <% @loading -> %>
-          <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
+          <div class="panel">
+            <p>{dgettext("page-dataset-details", "Loading reuses…")}</p>
+          </div>
         <% @fetch_reuses_error -> %>
           <div class="panel reuses_not_available">
             🔌 {dgettext("page-dataset-details", "Reuses are temporarily unavailable")}

--- a/apps/transport/lib/transport_web/views/markdown_handler.ex
+++ b/apps/transport/lib/transport_web/views/markdown_handler.ex
@@ -6,16 +6,28 @@ defmodule TransportWeb.MarkdownHandler do
   alias Phoenix.HTML
 
   @doc """
-  transform an external markdown content into safe HTML
+  Transform an external markdown content into safe HTML.
   """
   @spec markdown_to_safe_html!(binary() | nil) :: HTML.safe()
   def markdown_to_safe_html!(nil), do: HTML.raw(nil)
 
   def markdown_to_safe_html!(md) do
+    markdown_to_safe_html!(md, &Function.identity/1)
+  end
+
+  @doc """
+  Transform markdown to safe HTML with a custom transform applied after Earmark.
+  The transform receives sanitized HTML and returns the final HTML string.
+  """
+  @spec markdown_to_safe_html!(binary(), (String.t() -> String.t())) :: HTML.safe()
+  def markdown_to_safe_html!(nil, _transform), do: HTML.raw(nil)
+
+  def markdown_to_safe_html!(md, transform) do
     {:safe, txt} =
       md
       |> Earmark.as_html!(gfm_tables: true, breaks: true)
       |> HtmlSanitizeEx.basic_html()
+      |> transform.()
       |> HTML.raw()
 
     {:safe, String.replace(txt, "<table>", ~s(<table class="table">), global: true)}

--- a/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/en/LC_MESSAGES/page-dataset-details.po
@@ -551,7 +551,7 @@ msgid "transport.data.gouv.fr automatically sends notifications to data producer
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "loading discussions..."
+msgid "Loading discussions…"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
+++ b/apps/transport/priv/gettext/fr/LC_MESSAGES/page-dataset-details.po
@@ -551,8 +551,8 @@ msgid "transport.data.gouv.fr automatically sends notifications to data producer
 msgstr "transport.data.gouv.fr envoie automatiquement des notifications au producteur du jeu de données afin d'en améliorer la qualité. Les notifications suivantes ont été envoyées au cours des %{nb} derniers jours."
 
 #, elixir-autogen, elixir-format
-msgid "loading discussions..."
-msgstr "chargement des discussions..."
+msgid "Loading discussions…."
+msgstr "Chargement des discussions…"
 
 #, elixir-autogen, elixir-format
 msgid "This transport service operates seasonally. The associated resources may be outdated depending on the time of year. Contact the data producer through Discussions for more information."

--- a/apps/transport/priv/gettext/page-dataset-details.pot
+++ b/apps/transport/priv/gettext/page-dataset-details.pot
@@ -551,7 +551,7 @@ msgid "transport.data.gouv.fr automatically sends notifications to data producer
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "loading discussions..."
+msgid "Loading discussions…"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/apps/transport/test/transport_web/live_views/reuses_live_test.exs
+++ b/apps/transport/test/transport_web/live_views/reuses_live_test.exs
@@ -29,6 +29,30 @@ defmodule Transport.TransportWeb.ReusesLiveTest do
     assert render(view) =~ "Bornes et station de recharge pour véhicules électriques"
   end
 
+  test "shifts heading levels in reuse descriptions", %{conn: conn} do
+    insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
+
+    Datagouvfr.Client.Reuses.Mock
+    |> expect(:get, 1, fn %{datagouv_id: ^datagouv_id} ->
+      {:ok, [reuse_with_headings()]}
+    end)
+
+    {:ok, view, _html} =
+      live_isolated(conn, TransportWeb.ReusesLive,
+        session: %{
+          "dataset_datagouv_id" => datagouv_id,
+          "locale" => "fr"
+        }
+      )
+
+    rendered = render(view)
+
+    # h1 in markdown → h4 in rendered reuse card (card itself uses h3 for title)
+    assert rendered =~ ~r/<h4>(?s).*Section principale<\/h4>/
+    # h2 in markdown → h5
+    assert rendered =~ ~r/<h5>(?s).*Sous-section<\/h5>/
+  end
+
   test "renders even if data.gouv is down", %{conn: conn} do
     insert(:dataset, datagouv_id: datagouv_id = Ecto.UUID.generate())
 
@@ -75,6 +99,16 @@ defmodule Transport.TransportWeb.ReusesLiveTest do
     )
 
     assert render(view) =~ ~r/Réutilisations\s*\(10\)/
+  end
+
+  defp reuse_with_headings do
+    Map.put(
+      hd(reuses()),
+      "description",
+      "# Section principale\nParagraphe.
+
+## Sous-section\nAutre paragraphe."
+    )
   end
 
   defp reuses do

--- a/apps/transport/test/transport_web/views/markdown_handler_test.exs
+++ b/apps/transport/test/transport_web/views/markdown_handler_test.exs
@@ -58,4 +58,42 @@ defmodule TransportWeb.MarkdownHandlerTest do
              ~s(<table class="table">\n  <thead>\n    <tr>\n      <th>\nState      </th>\n      <th>\nAbbrev      </th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>\nTexas      </td>\n      <td>\nTX      </td>\n    </tr>\n  </tbody>\n</table>\n)
            }
   end
+
+  describe "markdown_to_safe_html!/2 with transform" do
+    # Shift function matching ReusesLive.shift_headings/1
+    defp shift_headings(html) do
+      html
+      |> Floki.parse_fragment!()
+      |> Floki.traverse_and_update(&shift_headings_tag/1)
+      |> Floki.raw_html()
+    end
+
+    defp shift_headings_tag({tag, attrs, children}) do
+      tag =
+        case tag do
+          "h1" -> "h4"
+          unaltered -> unaltered
+        end
+
+      {tag, attrs, children}
+    end
+
+    test "shifts h1 to h4" do
+      content = "# Titre principal"
+      {:safe, html} = MarkdownHandler.markdown_to_safe_html!(content, &shift_headings/1)
+      assert html =~ ~r/<h4>(?s).*(?:\n)?Titre principal<\/h4>/
+    end
+
+    test "sanitizes dangerous HTML" do
+      content = "# Titre<svg/onload=alert(1)>\nParagraph"
+
+      {:safe, html} = MarkdownHandler.markdown_to_safe_html!(content, &shift_headings/1)
+      refute html =~ ~r/<svg/
+      assert html =~ ~r/<h4>/
+    end
+
+    test "returns safe empty string for nil input" do
+      assert MarkdownHandler.markdown_to_safe_html!(nil, &Function.identity/1) == {:safe, ""}
+    end
+  end
 end


### PR DESCRIPTION
Fixe https://github.com/etalab/transport-site/pull/5623#issuecomment-5608154256.

Le markdown peut produire des titres `<h1>` etc dans un contexte où un titre `<h3>` est déjà présent. Ce commit décale les titres de `<h1>` à `<h4>` et ainsi de suite pour les réutilisations uniquement.

La première implémentation naïve transforme le HTML par regex, j'envisage sérieusement de passer par `Floki.traverse_and_update/2` pour plus de sécurité d'exécution et du code plus maintenable. Ca permettra également sans doute de faire de même à d'autres endroits où ce problème se présente également.